### PR TITLE
Implement the idea from @thijssteel on #26

### DIFF
--- a/examples/eigen/example_eigen.cpp
+++ b/examples/eigen/example_eigen.cpp
@@ -55,7 +55,7 @@ int main( int argc, char** argv )
     // Compute QR decomposision in place
     geqr2( Q, tau, work );
     // Copy the upper triangle to R
-    lacpy( upperTriangle, submatrix(Q,pair{0,n},pair{0,n}), R );
+    lacpy( upperTriangle, slice(Q,pair{0,n},pair{0,n}), R );
     // Generate Q
     org2r( n, Q, tau, work );
 

--- a/include/lapack/geqr2.hpp
+++ b/include/lapack/geqr2.hpp
@@ -79,7 +79,7 @@ int geqr2( matrix_t& A, vector_t &tau, work_t &work )
     for(idx_t i = 0; i < k; ++i) {
 
         // Define x := A[i+1:m,i]
-        auto x = subvector( col( A, i ), pair{i+1,m} );
+        auto x = slice( A, pair{i+1,m}, i );
 
         // Generate the (i+1)-th elementary Household reflection on x
         larfg( A(i,i), x, tau[i] );
@@ -88,9 +88,9 @@ int geqr2( matrix_t& A, vector_t &tau, work_t &work )
         A(i,i) = one;
 
         // Define v := A[i:m,i] and C := A[i:m,i+1:n], and w := work[i:n-1]
-        const auto v = subvector( col( A, i ), pair{i,m} );
-              auto C = submatrix( A, pair{i,m}, pair{i+1,n} );
-              auto w = subvector( work, pair{i,n-1} );
+        const auto v = slice( A, pair{i,m}, i );
+              auto C = slice( A, pair{i,m}, pair{i+1,n} );
+              auto w = slice( work, pair{i,n-1} );
 
         // C := I - tau_i v v^H
         larf( left_side, v, tau[i], C, w );
@@ -99,7 +99,7 @@ int geqr2( matrix_t& A, vector_t &tau, work_t &work )
 	}
     if( n-1 < m ) {
         // Define x := A[n:m,n-1]
-        auto x = subvector( col( A, n-1 ), pair{n,m} );
+        auto x = slice( A, pair{n,m}, n-1 );
         // Generate the n-th elementary Household reflection on x
         larfg( A(n-1,n-1), x, tau[n-1] );
     }

--- a/include/lapack/lanhe.hpp
+++ b/include/lapack/lanhe.hpp
@@ -172,11 +172,11 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
         // Sum off-diagonals
         if( uplo == Uplo::Upper ) {
             for (idx_t j = 1; j < n; ++j)
-                lassq( subvector( col(A,j), pair{0,j} ), scale, ssq );
+                lassq( slice(A, pair{0,j}, j ), scale, ssq );
         }
         else {
             for (idx_t j = 0; j < n-1; ++j)
-                lassq( subvector( col(A,j), pair{j+1,n} ), scale, ssq );
+                lassq( slice(A, pair{j+1,n}, j ), scale, ssq );
         }
         ssq *= 2;
 

--- a/include/lapack/lansy.hpp
+++ b/include/lapack/lansy.hpp
@@ -146,11 +146,11 @@ lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
         // Sum off-diagonals
         if( uplo == Uplo::Upper ) {
             for (idx_t j = 1; j < n; ++j)
-                lassq( subvector( col(A,j), pair{0,j} ), scale, ssq );
+                lassq( slice( A, pair{0,j}, j ), scale, ssq );
         }
         else {
             for (idx_t j = 0; j < n-1; ++j)
-                lassq( subvector( col(A,j), pair{j+1,n} ), scale, ssq );
+                lassq( slice( A, pair{j+1,n}, j ), scale, ssq );
         }
         ssq *= 2;
 

