### PR TITLE
Add the option to include tests on `test/src`

### DIFF
--- a/cmake/FetchPackage.cmake
+++ b/cmake/FetchPackage.cmake
@@ -14,12 +14,7 @@ macro( FetchPackage pkg pkgURL gitTag )
   find_package( ${pkg} QUIET ) # Try to load ${pkg} from the system
   if( NOT ${pkg}_FOUND )
 
-    if( EXISTS "${pkg}_DIR" )
-
-      add_subdirectory( ${${pkg}_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${pkg} )
-      message( STATUS "Using ${pkg} from ${${pkg}_DIR}" )
-
-    elseif( EXISTS "$ENV{${pkg}_DIR}" )
+    if( EXISTS "$ENV{${pkg}_DIR}" )
 
       get_property( docString CACHE ${pkg}_DIR PROPERTY HELPSTRING )
       set( ${pkg}_DIR $ENV{${pkg}_DIR} CACHE STRING "${docString}" FORCE )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,10 +7,6 @@
 include( "${TLAPACK_SOURCE_DIR}/cmake/FetchPackage.cmake" )
 
 #-------------------------------------------------------------------------------
-# Load testBLAS
-FetchPackage( "testBLAS" "https://github.com/tlapack/testBLAS.git" "master" )
-
-#-------------------------------------------------------------------------------
 # Build BLAS++ tests
 if( BUILD_BLASPP_TESTS )
   add_subdirectory( blaspp )
@@ -21,3 +17,43 @@ endif()
 if( BUILD_LAPACKPP_TESTS )
   add_subdirectory( lapackpp )
 endif()
+
+#########################
+## Tests from <T>LAPACK :
+
+#-------------------------------------------------------------------------------
+# Load Catch2
+FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "v2.13.1" )
+
+#-------------------------------------------------------------------------------
+# Add folder with Catch.cmake to the CMAKE_MODULE_PATH
+set( CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${Catch2_SOURCE_DIR}/extras;${Catch2_SOURCE_DIR}/contrib" )
+
+#-------------------------------------------------------------------------------
+# Test sources
+file( GLOB test_sources
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/test_*.cpp" )
+
+#-------------------------------------------------------------------------------
+# tester: Program for tests
+
+add_executable( tester tests_main.cpp ${test_sources} )
+
+# Load testBLAS tests
+FetchPackage( "testBLAS" "https://github.com/tlapack/testBLAS.git" "master" )
+
+target_include_directories( tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+target_link_libraries( tester PRIVATE Catch2::Catch2 tlapack )
+
+if( TEST_MPFR )
+  target_include_directories( tester PRIVATE ${MPFR_INCLUDES} ${GMP_INCLUDES} )
+  target_link_libraries( tester PRIVATE ${MPFR_LIBRARIES} ${GMP_LIBRARIES} )
+endif()
+
+set_target_properties( tester
+PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" )
+
+# Add tests to CTest
+include(Catch)
+catch_discover_tests(tester)

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -1,0 +1,61 @@
+/// @file test_utils.cpp
+/// @brief Test utils from <T>LAPACK.
+//
+// Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of testBLAS.
+// testBLAS is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <catch2/catch.hpp>
+#include <tlapack.hpp>
+
+using namespace blas;
+using namespace lapack;
+
+TEST_CASE( "MatrixAccessPolicy can be cast to Uplo", "[utils]" ) {
+    Uplo uplo;
+    MatrixAccessPolicy runtimeAccess;
+    
+    uplo = Uplo::Upper;
+    runtimeAccess = MatrixAccessPolicy::UpperTriangle;
+    
+    CHECK( uplo == (Uplo) runtimeAccess );
+    CHECK( uplo == upperTriangle );
+    CHECK( uplo == (Uplo) upperTriangle );
+
+    CHECK( runtimeAccess == (MatrixAccessPolicy) uplo );
+    CHECK( runtimeAccess == upperTriangle );
+    CHECK( runtimeAccess == (MatrixAccessPolicy) upperTriangle );
+
+    CHECK( upperTriangle == (Uplo) runtimeAccess );
+    CHECK( upperTriangle == (MatrixAccessPolicy) uplo );
+
+    uplo = Uplo::Lower;
+    runtimeAccess = MatrixAccessPolicy::LowerTriangle;
+    
+    CHECK( uplo == (Uplo) runtimeAccess );
+    CHECK( uplo == lowerTriangle );
+    CHECK( uplo == (Uplo) lowerTriangle );
+
+    CHECK( runtimeAccess == (MatrixAccessPolicy) uplo );
+    CHECK( runtimeAccess == lowerTriangle );
+    CHECK( runtimeAccess == (MatrixAccessPolicy) lowerTriangle );
+
+    CHECK( lowerTriangle == (Uplo) runtimeAccess );
+    CHECK( lowerTriangle == (MatrixAccessPolicy) uplo );
+
+    uplo = Uplo::General;
+    runtimeAccess = MatrixAccessPolicy::Dense;
+    
+    CHECK( uplo == (Uplo) runtimeAccess );
+    CHECK( uplo == dense );
+    CHECK( uplo == (Uplo) dense );
+
+    CHECK( runtimeAccess == (MatrixAccessPolicy) uplo );
+    CHECK( runtimeAccess == dense );
+    CHECK( runtimeAccess == (MatrixAccessPolicy) dense );
+
+    CHECK( dense == (Uplo) runtimeAccess );
+    CHECK( dense == (MatrixAccessPolicy) uplo );
+}

--- a/test/tests_main.cpp
+++ b/test/tests_main.cpp
@@ -1,0 +1,8 @@
+// Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>


### PR DESCRIPTION
This PR adds the option to include tests on `test/src`. It is basically a work on CMake to make the tests work. I add a single test to `test/src` to verify the it is working.

* The macro FetchPackage was updated: it did not make sense to check `${pkg}_DIR` right after calling `find_package`.