### PR TITLE
Use unitary instead of orthogonal

### DIFF
--- a/examples/eigen/README.md
+++ b/examples/eigen/README.md
@@ -13,7 +13,7 @@ In this example, we compute the QR factorization of an Eigen::Matrix using \<T\>
     };
 ```
 
-The code uses the routine [lapack::geqr2](../../include/lapack/geqr2.hpp) to perform the complete factorization in place, and [lapack::org2r](../../include/lapack/org2r.hpp) to generate the m-by-n matrix Q. We store R in a n-by-n upper triangular matrix. Also, we use other template BLAS routines.
+The code uses the routine [lapack::geqr2](../../include/lapack/geqr2.hpp) to perform the complete factorization in place, and [lapack::ung2r](../../include/lapack/ung2r.hpp) to generate the m-by-n matrix Q. We store R in a n-by-n upper triangular matrix. Also, we use other template BLAS routines.
 
 To examine the accuracy of the method, we measure
 <img src="https://latex.codecogs.com/gif.latex?\|Q^tQ&space;-&space;I\|_F" />

--- a/examples/eigen/example_eigen.cpp
+++ b/examples/eigen/example_eigen.cpp
@@ -57,7 +57,7 @@ int main( int argc, char** argv )
     // Copy the upper triangle to R
     lacpy( upperTriangle, slice(Q,pair{0,n},pair{0,n}), R );
     // Generate Q
-    org2r( n, Q, tau, work );
+    ung2r( n, Q, tau, work );
 
     std::cout << "Q = " << std::endl << Q << std::endl;
     std::cout << std::endl;

--- a/examples/geqr2/README.md
+++ b/examples/geqr2/README.md
@@ -4,7 +4,7 @@ In this example, we compute the QR factorization of a matrix filled with random 
 
 - A is a m-by-n matrix filled with random numbers.
 
-The code uses the routine [lapack::geqr2](../../include/lapack/geqr2.hpp) to perform the complete factorization in place, and [lapack::org2r](../../include/lapack/org2r.hpp) to generate the m-by-n matrix Q. We store R in a n-by-n upper triangular matrix.
+The code uses the routine [lapack::geqr2](../../include/lapack/geqr2.hpp) to perform the complete factorization in place, and [lapack::ung2r](../../include/lapack/ung2r.hpp) to generate the m-by-n matrix Q. We store R in a n-by-n upper triangular matrix.
 
 To examine the accuracy of the method, we measure
 <img src="https://latex.codecogs.com/gif.latex?\|Q^tQ&space;-&space;I\|_F" />

--- a/examples/geqr2/example_geqr2.cpp
+++ b/examples/geqr2/example_geqr2.cpp
@@ -101,7 +101,7 @@ void run( size_t m, size_t n )
         lapack::lacpy( lapack::upperTriangle, Q, R );
 
         // Generates Q = H_1 H_2 ... H_n
-        blas_error_if( lapack::org2r( n, Q, tau, work ) );
+        blas_error_if( lapack::ung2r( n, Q, tau, work ) );
     }
     // Record end time
     auto endQR = std::chrono::high_resolution_clock::now();

--- a/include/lapack/larf.hpp
+++ b/include/lapack/larf.hpp
@@ -59,7 +59,7 @@ namespace lapack {
 template< class side_t, class vector_t, class tau_t, class matrix_t, class work_t >
 inline void larf(
     side_t side,
-    vector_t const& v, tau_t& tau,
+    vector_t const& v, const tau_t& tau,
     matrix_t& C, work_t& work )
 {
     using blas::gemv;

--- a/include/lapack/ung2r.hpp
+++ b/include/lapack/ung2r.hpp
@@ -1,6 +1,6 @@
-/// @file org2r.hpp
+/// @file ung2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/org2r.h
+/// Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
 //
 // Copyright (c) 2013-2022, University of Colorado Denver. All rights reserved.
 //
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __ORG2R_HH__
-#define __ORG2R_HH__
+#ifndef __UNG2R_HH__
+#define __UNG2R_HH__
 
 #include "lapack/utils.hpp"
 #include "lapack/types.hpp"
@@ -23,14 +23,14 @@ namespace lapack {
  * 
  * @param work Vector of size n-1.
  *     It is possible to use the subarray tau[1:n-1] as the work vector, i.e.,
- *         org2r( ..., tau, &(tau[1]) )
+ *         ung2r( ..., tau, &(tau[1]) )
  *     and, in this case, the original vector tau is lost. 
- * @see org2r( blas::idx_t, blas::idx_t, blas::idx_t, TA*, blas::idx_t, const Ttau* )
+ * @see ung2r( blas::idx_t, blas::idx_t, blas::idx_t, TA*, blas::idx_t, const Ttau* )
  * 
  * @ingroup geqrf
  */
 template< class matrix_t, class vector_t, class work_t >
-int org2r(
+int ung2r(
     size_type< matrix_t > k, matrix_t& A, vector_t &tau, work_t &work )
 {
     using blas::scal;
@@ -88,4 +88,4 @@ int org2r(
 
 }
 
-#endif // __ORG2R_HH__
+#endif // __UNG2R_HH__

--- a/include/lapack/unm2r.hpp
+++ b/include/lapack/unm2r.hpp
@@ -1,4 +1,4 @@
-/// @file orm2r.hpp
+/// @file unm2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
 //
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __ORM2R_HH__
-#define __ORM2R_HH__
+#ifndef __UNM2R_HH__
+#define __UNM2R_HH__
 
 #include "lapack/utils.hpp"
 #include "lapack/types.hpp"
@@ -17,17 +17,17 @@
 
 namespace lapack {
 
-/** Applies orthogonal matrix Q to a matrix C.
+/** Applies unitary matrix Q to a matrix C.
  * 
  * @param work Vector of size n (m if side == Side::Right).
- * @see orm2r( Side, Op, blas::idx_t, blas::idx_t, blas::idx_t, const TA*, blas::idx_t, const blas::real_type<TA,TC>*, TC*, blas::idx_t )
+ * @see unm2r( Side, Op, blas::idx_t, blas::idx_t, blas::idx_t, const TA*, blas::idx_t, const blas::real_type<TA,TC>*, TC*, blas::idx_t )
  * 
  * @ingroup geqrf
  */
 template<
     class matrixA_t, class matrixC_t, class tau_t, class work_t,
     class side_t, class trans_t >
-int orm2r(
+int unm2r(
     side_t side, trans_t trans,
     matrixA_t& A,
     const tau_t& tau,
@@ -55,8 +55,8 @@ int orm2r(
 
     // const expressions
     constexpr bool positiveInc = (
-        ( (side == Side::Left) && !(trans == Op::Trans) ) ||
-        ( !(side == Side::Left) && (trans == Op::Trans) )
+        ( (side == Side::Left) &&  (trans == Op::NoTrans) ) ||
+        (!(side == Side::Left) && !(trans == Op::NoTrans) )
     );
     constexpr idx_t i0 = (positiveInc) ? 0 : k-1;
     constexpr idx_t iN = (positiveInc) ? k :  -1;
@@ -77,7 +77,10 @@ int orm2r(
         
         const auto Aii = A(i,i);
         A(i,i) = one;
-        larf( side, v, tau[i], Ci, work );
+        larf(
+            side, v,
+            (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i],
+            Ci, work );
         A(i,i) = Aii;
     }
 
@@ -86,4 +89,4 @@ int orm2r(
 
 }
 
-#endif // __ORM2R_HH__
+#endif // __UNM2R_HH__

--- a/include/legacy_api/lapack.hpp
+++ b/include/legacy_api/lapack.hpp
@@ -47,8 +47,8 @@
 // ----------------
 
 #include "legacy_api/lapack/geqr2.hpp"
-#include "legacy_api/lapack/org2r.hpp"
-#include "legacy_api/lapack/orm2r.hpp"
+#include "legacy_api/lapack/ung2r.hpp"
+#include "legacy_api/lapack/unm2r.hpp"
 #include "legacy_api/lapack/unmqr.hpp"
 #include "legacy_api/lapack/potrf.hpp"
 #include "legacy_api/lapack/potrs.hpp"

--- a/include/legacy_api/lapack/ung2r.hpp
+++ b/include/legacy_api/lapack/ung2r.hpp
@@ -1,6 +1,6 @@
-/// @file org2r.hpp
+/// @file ung2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/org2r.h
+/// Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
 //
 // Copyright (c) 2013-2022, University of Colorado Denver. All rights reserved.
 //
@@ -8,10 +8,10 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ORG2R_HH__
-#define __TLAPACK_LEGACY_ORG2R_HH__
+#ifndef __TLAPACK_LEGACY_UNG2R_HH__
+#define __TLAPACK_LEGACY_UNG2R_HH__
 
-#include "lapack/org2r.hpp"
+#include "lapack/ung2r.hpp"
 
 #include "tblas.hpp"
 
@@ -40,7 +40,7 @@ namespace lapack {
  * @ingroup geqrf
  */
 template< typename TA, typename Ttau >
-inline int org2r(
+inline int ung2r(
     blas::idx_t m, blas::idx_t n, blas::idx_t k,
     TA* A, blas::idx_t lda,
     const Ttau* tau )
@@ -66,7 +66,7 @@ inline int org2r(
     auto _tau  = vector<Ttau>( (Ttau*)tau, std::min<blas::idx_t>( m, n ), 1 );
     auto _work = vector<TA>  ( work, n-1, 1 );
     
-    info = org2r( k, _A, _tau, _work );
+    info = ung2r( k, _A, _tau, _work );
 
     delete[] work;
     return info;
@@ -74,4 +74,4 @@ inline int org2r(
 
 }
 
-#endif // __TLAPACK_LEGACY_ORG2R_HH__
+#endif // __TLAPACK_LEGACY_UNG2R_HH__

--- a/include/legacy_api/lapack/unm2r.hpp
+++ b/include/legacy_api/lapack/unm2r.hpp
@@ -1,4 +1,4 @@
-/// @file orm2r.hpp
+/// @file unm2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
 //
@@ -8,14 +8,14 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ORM2R_HH__
-#define __TLAPACK_LEGACY_ORM2R_HH__
+#ifndef __TLAPACK_LEGACY_UNM2R_HH__
+#define __TLAPACK_LEGACY_UNM2R_HH__
 
-#include "lapack/orm2r.hpp"
+#include "lapack/unm2r.hpp"
 
 namespace lapack {
 
-/** Applies orthogonal matrix Q to a matrix C.
+/** Applies unitary matrix Q to a matrix C.
  * 
  * @return  0 if success
  * @return -i if the ith argument is invalid
@@ -48,7 +48,7 @@ namespace lapack {
  * @ingroup geqrf
  */
 template< class side_t, class trans_t, typename TA, typename TC>
-inline int orm2r(
+inline int unm2r(
     side_t side, trans_t trans,
     blas::idx_t m, blas::idx_t n, blas::idx_t k,
     TA* A, blas::idx_t lda,
@@ -84,7 +84,7 @@ inline int orm2r(
     auto _C = colmajor_matrix<TC>( C, m, n, ldc );
     auto _work = vector<TC>( work, q );
 
-    int info = orm2r( side, trans, A, _tau, _C, _work );
+    int info = unm2r( side, trans, A, _tau, _C, _work );
 
     delete[] work;
     return info;
@@ -92,4 +92,4 @@ inline int orm2r(
 
 }
 
-#endif // __TLAPACK_LEGACY_ORM2R_HH__
+#endif // __TLAPACK_LEGACY_UNM2R_HH__

--- a/include/tlapack.hpp
+++ b/include/tlapack.hpp
@@ -37,8 +37,8 @@
 // ----------------
 
 #include "lapack/geqr2.hpp"
-#include "lapack/org2r.hpp"
-#include "lapack/orm2r.hpp"
+#include "lapack/ung2r.hpp"
+#include "lapack/unm2r.hpp"
 #include "lapack/unmqr.hpp"
 
 // Solution of positive definite systems


### PR DESCRIPTION
In LAPACK there is a clear distinction between Orthogonal and Unitary complex matrices on the interface. Routines dealing with orthogonal matrices start with `SOR` and `DOR`; while the equivalent routines for unitary complex matrices start with `CUN` and `ZUN`. This distinction do not interfere on the major design since every routine has a defined type on Fortran. On \<T\>LAPACK, we should avoid such distinction since the data type is a template argument.

This PR replaces `org2r` by `ung2r` and `orm2r` by `unm2r` and updates the documentation.