--- a/include/lapack/larft.hpp
+++ b/include/lapack/larft.hpp
@@ -142,7 +142,7 @@ int larft(
     if (direction == Direction::Forward) {
         T(0,0) = tau[0];
         for (idx_t i = 1; i < k; ++i) {
-            auto Ti = subvector( col( T, i ), pair{0,i} );
+            auto Ti = slice( T, pair{0,i}, i );
             if (tau[i] == tzero) {
                 // H(i)  =  I
                 for (idx_t j = 0; j <= i; ++j)
@@ -156,8 +156,8 @@ int larft(
                     // T(0:i,i) := - tau[i] V(i+1:n,0:i)^H V(i+1:n,i)
                     gemv( conjTranspose,
                         -tau[i],
-                        submatrix( V, pair{i+1,n}, pair{0,i} ),
-                        subvector( col( V, i ), pair{i+1,n} ),
+                        slice( V, pair{i+1,n}, pair{0,i} ),
+                        slice( V, pair{i+1,n}, i ),
                         one, Ti
                     );
                 }
@@ -166,25 +166,25 @@ int larft(
                         T(j,i) = -tau[i] * V(j,i);
                     // T(0:i,i) := - tau[i] V(0:i,i:n) V(i,i+1:n)^H
                     if( is_complex<scalar_t>::value ) {
-                        auto matrixTi = submatrix( T, pair{0,i}, pair{i,i+1} );
+                        auto matrixTi = slice( T, pair{0,i}, pair{i,i+1} );
                         gemm( noTranspose, conjTranspose,
                             -tau[i],
-                            submatrix( V, pair{0,i}, pair{i+1,n} ),
-                            submatrix( V, pair{i,i+1}, pair{i+1,n} ),
+                            slice( V, pair{0,i}, pair{i+1,n} ),
+                            slice( V, pair{i,i+1}, pair{i+1,n} ),
                             one, matrixTi
                         );
                     } else {
                         gemv( noTranspose,
                             -tau[i],
-                            submatrix( V, pair{0,i}, pair{i+1,n} ),
-                            subvector( row( V, i ), pair{i+1,n} ),
+                            slice( V, pair{0,i}, pair{i+1,n} ),
+                            slice( V,         i, pair{i+1,n} ),
                             one, Ti
                         );
                     }
                 }
                 // T(0:i,i) := T(0:i,0:i) * T(0:i,i)
                 trmv( upperTriangle, noTranspose, nonUnit_diagonal,
-                    submatrix( T, pair{0,i}, pair{0,i} ), Ti 
+                    slice( T, pair{0,i}, pair{0,i} ), Ti 
                 );
                 T(i,i) = tau[i];
             }
@@ -193,7 +193,7 @@ int larft(
     else { // direct==Direction::Backward
         T(k-1,k-1) = tau[k-1];
         for (idx_t i = k-2; i != idx_t(-1); --i) {
-            auto Ti = subvector( col( T, i ), pair{i+1,k} );
+            auto Ti = slice( T, pair{i+1,k}, i );
             if (tau[i] == tzero) {
                 for (idx_t j = i; j < k; ++j)
                     T(j,i) = zero;
@@ -205,8 +205,8 @@ int larft(
                     // T(i+1:k,i) := - tau[i] V(0:n-k+i,i+1:k)^H V(0:n-k+i,i)
                     gemv( conjTranspose,
                         -tau[i],
-                        submatrix( V, pair{0,n-k+i}, pair{i+1,k} ),
-                        subvector( col( V, i ), pair{0,n-k+i} ),
+                        slice( V, pair{0,n-k+i}, pair{i+1,k} ),
+                        slice( V, pair{0,n-k+i}, i ),
                         one, Ti
                     );
                 }
@@ -215,24 +215,24 @@ int larft(
                         T(j,i) = -tau[i] * V(j,n-k+i);
                     // T(i+1:k,i) := - tau[i] V(i+1:k,0:n-k+i) V(i,0:n-k+i)^H
                     if( blas::is_complex<scalar_t>::value ) {
-                        auto matrixTi = submatrix( T, pair{i+1,k}, pair{i,i+1} );
+                        auto matrixTi = slice( T, pair{i+1,k}, pair{i,i+1} );
                         gemm( noTranspose, conjTranspose,
                             -tau[i],
-                            submatrix( V, pair{i+1,k}, pair{0,n-k+i} ),
-                            submatrix( V, pair{i,i+1}, pair{0,n-k+i} ),
+                            slice( V, pair{i+1,k}, pair{0,n-k+i} ),
+                            slice( V, pair{i,i+1}, pair{0,n-k+i} ),
                             one, matrixTi
                         );
                     } else {
                         gemv( noTranspose,
                             -tau[i],
-                            submatrix( V, pair{i+1,k}, pair{0,n-k+i} ),
-                            subvector( row( V, i ), pair{0,n-k+i} ),
+                            slice( V, pair{i+1,k}, pair{0,n-k+i} ),
+                            slice( V,           i, pair{0,n-k+i} ),
                             one, Ti
                         );
                     }
                 }
                 trmv( lowerTriangle, noTranspose, nonUnit_diagonal,
-                    submatrix( T, pair{i+1,k}, pair{i+1,k} ), Ti 
+                    slice( T, pair{i+1,k}, pair{i+1,k} ), Ti 
                 );
                 T(i,i) = tau[i];
             }

--- a/include/lapack/org2r.hpp
+++ b/include/lapack/org2r.hpp
@@ -66,14 +66,14 @@ int org2r(
             A(i,i) = one;
 
             // Define v and C
-            auto v = subvector( col( A, i ), pair{i,m} );
-            auto C = submatrix( A, pair{i,m}, pair{i+1,n} );
-            auto w = subvector( work, pair{i,n-1} );
+            auto v = slice( A, pair{i,m}, i );
+            auto C = slice( A, pair{i,m}, pair{i+1,n} );
+            auto w = slice( work, pair{i,n-1} );
 
             larf( left_side, std::move(v), tau[i], C, w );
         }
         if ( i+1 < m ) {
-            auto v = subvector( col( A, i ), pair{i+1,m} );
+            auto v = slice( A, pair{i+1,m}, i );
             scal( -tau[i], v );
         }
         A(i,i) = one - tau[i];

--- a/include/lapack/orm2r.hpp
+++ b/include/lapack/orm2r.hpp
@@ -69,8 +69,8 @@ int orm2r(
     for (idx_t i = i0; i != iN; i += inc) {
         
         const auto& v = (side == Side::Left)
-                      ? subvector( col( A, i ), pair{i,m} )
-                      : subvector( col( A, i ), pair{i,n} );
+                      ? slice( A, pair{i,m}, i )
+                      : slice( A, pair{i,n}, i );
         auto& Ci = (side == Side::Left)
                  ? rows( C, pair{i,m} )
                  : cols( C, pair{i,n} );

--- a/include/lapack/potrf.hpp
+++ b/include/lapack/potrf.hpp
@@ -104,8 +104,8 @@ int potrf( uplo_t uplo, matrix_t& A, opts_t&& opts )
                 idx_t jb = min( nb, n-j );
 
                 // Define AJJ and A1J
-                auto AJJ = submatrix( A, pair{j,j+jb}, pair{j,j+jb} );
-                auto A1J = submatrix( A, pair{0,j}, pair{j,j+jb} );
+                auto AJJ = slice( A, pair{j,j+jb}, pair{j,j+jb} );
+                auto A1J = slice( A, pair{0,j}, pair{j,j+jb} );
 
                 herk( uplo, conjTranspose, -one, A1J, one, AJJ );
                 
@@ -116,8 +116,8 @@ int potrf( uplo_t uplo, matrix_t& A, opts_t&& opts )
                 if( j+jb <= n ){
 
                     // Define B and C
-                    auto B = submatrix( A, pair{0,j}, pair{j+jb,n} );
-                    auto C = submatrix( A, pair{j,j+jb}, pair{j+jb,n} );
+                    auto B = slice( A, pair{0,j}, pair{j+jb,n} );
+                    auto C = slice( A, pair{j,j+jb}, pair{j+jb,n} );
                 
                     // Compute the current block row
                     gemm( conjTranspose, noTranspose, -one, A1J, B, one, C );
@@ -131,8 +131,8 @@ int potrf( uplo_t uplo, matrix_t& A, opts_t&& opts )
                 idx_t jb = min( nb, n-j );
 
                 // Define AJJ and AJ1
-                auto AJJ = submatrix( A, pair{j,j+jb}, pair{j,j+jb} );
-                auto AJ1 = submatrix( A, pair{j,j+jb}, pair{0,j} );
+                auto AJJ = slice( A, pair{j,j+jb}, pair{j,j+jb} );
+                auto AJ1 = slice( A, pair{j,j+jb}, pair{0,j} );
 
                 herk( uplo, noTranspose, -one, AJ1, one, AJJ );
                 
@@ -143,8 +143,8 @@ int potrf( uplo_t uplo, matrix_t& A, opts_t&& opts )
                 if( j+jb <= n ){
 
                     // Define B and C
-                    auto B = submatrix( A, pair{j+jb,n}, pair{0,j} );
-                    auto C = submatrix( A, pair{j+jb,n}, pair{j,j+jb} );
+                    auto B = slice( A, pair{j+jb,n}, pair{0,j} );
+                    auto C = slice( A, pair{j+jb,n}, pair{j,j+jb} );
                 
                     // Compute the current block row
                     gemm( noTranspose, conjTranspose, -one, B, AJ1, one, C );

--- a/include/lapack/potrf2.hpp
+++ b/include/lapack/potrf2.hpp
@@ -104,8 +104,8 @@ int potrf2( uplo_t uplo, matrix_t& A )
         const idx_t n1 = n/2;
 
         // Define A11 and A22
-        auto A11 = submatrix( A, pair{0,n1}, pair{0,n1} );
-        auto A22 = submatrix( A, pair{n1,n}, pair{n1,n} );
+        auto A11 = slice( A, pair{0,n1}, pair{0,n1} );
+        auto A22 = slice( A, pair{n1,n}, pair{n1,n} );
         
         // Factor A11
         int info = potrf2( uplo, A11 );
@@ -115,7 +115,7 @@ int potrf2( uplo_t uplo, matrix_t& A )
         if( uplo == Uplo::Upper ) {
 
             // Update and scale A12
-            auto A12 = submatrix( A, pair{0,n1}, pair{n1,n} );
+            auto A12 = slice( A, pair{0,n1}, pair{n1,n} );
             trsm(
                 Side::Left, Uplo::Upper,
                 Op::ConjTrans, Diag::NonUnit,
@@ -127,7 +127,7 @@ int potrf2( uplo_t uplo, matrix_t& A )
         else {
 
             // Update and scale A21
-            auto A21 = submatrix( A, pair{n1,n}, pair{0,n1} );
+            auto A21 = slice( A, pair{n1,n}, pair{0,n1} );
             trsm(
                 Side::Right, Uplo::Lower,
                 Op::ConjTrans, Diag::NonUnit,

--- a/include/lapack/unmqr.hpp
+++ b/include/lapack/unmqr.hpp
@@ -151,9 +151,9 @@ int unmqr(
     for (idx_t i = i0; i != iN; i += step) {
         
         idx_t ib = min<idx_t>( nb, k-i );
-        const auto V = submatrix( A, pair{i,nA}, pair{i,i+ib} );
-        const auto taui = subvector( tau, pair{i,i+ib} );
-        auto T = submatrix( W, pair{nw,nw+ib}, pair{nw,nw+ib} );
+        const auto V = slice( A, pair{i,nA}, pair{i,i+ib} );
+        const auto taui = slice( tau, pair{i,i+ib} );
+        auto T = slice( W, pair{nw,nw+ib}, pair{nw,nw+ib} );
 
         // Form the triangular factor of the block reflector
         // $H = H(i) H(i+1) ... H(i+ib-1)$
@@ -161,11 +161,11 @@ int unmqr(
 
         // H or H**H is applied to either C[i:m,0:n] or C[0:m,i:n]
         auto Ci = ( side == Side::Left )
-           ? submatrix( C, pair{i,m}, pair{0,n} )
-           : submatrix( C, pair{0,m}, pair{i,n} );
+           ? slice( C, pair{i,m}, pair{0,n} )
+           : slice( C, pair{0,m}, pair{i,n} );
 
         // Apply H or H**H
-        auto W0 = submatrix( W, pair{0,ib}, pair{0,nw} );
+        auto W0 = slice( W, pair{0,ib}, pair{0,nw} );
         larfb(
             side, trans, forward, columnwise_storage,
             V, T, Ci, W0

--- a/include/plugins/tlapack_abstractArray.hpp
+++ b/include/plugins/tlapack_abstractArray.hpp
@@ -121,9 +121,9 @@ namespace blas {
     // Block operations with matrices in <T>LAPACK
 
     /**
-     * @brief Extracts a submatrix from a given matrix.
+     * @brief Extracts a slice from a given matrix.
      * 
-     * Note that a submatrix is also a matrix.
+     * @returns a matrix.
      * 
      * @tparam matrix_t Matrix type.
      * @tparam pair_t   Pair of integers.
@@ -141,12 +141,60 @@ namespace blas {
      */
     template< class matrix_t, class pair_t >
     inline constexpr auto
-    submatrix( const matrix_t& A, pair_t&& rows, pair_t&& cols );
+    slice( const matrix_t& A, pair_t&& rows, pair_t&& cols );
+
+    /**
+     * @brief Extracts a slice from a given matrix.
+     * 
+     * @returns a vector.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam idx_t    Index type.
+     * @tparam pair_t   Pair of integers.
+     *      Stored in pair::first and pair::second.
+     * 
+     * @param A         Matrix.
+     * @param rowIdx    Row index.
+     * @param cols  Pair (j,l).
+     *      j   is the index of the first column, and
+     *      l-1 is the index of the last column.
+     * 
+     * @ingroup utils
+     */
+    template< class matrix_t, class idx_t, class pair_t >
+    inline constexpr auto
+    slice( const matrix_t& A, idx_t rowIdx, pair_t&& cols );
+
+    /**
+     * @brief Extracts a slice from a given matrix.
+     * 
+     * @returns a vector.
+     * 
+     * Default column value is zero. This is useful to obtain vectors from a 
+     * given array since `slice( work, {0,n} )` returns a vector of size `n` no
+     * matter if `work` is a matrix or a vector.
+     * 
+     * @tparam matrix_t Matrix type.
+     * @tparam pair_t   Pair of integers.
+     *      Stored in pair::first and pair::second.
+     * @tparam idx_t    Index type.
+     * 
+     * @param A         Matrix.
+     * @param rows      Pair (i,k).
+     *      i   is the index of the first row, and
+     *      k-1 is the index of the last row.
+     * @param colIdx    Column index. Default value is zero.
+     * 
+     * @ingroup utils
+     */
+    template< class matrix_t, class pair_t, class idx_t >
+    inline constexpr auto
+    slice( const matrix_t& A, pair_t&& rows, idx_t colIdx = 0 );
     
     /**
      * @brief Extracts a set of rows from a given matrix.
      * 
-     * @note A set of rows is also a matrix.
+     * @returns a matrix.
      * 
      * @tparam matrix_t Matrix type.
      * @tparam pair_t   Pair of integers.
@@ -166,7 +214,7 @@ namespace blas {
     /**
      * @brief Extracts a set of columns from a given matrix.
      * 
-     * @note A set of columns is also a matrix.
+     * @returns a matrix.
      * 
      * @tparam matrix_t Matrix type.
      * @tparam pair_t   Pair of integers.
@@ -186,7 +234,7 @@ namespace blas {
     /**
      * @brief Extracts a row from a given matrix.
      * 
-     * @note A row is treated as a vector.
+     * @returns a vector.
      * 
      * @tparam matrix_t Matrix type.
      * @tparam idx_t    Index type.
@@ -203,7 +251,7 @@ namespace blas {
     /**
      * @brief Extracts a column from a given matrix.
      * 
-     * @note A column is treated as a vector.
+     * @returns a vector.
      * 
      * @tparam matrix_t Matrix type.
      * @tparam idx_t    Index type.
@@ -218,9 +266,9 @@ namespace blas {
     col( const matrix_t& A, idx_t colIdx );
 
     /**
-     * @brief Extracts a diagonal from a given matrix. 
+     * @brief Extracts a diagonal from a given matrix.
      * 
-     * @note A diagonal is treated as a vector.
+     * @returns a vector.
      * 
      * @tparam matrix_t Matrix type.
      * @tparam idx_t    Index type.
@@ -244,9 +292,9 @@ namespace blas {
     // Block operations with vectors in <T>LAPACK
 
     /**
-     * @brief Extracts a subvector from a vector.
+     * @brief Extracts a slice from a vector.
      * 
-     * @note A subvector is also a vector.
+     * @returns a vector.
      * 
      * @tparam vector_t Vector type.
      * @tparam pair_t   Pair of integers.
@@ -261,7 +309,7 @@ namespace blas {
      */
     template< class vector_t, class pair_t >
     inline constexpr auto
-    subvector( const vector_t& v, pair_t&& rows );
+    slice( const vector_t& v, pair_t&& rows );
 
 } // namespace blas
 
@@ -276,16 +324,13 @@ namespace lapack {
     // Data descriptors for vectors in <T>LAPACK
     using blas::size;
 
-    // Block operations with matrices in <T>LAPACK
-    using blas::submatrix;
+    // Block operations in <T>LAPACK
+    using blas::slice;
     using blas::rows;
     using blas::cols;
     using blas::row;
     using blas::col;
     using blas::diag;
-
-    // Block operations with vectors in <T>LAPACK
-    using blas::subvector;
 
 } // namespace lapack
 

--- a/include/plugins/tlapack_eigen.hpp
+++ b/include/plugins/tlapack_eigen.hpp
@@ -99,29 +99,83 @@ namespace blas{
     // -----------------------------------------------------------------------------
     // blas functions to access Eigen block operations
 
-    // Submatrix
-    template<class T, typename SliceSpecRow, typename SliceSpecCol>
-    inline constexpr auto submatrix(
+    #define isSlice(SliceSpec) !std::is_convertible< SliceSpec, Eigen::Index >::value
+
+    // Slice
+    template<class T, typename SliceSpecRow, typename SliceSpecCol,
+        typename std::enable_if< isSlice(SliceSpecRow) && isSlice(SliceSpecCol), int >::type = 0
+    >
+    inline constexpr auto slice(
         const Eigen::DenseBase<T>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept
     {
         return A.block( rows.first, cols.first,
                         rows.second-rows.first, cols.second-cols.first );
     }
-    template<class T, typename SliceSpecRow, typename SliceSpecCol>
-    inline constexpr auto submatrix(
+    template<class T, typename SliceSpecRow, typename SliceSpecCol,
+        typename std::enable_if< isSlice(SliceSpecRow) && isSlice(SliceSpecCol), int >::type = 0
+    >
+    inline constexpr auto slice(
         Eigen::DenseBase<T>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept
     {
         return A.block( rows.first, cols.first,
                         rows.second-rows.first, cols.second-cols.first );
     }
     template< typename XprType, int BlockRows, int BlockCols, bool InnerPanel,
-              typename SliceSpecRow, typename SliceSpecCol >
-    inline constexpr auto submatrix(
+              typename SliceSpecRow, typename SliceSpecCol,
+        typename std::enable_if< isSlice(SliceSpecRow) && isSlice(SliceSpecCol), int >::type = 0
+    >
+    inline constexpr auto slice(
         Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>&& A,
         SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept
     {
         return A.block( rows.first, cols.first,
                         rows.second-rows.first, cols.second-cols.first );
+    }
+
+    #undef isSlice
+
+    // Slice
+    template<class T, typename SliceSpecCol>
+    inline constexpr auto slice(
+        const Eigen::DenseBase<T>& A, Eigen::Index rowIdx, SliceSpecCol&& cols ) noexcept
+    {
+        return A.row( rowIdx ).segment( cols.first, cols.second-cols.first );
+    }
+    template<class T, typename SliceSpecCol>
+    inline constexpr auto slice(
+        Eigen::DenseBase<T>& A, Eigen::Index rowIdx, SliceSpecCol&& cols ) noexcept
+    {
+        return A.row( rowIdx ).segment( cols.first, cols.second-cols.first );
+    }
+    template< typename XprType, int BlockRows, int BlockCols, bool InnerPanel,
+              typename SliceSpecCol >
+    inline constexpr auto slice(
+        Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>&& A,
+        Eigen::Index rowIdx, SliceSpecCol&& cols ) noexcept
+    {
+        return A.row( rowIdx ).segment( cols.first, cols.second-cols.first );
+    }
+
+    // Slice
+    template<class T, typename SliceSpecRow>
+    inline constexpr auto slice(
+        const Eigen::DenseBase<T>& A, SliceSpecRow&& rows, Eigen::Index colIdx = 0 ) noexcept
+    {
+        return A.col( colIdx ).segment( rows.first, rows.second-rows.first );
+    }
+    template<class T, typename SliceSpecRow>
+    inline constexpr auto slice(
+        Eigen::DenseBase<T>& A, SliceSpecRow&& rows, Eigen::Index colIdx = 0 ) noexcept
+    {
+        return A.col( colIdx ).segment( rows.first, rows.second-rows.first );
+    }
+    template< typename XprType, int BlockRows, int BlockCols, bool InnerPanel,
+              typename SliceSpecRow >
+    inline constexpr auto slice(
+        Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>&& A,
+        SliceSpecRow&& rows, Eigen::Index colIdx = 0 ) noexcept
+    {
+        return A.col( colIdx ).segment( rows.first, rows.second-rows.first );
     }
 
     // Rows
@@ -201,23 +255,6 @@ namespace blas{
         return A.col( colIdx );
     }
 
-    // Subvector
-    template<class T, typename SliceSpec>
-    inline constexpr auto subvector( const Eigen::DenseBase<T>& v, SliceSpec&& rows ) noexcept
-    {
-        return v.segment( rows.first, rows.second-rows.first );
-    }
-    template<class T, typename SliceSpec>
-    inline constexpr auto subvector( Eigen::DenseBase<T>& v, SliceSpec&& rows ) noexcept
-    {
-        return v.segment( rows.first, rows.second-rows.first );
-    }
-    template<typename XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto subvector( Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>&& v, SliceSpec&& rows ) noexcept
-    {
-        return v.segment( rows.first, rows.second-rows.first );
-    }
-
     // Diagonal
     template<class T, class int_t>
     inline constexpr auto diag( const Eigen::MatrixBase<T>& A, int_t diagIdx = 0 ) noexcept
@@ -245,12 +282,11 @@ namespace lapack {
     using blas::read_policy;
     using blas::write_policy;
 
-    using blas::submatrix;
+    using blas::slice;
     using blas::rows;
     using blas::row;
     using blas::cols;
     using blas::col;
-    using blas::subvector;
     using blas::diag;
 
 } // namespace lapack

--- a/include/plugins/tlapack_stdvector.hpp
+++ b/include/plugins/tlapack_stdvector.hpp
@@ -45,9 +45,9 @@ namespace blas {
     // -----------------------------------------------------------------------------
     // blas functions to access std::vector block operations
 
-    // Subvector
+    // slice
     template< class T, class Allocator, class SliceSpec >
-    inline constexpr auto subvector( const std::vector<T,Allocator>& v, SliceSpec&& rows )
+    inline constexpr auto slice( const std::vector<T,Allocator>& v, SliceSpec&& rows )
     {
         #ifndef TLAPACK_USE_MDSPAN
             return legacyVector<T>( rows.second - rows.first, (T*) &v[ rows.first ] );
@@ -64,7 +64,7 @@ namespace lapack {
 
     using blas::size;
 
-    using blas::subvector;
+    using blas::slice;
 
 } // namespace lapack
 


### PR DESCRIPTION
Use `slice` to represent the block operations on both matrices and vectors like proposed on #26. It considerably reduces the wordiness of the code. I personally like the way the code looks now. Note that I maintained the block operations: `row`, `rows`, `col` and `cols`. Any other suggestion on this thread, @thijssteel ?