### PR TITLE
Fix #35 ( and accidentally also fixed #31)

### DIFF
--- a/include/lapack/geqr2.hpp
+++ b/include/lapack/geqr2.hpp
@@ -78,30 +78,24 @@ int geqr2( matrix_t& A, vector_t &tau, work_t &work )
 
     for(idx_t i = 0; i < k; ++i) {
 
-        // Define x := A[i+1:m,i]
-        auto x = subvector( col( A, i ), pair{i+1,m} );
+        // Define v := A[i:m,i]
+        auto v = subvector( col( A, i ), pair{i,m} );
 
         // Generate the (i+1)-th elementary Householder reflection on x
-        larfg( A(i,i), x, tau[i] );
-
-        const auto alpha = A(i,i);
-        A(i,i) = one;
+        larfg( v, tau[i] );
 
         // Define v := A[i:m,i] and C := A[i:m,i+1:n], and w := work[i:n-1]
-        const auto v = subvector( col( A, i ), pair{i,m} );
-              auto C = submatrix( A, pair{i,m}, pair{i+1,n} );
-              auto w = subvector( work, pair{i,n-1} );
+        auto C = submatrix( A, pair{i,m}, pair{i+1,n} );
+        auto w = subvector( work, pair{i,n-1} );
 
         // C := I - tau_i v v^H
         larf( left_side, v, tau[i], C, w );
-
-        A(i,i) = alpha;
 	}
     if( n-1 < m ) {
-        // Define x := A[n:m,n-1]
-        auto x = subvector( col( A, n-1 ), pair{n,m} );
+        // Define v := A[n-1:m,n-1]
+        auto v = subvector( col( A, n-1 ), pair{n-1,m} );
         // Generate the n-th elementary Householder reflection on x
-        larfg( A(n-1,n-1), x, tau[n-1] );
+        larfg( v, tau[n-1] );
     }
 
     return 0;

--- a/include/lapack/larfg.hpp
+++ b/include/lapack/larfg.hpp
@@ -109,6 +109,43 @@ void larfg( alpha_t& alpha, vectorX_t& x, tau_t& tau )
     }
 }
 
+/** Generates a elementary Householder reflection.
+ *
+ * larfg generates a elementary Householder reflection H of order n, such that
+ * 
+ *        H * ( alpha ) = ( beta ),   H' * H = I.
+ *            (   x   )   (   0  )
+ * 
+ * where alpha and beta are scalars, with beta real, and x is an (n-1)-element vector.
+ * H is represented in the form
+ * 
+ *        H = I - tau * ( 1 ) * ( 1 v' ) 
+ *                      ( v )
+ * 
+ * where tau is a scalar and v is a (n-1)-element vector.
+ * Note that H is symmetric but not hermitian.
+ * 
+ * If the elements of x are all zero and alpha is real, then tau = 0
+ * and H is taken to be the identity matrix.
+ * 
+ * Otherwise  1 <= real(tau) <= 2 and abs(tau-1) <= 1.
+ * 
+ * @param[in,out] v Array of length n.  On entry, the vector (alpha, x).  On exit, it is overwritten with the vector (beta, v).
+ * @param[out] tau On exit, the value tau.
+ * 
+ * @ingroup auxiliary
+ */
+template< class vector_t, class tau_t >
+void larfg( vector_t& v, tau_t& tau )
+{
+    using idx_t = size_type< vector_t >;
+    using pair  = std::pair<idx_t,idx_t>;
+
+    const idx_t n = size(v);
+    auto x = subvector( v, n > 1 ? pair{1,n} : pair{0,0} );
+    larfg( v[0], x, tau );
+}
+
 }
 
 #endif // __LARFG_HH__


### PR DESCRIPTION
Closes #35 and #31 

Fixing Issue #35 is a bit more difficult than I thought.

I could think of the following 

- make a copy of `v` inside `larf`, requiring some extra workspace and set `v[0]` to 1
- instead of calling `gemv` and `ger`, we do the calculation using loops
- we call `gemv` and `ger' on submatrices and then add the parts we skipped later
- use a specialized vector class that returns 1.0 for index 0 and v[i] otherwise

This PR is an attempt at the last option.

I can't get the type trait to work, but otherwise, it should be finished.