### PR TITLE
Try use of lambda function on lassq

### DIFF
--- a/include/lapack/lanhe.hpp
+++ b/include/lapack/lanhe.hpp
@@ -180,12 +180,10 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
         ssq *= 2;
 
         // Sum the real part in the diagonal
-        struct absReValue {
-            static inline real_t abs( const T& x ) {
-                return blas::abs( real(x) );
-            }
-        };
-        lassq< absReValue >( diag(A,0), scale, ssq );
+        lassq( diag(A,0), scale, ssq,
+            // Lambda function to get the absolute value of the real part :
+            []( const T& x ) { return blas::abs( real(x) ); }
+        );
 
         // Compute the scaled square root
         norm = scale * sqrt(ssq);


### PR DESCRIPTION
`lassq` receives the function to compute the absolute value on its interface. This is helpful on `lanhe` because we need to access only the real part in the diagonal. Using this additional parameter, we do not need to copy data. This strategy is already in place.

This PR introduces cosmetic changes to pass the absolute function as an argument to the `lassq` (using lambda function), instead of passing as a template argument. This is also a question: what code is the best in terms of abstraction? There is no rush to decide, this is just an idea that I had in mind and wanted to share.

I didn't put this on the discussion section __Ideas__ because I wanted to show how the current code would look like in practice.

- [x] Update on documentation.