### PR TITLE
Various fixes (including removing -ltblas) for examples to build with Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ build*
 
 # Visual Studio Code files
 .vscode
+
+# Temporary files
+*.swp
+
+# Other
+notes/*

--- a/examples/cwrapper_gemm/make.inc
+++ b/examples/cwrapper_gemm/make.inc
@@ -4,6 +4,6 @@ tlapack_inc = /usr/local/include
 tlapack_lib = /usr/local/lib
 
 CXXFLAGS = -I$(tlapack_inc) -Wall -pedantic
-LDFLAGS  = -L$(tlapack_lib) -ltblas_c -ltblas
+LDFLAGS  = -L$(tlapack_lib) -ltblas_c
 
 LD = g++

--- a/examples/fortranModule_caxpy/make.inc
+++ b/examples/fortranModule_caxpy/make.inc
@@ -1,9 +1,9 @@
 #-------------------------------------------------------------------------------
 # <T>LAPACK library
-tlapack_inc     = /usr/local/include
-tlapack_lib     = /usr/local/lib
+tlapack_inc = /usr/local/include
+tlapack_lib = /usr/local/lib
 
 FFLAGS = -I$(tlapack_inc) -Wall -pedantic
-LDFLAGS  = -L$(tlapack_lib) -ltblas_fortran -ltblas_c -ltblas -lgfortran
+LDFLAGS  = -L$(tlapack_lib) -ltblas_fortran -ltblas_c -lgfortran
 
 LD = g++

--- a/examples/fortranWrapper_ssymm/Makefile
+++ b/examples/fortranWrapper_ssymm/Makefile
@@ -13,7 +13,7 @@ example_fortranWrapper_ssymm: example_fortranWrapper_ssymm.o
 
 .PHONY: all
 
-%.o: %.f90 constants.mod
+%.o: %.f90 $(tlapack_inc)/constants.mod
 	$(FC) $(FFLAGS) -c -o $@ $<
 
 clean:

--- a/examples/fortranWrapper_ssymm/make.inc
+++ b/examples/fortranWrapper_ssymm/make.inc
@@ -4,6 +4,6 @@ tlapack_inc     = /usr/local/include
 tlapack_lib     = /usr/local/lib
 
 FFLAGS = -I$(tlapack_inc) -Wall -pedantic
-LDFLAGS  = -L$(tlapack_lib) -ltblas_fortran -ltblas_c -ltblas -lgfortran
+LDFLAGS  = -L$(tlapack_lib) -ltblas_fortran -ltblas_c -lgfortran
 
 LD = g++

--- a/examples/gemm/make.inc
+++ b/examples/gemm/make.inc
@@ -4,4 +4,4 @@ tlapack_inc = /usr/local/include
 tlapack_lib = /usr/local/lib
 
 CXXFLAGS = -I$(tlapack_inc) -Wall -pedantic # -DUSE_MPFR
-LDFLAGS  = -L$(tlapack_lib) -ltblas # -lmpfr -lgmp
+LDFLAGS  = -L$(tlapack_lib) # -lmpfr -lgmp

--- a/examples/geqr2/make.inc
+++ b/examples/geqr2/make.inc
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 # <T>LAPACK library
-tlapack_inc = /usr/local/include
-tlapack_lib = /usr/local/lib
+tlapack_inc = /opt/tlapack/include #/usr/local/include
+tlapack_lib = /opt/tlapack/lib #/usr/local/lib
 
 CXXFLAGS = -I$(tlapack_inc) -Wall -pedantic
-LDFLAGS  = -L$(tlapack_lib) -ltblas
+LDFLAGS  = -L$(tlapack_lib)

--- a/examples/mdspan/make.inc
+++ b/examples/mdspan/make.inc
@@ -4,4 +4,4 @@ tlapack_inc = /usr/local/include
 tlapack_lib = /usr/local/lib
 
 CXXFLAGS = -I$(tlapack_inc) -Wall -pedantic
-LDFLAGS  = -L$(tlapack_lib) -ltlapack
+LDFLAGS  = -L$(tlapack_lib)


### PR DESCRIPTION
Hi Weslley! This PR should resolve #9. I've verified that all examples affected by these changes build correctly. (Note that I didn't change or test the "eigen" example. But it didn't have the ``-ltblas`` issue.)