### PR TITLE
Allow use of compile time and runtime parameters on the <T>LAPACK routines inside the directory `lapack`

### DIFF
--- a/include/blas/arrayTraits.hpp
+++ b/include/blas/arrayTraits.hpp
@@ -11,15 +11,6 @@
 
 namespace blas {
 
-    /// Layouts
-    enum class Layout { ColMajor = 'C', RowMajor = 'R' };
-    struct ColMajor_t {
-        constexpr operator Layout() const { return Layout::ColMajor; }
-    };
-    struct RowMajor_t {
-        constexpr operator Layout() const { return Layout::RowMajor; }
-    };
-
     /// Data type
     template< class T > struct type_trait {};
     template< class T >
@@ -29,24 +20,30 @@ namespace blas {
     template< class T > struct sizet_trait {};
     template< class T >
     using size_type = typename sizet_trait< T >::type;
-    
-    /// Layout type
-    template< class T > struct layout_trait {
-        using type = void;
+
+    /// Runtime layouts
+    enum class Layout {
+        ColMajor = 'C',
+        RowMajor = 'R', 
+        Scalar = 0, 
+        StridedVector = 1
     };
-    template< class T >
-    using layout_type = typename layout_trait< T >::type;
 
     /// Verifies if the set of data structures allow optimization using optBLAS.
     template<class...>
     struct allow_optblas {
         using type = bool; ///< Floating datatype.
+        static constexpr Layout layout = Layout::Scalar; ///< Layout type.
         static constexpr bool value = false; ///< True if it allows optBLAS.
     };
 
     /// Alias for allow_optblas<>::type.
     template<class... Ts>
     using allow_optblas_t = typename allow_optblas< Ts... >::type;
+
+    /// Alias for allow_optblas<>::layout.
+    template<class... Ts>
+    constexpr Layout allow_optblas_l = allow_optblas< Ts... >::layout;
 
     /// Alias for allow_optblas<>::value.
     template<class... Ts>

--- a/include/blas/arrayTraits.hpp
+++ b/include/blas/arrayTraits.hpp
@@ -11,6 +11,15 @@
 
 namespace blas {
 
+    /// Layouts
+    enum class Layout { ColMajor = 'C', RowMajor = 'R' };
+    struct ColMajor_t {
+        constexpr operator Layout() const { return Layout::ColMajor; }
+    };
+    struct RowMajor_t {
+        constexpr operator Layout() const { return Layout::RowMajor; }
+    };
+
     /// Data type
     template< class T > struct type_trait {};
     template< class T >
@@ -20,30 +29,24 @@ namespace blas {
     template< class T > struct sizet_trait {};
     template< class T >
     using size_type = typename sizet_trait< T >::type;
-
-    /// Runtime layouts
-    enum class Layout {
-        ColMajor = 'C',
-        RowMajor = 'R', 
-        Scalar = 0, 
-        StridedVector = 1
+    
+    /// Layout type
+    template< class T > struct layout_trait {
+        using type = void;
     };
+    template< class T >
+    using layout_type = typename layout_trait< T >::type;
 
     /// Verifies if the set of data structures allow optimization using optBLAS.
     template<class...>
     struct allow_optblas {
         using type = bool; ///< Floating datatype.
-        static constexpr Layout layout = Layout::Scalar; ///< Layout type.
         static constexpr bool value = false; ///< True if it allows optBLAS.
     };
 
     /// Alias for allow_optblas<>::type.
     template<class... Ts>
     using allow_optblas_t = typename allow_optblas< Ts... >::type;
-
-    /// Alias for allow_optblas<>::layout.
-    template<class... Ts>
-    constexpr Layout allow_optblas_l = allow_optblas< Ts... >::layout;
 
     /// Alias for allow_optblas<>::value.
     template<class... Ts>

--- a/include/blas/utils.hpp
+++ b/include/blas/utils.hpp
@@ -350,30 +350,27 @@ inline real_t abs1( const std::complex<real_t>& x )
 // -----------------------------------------------------------------------------
 /// Optimized BLAS
 
-template< class T1, class T2, class... Ts >
-constexpr bool has_compatible_layout = 
-    has_compatible_layout<T1, T2> &&
-    has_compatible_layout<T1, Ts...> &&
-    has_compatible_layout<T2, Ts...>;
-
-template< class T1, class T2 >
-constexpr bool has_compatible_layout<T1,T2> = ( 
-    is_same_v< layout_type<T1>, void > ||
-    is_same_v< layout_type<T2>, void > ||
-    is_same_v< layout_type<T1>, layout_type<T2> >
-);
-
 /// Specify the rules for allow_optblas for multiple data structures.
 template< class T1, class T2, class... Ts >
 struct allow_optblas< T1, T2, Ts... > {
     
     using type = allow_optblas_t<T1>;
     
+    static constexpr Layout layout =
+        (   allow_optblas_l<T1> == Layout::Scalar || 
+            allow_optblas_l<T1> == Layout::StridedVector )
+                ? allow_optblas_l<T2, Ts...>
+                : allow_optblas_l<T1>;
+    
     static constexpr bool value = 
         allow_optblas_v<T1> &&
         allow_optblas_v<T2, Ts...> &&
         is_same_v< real_type<type>, real_type<allow_optblas_t<T2>> > &&
-        has_compatible_layout< T1, T2, Ts... >;
+        (   allow_optblas_l<T1> == Layout::Scalar || 
+            allow_optblas_l<T1> == Layout::StridedVector ||
+            allow_optblas_l<T2, Ts...> == Layout::Scalar ||
+            allow_optblas_l<T2, Ts...> == Layout::StridedVector ||
+            layout == allow_optblas_l<T2, Ts...> );
 };
 
 template<class T1, class... Ts>
@@ -389,6 +386,7 @@ using disable_if_allow_optblas_t = enable_if_t<(
 #define TLAPACK_OPT_TYPE( T ) \
     template<> struct allow_optblas< T > { \
         using type = T; \
+        static constexpr Layout layout = Layout::Scalar; \
         static constexpr bool value = true; \
     }
 

--- a/include/lapack/lacpy.hpp
+++ b/include/lapack/lacpy.hpp
@@ -31,14 +31,7 @@ namespace lapack {
  * 
  * @ingroup auxiliary
  */
-template< class uplo_t, class matrixA_t, class matrixB_t,
-    enable_if_t<(
-    /* Requires: */
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t > || 
-        is_same_v< uplo_t, general_matrix_t >
-    ), int > = 0
->
+template< class uplo_t, class matrixA_t, class matrixB_t >
 void lacpy( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
 {
     // data traits
@@ -48,7 +41,7 @@ void lacpy( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
-    if( is_same_v< uplo_t, upper_triangle_t > ) {
+    if( uplo == Uplo::Upper ) {
         // Set the strictly upper triangular or trapezoidal part of B
         for (idx_t j = 0; j < n; ++j) {
             const auto M = std::min( m, j+1 );
@@ -56,7 +49,7 @@ void lacpy( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
                 B(i,j) = A(i,j);
         }
     }
-    else if( is_same_v< uplo_t, lower_triangle_t > ) {
+    else if( uplo == Uplo::Lower ) {
         // Set the strictly lower triangular or trapezoidal part of B
         const auto N = std::min(m,n);
         for (idx_t j = 0; j < N; ++j)

--- a/include/lapack/lacpy.hpp
+++ b/include/lapack/lacpy.hpp
@@ -41,6 +41,11 @@ void lacpy( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
+    // check arguments
+    blas_error_if(  uplo != Uplo::Lower &&
+                    uplo != Uplo::Upper &&
+                    uplo != Uplo::General );
+
     if( uplo == Uplo::Upper ) {
         // Set the strictly upper triangular or trapezoidal part of B
         for (idx_t j = 0; j < n; ++j) {

--- a/include/lapack/lange.hpp
+++ b/include/lapack/lange.hpp
@@ -132,15 +132,21 @@ lange( norm_t normType, const matrix_t& A, work_t& work )
     using idx_t  = size_type< matrix_t >;
     using blas::isnan;
 
+    // check arguments
+    blas_error_if(  normType != Norm::Fro &&
+                    normType != Norm::Inf &&
+                    normType != Norm::Max &&
+                    normType != Norm::One );
+
     // redirect for max-norm, one-norm and Frobenius norm
     if      ( normType == Norm::Max  ) return lange( max_norm,  A );
     else if ( normType == Norm::One  ) return lange( one_norm,  A );
-    else if ( normType == Norm::Fro ) return lange( frob_norm, A );
-    else if ( normType == Norm::Inf ) {
+    else if ( normType == Norm::Fro  ) return lange( frob_norm, A );
+    else if ( normType == Norm::Inf  ) {
 
         // the code below uses a workspace and is meant for column-major layout
         // so as to do one pass on the data in a contiguous way when computing
-	// the infinite norm
+	    // the infinite norm
  
         // constants
         const real_t rzero(0.0);

--- a/include/lapack/lange.hpp
+++ b/include/lapack/lange.hpp
@@ -36,13 +36,7 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template< typename norm_t, typename matrix_t,
-    enable_if_t<
-        ( is_same_v<norm_t,max_norm_t> || 
-          is_same_v<norm_t,one_norm_t> ||
-          is_same_v<norm_t,frob_norm_t> || 
-          is_same_v<norm_t,inf_norm_t>  ), bool > = true
->
+template< typename norm_t, typename matrix_t >
 real_type< type_t< matrix_t > >
 lange( norm_t normType, const matrix_t& A )
 {
@@ -64,7 +58,7 @@ lange( norm_t normType, const matrix_t& A )
     // Norm value
     real_t norm = rzero;
 
-    if( is_same_v<norm_t,max_norm_t> )
+    if( normType == Norm::Max )
     {
         for (idx_t j = 0; j < n; ++j) {
             for (idx_t i = 0; i < m; ++i)
@@ -80,7 +74,7 @@ lange( norm_t normType, const matrix_t& A )
             }
         }
     }
-    else if ( is_same_v<norm_t,inf_norm_t> )
+    else if ( normType == Norm::Inf )
     {
         for (idx_t i = 0; i < m; ++i)
         {
@@ -96,7 +90,7 @@ lange( norm_t normType, const matrix_t& A )
             }
         }
     }
-    else if ( is_same_v<norm_t,one_norm_t> )
+    else if ( normType == Norm::One )
     {
         for (idx_t j = 0; j < n; ++j)
         {
@@ -123,13 +117,7 @@ lange( norm_t normType, const matrix_t& A )
     return norm;
 }
 
-template< typename norm_t, typename matrix_t, class work_t,
-    enable_if_t<
-        ( is_same_v<norm_t,max_norm_t> || 
-          is_same_v<norm_t,one_norm_t> || 
-          is_same_v<norm_t,inf_norm_t> || 
-          is_same_v<norm_t,frob_norm_t> ), bool > = true
->
+template< typename norm_t, typename matrix_t, class work_t >
 real_type< type_t< matrix_t > >
 lange( norm_t normType, const matrix_t& A, work_t& work )
 {
@@ -139,10 +127,10 @@ lange( norm_t normType, const matrix_t& A, work_t& work )
     using blas::isnan;
 
     // redirect for max-norm, one-norm and Frobenius norm
-    if      ( is_same_v<norm_t,max_norm_t>  ) return lange( max_norm,  A );
-    else if ( is_same_v<norm_t,one_norm_t>  ) return lange( one_norm,  A );
-    else if ( is_same_v<norm_t,frob_norm_t> ) return lange( frob_norm, A );
-    else if ( is_same_v<norm_t,inf_norm_t> ) {
+    if      ( normType == Norm::Max  ) return lange( max_norm,  A );
+    else if ( normType == Norm::One  ) return lange( one_norm,  A );
+    else if ( normType == Norm::Fro ) return lange( frob_norm, A );
+    else if ( normType == Norm::Inf ) {
 
         // the code below uses a workspace and is meant for column-major layout
         // so as to do one pass on the data in a contiguous way when computing

--- a/include/lapack/lange.hpp
+++ b/include/lapack/lange.hpp
@@ -51,6 +51,12 @@ lange( norm_t normType, const matrix_t& A )
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
+    // check arguments
+    blas_error_if(  normType != Norm::Fro &&
+                    normType != Norm::Inf &&
+                    normType != Norm::Max &&
+                    normType != Norm::One );
+
     // quick return
     if (m == 0 || n == 0)
         return rzero;

--- a/include/lapack/lanhe.hpp
+++ b/include/lapack/lanhe.hpp
@@ -37,16 +37,7 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template< class norm_t, class uplo_t, class matrix_t,
-    enable_if_t<
-    /* Requires: */
-    (   is_same_v<norm_t,max_norm_t> ||
-        is_same_v<norm_t,frob_norm_t>
-    ) && (
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t >
-    ), bool > = true
->
+template< class norm_t, class uplo_t, class matrix_t >
 real_type< type_t<matrix_t> >
 lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
 {
@@ -68,9 +59,9 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
     // Norm value
     real_t norm(0.0);
 
-    if( is_same_v<norm_t,max_norm_t> )
+    if( normType == Norm::Max )
     {
-        if( is_same_v<uplo_t,upper_triangle_t> ) {
+        if( uplo == Uplo::Upper ) {
             for (idx_t j = 0; j < n; ++j) {
                 for (idx_t i = 0; i < j; ++i)
                 {
@@ -127,7 +118,7 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
         real_t scale(0), ssq(1);
         
         // Sum off-diagonals
-        if( is_same_v<uplo_t,upper_triangle_t> ) {
+        if( uplo == Uplo::Upper ) {
             for (idx_t j = 1; j < n; ++j)
                 lassq( subvector( col(A,j), pair{0,j} ), scale, ssq );
         }
@@ -152,18 +143,7 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
     return norm;
 }
 
-template< class norm_t, class uplo_t, class matrix_t, class work_t,
-    enable_if_t<
-    /* Requires: */
-    (   is_same_v<norm_t,max_norm_t> || 
-        is_same_v<norm_t,one_norm_t> || 
-        is_same_v<norm_t,inf_norm_t> || 
-        is_same_v<norm_t,frob_norm_t>
-    ) && (
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t >
-    ), bool > = true
->
+template< class norm_t, class uplo_t, class matrix_t, class work_t >
 real_type< type_t<matrix_t> >
 lanhe( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
 {
@@ -173,8 +153,8 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
     using blas::real;
 
     // quick redirect
-    if      ( is_same_v<norm_t,max_norm_t>  ) return lansy( max_norm,  uplo, A );
-    else if ( is_same_v<norm_t,frob_norm_t> ) return lansy( frob_norm, uplo, A );
+    if      ( normType == Norm::Max  ) return lansy( max_norm,  uplo, A );
+    else if ( normType == Norm::Fro ) return lansy( frob_norm, uplo, A );
 
     // constants
     const real_t zero(0.0);
@@ -189,7 +169,7 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
     for (idx_t i = 0; i < n; ++i)
         work[i] = type_t<work_t>(0);
 
-    if( is_same_v<uplo_t,upper_triangle_t> ) {
+    if( uplo == Uplo::Upper ) {
         for (idx_t j = 0; j < n; ++j)
         {
             real_t sum = zero;

--- a/include/lapack/lansy.hpp
+++ b/include/lapack/lansy.hpp
@@ -37,16 +37,7 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template< class norm_t, class uplo_t, class matrix_t,
-    enable_if_t<
-    /* Requires: */
-    (   is_same_v<norm_t,max_norm_t> ||
-        is_same_v<norm_t,frob_norm_t>
-    ) && (
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t >
-    ), bool > = true
->
+template< class norm_t, class uplo_t, class matrix_t >
 real_type< type_t<matrix_t> >
 lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
 {
@@ -66,9 +57,9 @@ lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
     // Norm value
     real_t norm(0.0);
 
-    if( is_same_v<norm_t,max_norm_t> )
+    if( normType == Norm::Max )
     {
-        if( is_same_v<uplo_t,upper_triangle_t> ) {
+        if( uplo == Uplo::Upper ) {
             for (idx_t j = 0; j < n; ++j) {
                 for (idx_t i = 0; i <= j; ++i)
                 {
@@ -105,7 +96,7 @@ lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
         real_t scale(0), ssq(1);
         
         // Sum off-diagonals
-        if( is_same_v<uplo_t,upper_triangle_t> ) {
+        if( uplo == Uplo::Upper ) {
             for (idx_t j = 1; j < n; ++j)
                 lassq( subvector( col(A,j), pair{0,j} ), scale, ssq );
         }
@@ -125,18 +116,7 @@ lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
     return norm;
 }
 
-template< class norm_t, class uplo_t, class matrix_t, class work_t,
-    enable_if_t<
-    /* Requires: */
-    (   is_same_v<norm_t,max_norm_t> || 
-        is_same_v<norm_t,one_norm_t> || 
-        is_same_v<norm_t,inf_norm_t> || 
-        is_same_v<norm_t,frob_norm_t>
-    ) && (
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t >
-    ), bool > = true
->
+template< class norm_t, class uplo_t, class matrix_t, class work_t >
 real_type< type_t<matrix_t> >
 lansy( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
 {
@@ -145,8 +125,8 @@ lansy( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
     using blas::isnan;
 
     // quick redirect
-    if      ( is_same_v<norm_t,max_norm_t>  ) return lansy( max_norm,  uplo, A );
-    else if ( is_same_v<norm_t,frob_norm_t> ) return lansy( frob_norm, uplo, A );
+    if      ( normType == Norm::Max  ) return lansy( max_norm,  uplo, A );
+    else if ( normType == Norm::Fro ) return lansy( frob_norm, uplo, A );
 
     // constants
     const real_t zero(0.0);
@@ -161,7 +141,7 @@ lansy( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
     for (idx_t i = 0; i < n; ++i)
         work[i] = type_t<work_t>(0);
 
-    if( is_same_v<uplo_t,upper_triangle_t> ) {
+    if( uplo == Uplo::Upper ) {
         for (idx_t j = 0; j < n; ++j)
         {
             real_t sum = zero;

--- a/include/lapack/larf.hpp
+++ b/include/lapack/larf.hpp
@@ -56,13 +56,7 @@ namespace lapack {
  * 
  * @ingroup auxiliary
  */
-template< class side_t, class vector_t, class tau_t, class matrix_t, class work_t,
-    enable_if_t<(
-    /* Requires: */
-        is_same_v< side_t, left_side_t > || 
-        is_same_v< side_t, right_side_t >
-    ), int > = 0
->
+template< class side_t, class vector_t, class tau_t, class matrix_t, class work_t >
 inline void larf(
     side_t side,
     vector_t const& v, tau_t& tau,
@@ -78,7 +72,7 @@ inline void larf(
     const T one(1.0);
     const T zero(0.0);
 
-    if( is_same_v<side_t,left_side_t> ) {
+    if( side == Side::Left ) {
         gemv(Op::ConjTrans, one, C, v, zero, work);
         ger(-tau, v, work, C);
     }

--- a/include/lapack/larf.hpp
+++ b/include/lapack/larf.hpp
@@ -72,6 +72,10 @@ inline void larf(
     const T one(1.0);
     const T zero(0.0);
 
+    // check arguments
+    blas_error_if( side != Side::Left &&
+                   side != Side::Right );
+
     if( side == Side::Left ) {
         gemv(Op::ConjTrans, one, C, v, zero, work);
         ger(-tau, v, work, C);

--- a/include/lapack/larfb.hpp
+++ b/include/lapack/larfb.hpp
@@ -120,25 +120,7 @@ namespace lapack {
  */
 template<
     class matrixV_t, class matrixT_t, class matrixC_t, class matrixW_t,
-    class side_t, class trans_t, class direction_t, class storage_t,
-    enable_if_t<(
-    /* Requires: */
-    (
-        is_same_v< side_t, left_side_t > || 
-        is_same_v< side_t, right_side_t > 
-    ) && (
-        is_same_v< trans_t, noTranspose_t > || 
-        is_same_v< trans_t, conjTranspose_t > ||
-        is_same_v< trans_t, transpose_t >
-    ) && (
-        is_same_v< direction_t, forward_t > || 
-        is_same_v< direction_t, backward_t > 
-    ) && (
-        is_same_v< storage_t, columnwise_storage_t > || 
-        is_same_v< storage_t, rowwise_storage_t >
-    )
-    ), int > = 0
->
+    class side_t, class trans_t, class direction_t, class storage_t >
 int larfb(
     side_t side, trans_t trans,
     direction_t direction, storage_t storeMode,
@@ -160,14 +142,14 @@ int larfb(
 
     // check arguments
     if( is_complex< type_t< matrixV_t > >::value )
-        lapack_error_if( (is_same_v< trans_t, transpose_t >), -2 );
+        lapack_error_if( trans == Op::Trans, -2 );
 
     // Quick return
     if (m <= 0 || n <= 0) return 0;
 
-    if( is_same_v< storage_t, columnwise_storage_t > ){
-        if( is_same_v< direction_t, forward_t > ){
-            if( is_same_v< side_t, left_side_t > ){
+    if( storeMode == StoreV::Columnwise ){
+        if( direction == Direction::Forward ){
+            if( side == Side::Left ){
                 // W is an k-by-n matrix
                 // V is an m-by-k matrix
 
@@ -255,7 +237,7 @@ int larfb(
             }
         }
         else { // direct == Direction::Backward
-            if( is_same_v< side_t, left_side_t > ){
+            if( side == Side::Left ){
                 // W is an k-by-n matrix
                 // V is an m-by-k matrix
 
@@ -344,8 +326,8 @@ int larfb(
         }
     }
     else { // storeV == StoreV::Rowwise
-        if( is_same_v< direction_t, forward_t > ){
-            if( is_same_v< side_t, left_side_t > ){
+        if( direction == Direction::Forward ){
+            if( side == Side::Left ){
                 // W is an k-by-n matrix
                 // V is an k-by-m matrix
 
@@ -433,7 +415,7 @@ int larfb(
             }
         }
         else { // direct == Direction::Backward
-            if( is_same_v< side_t, left_side_t > ){
+            if( side == Side::Left ){
                 // W is an k-by-n matrix
                 // V is an k-by-m matrix
 

--- a/include/lapack/larfb.hpp
+++ b/include/lapack/larfb.hpp
@@ -141,8 +141,18 @@ int larfb(
     const idx_t k = nrows(T);
 
     // check arguments
-    if( is_complex< type_t< matrixV_t > >::value )
-        lapack_error_if( trans == Op::Trans, -2 );
+    lapack_error_if(    side != Side::Left &&
+                        side != Side::Right, -1 );
+    lapack_error_if(    trans != Op::NoTrans &&
+                        trans != Op::ConjTrans &&
+                        (
+                            (trans != Op::Trans) ||
+                            is_complex< type_t< matrixV_t > >::value
+                        ), -2 );
+    lapack_error_if(    direction != Direction::Backward &&
+                        direction != Direction::Forward, -3 );
+    lapack_error_if(    storeMode != StoreV::Columnwise &&
+                        storeMode != StoreV::Columnwise, -4 );
 
     // Quick return
     if (m <= 0 || n <= 0) return 0;

--- a/include/lapack/larft.hpp
+++ b/include/lapack/larft.hpp
@@ -113,9 +113,12 @@ int larft(
                     : nrows( V );
 
     // check arguments
-    lapack_error_if( size( tau ) != k, -4 );
-    lapack_error_if( nrows( T ) != k ||
-                     ncols( T ) != k, -5 );
+    lapack_error_if(    direction != Direction::Backward &&
+                        direction != Direction::Forward, -1 );
+    lapack_error_if(    storeMode != StoreV::Columnwise &&
+                        storeMode != StoreV::Columnwise, -2 );
+    lapack_error_if(    size( tau ) != k, -4 );
+    lapack_error_if(    nrows( T ) != k || ncols( T ) != k, -5 );
 
     // Quick return
     if (n == 0 || k == 0)

--- a/include/lapack/larft.hpp
+++ b/include/lapack/larft.hpp
@@ -82,18 +82,7 @@ namespace lapack {
  */
 template< 
     class direction_t, class storage_t,
-    class matrixV_t, class vector_t, class matrixT_t,
-    enable_if_t<(
-    /* Requires: */
-    (
-        is_same_v< direction_t, forward_t > || 
-        is_same_v< direction_t, backward_t > 
-    ) && (
-        is_same_v< storage_t, columnwise_storage_t > || 
-        is_same_v< storage_t, rowwise_storage_t >
-    )
-    ), int > = 0
->
+    class matrixV_t, class vector_t, class matrixT_t >
 int larft(
     direction_t direction, storage_t storeMode,
     const matrixV_t& V, const vector_t& tau, matrixT_t& T)
@@ -116,10 +105,10 @@ int larft(
     const scalar_t one(1);
     const scalar_t zero(0);
     const tau_t    tzero(0);
-    const idx_t n    = (is_same_v< storage_t, columnwise_storage_t >)
+    const idx_t n    = (storeMode == StoreV::Columnwise)
                     ? nrows( V )
                     : ncols( V );
-    const idx_t k    = (is_same_v< storage_t, columnwise_storage_t >)
+    const idx_t k    = (storeMode == StoreV::Columnwise)
                     ? ncols( V )
                     : nrows( V );
 
@@ -132,7 +121,7 @@ int larft(
     if (n == 0 || k == 0)
         return 0;
 
-    if (is_same_v< direction_t, forward_t >) {
+    if (direction == Direction::Forward) {
         T(0,0) = tau[0];
         for (idx_t i = 1; i < k; ++i) {
             auto Ti = subvector( col( T, i ), pair{0,i} );
@@ -143,7 +132,7 @@ int larft(
             }
             else {
                 // General case
-                if (is_same_v< storage_t, columnwise_storage_t >) {
+                if (storeMode == StoreV::Columnwise) {
                     for (idx_t j = 0; j < i; ++j)
                         T(j,i) = -tau[i] * conj(V(i,j));
                     // T(0:i,i) := - tau[i] V(i+1:n,0:i)^H V(i+1:n,i)
@@ -192,7 +181,7 @@ int larft(
                     T(j,i) = zero;
             }
             else {
-                if (is_same_v< storage_t, columnwise_storage_t >) {
+                if (storeMode == StoreV::Columnwise) {
                     for (idx_t j = i+1; j < k; ++j)
                         T(j,i) = -tau[i] * conj(V(n-k+i,j));
                     // T(i+1:k,i) := - tau[i] V(0:n-k+i,i+1:k)^H V(0:n-k+i,i)

--- a/include/lapack/lascl.hpp
+++ b/include/lapack/lascl.hpp
@@ -55,14 +55,23 @@ namespace lapack {
  * 
  * @ingroup auxiliary
  */
-template< class uplo_t, class matrix_t, class a_type, class b_type,
-    enable_if_t<(
+template< class matrix_t, class a_type, class b_type, class sparse_t,
+    enable_if_t<((
     /* Requires: */
+        is_same_v< sparse_t, general_matrix_t > || 
+        is_same_v< sparse_t, lower_triangle_t > || 
+        is_same_v< sparse_t, upper_triangle_t > || 
+        is_same_v< sparse_t, hessenberg_matrix_t > || 
+        is_same_v< sparse_t, symmetric_lowerband_t > || 
+        is_same_v< sparse_t, symmetric_upperband_t > || 
+        is_same_v< sparse_t, band_matrix_t >
+    ) && 
         !is_complex< a_type >::value &&
         !is_complex< b_type >::value
-    ), int > = 0 >
+    ), int > = 0
+>
 int lascl(
-    uplo_t uplo,
+    sparse_t matrixtype,
     const b_type& b, const a_type& a,
     const matrix_t& A )
 {
@@ -88,8 +97,24 @@ int lascl(
     const real_t big   = safe_max<real_t>();
     
     // check arguments
+    if( is_same_v< sparse_t, symmetric_lowerband_t > ||
+        is_same_v< sparse_t, symmetric_upperband_t > )
+    {
+        lapack_error_if((matrixtype.bandwidth + 1 > m && m > 0) ||
+                        (matrixtype.bandwidth + 1 > n && n > 0), -1 );
+    }
+    else if( is_same_v< sparse_t, band_matrix_t > )
+    {
+        lapack_error_if((matrixtype.lower_bandwidth + 1 > m && m > 0) ||
+                        (matrixtype.upper_bandwidth + 1 > n && n > 0), -1 );
+    }
     lapack_error_if( (b == b_type(0)) || isnan(b), -2 );
     lapack_error_if( isnan(a), -3 );
+    if( is_same_v< sparse_t, symmetric_lowerband_t > ||
+        is_same_v< sparse_t, symmetric_upperband_t > )
+    {
+        lapack_error_if( m != n, -4 );
+    }
 
     // quick return
     if( m <= 0 || n <= 0 )
@@ -140,151 +165,48 @@ int lascl(
             }
         }
 
-        if ( uplo == Uplo::Lower )
-        {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = j; i < m; ++i)
-                    A(i,j) *= c;
-        }
-        else if ( uplo == Uplo::Upper )
-        {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; (i < m) && (i <= j); ++i)
-                    A(i,j) *= c;
-        }
-        // else if ( uplo == Uplo::Hessenberg )
-        // {
-        //     for (idx_t j = 0; j < n; ++j)
-        //         for (idx_t i = 0; (i < m) && (i <= j + 1); ++i)
-        //             A(i,j) *= c;
-        // }
-        else // if ( uplo == Uplo::General )
+        if ( is_same_v< sparse_t, general_matrix_t > )
         {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < m; ++i)
                     A(i,j) *= c;
         }
-    }
-
-    return 0;
-}
-
-template< class matrix_t, class a_type, class b_type,
-    enable_if_t<(
-    /* Requires: */
-        !is_complex< a_type >::value &&
-        !is_complex< b_type >::value
-    ) && (
-        is_same_v< layout_type< matrix_t >, band_matrix_t > ||
-        is_same_v< layout_type< matrix_t >, symmetric_lowerband_t > ||
-        is_same_v< layout_type< matrix_t >, symmetric_upperband_t >
-    ), int > = 0
->
-int lascl( const b_type& b, const a_type& a, const matrix_t& A )
-{
-    // data traits
-    using idx_t  = size_type< matrix_t >;
-    using real_t = real_type< a_type, b_type >;
-    using layout_t = layout_type< matrix_t >;
-    
-    // using
-    using blas::isnan;
-    using blas::abs;
-    using blas::safe_min;
-    using blas::safe_max;
-
-    // constants
-    const idx_t m = nrows(A);
-    const idx_t n = ncols(A);
-    const idx_t kl = lowerband(A);
-    const idx_t ku = upperband(A);
-
-    // constants
-    const idx_t izero = 0;
-    const real_t zero = 0.0;
-    const real_t one(1.0);
-    const real_t small = safe_min<real_t>();
-    const real_t big   = safe_max<real_t>();
-    
-    // check arguments
-    lapack_error_if( (b == b_type(0)) || isnan(b), -1 );
-    lapack_error_if( isnan(a), -2 );
-    lapack_error_if((kl + 1 > m && m > 0) ||
-                    (ku + 1 > n && n > 0), -3 );
-    if( is_same_v< layout_t, symmetric_lowerband_t > ||
-        is_same_v< layout_t, symmetric_upperband_t > )
-    {
-        lapack_error_if( kl != ku, -3 );
-        lapack_error_if( m != n, -3 );
-    }
-
-    // quick return
-    if( m <= 0 || n <= 0 )
-        return 0;
-
-    bool done = false;
-    while (!done)
-    {
-        real_t c;
-        a_type a1;
-        b_type b1 = b * small;
-        if (b1 == b) {
-            // b is not finite:
-            //  c is a correctly signed zero if a is finite,
-            //  c is NaN otherwise.
-            c = a / b;
-            done = true;
-        }
-        else { // b is finite
-            a1 = a / big;
-            if (a1 == a) {
-                // a is either 0 or an infinity number:
-                //  in both cases, c = a serves as the correct multiplication factor.
-                c = a;
-                done = true;
-            }
-            else if ( (abs(b1) > abs(a)) && (a != a_type(0)) ) {
-                // a is a non-zero finite number and abs(a/b) < small:
-                //  Set c = small as the multiplication factor,
-                //  Multiply b by the small factor.
-                c = small;
-                done = false;
-                b = b1;
-            }
-            else if (abs(a1) > abs(b)) {
-                // abs(a/b) > big:
-                //  Set c = big as the multiplication factor,
-                //  Divide a by the big factor.
-                c = big;
-                done = false;
-                a = a1;
-            }
-            else {
-                // small <= abs(a/b) <= big:
-                //  Set c = a/b as the multiplication factor.
-                c = a / b;
-                done = true;
-            }
-        }
-
-        if ( is_same_v< layout_t, symmetric_lowerband_t > )
+        else if ( is_same_v< sparse_t, lower_triangle_t > )
         {
-            const auto& k = kl;
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = j; i < m; ++i)
+                    A(i,j) *= c;
+        }
+        else if ( is_same_v< sparse_t, general_matrix_t > )
+        {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; (i < m) && (i <= j); ++i)
+                    A(i,j) *= c;
+        }
+        else if ( is_same_v< sparse_t, hessenberg_matrix_t > )
+        {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; (i < m) && (i <= j + 1); ++i)
+                    A(i,j) *= c;
+        }
+        else if ( is_same_v< sparse_t, symmetric_lowerband_t > )
+        {
+            const idx_t k = matrixtype.bandwidth;
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; (i <= k) && (i < n - j); ++i)
                     A(i,j) *= c;
         }
-        else if ( is_same_v< layout_t, symmetric_upperband_t > )
+        else if ( is_same_v< sparse_t, symmetric_upperband_t > )
         {
-            const auto& k = kl;
+            const idx_t k = matrixtype.bandwidth;
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = max(k - j, izero); i <= k; ++i)
                     A(i,j) *= c;
         }
-        else if ( is_same_v< layout_t, band_matrix_t > )
+        else if ( is_same_v< sparse_t, band_matrix_t > )
         {
-            const idx_t kl = kl;
-            const idx_t ku = ku;
+            const idx_t kl = matrixtype.lower_bandwidth;
+            const idx_t ku = matrixtype.upper_bandwidth;
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = max(kl + ku - j, kl); i <= min(2 * kl + ku, kl + ku + m - j); ++i)
                     A(i,j) *= c;
@@ -292,23 +214,6 @@ int lascl( const b_type& b, const a_type& a, const matrix_t& A )
     }
 
     return 0;
-}
-
-template< class matrix_t, class a_type, class b_type,
-    enable_if_t<(
-    /* Requires: */
-        !is_complex< a_type >::value &&
-        !is_complex< b_type >::value
-    ) && (
-        !is_same_v< layout_type< matrix_t >, band_matrix_t > &&
-        !is_same_v< layout_type< matrix_t >, symmetric_lowerband_t > &&
-        !is_same_v< layout_type< matrix_t >, symmetric_upperband_t >
-    ), int > = 0
->
-inline
-int lascl( const b_type& b, const a_type& a, const matrix_t& A )
-{
-    return lascl( general_matrix, b, a, A );
 }
 
 }

--- a/include/lapack/laset.hpp
+++ b/include/lapack/laset.hpp
@@ -33,13 +33,7 @@ namespace lapack {
  */
 template<
     class uplo_t, class matrix_t,
-    class alpha_t, class beta_t,
-    enable_if_t<(
-    /* Requires: */
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t > || 
-        is_same_v< uplo_t, general_matrix_t >
-    ), int > = 0
+    class alpha_t, class beta_t
 >
 void laset(
     uplo_t uplo,
@@ -53,7 +47,7 @@ void laset(
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
-    if (is_same_v< uplo_t, upper_triangle_t >) {
+    if (uplo == Uplo::Upper) {
         // Set the strictly upper triangular or trapezoidal part of
         // the array to alpha.
         for (idx_t j = 1; j < n; ++j) {
@@ -62,7 +56,7 @@ void laset(
                 A(i,j) = alpha;
         }
     }
-    else if (is_same_v< uplo_t, lower_triangle_t >) {
+    else if (uplo == Uplo::Lower) {
         // Set the strictly lower triangular or trapezoidal part of
         // the array to alpha.
         const idx_t N = min(m,n);

--- a/include/lapack/laset.hpp
+++ b/include/lapack/laset.hpp
@@ -47,6 +47,11 @@ void laset(
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
+    // check arguments
+    blas_error_if(  uplo != Uplo::Lower &&
+                    uplo != Uplo::Upper &&
+                    uplo != Uplo::General );
+
     if (uplo == Uplo::Upper) {
         // Set the strictly upper triangular or trapezoidal part of
         // the array to alpha.

--- a/include/lapack/orm2r.hpp
+++ b/include/lapack/orm2r.hpp
@@ -43,10 +43,18 @@ int orm2r(
     const idx_t m = nrows(C);
     const idx_t n = ncols(C);
     const idx_t k = size(tau);
-    constexpr bool leftSide = side == Side::Left;
+
+    // check arguments
+    lapack_error_if( side != Side::Left &&
+                     side != Side::Right, -1 );
+    lapack_error_if( trans != Op::NoTrans &&
+                     trans != Op::Trans &&
+                     trans != Op::ConjTrans, -2 );
+
+    // const expressions
     constexpr bool positiveInc = (
-        ( leftSide && !(trans == Op::Trans) ) ||
-        ( !leftSide && (trans == Op::Trans) )
+        ( (side == Side::Left) && !(trans == Op::Trans) ) ||
+        ( !(side == Side::Left) && (trans == Op::Trans) )
     );
     constexpr idx_t i0 = (positiveInc) ? 0 : k-1;
     constexpr idx_t iN = (positiveInc) ? k :  -1;
@@ -58,10 +66,10 @@ int orm2r(
 
     for (idx_t i = i0; i != iN; i += inc) {
         
-        const auto& v = (leftSide)
+        const auto& v = (side == Side::Left)
                       ? subvector( col( A, i ), pair{i,m} )
                       : subvector( col( A, i ), pair{i,n} );
-        auto& Ci = (leftSide)
+        auto& Ci = (side == Side::Left)
                  ? rows( C, pair{i,m} )
                  : cols( C, pair{i,n} );
         

--- a/include/lapack/orm2r.hpp
+++ b/include/lapack/orm2r.hpp
@@ -26,19 +26,7 @@ namespace lapack {
  */
 template<
     class matrixA_t, class matrixC_t, class tau_t, class work_t,
-    class side_t, class trans_t,
-    enable_if_t<(
-    /* Requires: */
-    (
-        is_same_v< side_t, left_side_t > || 
-        is_same_v< side_t, right_side_t > 
-    ) && (
-        is_same_v< trans_t, noTranspose_t > || 
-        is_same_v< trans_t, conjTranspose_t > ||
-        is_same_v< trans_t, transpose_t >
-    )
-    ), int > = 0
->
+    class side_t, class trans_t >
 int orm2r(
     side_t side, trans_t trans,
     const matrixA_t& A,
@@ -55,10 +43,10 @@ int orm2r(
     const idx_t m = nrows(C);
     const idx_t n = ncols(C);
     const idx_t k = size(tau);
-    constexpr bool leftSide = is_same_v< side_t, left_side_t >;
+    constexpr bool leftSide = side == Side::Left;
     constexpr bool positiveInc = (
-        ( leftSide && !is_same_v< trans_t, noTranspose_t > ) ||
-        ( !leftSide && is_same_v< trans_t, noTranspose_t > )
+        ( leftSide && !(trans == Op::Trans) ) ||
+        ( !leftSide && (trans == Op::Trans) )
     );
     constexpr idx_t i0 = (positiveInc) ? 0 : k-1;
     constexpr idx_t iN = (positiveInc) ? k :  -1;

--- a/include/lapack/potrf.hpp
+++ b/include/lapack/potrf.hpp
@@ -82,8 +82,10 @@ int potrf( uplo_t uplo, matrix_t& A, opts_t&& opts )
     // Options
     const idx_t nb = get_nb(opts);
 
-    // Check arguments
-    lapack_error_if( nrows(A) != ncols(A), -2 );
+    // check arguments
+    lapack_error_if(    uplo != Uplo::Lower &&
+                        uplo != Uplo::Upper, -1 );
+    lapack_error_if(    nrows(A) != ncols(A), -2 );
 
     // Quick return
     if (n <= 0)

--- a/include/lapack/potrf.hpp
+++ b/include/lapack/potrf.hpp
@@ -62,13 +62,7 @@ namespace lapack {
  *
  * @ingroup posv_computational
  */
-template< class uplo_t, class matrix_t, class opts_t,
-    enable_if_t<(
-    /* Requires: */
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t >
-    ), int > = 0
->
+template< class uplo_t, class matrix_t, class opts_t >
 int potrf( uplo_t uplo, matrix_t& A, opts_t&& opts )
 {
     using T      = type_t< matrix_t >;
@@ -101,7 +95,7 @@ int potrf( uplo_t uplo, matrix_t& A, opts_t&& opts )
     
     // Blocked code
     else {
-        if( is_same_v< uplo_t, upper_triangle_t > ) {
+        if( uplo == Uplo::Upper ) {
             for (idx_t j = 0; j < n; j+=nb)
             {
                 idx_t jb = min( nb, n-j );

--- a/include/lapack/potrf2.hpp
+++ b/include/lapack/potrf2.hpp
@@ -60,13 +60,7 @@ namespace lapack {
  *
  * @ingroup posv_computational
  */
-template< class uplo_t, class matrix_t,
-    enable_if_t<(
-    /* Requires: */
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t >
-    ), int > = 0
->
+template< class uplo_t, class matrix_t >
 int potrf2( uplo_t uplo, matrix_t& A )
 {
     using T      = type_t< matrix_t >;
@@ -115,7 +109,7 @@ int potrf2( uplo_t uplo, matrix_t& A )
         if( info != 0 )
             return info;
 
-        if( is_same_v< uplo_t, upper_triangle_t > ) {
+        if( uplo == Uplo::Upper ) {
 
             // Update and scale A12
             auto A12 = submatrix( A, pair{0,n1}, pair{n1,n} );

--- a/include/lapack/potrf2.hpp
+++ b/include/lapack/potrf2.hpp
@@ -78,8 +78,10 @@ int potrf2( uplo_t uplo, matrix_t& A )
     const real_t rzero( 0.0 );
     const idx_t n = nrows(A);
 
-    // Check arguments
-    lapack_error_if( nrows(A) != ncols(A), -2 );
+    // check arguments
+    lapack_error_if(    uplo != Uplo::Lower &&
+                        uplo != Uplo::Upper, -1 );
+    lapack_error_if(    nrows(A) != ncols(A), -2 );
 
     // Quick return
     if (n <= 0)

--- a/include/lapack/potrs.hpp
+++ b/include/lapack/potrs.hpp
@@ -46,8 +46,10 @@ int potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
     const T one( 1.0 );
 
     // Check arguments
-    lapack_error_if( nrows(A) != ncols(A), -2 );
-    lapack_error_if( nrows(B) != ncols(A), -3 );
+    lapack_error_if(    uplo != Uplo::Lower &&
+                        uplo != Uplo::Upper, -1 );
+    lapack_error_if(    nrows(A) != ncols(A), -2 );
+    lapack_error_if(    nrows(B) != ncols(A), -3 );
 
     if( uplo == Uplo::Upper ) {
         // Solve A*X = B where A = U**H *U.

--- a/include/lapack/potrs.hpp
+++ b/include/lapack/potrs.hpp
@@ -36,13 +36,7 @@ namespace lapack {
  *
  * @ingroup posv_computational
  */
-template< class uplo_t, class matrixA_t, class matrixB_t,
-    enable_if_t<(
-    /* Requires: */
-        is_same_v< uplo_t, upper_triangle_t > || 
-        is_same_v< uplo_t, lower_triangle_t >
-    ), int > = 0
->
+template< class uplo_t, class matrixA_t, class matrixB_t >
 int potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
 {
     using T = type_t< matrixB_t >;
@@ -55,7 +49,7 @@ int potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
     lapack_error_if( nrows(A) != ncols(A), -2 );
     lapack_error_if( nrows(B) != ncols(A), -3 );
 
-    if( is_same_v< uplo_t, upper_triangle_t > ) {
+    if( uplo == Uplo::Upper ) {
         // Solve A*X = B where A = U**H *U.
         trsm( left_side, uplo, conjTranspose, nonUnit_diagonal, one, A, B );
         trsm( left_side, uplo, noTranspose,   nonUnit_diagonal, one, A, B );

--- a/include/lapack/types.hpp
+++ b/include/lapack/types.hpp
@@ -21,7 +21,6 @@ using blas::scalar_type;
 using blas::is_complex;
 using blas::zero_t;
 
-using blas::Layout;
 using blas::Op;
 using blas::Uplo;
 using blas::Diag;
@@ -29,15 +28,16 @@ using blas::Side;
 
 using blas::type_t;
 using blas::size_type;
+using blas::layout_type;
 
 // -----------------------------------------------------------------------------
 // Diagonal matrices
 
 struct nonUnit_diagonal_t {
-    constexpr operator blas::Diag() const { return blas::Diag::NonUnit; }
+    constexpr operator Diag() const { return Diag::NonUnit; }
 };
 struct unit_diagonal_t {
-    constexpr operator blas::Diag() const { return blas::Diag::Unit; }
+    constexpr operator Diag() const { return Diag::Unit; }
 };
 
 // constants
@@ -48,13 +48,13 @@ constexpr unit_diagonal_t unit_diagonal = { };
 // Operations over data
 
 struct noTranspose_t {
-    constexpr operator blas::Op() const { return blas::Op::NoTrans; }
+    constexpr operator Op() const { return Op::NoTrans; }
 };
 struct transpose_t {
-    constexpr operator blas::Op() const { return blas::Op::Trans; }
+    constexpr operator Op() const { return Op::Trans; }
 };
 struct conjTranspose_t {
-    constexpr operator blas::Op() const { return blas::Op::ConjTrans; }
+    constexpr operator Op() const { return Op::ConjTrans; }
 };
 
 // Constants
@@ -67,17 +67,17 @@ constexpr conjTranspose_t conjTranspose = { };
 
 // Full matrix type
 struct general_matrix_t {
-    constexpr operator blas::Uplo() const { return blas::Uplo::General; }
+    constexpr operator Uplo() const { return Uplo::General; }
 };
 
 // Upper triangle type
 struct upper_triangle_t {
-    constexpr operator blas::Uplo() const { return blas::Uplo::Upper; }
+    constexpr operator Uplo() const { return Uplo::Upper; }
 };
 
 // Lower triangle type
 struct lower_triangle_t {
-    constexpr operator blas::Uplo() const { return blas::Uplo::Lower; }
+    constexpr operator Uplo() const { return Uplo::Lower; }
 };
 
 // Hessenberg matrix type
@@ -113,10 +113,26 @@ constexpr hessenberg_matrix_t hessenberg_matrix = { };
 // -----------------------------------------------------------------------------
 // Norm types
 
-struct max_norm_t { };
-struct one_norm_t { };
-struct inf_norm_t { };
-struct frob_norm_t { };
+enum class Norm {
+    One = '1',  // or 'O'
+    Two = '2',
+    Inf = 'I',
+    Fro = 'F',  // or 'E'
+    Max = 'M',
+};
+
+struct max_norm_t {
+    constexpr operator Norm() const { return Norm::Max; }
+};
+struct one_norm_t {
+    constexpr operator Norm() const { return Norm::One; }
+};
+struct inf_norm_t {
+    constexpr operator Norm() const { return Norm::Inf; }
+};
+struct frob_norm_t {
+    constexpr operator Norm() const { return Norm::Fro; }
+};
 
 // Constants
 constexpr max_norm_t max_norm = { };
@@ -127,8 +143,17 @@ constexpr frob_norm_t frob_norm = { };
 // -----------------------------------------------------------------------------
 // Directions
 
-struct forward_t { };
-struct backward_t { };
+enum class Direction {
+    Forward     = 'F',
+    Backward    = 'B',
+};
+
+struct forward_t {
+    constexpr operator Direction() const { return Direction::Forward; }
+};
+struct backward_t {
+    constexpr operator Direction() const { return Direction::Backward; }
+};
 
 // Constants
 constexpr forward_t forward { };
@@ -137,8 +162,17 @@ constexpr backward_t backward { };
 // -----------------------------------------------------------------------------
 // Storage types
 
-struct columnwise_storage_t { };
-struct rowwise_storage_t { };
+enum class StoreV {
+    Columnwise  = 'C',
+    Rowwise     = 'R',
+};
+
+struct columnwise_storage_t {
+    constexpr operator StoreV() const { return StoreV::Columnwise; }
+};
+struct rowwise_storage_t {
+    constexpr operator StoreV() const { return StoreV::Rowwise; }
+};
 
 // Constants
 constexpr columnwise_storage_t columnwise_storage { };
@@ -148,10 +182,10 @@ constexpr rowwise_storage_t rowwise_storage { };
 // Sides
 
 struct left_side_t {
-    constexpr operator blas::Side() const { return blas::Side::Left; }
+    constexpr operator Side() const { return Side::Left; }
 };
 struct right_side_t {
-    constexpr operator blas::Side() const { return blas::Side::Right; }
+    constexpr operator Side() const { return Side::Right; }
 };
 
 // Constants

--- a/include/lapack/types.hpp
+++ b/include/lapack/types.hpp
@@ -21,6 +21,7 @@ using blas::scalar_type;
 using blas::is_complex;
 using blas::zero_t;
 
+using blas::Layout;
 using blas::Op;
 using blas::Uplo;
 using blas::Diag;
@@ -28,7 +29,6 @@ using blas::Side;
 
 using blas::type_t;
 using blas::size_type;
-using blas::layout_type;
 
 // -----------------------------------------------------------------------------
 // Diagonal matrices

--- a/include/lapack/unmqr.hpp
+++ b/include/lapack/unmqr.hpp
@@ -93,19 +93,9 @@ template<
     class matrixA_t, class matrixC_t,
     class tau_t, class side_t, class trans_t,
     class opts_t,
-    enable_if_t<(
-    /* Requires: */
-    (
-        is_same_v< side_t, left_side_t > || 
-        is_same_v< side_t, right_side_t > 
-    ) && (
-        is_same_v< trans_t, noTranspose_t > || 
-        is_same_v< trans_t, conjTranspose_t > ||
-        is_same_v< trans_t, transpose_t >
-    ) &&
-        /// TODO: Remove this requirement when get_work() is fully functional
+    enable_if_t< /// TODO: Remove this requirement when get_work() is fully functional
         has_work_v< opts_t >
-    ), int > = 0
+    , int > = 0
 >
 int unmqr(
     side_t side, trans_t trans,
@@ -122,7 +112,7 @@ int unmqr(
     const idx_t n = ncols(C);
     const idx_t k = size(tau);
     const idx_t nA = nrows(A);
-    const idx_t nw = ( is_same_v< side_t, left_side_t > ) ? max<idx_t>(1,n) : max<idx_t>(1,m);
+    const idx_t nw = ( side == Side::Left ) ? max<idx_t>(1,n) : max<idx_t>(1,m);
     
     // Options
     const idx_t nb = get_nb(opts); // Block size
@@ -131,11 +121,11 @@ int unmqr(
     // Preparing loop indexes
     idx_t i0, iN, step;
     if(
-        ( is_same_v< side_t, left_side_t > &&
-        ! is_same_v< trans_t, noTranspose_t > )
+        ( (side == Side::Left) &&
+          !(trans == Op::Trans) )
     ||
-        ( is_same_v< side_t, right_side_t > &&
-          is_same_v< trans_t, noTranspose_t > )
+        ( (side == Side::Right) &&
+          (trans == Op::Trans) )
     ){
         i0 = 0;
         iN = k-1+nb;
@@ -160,7 +150,7 @@ int unmqr(
         larft( forward, columnwise_storage, V, taui, T );
 
         // H or H**H is applied to either C[i:m,0:n] or C[0:m,i:n]
-        auto Ci = ( is_same_v< side_t, left_side_t > )
+        auto Ci = ( side == Side::Left )
            ? submatrix( C, pair{i,m}, pair{0,n} )
            : submatrix( C, pair{0,m}, pair{i,n} );
 

--- a/include/lapack/unmqr.hpp
+++ b/include/lapack/unmqr.hpp
@@ -118,6 +118,13 @@ int unmqr(
     const idx_t nb = get_nb(opts); // Block size
     auto W = get_work(opts); // (nb)-by-(nw+nb) matrix
 
+    // check arguments
+    lapack_error_if( side != Side::Left &&
+                     side != Side::Right, -1 );
+    lapack_error_if( trans != Op::NoTrans &&
+                     trans != Op::Trans &&
+                     trans != Op::ConjTrans, -2 );
+
     // Preparing loop indexes
     idx_t i0, iN, step;
     if(

--- a/include/legacy_api/lapack/lacpy.hpp
+++ b/include/legacy_api/lapack/lacpy.hpp
@@ -22,17 +22,17 @@ void lacpy(
     TB* B, blas::idx_t ldb )
 {
     using blas::internal::colmajor_matrix;
+
+    // check arguments
+    blas_error_if(  uplo != Uplo::Lower &&
+                    uplo != Uplo::Upper &&
+                    uplo != Uplo::General );
     
     // Matrix views
     const auto _A = colmajor_matrix<TA>( (TA*)A, m, n, lda );
     auto _B = colmajor_matrix<TB>( B, m, n, ldb );
 
-    if (uplo == Uplo::Upper)
-        lacpy( upper_triangle, _A, _B );
-    else if (uplo == Uplo::Lower) 
-        lacpy( lower_triangle, _A, _B );
-    else
-        lacpy( general_matrix, _A, _B );
+    lacpy( uplo, _A, _B );
 }
 
 /** Copies a real matrix from A to B where A is either a full, upper triangular or lower triangular matrix.

--- a/include/legacy_api/lapack/lacpy.hpp
+++ b/include/legacy_api/lapack/lacpy.hpp
@@ -15,9 +15,9 @@
 
 namespace lapack {
 
-template< typename TA, typename TB >
+template< class uplo_t, typename TA, typename TB >
 void lacpy(
-    Uplo uplo, blas::idx_t m, blas::idx_t n,
+    uplo_t uplo, blas::idx_t m, blas::idx_t n,
     const TA* A, blas::idx_t lda,
     TB* B, blas::idx_t ldb )
 {

--- a/include/legacy_api/lapack/lange.hpp
+++ b/include/legacy_api/lapack/lange.hpp
@@ -40,12 +40,7 @@ inline real_type<TA> lange(
     norm_t normType, blas::idx_t m, blas::idx_t n,
     const TA *_A, blas::idx_t lda )
 {
-    using real_t = real_type<TA>;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-
-    // constants
-    const real_t rzero(0);
 
     // check arguments
     blas_error_if(  normType != Norm::Fro &&
@@ -55,10 +50,10 @@ inline real_type<TA> lange(
 
     // quick return
     if (m == 0 || n == 0)
-        return rzero;
+        return 0;
 
     // Views
-    const auto A = colmajor_matrix<TA>( (TA*)_A, m, n, lda );
+    auto A = colmajor_matrix<TA>( (TA*)_A, m, n, lda );
 
     return lange( normType, A );
 }

--- a/include/legacy_api/lapack/lange.hpp
+++ b/include/legacy_api/lapack/lange.hpp
@@ -35,9 +35,9 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template <typename TA>
+template <class norm_t, typename TA>
 inline real_type<TA> lange(
-    Norm normType, blas::idx_t m, blas::idx_t n,
+    norm_t normType, blas::idx_t m, blas::idx_t n,
     const TA *_A, blas::idx_t lda )
 {
     using real_t = real_type<TA>;

--- a/include/legacy_api/lapack/lange.hpp
+++ b/include/legacy_api/lapack/lange.hpp
@@ -47,6 +47,12 @@ inline real_type<TA> lange(
     // constants
     const real_t rzero(0);
 
+    // check arguments
+    blas_error_if(  normType != Norm::Fro &&
+                    normType != Norm::Inf &&
+                    normType != Norm::Max &&
+                    normType != Norm::One );
+
     // quick return
     if (m == 0 || n == 0)
         return rzero;
@@ -54,20 +60,7 @@ inline real_type<TA> lange(
     // Views
     const auto A = colmajor_matrix<TA>( (TA*)_A, m, n, lda );
 
-    if( normType == Norm::Max )
-        return lange( max_norm, A );
-    else if ( normType == Norm::One )
-        return lange( one_norm, A );
-    else if ( normType == Norm::Inf ){
-        real_t *work = new real_t[m];
-        auto _work = vector<real_t>( work, m );
-        auto aux = lange( inf_norm, A, _work );
-        delete[] work;
-        return aux;
-    } else if ( normType == Norm::Fro )
-        return lange( frob_norm, A );
-    else
-        return rzero;
+    return lange( normType, A );
 }
 
 } // lapack

--- a/include/legacy_api/lapack/lanhe.hpp
+++ b/include/legacy_api/lapack/lanhe.hpp
@@ -38,9 +38,9 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template <typename TA>
+template <class norm_t, typename TA>
 real_type<TA> lanhe(
-    Norm normType, Uplo uplo, blas::idx_t n,
+    norm_t normType, Uplo uplo, blas::idx_t n,
     const TA *A, blas::idx_t lda )
 {
     typedef real_type<TA> real_t;

--- a/include/legacy_api/lapack/lanhe.hpp
+++ b/include/legacy_api/lapack/lanhe.hpp
@@ -43,35 +43,21 @@ real_type<TA> lanhe(
     norm_t normType, Uplo uplo, blas::idx_t n,
     const TA *A, blas::idx_t lda )
 {
-    typedef real_type<TA> real_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
 
-    // constants
-    const real_t zero( 0 );
+    // check arguments
+    blas_error_if(  normType != Norm::Fro &&
+                    normType != Norm::Inf &&
+                    normType != Norm::Max &&
+                    normType != Norm::One );
 
     // quick return
-    if ( n == 0 ) return zero;
+    if ( n == 0 ) return 0;
 
     // Matrix views
-    const auto _A = colmajor_matrix<TA>( (TA*)A, n, n, lda );
+    auto _A = colmajor_matrix<TA>( (TA*)A, n, n, lda );
 
-    if( normType == Norm::Max ) {
-        if( uplo == Uplo::Upper )   return lanhe( max_norm, upper_triangle, _A );
-        else                        return lanhe( max_norm, lower_triangle, _A );
-    }
-    else if ( normType == Norm::One ||normType == Norm::Inf ) {
-        std::unique_ptr<real_t[]> work( new real_t[n] );
-        auto _work = vector<real_t>( &work[0], n );
-        if( uplo == Uplo::Upper )   return lanhe( one_norm, upper_triangle, _A, _work );
-        else                        return lanhe( one_norm, lower_triangle, _A, _work );
-    }
-    else if ( normType == Norm::Fro ) {
-        if( uplo == Uplo::Upper )   return lanhe( frob_norm, upper_triangle, _A );
-        else                        return lanhe( frob_norm, lower_triangle, _A );
-    }
-
-    return zero;
+    return lanhe( normType, uplo, _A );
 }
 
 } // lapack

--- a/include/legacy_api/lapack/lansy.hpp
+++ b/include/legacy_api/lapack/lansy.hpp
@@ -43,35 +43,21 @@ real_type<TA> lansy(
     norm_t normType, Uplo uplo, blas::idx_t n,
     const TA *A, blas::idx_t lda )
 {
-    typedef real_type<TA> real_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
 
-    // constants
-    const real_t zero( 0 );
+    // check arguments
+    blas_error_if(  normType != Norm::Fro &&
+                    normType != Norm::Inf &&
+                    normType != Norm::Max &&
+                    normType != Norm::One );
 
     // quick return
-    if ( n == 0 ) return zero;
+    if ( n == 0 ) return 0;
 
     // Matrix views
-    const auto _A = colmajor_matrix<TA>( (TA*)A, n, n, lda );
+    auto _A = colmajor_matrix<TA>( (TA*)A, n, n, lda );
 
-    if( normType == Norm::Max ) {
-        if( uplo == Uplo::Upper )   return lansy( max_norm, upper_triangle, _A );
-        else                        return lansy( max_norm, lower_triangle, _A );
-    }
-    else if ( normType == Norm::One ||normType == Norm::Inf ) {
-        std::unique_ptr<real_t[]> work( new real_t[n] );
-        auto _work = vector<real_t>( &work[0], n );
-        if( uplo == Uplo::Upper )   return lansy( one_norm, upper_triangle, _A, _work );
-        else                        return lansy( one_norm, lower_triangle, _A, _work );
-    }
-    else if ( normType == Norm::Fro ) {
-        if( uplo == Uplo::Upper )   return lansy( frob_norm, upper_triangle, _A );
-        else                        return lansy( frob_norm, lower_triangle, _A );
-    }
-
-    return zero;
+    return lansy( normType, uplo, _A );
 }
 
 } // lapack

--- a/include/legacy_api/lapack/lansy.hpp
+++ b/include/legacy_api/lapack/lansy.hpp
@@ -38,9 +38,9 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template <typename TA>
+template <class norm_t, typename TA>
 real_type<TA> lansy(
-    Norm normType, Uplo uplo, blas::idx_t n,
+    norm_t normType, Uplo uplo, blas::idx_t n,
     const TA *A, blas::idx_t lda )
 {
     typedef real_type<TA> real_t;

--- a/include/legacy_api/lapack/larf.hpp
+++ b/include/legacy_api/lapack/larf.hpp
@@ -22,9 +22,9 @@ namespace lapack {
  * 
  * @ingroup auxiliary
  */
-template< typename TV, typename TC >
+template< class side_t, typename TV, typename TC >
 inline void larf(
-    Side side,
+    side_t side,
     blas::idx_t m, blas::idx_t n,
     TV const *v, blas::int_t incv,
     blas::scalar_type< TV, TC > tau,

--- a/include/legacy_api/lapack/larf.hpp
+++ b/include/legacy_api/lapack/larf.hpp
@@ -58,10 +58,7 @@ inline void larf(
         lenv, incv );
     auto _work = vector<scalar_t>( &work[0], lwork, 1 );
 
-    if( side == Side::Left )
-        larf( left_side, _v, tau, _C, _work);
-    else
-        larf( right_side, _v, tau, _C, _work);
+    larf( side, _v, tau, _C, _work);
         
     // delete[] work;
 }

--- a/include/legacy_api/lapack/larfb.hpp
+++ b/include/legacy_api/lapack/larfb.hpp
@@ -125,8 +125,18 @@ int larfb(
     using blas::internal::colmajor_matrix;
 
     // check arguments
-    if( is_complex<TV>::value )
-        lapack_error_if( trans == Op::Trans, -2 );
+    lapack_error_if(    side != Side::Left &&
+                        side != Side::Right, -1 );
+    lapack_error_if(    trans != Op::NoTrans &&
+                        trans != Op::ConjTrans &&
+                        (
+                            (trans != Op::Trans) ||
+                            is_complex< TV >::value
+                        ), -2 );
+    lapack_error_if(    direct != Direction::Backward &&
+                        direct != Direction::Forward, -3 );
+    lapack_error_if(    storeV != StoreV::Columnwise &&
+                        storeV != StoreV::Columnwise, -4 );
 
     // Quick return
     if (m <= 0 || n <= 0) return 0;
@@ -144,163 +154,7 @@ int larfb(
                ? colmajor_matrix<scalar_t>( W, k, n )
                : colmajor_matrix<scalar_t>( W, m, k );
 
-    int info = 0;
-    if (storeV == StoreV::Columnwise) {
-        if (direct == Direction::Forward) {
-            if (side == Side::Left) {
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        left_side, noTranspose,
-                        forward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        left_side, transpose,
-                        forward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        left_side, conjTranspose,
-                        forward, columnwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-            else { // side == Side::Right
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        right_side, noTranspose,
-                        forward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        right_side, transpose,
-                        forward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        right_side, conjTranspose,
-                        forward, columnwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-        }
-        else { // direct == Direction::Backward
-            if (side == Side::Left) {
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        left_side, noTranspose,
-                        backward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        left_side, transpose,
-                        backward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        left_side, conjTranspose,
-                        backward, columnwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-            else { // side == Side::Right
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        right_side, noTranspose,
-                        backward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        right_side, transpose,
-                        backward, columnwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        right_side, conjTranspose,
-                        backward, columnwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-        }
-    }
-    else { // storeV == StoreV::Rowwise
-        if (direct == Direction::Forward) {
-            if (side == Side::Left) {
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        left_side, noTranspose,
-                        forward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        left_side, transpose,
-                        forward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        left_side, conjTranspose,
-                        forward, rowwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-            else { // side == Side::Right
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        right_side, noTranspose,
-                        forward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        right_side, transpose,
-                        forward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        right_side, conjTranspose,
-                        forward, rowwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-        }
-        else { // direct == Direction::Backward
-            if (side == Side::Left) {
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        left_side, noTranspose,
-                        backward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        left_side, transpose,
-                        backward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        left_side, conjTranspose,
-                        backward, rowwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-            else { // side == Side::Right
-                if (trans == Op::NoTrans) {
-                    info = larfb(
-                        right_side, noTranspose,
-                        backward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else if (trans == Op::Trans) {
-                    info = larfb(
-                        right_side, transpose,
-                        backward, rowwise_storage,
-                        _V, _T, _C, _W );
-                } else { // (trans == Op::ConjTrans)
-                    info = larfb(
-                        right_side, conjTranspose,
-                        backward, rowwise_storage,
-                        _V, _T, _C, _W );
-                }
-            }
-        }
-    }
+    int info = larfb( side, trans, direct, storeV, _V, _T, _C, _W );
 
     delete[] W;
     return info;

--- a/include/legacy_api/lapack/larfb.hpp
+++ b/include/legacy_api/lapack/larfb.hpp
@@ -111,10 +111,11 @@ namespace lapack {
  * @ingroup auxiliary
  */
 
-template <typename TV, typename TC>
+template <class side_t, class trans_t, class direction_t, class storeV_t,
+    typename TV, typename TC>
 int larfb(
-    Side side, Op trans,
-    Direction direct, StoreV storeV,
+    side_t side, trans_t trans,
+    direction_t direct, storeV_t storeV,
     idx_t m, idx_t n, idx_t k,
     TV const* V, idx_t ldV,
     TV const* T, idx_t ldT,

--- a/include/legacy_api/lapack/larft.hpp
+++ b/include/legacy_api/lapack/larft.hpp
@@ -78,9 +78,9 @@ namespace lapack {
  * 
  * @ingroup auxiliary
  */
-template <typename scalar_t>
+template <class direction_t, class storeV_t, typename scalar_t>
 int larft(
-    Direction direction, StoreV storeV,
+    direction_t direction, storeV_t storeV,
     idx_t n, idx_t k,
     const scalar_t *V, idx_t ldV,
     const scalar_t *tau,

--- a/include/legacy_api/lapack/larft.hpp
+++ b/include/legacy_api/lapack/larft.hpp
@@ -110,18 +110,7 @@ int larft(
     auto _tau = vector<scalar_t>( (scalar_t*)tau, k, 1 );
     auto _T = colmajor_matrix<scalar_t>( T, k, k, ldT );
 
-    if(direction == Direction::Forward) {
-        if(storeV == StoreV::Columnwise)
-            return larft( forward, columnwise_storage, _V, _tau, _T);
-        else
-            return larft( forward, rowwise_storage, _V, _tau, _T);
-    }
-    else {
-        if(storeV == StoreV::Columnwise)
-            return larft( backward, columnwise_storage, _V, _tau, _T);
-        else
-            return larft( backward, rowwise_storage, _V, _tau, _T);
-    }
+    return larft( direction, storeV, _V, _tau, _T);
 }
 
 }

--- a/include/legacy_api/lapack/lascl.hpp
+++ b/include/legacy_api/lapack/lascl.hpp
@@ -54,9 +54,9 @@ namespace lapack {
  * 
  * @ingroup auxiliary
  */
-template< typename T >
+template< class matrixType_t, typename T >
 int lascl(
-    lapack::MatrixType matrixtype,
+    matrixType_t matrixtype,
     idx_t kl, idx_t ku,
     const real_type<T>& b, const real_type<T>& a,
     idx_t m, idx_t n,

--- a/include/legacy_api/lapack/lascl.hpp
+++ b/include/legacy_api/lapack/lascl.hpp
@@ -54,9 +54,9 @@ namespace lapack {
  * 
  * @ingroup auxiliary
  */
-template< class matrixType_t, typename T >
+template< typename T >
 int lascl(
-    matrixType_t matrixtype,
+    lapack::MatrixType matrixtype,
     idx_t kl, idx_t ku,
     const real_type<T>& b, const real_type<T>& a,
     idx_t m, idx_t n,

--- a/include/legacy_api/lapack/laset.hpp
+++ b/include/legacy_api/lapack/laset.hpp
@@ -23,6 +23,11 @@ void laset(
 {
     using blas::internal::colmajor_matrix;
 
+    // check arguments
+    blas_error_if(  uplo != Uplo::Lower &&
+                    uplo != Uplo::Upper &&
+                    uplo != Uplo::General );
+
     // quick return
     if( m <= 0 || n <= 0 )
         return;
@@ -30,9 +35,7 @@ void laset(
     // Matrix views
     auto _A = colmajor_matrix<TA>( A, m, n, lda );
 
-    if (uplo == Uplo::Upper) laset( upper_triangle, alpha, beta, _A );
-    else if (uplo == Uplo::Lower) laset( lower_triangle, alpha, beta, _A );
-    else laset( general_matrix, alpha, beta, _A );
+    return laset( uplo, alpha, beta, _A );
 }
 
 /** Initializes a matrix to diagonal and off-diagonal values

--- a/include/legacy_api/lapack/laset.hpp
+++ b/include/legacy_api/lapack/laset.hpp
@@ -15,9 +15,9 @@
 
 namespace lapack {
 
-template< typename TA >
+template< class uplo_t, typename TA >
 void laset(
-    Uplo uplo, blas::idx_t m, blas::idx_t n,
+    uplo_t uplo, blas::idx_t m, blas::idx_t n,
     TA alpha, TA beta,
     TA* A, blas::idx_t lda )
 {

--- a/include/legacy_api/lapack/orm2r.hpp
+++ b/include/legacy_api/lapack/orm2r.hpp
@@ -47,9 +47,9 @@ namespace lapack {
  * 
  * @ingroup geqrf
  */
-template<typename TA, typename TC>
+template< class side_t, class trans_t, typename TA, typename TC>
 inline int orm2r(
-    Side side, Op trans,
+    side_t side, trans_t trans,
     blas::idx_t m, blas::idx_t n, blas::idx_t k,
     const TA* A, blas::idx_t lda,
     const blas::real_type<TA,TC>* tau,

--- a/include/legacy_api/lapack/orm2r.hpp
+++ b/include/legacy_api/lapack/orm2r.hpp
@@ -76,7 +76,6 @@ inline int orm2r(
     if ((m == 0) || (n == 0) || (k == 0))
         return 0;
 
-    int info = 0;
     scalar_t* work = new scalar_t[ (q > 0) ? q : 0 ];
 
     // Matrix views
@@ -85,22 +84,7 @@ inline int orm2r(
     auto _C = colmajor_matrix<TC>( C, m, n, ldc );
     auto _work = vector<TC>( work, q );
 
-    if( side == Side::Left ) {
-        if( trans == Op::NoTrans )
-            info = orm2r( left_side, noTranspose, A, _tau, _C, _work );
-        else if( trans == Op::Trans )
-            info = orm2r( left_side, transpose, A, _tau, _C, _work );
-        else
-            info = orm2r( left_side, conjTranspose, A, _tau, _C, _work );
-    }
-    else { // side == Side::Right
-        if( trans == Op::NoTrans )
-            info = orm2r( right_side, noTranspose, A, _tau, _C, _work );
-        else if( trans == Op::Trans )
-            info = orm2r( right_side, transpose, A, _tau, _C, _work );
-        else
-            info = orm2r( right_side, conjTranspose, A, _tau, _C, _work );
-    }
+    int info = orm2r( side, trans, A, _tau, _C, _work );
 
     delete[] work;
     return info;

--- a/include/legacy_api/lapack/potrf.hpp
+++ b/include/legacy_api/lapack/potrf.hpp
@@ -21,8 +21,8 @@ namespace lapack {
  * 
  * @ingroup posv_computational
  */
-template< typename T >
-inline int potrf( Uplo uplo, idx_t n, T* A, idx_t lda )
+template< class uplo_t, typename T >
+inline int potrf( uplo_t uplo, idx_t n, T* A, idx_t lda )
 {
     using blas::internal::colmajor_matrix;
 

--- a/include/legacy_api/lapack/potrf.hpp
+++ b/include/legacy_api/lapack/potrf.hpp
@@ -26,16 +26,17 @@ inline int potrf( uplo_t uplo, idx_t n, T* A, idx_t lda )
 {
     using blas::internal::colmajor_matrix;
 
+    // check arguments
+    lapack_error_if(    uplo != Uplo::Lower &&
+                        uplo != Uplo::Upper, -1 );
+
     // Matrix views
     auto _A = colmajor_matrix<T>( A, n, n, lda );
 
     // Options
     struct { idx_t nb = 32; } opts;
 
-    if( uplo == Uplo::Upper )
-        return potrf( upper_triangle, _A, opts );
-    else
-        return potrf( lower_triangle, _A, opts );
+    return potrf( uplo, _A, opts );
 }
 
 } // lapack

--- a/include/legacy_api/lapack/potrs.hpp
+++ b/include/legacy_api/lapack/potrs.hpp
@@ -20,9 +20,9 @@ namespace lapack {
  * 
  * @ingroup posv_computational
  */
-template< typename T >
+template< class uplo_t, typename T >
 inline int potrs(
-    Uplo uplo, idx_t n, idx_t nrhs,
+    uplo_t uplo, idx_t n, idx_t nrhs,
     const T* A, idx_t lda,
     T* B, idx_t ldb )
 {

--- a/include/legacy_api/lapack/potrs.hpp
+++ b/include/legacy_api/lapack/potrs.hpp
@@ -28,14 +28,15 @@ inline int potrs(
 {
     using blas::internal::colmajor_matrix;
 
+    // Check arguments
+    lapack_error_if(    uplo != Uplo::Lower &&
+                        uplo != Uplo::Upper, -1 );
+
     // Matrix views
     const auto _A = colmajor_matrix<T>( (T*) A, n, n, lda );
           auto _B = colmajor_matrix<T>( B, n, nrhs, ldb );
 
-    if( uplo == Uplo::Upper )
-        return potrs( upper_triangle, _A, _B );
-    else
-        return potrs( lower_triangle, _A, _B );
+    return potrs( uplo, _A, _B );
 }
 
 } // lapack

--- a/include/legacy_api/lapack/types.hpp
+++ b/include/legacy_api/lapack/types.hpp
@@ -23,15 +23,6 @@ enum class Sides {
 };
 
 // -----------------------------------------------------------------------------
-enum class Norm {
-    One = '1',  // or 'O'
-    Two = '2',
-    Inf = 'I',
-    Fro = 'F',  // or 'E'
-    Max = 'M',
-};
-
-// -----------------------------------------------------------------------------
 // Job for computing eigenvectors and singular vectors
 // # needs custom map
 enum class Job {
@@ -81,20 +72,6 @@ enum class Vect {
 };
 
 // -----------------------------------------------------------------------------
-// larfb
-enum class Direction {
-    Forward     = 'F',
-    Backward    = 'B',
-};
-
-// -----------------------------------------------------------------------------
-// larfb
-enum class StoreV {
-    Columnwise  = 'C',
-    Rowwise     = 'R',
-};
-
-// -----------------------------------------------------------------------------
 // lascl
 enum class MatrixType {
     General     = 'G',
@@ -105,6 +82,62 @@ enum class MatrixType {
     UpperBand   = 'Q',
     Band        = 'Z',
 };
+// class MatrixType {
+// public:
+
+//     /// Values are accessed like MatrixType::General and MatrixType::Band
+//     enum Value : char {
+//         General     = 'G',
+//         Lower       = 'L',
+//         Upper       = 'U',
+//         Hessenberg  = 'H',
+//         LowerBand   = 'B',
+//         UpperBand   = 'Q',
+//         Band        = 'Z'
+//     };
+
+//     // Constructors
+//     MatrixType() = default;
+//     constexpr MatrixType(Value v) : _value(v) { }
+//     constexpr MatrixType(char c) : _value(Value(c)) { }
+
+//     // Operators
+//     inline constexpr operator Value() const { return _value; }
+//     explicit  operator bool() = delete; ///< Prevents if( MatrixType )
+
+//     /** Converts MatrixType to Uplo
+//      * 
+//      * This is useful because MatrixType and Uplo share semantics
+//      * 
+//      * @return Equivalent Uplo object if possible.
+//      *      If there is no equivalent Uplo object, returns the invalid Uplo(' ')
+//      */
+//     inline constexpr operator Uplo() const {
+//         if (_value == General)  return Uplo::General;
+//         if (_value == Lower)    return Uplo::Lower;
+//         if (_value == Upper)    return Uplo::Upper;
+//         else                    return Uplo(' ');
+//     }
+
+//     // /// Compares MatrixType with Uplo
+//     // inline bool operator==( Uplo uplo ) const {
+//     //     if (_value == General)  return (uplo == Uplo::General);
+//     //     if (_value == Lower)    return (uplo == Uplo::Lower);
+//     //     if (_value == Upper)    return (uplo == Uplo::Upper);
+//     //     else                    return false;
+//     // }
+
+//     // /// Compares MatrixType with Uplo
+//     // inline bool operator!=( Uplo uplo ) const {
+//     //     if (_value == General)  return (uplo != Uplo::General);
+//     //     if (_value == Lower)    return (uplo != Uplo::Lower);
+//     //     if (_value == Upper)    return (uplo != Uplo::Upper);
+//     //     else                    return true;
+//     // }
+
+// private:
+//     Value _value;
+// };
 
 // -----------------------------------------------------------------------------
 // trevc

--- a/include/legacy_api/lapack/types.hpp
+++ b/include/legacy_api/lapack/types.hpp
@@ -82,62 +82,6 @@ enum class MatrixType {
     UpperBand   = 'Q',
     Band        = 'Z',
 };
-// class MatrixType {
-// public:
-
-//     /// Values are accessed like MatrixType::General and MatrixType::Band
-//     enum Value : char {
-//         General     = 'G',
-//         Lower       = 'L',
-//         Upper       = 'U',
-//         Hessenberg  = 'H',
-//         LowerBand   = 'B',
-//         UpperBand   = 'Q',
-//         Band        = 'Z'
-//     };
-
-//     // Constructors
-//     MatrixType() = default;
-//     constexpr MatrixType(Value v) : _value(v) { }
-//     constexpr MatrixType(char c) : _value(Value(c)) { }
-
-//     // Operators
-//     inline constexpr operator Value() const { return _value; }
-//     explicit  operator bool() = delete; ///< Prevents if( MatrixType )
-
-//     /** Converts MatrixType to Uplo
-//      * 
-//      * This is useful because MatrixType and Uplo share semantics
-//      * 
-//      * @return Equivalent Uplo object if possible.
-//      *      If there is no equivalent Uplo object, returns the invalid Uplo(' ')
-//      */
-//     inline constexpr operator Uplo() const {
-//         if (_value == General)  return Uplo::General;
-//         if (_value == Lower)    return Uplo::Lower;
-//         if (_value == Upper)    return Uplo::Upper;
-//         else                    return Uplo(' ');
-//     }
-
-//     // /// Compares MatrixType with Uplo
-//     // inline bool operator==( Uplo uplo ) const {
-//     //     if (_value == General)  return (uplo == Uplo::General);
-//     //     if (_value == Lower)    return (uplo == Uplo::Lower);
-//     //     if (_value == Upper)    return (uplo == Uplo::Upper);
-//     //     else                    return false;
-//     // }
-
-//     // /// Compares MatrixType with Uplo
-//     // inline bool operator!=( Uplo uplo ) const {
-//     //     if (_value == General)  return (uplo != Uplo::General);
-//     //     if (_value == Lower)    return (uplo != Uplo::Lower);
-//     //     if (_value == Upper)    return (uplo != Uplo::Upper);
-//     //     else                    return true;
-//     // }
-
-// private:
-//     Value _value;
-// };
 
 // -----------------------------------------------------------------------------
 // trevc

--- a/include/legacy_api/lapack/unmqr.hpp
+++ b/include/legacy_api/lapack/unmqr.hpp
@@ -84,10 +84,18 @@ inline int unmqr(
     using blas::internal::vector;
 
     // Constants
-    const idx_t nb = 32; // number of blocks (TODO: Improve me!)
+    const idx_t nb = 32; // number of blocks
+                         /// TODO: Improve me!
     const idx_t nw = (side == Side::Left)
                 ? ( (n >= 1) ? n : 1 )
                 : ( (m >= 1) ? m : 1 );
+
+    // check arguments
+    lapack_error_if( side != Side::Left &&
+                     side != Side::Right, -1 );
+    lapack_error_if( trans != Op::NoTrans &&
+                     trans != Op::Trans &&
+                     trans != Op::ConjTrans, -2 );
     
     // Allocate work
     std::unique_ptr<scalar_t[]> _work( new scalar_t[ nb * (nw + nb) ] );
@@ -106,36 +114,7 @@ inline int unmqr(
         decltype(_W)* workPtr;
     } opts = { nb, &_W };
     
-    if (side == Side::Left) {
-        if (trans == Op::NoTrans) {
-            return unmqr(
-                left_side, noTranspose,
-                _A, _tau, _C, std::move(opts) );
-        } else if (trans == Op::Trans) {
-            return unmqr(
-                left_side, transpose,
-                _A, _tau, _C, std::move(opts) );
-        } else { // (trans == Op::ConjTrans)
-            return unmqr(
-                left_side, conjTranspose,
-                _A, _tau, _C, std::move(opts) );
-        }
-    }
-    else { // side == Side::Right
-        if (trans == Op::NoTrans) {
-            return unmqr(
-                right_side, noTranspose,
-                _A, _tau, _C, std::move(opts) );
-        } else if (trans == Op::Trans) {
-            return unmqr(
-                right_side, transpose,
-                _A, _tau, _C, std::move(opts) );
-        } else { // (trans == Op::ConjTrans)
-            return unmqr(
-                right_side, conjTranspose,
-                _A, _tau, _C, std::move(opts) );
-        }
-    }
+    return unmqr( side, trans, _A, _tau, _C, std::move(opts) );
 }
 
 }

--- a/include/legacy_api/lapack/unmqr.hpp
+++ b/include/legacy_api/lapack/unmqr.hpp
@@ -71,9 +71,9 @@ namespace lapack {
  *
  * @ingroup geqrf
  */
-template< typename TA, typename TC >
+template< class side_t, class trans_t, typename TA, typename TC >
 inline int unmqr(
-    Side side, Op trans,
+    side_t side, trans_t trans,
     blas::idx_t m, blas::idx_t n, blas::idx_t k,
     TA const* A, blas::idx_t lda,
     TA const* tau,

--- a/include/legacy_api/legacyArray.hpp
+++ b/include/legacy_api/legacyArray.hpp
@@ -12,9 +12,6 @@
 
 namespace blas {
 
-    // -----------------------------------------------------------------------------
-    // Directions
-
     /// Runtime direction
     enum class Direction { Forward = 'F', Backward = 'B' };
 

--- a/include/plugins/tlapack_legacyArray.hpp
+++ b/include/plugins/tlapack_legacyArray.hpp
@@ -23,16 +23,12 @@ namespace blas {
     // Size type
     template< typename T, Layout layout >
     struct sizet_trait< legacyMatrix<T,layout> > { using type = typename legacyMatrix<T>::idx_t; };
-    // Layout type
-    template< typename T >
-    struct layout_trait< legacyMatrix<T> > { using type = ColMajor_t; };
-    template< typename T >
-    struct layout_trait< legacyMatrix<T,Layout::RowMajor> > { using type = RowMajor_t; };
 
     /// Specialization of has_blas_type for arrays.
     template< typename T, Layout L >
     struct allow_optblas< legacyMatrix<T,L> > {
         using type = T;
+        static constexpr Layout layout = L;
         static constexpr bool value = allow_optblas_v<type>;
     };
 
@@ -42,11 +38,12 @@ namespace blas {
     // Size type
     template< typename T, typename int_t, Direction direction >
     struct sizet_trait< legacyVector<T,int_t,direction> > { using type = typename legacyVector<T>::idx_t; };
-    
+
     /// Specialization of has_blas_type for arrays.
     template< typename T, typename int_t, Direction direction >
     struct allow_optblas< legacyVector<T,int_t,direction> > {
         using type = T;
+        static constexpr Layout layout = Layout::StridedVector;
         static constexpr bool value = allow_optblas_v<type>;
     };
 

--- a/include/plugins/tlapack_legacyArray.hpp
+++ b/include/plugins/tlapack_legacyArray.hpp
@@ -23,12 +23,16 @@ namespace blas {
     // Size type
     template< typename T, Layout layout >
     struct sizet_trait< legacyMatrix<T,layout> > { using type = typename legacyMatrix<T>::idx_t; };
+    // Layout type
+    template< typename T >
+    struct layout_trait< legacyMatrix<T> > { using type = ColMajor_t; };
+    template< typename T >
+    struct layout_trait< legacyMatrix<T,Layout::RowMajor> > { using type = RowMajor_t; };
 
     /// Specialization of has_blas_type for arrays.
     template< typename T, Layout L >
     struct allow_optblas< legacyMatrix<T,L> > {
         using type = T;
-        static constexpr Layout layout = L;
         static constexpr bool value = allow_optblas_v<type>;
     };
 
@@ -38,12 +42,11 @@ namespace blas {
     // Size type
     template< typename T, typename int_t, Direction direction >
     struct sizet_trait< legacyVector<T,int_t,direction> > { using type = typename legacyVector<T>::idx_t; };
-
+    
     /// Specialization of has_blas_type for arrays.
     template< typename T, typename int_t, Direction direction >
     struct allow_optblas< legacyVector<T,int_t,direction> > {
         using type = T;
-        static constexpr Layout layout = Layout::StridedVector;
         static constexpr bool value = allow_optblas_v<type>;
     };
 


### PR DESCRIPTION
The advantage of using template types (e.g., `uplo_t`) instead parameters (e.g., `Uplo`) on the interface is that one may call a routine (e.g., `potrf2( uplo_t uplo, matrix_t& A )`) in the following ways:

```C++
uplo = Uplo::Upper;
potrf2( uplo, A ); // Choice of the parameter value at runtime. potrf2 will check the parameter at runtime.

potrf2( Uplo::Lower, A ); // Choice of the parameter value at compile time. potrf2 will check the parameter at runtime.

constexpr upper_triangle_t upper_triangle = { };
potrf2( upper_triangle, A ); // Choice of the parameter value at compile time. potrf2 will check the parameter at compile time.
```

Those 3 calls would call instantiations of the same template. The first two call `potrf2<Uplo,...>` and the last one calls `potrf2<upper_triangle_t,...>`. Note that, to obtain the desired behavior we must define the cast operator inside `upper_triangle_t`:

```C++
struct upper_triangle_t {
    constexpr operator Uplo() const { return Uplo::Upper; }
};
```

Inside `potrf2`, we use:
```C++
if( uplo == Uplo::Upper ) { ... }
```

See also this example using some Norm types: https://godbolt.org/z/3YM9z4356

This PR adds:
- the possibility of using runtime and compile time parameters on all <T>LAPACK routines inside the directory `lapack`.

Missing:
- Routine `lascl`.
- Add error checks to the routines.