### PR TITLE
Routines may accept vectors or matrices

### DIFF
--- a/examples/interpretAsMatrix/CMakeLists.txt
+++ b/examples/interpretAsMatrix/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
+#
+# This file is part of <T>LAPACK.
+# <T>LAPACK is free software: you can redistribute it and/or modify it under
+# the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+cmake_minimum_required(VERSION 3.1)
+
+project( interpretAsMatrix CXX )
+
+# Load <T>LAPACK
+if( NOT TARGET tlapack )
+  find_package( tlapack REQUIRED )
+endif()
+
+find_package( mdspan REQUIRED )
+
+# add the example interpretAsMatrix
+add_executable( example_interpretAsMatrix example_interpretAsMatrix.cpp )
+target_link_libraries( example_interpretAsMatrix PRIVATE tlapack std::mdspan )

--- a/examples/interpretAsMatrix/example_interpretAsMatrix.cpp
+++ b/examples/interpretAsMatrix/example_interpretAsMatrix.cpp
@@ -1,0 +1,49 @@
+/// @file example_interpretAsMatrix.cpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+// #include <tlapack.hpp>
+
+#include <vector>
+#include <iostream>
+
+#include <plugins/tlapack_mdspan.hpp>
+#include <tlapack.hpp>
+
+//------------------------------------------------------------------------------
+int main( int argc, char** argv )
+{
+    using T = float;
+    using idx_t = std::size_t;
+
+    using namespace lapack;
+    using std::experimental::mdspan;
+    using std::experimental::extents;
+    
+    // constants
+    const idx_t n = 10;
+    
+    // raw data arrays
+    T v_[ n ] = {1,2,3,4,5,6,7,8,9,10};
+    
+    // print array
+    for (idx_t i = 0; i < n; i++)
+        std::cout << v_[i] << ", ";
+    std::cout << std::endl;
+
+    // mdspan arrays
+    mdspan< T, extents<10,1> > A{ v_ };
+    mdspan< T, extents<1,10> > B{ v_ };
+    mdspan< T, extents<10> > v{ v_ };
+
+    std::cout << lange( one_norm, A ) << std::endl;
+    std::cout << lange( one_norm, B ) << std::endl;
+    std::cout << lange( one_norm, v ) << std::endl;
+
+    return 0;
+}

