### PR TITLE
Remove dynamic allocation from lansy; Remove duplicate code on lange

### DIFF
--- a/include/lapack/lange.hpp
+++ b/include/lapack/lange.hpp
@@ -36,99 +36,6 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template< typename norm_t, typename matrix_t, class work_t,
-    enable_if_t<
-        ( is_same_v<norm_t,max_norm_t> || 
-          is_same_v<norm_t,one_norm_t> || 
-          is_same_v<norm_t,inf_norm_t> || 
-          is_same_v<norm_t,frob_norm_t> ), bool > = true
->
-real_type< type_t< matrix_t > >
-lange( norm_t normType, const matrix_t& A, work_t& work )
-{
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-    using blas::isnan;
-    using blas::sqrt;
-
-    // constants
-    const real_t rzero(0.0);
-    const idx_t m = nrows(A);
-    const idx_t n = ncols(A);
-
-    // quick return
-    if (m == 0 || n == 0)
-        return rzero;
-
-    // Norm value
-    real_t norm = rzero;
-
-    if( is_same_v<norm_t,max_norm_t> )
-    {
-        for (idx_t j = 0; j < n; ++j) {
-            for (idx_t i = 0; i < m; ++i)
-            {
-                real_t temp = blas::abs( A(i,j) );
-
-                if (temp > norm)
-                    norm = temp;
-                else {
-                    if ( isnan(temp) ) 
-                        return temp;
-                }
-            }
-        }
-    }
-    else if ( is_same_v<norm_t,one_norm_t> )
-    {
-        for (idx_t j = 0; j < n; ++j)
-        {
-            real_t sum = rzero;
-            for (idx_t i = 0; i < m; ++i)
-                sum += blas::abs( A(i,j) );
-
-            if (sum > norm)
-                norm = sum;
-            else {
-                if ( isnan(sum) ) 
-                    return sum;
-            }
-        }
-    }
-    else if ( is_same_v<norm_t,inf_norm_t> )
-    {
-        for (idx_t i = 0; i < m; ++i)
-            work[i] = blas::abs( A(i,0) );
-        
-        for (idx_t j = 1; j < n; ++j)
-            for (idx_t i = 0; i < m; ++i)
-                work[i] += blas::abs( A(i,j) );
-
-        for (idx_t i = 0; i < m; ++i)
-        {
-            real_t temp = work[i];
-
-            if (temp > norm)
-                norm = temp;
-            else {
-                if (isnan(temp)) {
-                    return temp;
-                }
-            }
-        }
-    }
-    else if ( is_same_v<norm_t,frob_norm_t> )
-    {
-        real_t scale(0.0), sum(1.0);
-        for (idx_t j = 0; j < n; ++j)
-            lassq( col(A,j), scale, sum );
-        norm = scale * sqrt(sum);
-    }
-
-    return norm;
-}
-
 template< typename norm_t, typename matrix_t,
     enable_if_t<
         ( is_same_v<norm_t,max_norm_t> || 
@@ -188,12 +95,67 @@ lange( norm_t normType, const matrix_t& A )
             }
         }
     }
-    else if ( is_same_v<norm_t,frob_norm_t> )
+    else
     {
         real_t scale(0.0), sum(1.0);
         for (idx_t j = 0; j < n; ++j)
             lassq( col(A,j), scale, sum );
         norm = scale * sqrt(sum);
+    }
+
+    return norm;
+}
+
+template< typename norm_t, typename matrix_t, class work_t,
+    enable_if_t<
+        ( is_same_v<norm_t,max_norm_t> || 
+          is_same_v<norm_t,one_norm_t> || 
+          is_same_v<norm_t,inf_norm_t> || 
+          is_same_v<norm_t,frob_norm_t> ), bool > = true
+>
+real_type< type_t< matrix_t > >
+lange( norm_t normType, const matrix_t& A, work_t& work )
+{
+    using T      = type_t< matrix_t >;
+    using real_t = real_type< T >;
+    using idx_t  = size_type< matrix_t >;
+    using blas::isnan;
+    using blas::sqrt;
+
+    // quick redirect
+    if      ( is_same_v<norm_t,max_norm_t>  ) return lange( max_norm,  A );
+    else if ( is_same_v<norm_t,one_norm_t>  ) return lange( one_norm,  A );
+    else if ( is_same_v<norm_t,frob_norm_t> ) return lange( frob_norm, A );
+
+    // constants
+    const real_t rzero(0.0);
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+
+    // quick return
+    if (m == 0 || n == 0)
+        return rzero;
+
+    // Norm value
+    real_t norm = rzero;
+
+    for (idx_t i = 0; i < m; ++i)
+        work[i] = blas::abs( A(i,0) );
+    
+    for (idx_t j = 1; j < n; ++j)
+        for (idx_t i = 0; i < m; ++i)
+            work[i] += blas::abs( A(i,j) );
+
+    for (idx_t i = 0; i < m; ++i)
+    {
+        real_t temp = work[i];
+
+        if (temp > norm)
+            norm = temp;
+        else {
+            if (isnan(temp))
+                return temp;
+        }
     }
 
     return norm;

--- a/include/slate_api/lapack/lange.hpp
+++ b/include/slate_api/lapack/lange.hpp
@@ -45,7 +45,7 @@ inline real_type<TA> lange(
     using blas::internal::vector;
 
     // constants
-    real_t rzero(0);
+    const real_t rzero(0);
 
     // quick return
     if (m == 0 || n == 0)
@@ -60,7 +60,7 @@ inline real_type<TA> lange(
         return lange( one_norm, A );
     else if ( normType == Norm::Inf ){
         real_t *work = new real_t[m];
-        auto _work = vector<real_t>( work, m, 1 );
+        auto _work = vector<real_t>( work, m );
         auto aux = lange( inf_norm, A, _work );
         delete[] work;
         return aux;

--- a/include/slate_api/lapack/lansy.hpp
+++ b/include/slate_api/lapack/lansy.hpp
@@ -10,6 +10,8 @@
 #ifndef __SLATE_LANSY_HH__
 #define __SLATE_LANSY_HH__
 
+#include <memory>
+
 #include "lapack/types.hpp"
 #include "lapack/lansy.hpp"
 
@@ -43,6 +45,7 @@ real_type<TA> lansy(
 {
     typedef real_type<TA> real_t;
     using blas::internal::colmajor_matrix;
+    using blas::internal::vector;
 
     // constants
     const real_t zero( 0 );
@@ -58,8 +61,10 @@ real_type<TA> lansy(
         else                        return lansy( max_norm, lower_triangle, _A );
     }
     else if ( normType == Norm::One ||normType == Norm::Inf ) {
-        if( uplo == Uplo::Upper )   return lansy( one_norm, upper_triangle, _A );
-        else                        return lansy( one_norm, lower_triangle, _A );
+        std::unique_ptr<real_t[]> work( new real_t[n] );
+        auto _work = vector<real_t>( &work[0], n );
+        if( uplo == Uplo::Upper )   return lansy( one_norm, upper_triangle, _A, _work );
+        else                        return lansy( one_norm, lower_triangle, _A, _work );
     }
     else if ( normType == Norm::Fro ) {
         if( uplo == Uplo::Upper )   return lansy( frob_norm, upper_triangle, _A );


### PR DESCRIPTION
One of the design ideas for \<T\>LAPACK is that the abstract routines do not perform dynamic allocation. The only routine that was allocating memory dynamically on the input directory was the `lansy` for the one and inf norms. This PR moves the dynamic allocation to the lansy wrapper.

- This PR also removes the duplicate code on `lange`.