### PR TITLE
Improve documentation of the <T>LAPACK abstract array

### DIFF
--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -241,6 +241,6 @@
     @defgroup group_test Test routines
     @{
         @defgroup generate_matrix Test matrix generation
-        @defgroup util Utilities
+        @defgroup utils Utilities
     @}
 */

--- a/include/plugins/tlapack_abstractArray.hpp
+++ b/include/plugins/tlapack_abstractArray.hpp
@@ -1,3 +1,10 @@
+/// @file tlapack_abstractArray.hpp
+/// @author Weslley S Pereira, University of Colorado Denver, US
+///
+/// This file contains has two purposes:
+///     1. It serves as a template for writing <T>LAPACK abstract arrays.
+///     2. It is used by Doxygen to generate the documentation.
+//
 // Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
 //
 // This file is part of <T>LAPACK.
@@ -11,51 +18,199 @@
 
 namespace blas {
 
-    // -----------------------------------------------------------------------------
-    // Data description
+    // -------------------------------------------------------------------------
+    // Data descriptors for matrices in <T>LAPACK
+    
+    /**
+     * @brief Return the number of rows of a given matrix.
+     * 
+     * @tparam idx_t    Index type.
+     * @tparam matrix_t Matrix type.
+     * 
+     * @param A Matrix.
+     * 
+     * @ingroup utils
+     */
+    template< class idx_t, class matrix_t >
+    inline constexpr idx_t
+    nrows( const matrix_t& x );
 
-    // Size
-    template< class array_t, class idx_t >
-    idx_t size( const array_t& x );
+    /**
+     * @brief Return the number of columns of a given matrix.
+     * 
+     * @tparam idx_t    Index type.
+     * @tparam matrix_t Matrix type.
+     * 
+     * @param A Matrix.
+     * 
+     * @ingroup utils
+     */
+    template< class idx_t, class matrix_t >
+    inline constexpr idx_t
+    ncols( const matrix_t& A );
 
-    // Number of rows
+    // -------------------------------------------------------------------------
+    // Data descriptors for vectors in <T>LAPACK
+
+    /**
+     * @brief Return the number of elements of a given vector.
+     * 
+     * @tparam idx_t    Index type.
+     * @tparam vector_t Vector type.
+     * 
+     * @param v Vector.
+     * 
+     * @ingroup utils
+     */
+    template< class idx_t, class vector_t >
+    inline constexpr idx_t
+    size( const vector_t& v );
+
+    // -------------------------------------------------------------------------
+    // Block operations with matrices in <T>LAPACK
+
+    /**
+     * @brief Extracts a submatrix from a given matrix.
+     * 
+     * Note that a submatrix is also a matrix.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam pair_t   Pair of integers.
+     *      Stored in pair::first and pair::second.
+     * 
+     * @param A     Matrix.
+     * @param rows  Pair (i,k).
+     *      i   is the index of the first row, and
+     *      k-1 is the index of the last row.
+     * @param cols  Pair (j,l).
+     *      j   is the index of the first column, and
+     *      l-1 is the index of the last column.
+     * 
+     * @ingroup utils
+     */
+    template< class matrix_t, class pair_t >
+    inline constexpr auto
+    submatrix( const matrix_t& A, pair_t&& rows, pair_t&& cols );
+    
+    /**
+     * @brief Extracts a set of rows from a given matrix.
+     * 
+     * @note A set of rows is also a matrix.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam pair_t   Pair of integers.
+     *      Stored in pair::first and pair::second.
+     * 
+     * @param A     Matrix.
+     * @param rows  Pair (i,k).
+     *      i   is the index of the first row, and
+     *      k-1 is the index of the last row.
+     * 
+     * @ingroup utils
+     */
+    template< class matrix_t, class pair_t >
+    inline constexpr auto
+    rows( const matrix_t& A, pair_t&& rows );
+    
+    /**
+     * @brief Extracts a set of columns from a given matrix.
+     * 
+     * @note A set of columns is also a matrix.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam pair_t   Pair of integers.
+     *      Stored in pair::first and pair::second.
+     * 
+     * @param A     Matrix.
+     * @param cols  Pair (j,l).
+     *      j   is the index of the first column, and
+     *      l-1 is the index of the last column.
+     * 
+     * @ingroup utils
+     */
+    template< class matrix_t, class pair_t >
+    inline constexpr auto
+    cols( const matrix_t& A, pair_t&& cols );
+    
+    /**
+     * @brief Extracts a row from a given matrix.
+     * 
+     * @note A row is treated as a vector.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam idx_t    Index type.
+     * 
+     * @param A         Matrix.
+     * @param rowIdx    Row index.
+     * 
+     * @ingroup utils
+     */
     template< class matrix_t, class idx_t >
-    idx_t nrows( const matrix_t& x );
-
-    // Number of columns
+    inline constexpr auto
+    row( const matrix_t& A, idx_t rowIdx );
+    
+    /**
+     * @brief Extracts a column from a given matrix.
+     * 
+     * @note A column is treated as a vector.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam idx_t    Index type.
+     * 
+     * @param A         Matrix.
+     * @param colIdx    Column index.
+     * 
+     * @ingroup utils
+     */
     template< class matrix_t, class idx_t >
-    idx_t ncols( const matrix_t& x );
+    inline constexpr auto
+    col( const matrix_t& A, idx_t colIdx );
 
-    // -----------------------------------------------------------------------------
-    // Data blocks
-    
-    // Submatrix
-    template< class matrix_t, class SliceSpecRow, class SliceSpecCol >
-    matrix_t submatrix( const matrix_t& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept;
-    
-    // Rows
-    template< class matrix_t, class SliceSpec >
-    matrix_t rows( const matrix_t& A, SliceSpec&& rows ) noexcept;
-    
-    // Row
-    template< class matrix_t, class vector_t, class idx_t >
-    vector_t row( const matrix_t& A, idx_t rowIdx ) noexcept;
-    
-    // Columns
-    template< class matrix_t, class SliceSpec >
-    matrix_t cols( const matrix_t& A, SliceSpec&& rows ) noexcept;
-    
-    // Column
-    template< class matrix_t, class vector_t, class idx_t >
-    vector_t col( const matrix_t& A, idx_t colIdx ) noexcept;
+    /**
+     * @brief Extracts a diagonal from a given matrix. 
+     * 
+     * @note A diagonal is treated as a vector.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam idx_t    Index type.
+     * 
+     * @param A         Matrix of size m-by-n. 
+     * @param diagIdx   Diagonal index.
+     *      - diagIdx = 0: main diagonal.
+     *          Vector of size min( m, n ).
+     *      - diagIdx < 0: subdiagonal starting on A( -diagIdx, 0 ).
+     *          Vector of size min( m, n-diagIdx ) + diagIdx.
+     *      - diagIdx > 0: superdiagonal starting on A( 0, diagIdx ).
+     *          Vector of size min( m+diagIdx, n ) - diagIdx.
+     * 
+     * @ingroup utils
+     */
+    template< class matrix_t, class idx_t >
+    inline constexpr auto
+    diag( const matrix_t& A, idx_t diagIdx = 0 );
 
-    // Subvector
-    template< class vector_t, class SliceSpec >
-    vector_t subvector( const vector_t& v, SliceSpec&& rows ) noexcept;
+    // -------------------------------------------------------------------------
+    // Block operations with vectors in <T>LAPACK
 
-    // Diagonal
-    template< class matrix_t, class vector_t, class int_t >
-    vector_t diag( const matrix_t& A, int_t diagIdx = 0 ) noexcept;
+    /**
+     * @brief Extracts a subvector from a vector.
+     * 
+     * @note A subvector is also a vector.
+     * 
+     * @tparam vector_t Vector type.
+     * @tparam pair_t   Pair of integers.
+     *      Stored in pair::first and pair::second.
+     * 
+     * @param v     Vector.
+     * @param rows  Pair (i,k).
+     *      i   is the index of the first row, and
+     *      k-1 is the index of the last row.
+     * 
+     * @ingroup utils
+     */
+    template< class vector_t, class pair_t >
+    inline constexpr auto
+    subvector( const vector_t& v, pair_t&& rows );
 
 } // namespace blas
 
@@ -65,13 +220,16 @@ namespace lapack {
     using blas::nrows;
     using blas::ncols;
 
+    // Block operations with matrices in <T>LAPACK
     using blas::submatrix;
     using blas::rows;
-    using blas::row;
     using blas::cols;
+    using blas::row;
     using blas::col;
-    using blas::subvector;
     using blas::diag;
+
+    // Block operations with vectors in <T>LAPACK
+    using blas::subvector;
 
 } // namespace lapack
 


### PR DESCRIPTION
The semantics of how a <T>LAPACK routine works with data was not written anywhere. This PR adds the documentation to the plugin `abstractArray.hpp`. This file has two purposes:

1. It serves as a template for writing <T>LAPACK abstract arrays.
2. It is used by Doxygen to generate the documentation.