--- a/include/lapack/lange.hpp
+++ b/include/lapack/lange.hpp
@@ -36,15 +36,17 @@ namespace lapack {
  * 
  * @ingroup auxiliary
 **/
-template< typename norm_t, typename matrix_t >
-real_type< type_t< matrix_t > >
-lange( norm_t normType, const matrix_t& A )
+template< typename norm_t, typename array_t >
+auto
+lange( norm_t normType, const array_t& a )
 {
-    using T      = type_t< matrix_t >;
+    using T      = type_t< array_t >;
     using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
+    using idx_t  = size_type< array_t >;
     using blas::isnan;
     using blas::sqrt;
+
+    const auto& A = interpretAsMatrix( a );
 
     // constants
     const real_t rzero(0.0);

--- a/include/plugins/tlapack_abstractArray.hpp
+++ b/include/plugins/tlapack_abstractArray.hpp
@@ -240,6 +240,29 @@ namespace blas {
     inline constexpr auto
     diag( const matrix_t& A, idx_t diagIdx = 0 );
 
+    /**
+     * @brief Interpret a given vector as a 1-column matrix.
+     * 
+     * @tparam vector_t Vector type.
+     * 
+     * @param v Vector of size n.
+     * 
+     * @return Matrix of size n-by-1.
+     */
+    template< class vector_t >
+    inline constexpr
+    auto
+    interpretAsMatrix( const vector_t& v );
+
+    /// @returns The input because it is already a matrix.
+    template< class matrix_t >
+    inline constexpr
+    const auto&
+    interpretAsMatrix( const matrix_t& A )
+    {
+        return A;
+    }
+
     // -------------------------------------------------------------------------
     // Block operations with vectors in <T>LAPACK
 

--- a/include/plugins/tlapack_eigen.hpp
+++ b/include/plugins/tlapack_eigen.hpp
@@ -229,10 +229,34 @@ namespace blas{
     {
         return A.diagonal( diagIdx );
     }
-    template<typename XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec, class int_t>
+    template<typename XprType, int BlockRows, int BlockCols, bool InnerPanel, class int_t>
     inline constexpr auto diag( Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>&& A, int_t diagIdx = 0 ) noexcept
     {
         return A.diagonal( diagIdx );
+    }
+
+    // interpretAsMatrix
+    template<class T>
+    inline constexpr
+    const Eigen::MatrixBase<T>&
+    interpretAsMatrix( const Eigen::MatrixBase<T>& A ) noexcept
+    {
+        return A;
+    }
+    
+    template<class T>
+    inline constexpr
+    Eigen::MatrixBase<T>&
+    interpretAsMatrix( Eigen::MatrixBase<T>& A ) noexcept {
+        return A;
+    }
+    
+    template<typename XprType, int BlockRows, int BlockCols, bool InnerPanel>
+    inline constexpr
+    auto&&
+    interpretAsMatrix( Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>&& A ) noexcept
+    {
+        return std::forward(A);
     }
 
 } // namespace blas
@@ -252,6 +276,8 @@ namespace lapack {
     using blas::col;
     using blas::subvector;
     using blas::diag;
+
+    using blas::interpretAsMatrix;
 
 } // namespace lapack
 

--- a/include/plugins/tlapack_legacyArray.hpp
+++ b/include/plugins/tlapack_legacyArray.hpp
@@ -215,6 +215,27 @@ namespace blas {
         return legacyVector<T,int_t,direction>( rows.second-rows.first, &v[rows.first], v.inc );
     }
 
+    // interpretAsMatrix
+    template< typename T, Layout layout >
+    inline constexpr
+    const auto&
+    interpretAsMatrix( const legacyMatrix<T,layout>& A ) noexcept
+    {
+        return A;
+    }
+
+    // interpretAsMatrix
+    template< typename T, typename int_t, Direction direction >
+    inline constexpr
+    auto
+    interpretAsMatrix( const legacyVector<T,int_t,direction>& v )
+    {
+        if( v.inc == 1 )
+            return legacyMatrix< T >( v.n, 1, v.ptr, v.n );
+        else
+            throw Error("Invalid conversion from legacyVector to legacyMatrix");
+    }
+
     // -----------------------------------------------------------------------------
     // Cast to Legacy arrays
 
@@ -252,6 +273,8 @@ namespace lapack {
     using blas::diag;
 
     using blas::subvector;
+
+    using blas::interpretAsMatrix;
 
 } // namespace lapack
 

--- a/include/plugins/tlapack_mdspan.hpp
+++ b/include/plugins/tlapack_mdspan.hpp
@@ -189,6 +189,35 @@ namespace blas {
 
     #undef isSlice
 
+    // interpretAsMatrix
+    template< class ET, class Exts, class LP, class AP,
+        std::enable_if_t< Exts::rank() == 1 , int > = 0
+    >
+    inline constexpr
+    auto
+    interpretAsMatrix( const mdspan<ET,Exts,LP,AP>& v ) noexcept
+    {
+        using extents_t = std::experimental::extents<std::experimental::dynamic_extent,1>;
+        using mapping_t = typename LP::template mapping<extents_t>;
+
+        return std::experimental::mdspan<ET,extents_t,LP,AP>(
+            v.data(),
+            mapping_t( extents_t(v.size()) ),
+            v.accessor()
+        );
+    }
+
+    // interpretAsMatrix
+    template< class ET, class Exts, class LP, class AP,
+        std::enable_if_t< Exts::rank() == 2, int > = 0
+    >
+    inline constexpr
+    const auto&
+    interpretAsMatrix( const mdspan<ET,Exts,LP,AP>& A ) noexcept
+    {
+        return A;
+    }
+
     // -----------------------------------------------------------------------------
     // Convert to legacy array
 
@@ -241,6 +270,7 @@ namespace lapack {
     using blas::col;
     using blas::subvector;
     using blas::diag;
+    using blas::interpretAsMatrix;
 
 } // namespace lapack
 

--- a/include/plugins/tlapack_stdvector.hpp
+++ b/include/plugins/tlapack_stdvector.hpp
@@ -58,6 +58,20 @@ namespace blas {
         #endif
     }
 
+    // interpretAsMatrix
+    template< class T, class Allocator >
+    inline constexpr
+    auto
+    interpretAsMatrix( const std::vector<T,Allocator>& v ) noexcept
+    {
+        #ifndef TLAPACK_USE_MDSPAN
+            return legacyMatrix< T >( v.size(), 1, &v[0], v.size() );
+        #else
+            using extents_t = std::experimental::extents<std::experimental::dynamic_extent,1>;
+            return std::experimental::mdspan< T, extents_t >( &v[0], extents_t(v.size()) );
+        #endif
+    }
+
 } // namespace blas
 
 namespace lapack {
@@ -65,6 +79,7 @@ namespace lapack {
     using blas::size;
 
     using blas::subvector;
+    using blas::interpretAsMatrix;
 
 } // namespace lapack
 


### PR DESCRIPTION
This PR proposes a simple way to allow the seamless use of vectors as 1-column matrices. I test this functionality with the function `lange`, and use a new example to verify the proposal works.

If this proposal is satisfactory, we could reduce considerably the number of routines in \<T\>LAPACK. The matrix version of each routine would be the preferable one, e.g., `gemm`, `hemm`, `trmm` and `trsm`. Routines like `gemv`, `hemv`, `trmv` and `trsv` could be deprecated. Moreover, routines like `lange`, `nrm2` and `asum` could be easily integrated into a single one. The goal is to increase maintainability and reduce the number of functions, which also ease the use of the library. The modifications should not change the overall performance of the code.