### PR TITLE
Blocked hessenberg reduction

### DIFF
--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -109,9 +109,7 @@ void run(size_t n)
         std::vector<T> work(n);
 
         // Hessenberg factorization
-        struct {
-            size_t nb;
-        } opts = { 3 };
+        lapack::gehrd_opts_t<size_t, T> opts = {};
         blas_error_if(lapack::gehrd(0, n, Q, tau, opts));
         // blas_error_if(lapack::gehd2(0, n, Q, tau, work));
 

--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -109,8 +109,7 @@ void run(size_t n)
         std::vector<T> work(n);
 
         // Hessenberg factorization
-        lapack::gehrd_opts_t<size_t, T> opts = {};
-        blas_error_if(lapack::gehrd(0, n, Q, tau, opts));
+        blas_error_if(lapack::gehrd(0, n, Q, tau));
         // blas_error_if(lapack::gehd2(0, n, Q, tau, work));
 
 

--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -107,10 +107,12 @@ void run(size_t n)
     auto startQHQ = std::chrono::high_resolution_clock::now();
     {
         std::vector<T> work(n);
+        int err;
 
         // Hessenberg factorization
-        blas_error_if(lapack::gehrd(0, n, Q, tau));
+        err = lapack::gehrd(0, n, Q, tau);
         // blas_error_if(lapack::gehd2(0, n, Q, tau, work));
+        blas_error_if(err);
 
 
         // Save the H matrix
@@ -119,7 +121,8 @@ void run(size_t n)
                 H(i, j) = Q(i, j);
 
         // Generate Q = H_1 H_2 ... H_n
-        blas_error_if(lapack::unghr(0, n, Q, tau, work));
+        err = lapack::unghr(0, n, Q, tau, work);
+        blas_error_if(err);
 
         // Remove junk from lower half of H
         for (size_t j = 0; j < n; ++j)
@@ -128,7 +131,8 @@ void run(size_t n)
 
         // Shur factorization
         std::vector<std::complex<real_t>> w(n);
-        blas_error_if(lapack::lahqr(true, true, 0, n, H, w, Q));
+        err = lapack::lahqr(true, true, 0, n, H, w, Q);
+        blas_error_if(err);
     }
     // Record end time
     auto endQHQ = std::chrono::high_resolution_clock::now();

--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -16,6 +16,13 @@
 #include <chrono> // for high_resolution_clock
 #include <iostream>
 
+template <typename matrix_t>
+int visualiseMatrix(const matrix_t &A)
+{
+    return 5;
+}
+
+
 //------------------------------------------------------------------------------
 /// Print matrix A in the standard output
 template <typename matrix_t>
@@ -173,6 +180,9 @@ void run(size_t n)
 
     // 3) Compute ||QHQ* - A||_F / ||A||_F
 
+    std::unique_ptr<T[]> _H_copy(new T[n * n]);
+    auto H_copy = colmajor_matrix<T>(&_H_copy[0], n, n);
+    lapack::lacpy(lapack::Uplo::General,H, H_copy);
     {
         std::unique_ptr<T[]> _work(new T[n * n]);
         auto work = colmajor_matrix<T>(&_work[0], n, n);
@@ -197,6 +207,31 @@ void run(size_t n)
         norm_repres_1 = lapack::lange(lapack::frob_norm, H) / normA;
     }
 
+    // 4) Compute Q*AQ (usefull for debugging)
+
+    if(verbose){
+        std::unique_ptr<T[]> _work(new T[n * n]);
+        auto work = colmajor_matrix<T>(&_work[0], n, n);
+        for (size_t j = 0; j < n; ++j)
+            for (size_t i = 0; i < n; ++i)
+                work(i, j) = static_cast<float>(0xABADBABC);
+
+        blas::gemm(blas::Op::ConjTrans, blas::Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
+        blas::gemm(blas::Op::NoTrans, blas::Op::NoTrans, (T)1.0, work, Q, (T)0.0, A);
+
+        std::cout << std::endl
+                    << "Q'AQ = ";
+        printMatrix(A);
+
+        for (size_t j = 0; j < n; ++j)
+            for (size_t i = 0; i < n; ++i)
+                A(i, j) -= H_copy(i, j);
+
+        std::cout << std::endl
+                    << "Q'AQ - H = ";
+        printMatrix(A);
+    }
+
     std::cout << std::endl;
     std::cout << "time = " << elapsedQHQ.count() * 1.0e-6 << " ms";
     std::cout << std::endl;
@@ -211,7 +246,7 @@ int main(int argc, char **argv)
     int n;
 
     // Default arguments
-    n = (argc < 2) ? 5 : atoi(argv[1]);
+    n = (argc < 2) ? 7 : atoi(argv[1]);
 
     srand(3); // Init random seed
 

--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -16,13 +16,6 @@
 #include <chrono> // for high_resolution_clock
 #include <iostream>
 
-template <typename matrix_t>
-int visualiseMatrix(const matrix_t &A)
-{
-    return 5;
-}
-
-
 //------------------------------------------------------------------------------
 /// Print matrix A in the standard output
 template <typename matrix_t>

--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -102,7 +102,12 @@ void run(size_t n)
         std::vector<T> work(n);
 
         // Hessenberg factorization
-        blas_error_if(lapack::gehd2(0, n, Q, tau, work));
+        struct {
+            size_t nb;
+        } opts = { 3 };
+        blas_error_if(lapack::gehrd(0, n, Q, tau, opts));
+        // blas_error_if(lapack::gehd2(0, n, Q, tau, work));
+
 
         // Save the H matrix
         for (size_t j = 0; j < n; ++j)

--- a/include/lapack/gehrd.hpp
+++ b/include/lapack/gehrd.hpp
@@ -1,0 +1,142 @@
+/// @file gehrd.hpp
+/// @author Thijs Steel, KU Leuven, Belgium
+/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dgehrd.f
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef __GEHRD_HH__
+#define __GEHRD_HH__
+
+#include "legacy_api/blas/utils.hpp"
+#include "lapack/utils.hpp"
+#include "lapack/types.hpp"
+#include "lapack/lahr2.hpp"
+
+#include <memory>
+
+namespace lapack
+{
+
+    /** Reduces a general square matrix to upper Hessenberg form
+     *
+     * The matrix Q is represented as a product of elementary reflectors
+     * \[
+     *          Q = H_ilo H_ilo+1 ... H_ihi,
+     * \]
+     * Each H_i has the form
+     * \[
+     *          H_i = I - tau * v * v',
+     * \]
+     * where tau is a scalar, and v is a vector with
+     * \[
+     *          v[0] = v[1] = ... = v[i] = 0; v[i+1] = 1,
+     * \]
+     * with v[i+2] through v[ihi] stored on exit below the diagonal
+     * in the ith column of A, and tau in tau[i].
+     *
+     * @return  0 if success
+     * @return -i if the ith argument is invalid
+     *
+     * @param[in] ilo integer
+     * @param[in] ihi integer
+     *      It is assumed that A is already upper Hessenberg in columns
+     *      0:ilo and rows ihi:n and is already upper triangular in
+     *      columns ihi+1:n and rows 0:ilo.
+     *      0 <= ilo <= ihi <= max(1,n).
+     * @param[in,out] A n-by-n matrix.
+     *      On entry, the n by n general matrix to be reduced.
+     *      On exit, the upper triangle and the first subdiagonal of A
+     *      are overwritten with the upper Hessenberg matrix H, and the
+     *      elements below the first subdiagonal, with the array TAU,
+     *      represent the orthogonal matrix Q as a product of elementary
+     *      reflectors. See Further Details.
+     * @param[out] tau Real vector of length n-1.
+     *      The scalar factors of the elementary reflectors.
+     *
+     * @param[in,out] opts Options.
+     *      - opts.nb Block size.
+     *      If opts.nb does not exist or opts.nb <= 0, nb assumes a default value.
+     *
+     *      - opts.workPtr Workspace pointer.
+     *          - Pointer to a matrix of size (nb)-by-(n+nb) if side == Side::Left.
+     *          - Pointer to a matrix of size (nb)-by-(m+nb) if side == Side::Right.
+     *
+     * @ingroup gehrd
+     */
+    template <class matrix_t, class vector_t, class opts_t>
+    int gehrd(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t &A, vector_t &tau, opts_t &&opts = nullptr)
+    {
+        using TA = type_t<matrix_t>;
+        using idx_t = size_type<matrix_t>;
+        using pair = std::pair<idx_t, idx_t>;
+        using blas::conj;
+        using blas::internal::colmajor_matrix;
+        using blas::gemm;
+
+        // constants
+        const TA one(1);
+        const idx_t n = ncols(A);
+
+        // check arguments
+        lapack_error_if((ilo < 0) or (ilo >= n), -1);
+        lapack_error_if((ihi < 0) or (ihi > n), -2);
+        lapack_error_if(access_denied(dense, write_policy(A)), -3);
+        lapack_error_if(ncols(A) != nrows(A), -3);
+        lapack_error_if((idx_t)size(tau) < n - 1, -4);
+
+        // quick return
+        if (n <= 0)
+            return 0;
+
+        idx_t nb = 3;
+
+        // Allocate the workspace matrices
+        std::unique_ptr<TA[]> _Y(new TA[nb * n]);
+        std::unique_ptr<TA[]> _T(new TA[nb * nb]);
+        auto Y = colmajor_matrix<TA>(&_Y[0], n, nb, n);
+        auto T = colmajor_matrix<TA>(&_T[0], nb, nb, nb);
+
+        for (idx_t i = ilo; i < ihi; i = i + nb)
+        {
+            auto nb2 = std::min(nb, ihi - i - 1);
+
+            auto A2 = slice(A, pair{0, ihi}, pair{i, ihi});
+            auto tau2 = slice(tau, pair{i, ihi});
+            auto T2 = slice(T, pair{0, nb2}, pair{0, nb2});
+            auto Y2 = slice(Y, pair{0, n}, pair{0, nb2});
+            lahr2(i, nb2, A2, tau2, T2, Y2);
+            auto V1 = slice(A, pair{i, i+nb2}, pair{i, i+nb2});
+            auto V2 = slice(A, pair{i+nb2, ihi}, pair{i, i+nb2});
+
+            auto ei = A(i + nb2, i + nb2 - 1);
+            A(i + nb2, i + nb2 - 1) = one;
+
+            gemm( Op::NoTrans, Op::Trans, -one, Y2 )
+            A(i + nb2, i + nb2 - 1) = ei;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return *(opts.workPtr) if workPtr is a member of opts_t.
+     */
+    template <class opts_t, enable_if_t<has_workPtr_v<opts_t>, int> = 0>
+    inline constexpr auto construct_workspace(opts_t &&opts)
+    {
+        if (opts.workPtr)
+            return *(opts.workPtr);
+        else
+        {
+            /// TODO: Allocate space.
+            /// TODO: Create matrix.
+            /// TODO: Return matrix.
+            return *(opts.workPtr);
+        }
+    }
+
+} // lapack
+
+#endif // __GEHRD_HH__

--- a/include/lapack/gehrd.hpp
+++ b/include/lapack/gehrd.hpp
@@ -41,7 +41,7 @@ namespace lapack
      * @return idx_t The size of the required workspace
      */
     template <class matrix_t, class vector_t, typename idx_t = size_type<matrix_t>, typename TA = type_t<matrix_t>>
-    idx_t get_work_gehrd(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t &A, vector_t &tau, const gehrd_opts_t<idx_t, TA> &opts)
+    idx_t get_work_gehrd(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t &A, vector_t &tau, const gehrd_opts_t<idx_t, TA> &opts = {})
     {
         const idx_t n = ncols(A);
         idx_t nb = opts.nb;
@@ -91,7 +91,7 @@ namespace lapack
      * @ingroup gehrd
      */
     template <class matrix_t, class vector_t, typename idx_t = size_type<matrix_t>, typename TA = type_t<matrix_t>>
-    int gehrd(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t &A, vector_t &tau, gehrd_opts_t<idx_t, TA> &opts)
+    int gehrd(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t &A, vector_t &tau, const gehrd_opts_t<idx_t, TA> &opts = {})
     {
         using pair = std::pair<idx_t, idx_t>;
         using blas::axpy;

--- a/include/lapack/gehrd.hpp
+++ b/include/lapack/gehrd.hpp
@@ -25,7 +25,7 @@ namespace lapack
     template <typename idx_t, typename T>
     struct gehrd_opts_t {
         // Blocksize used in the blocked reduction
-        idx_t nb = 2;
+        idx_t nb = 64;
         // If only nx_switch columns are left, the algorithm will use unblocked code
         idx_t nx_switch = 2;
         // Workspace pointer, if no workspace is provided, one will be allocated internally
@@ -146,7 +146,7 @@ namespace lapack
         auto T = colmajor_matrix<TA>(&_T[0], nb, nb, nb);
 
         idx_t i = ilo;
-        for (; i < ihi-1-nx; i = i + nb)
+        for (; i+nx < ihi-1; i = i + nb)
         {
             auto nb2 = std::min(nb, ihi - i - 1);
 

--- a/include/lapack/lahqr.hpp
+++ b/include/lapack/lahqr.hpp
@@ -217,6 +217,7 @@ namespace lapack
                 if (istart + 1 == istop)
                 {
                     // 1x1 block
+                    k_defl = 0;
                     w[istart] = A(istart, istart);
                     istop = istart;
                     istart = ilo;
@@ -250,6 +251,7 @@ namespace lapack
                         auto y = col(Z, istart + 1);
                         blas::rot(x, y, cs, sn);
                     }
+                    k_defl = 0;
                     istop = istart;
                     istart = ilo;
                     continue;

--- a/include/lapack/lahr2.hpp
+++ b/include/lapack/lahr2.hpp
@@ -1,0 +1,164 @@
+/// @file lahqr.hpp
+/// @author Thijs Steel, KU Leuven, Belgium
+/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlahqr.f
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef __LAHR2_HH__
+#define __LAHR2_HH__
+
+#include "lapack/utils.hpp"
+#include "lapack/types.hpp"
+#include "lapack/larfg.hpp"
+#include "lapack/larf.hpp"
+#include "blas/gemv.hpp"
+
+namespace lapack
+{
+
+    /** Reduces a general square matrix to upper Hessenberg form
+     *
+     * The matrix Q is represented as a product of elementary reflectors
+     * \[
+     *          Q = H_ilo H_ilo+1 ... H_ihi,
+     * \]
+     * Each H_i has the form
+     * \[
+     *          H_i = I - tau * v * v',
+     * \]
+     * where tau is a scalar, and v is a vector with
+     * \[
+     *          v[0] = v[1] = ... = v[i] = 0; v[i+1] = 1,
+     * \]
+     * with v[i+2] through v[ihi] stored on exit below the diagonal
+     * in the ith column of A, and tau in tau[i].
+     *
+     * @return  0 if success
+     * @return -i if the ith argument is invalid
+     *
+     * @param[in] k integer
+     * @param[in] nb integer
+     * @param[in,out] A n-by-n matrix.
+     * @param[out] tau Real vector of length n-1.
+     *      The scalar factors of the elementary reflectors.
+     * @param[in,out] T nb-by-nb matrix.
+     * @param[in,out] Y n-by-nb matrix.
+     *
+     * @ingroup gehrd
+     */
+    template <class matrix_t, class vector_t, class T_t, class Y_t>
+    int lahr2(size_type<matrix_t> k, size_type<matrix_t> nb, matrix_t &A, vector_t &tau, T_t &T, Y_t &Y)
+    {
+        using TA = type_t<matrix_t>;
+        using idx_t = size_type<matrix_t>;
+        using pair = std::pair<idx_t, idx_t>;
+
+        using blas::axpy;
+        using blas::copy;
+        using blas::gemv;
+        using blas::scal;
+        using blas::trmv;
+
+        // constants
+        const TA one(1);
+        const TA zero(0);
+        const idx_t n = nrows(A);
+
+        // quick return if possible
+        if (n <= 1)
+            return 0;
+
+        TA ei;
+        for (idx_t i = 0; i < nb; ++i)
+        {
+            if (i > 0)
+            {
+                //
+                // Update A(K+1:N,I), this rest will be updated later via
+                // level 3 BLAS.
+                //
+
+                //
+                // Update I-th column of A - Y * V**T
+                // (Application of the reflectors from the right)
+                //
+                auto Y2 = slice(Y, pair{k + 1, n}, pair{0, i});
+                auto Vti = slice(A, k + i - 1, pair{0, i});
+                auto b = slice(A, pair{k + 1, n}, i);
+                gemv(Op::NoTrans, -one, Y2, Vti, one, b);
+                //
+                // Apply I - V * T**T * V**T to this column (call it b) from the
+                // left, using the last column of T as workspace
+                //
+                // Let  V = ( V1 )   and   b = ( b1 )   (first I-1 rows)
+                //          ( V2 )             ( b2 )
+                //
+                // where V1 is unit lower triangular
+                //
+                // w := V1**T * b1
+                //
+                auto b1 = slice(A, pair{k + 1, k + 1 + i}, i);
+                auto V1 = slice(A, pair{k + 1, k + 1 + i}, pair{0, i});
+                auto w = slice(T, pair{0, i}, nb - 1);
+                copy(b1, w);
+                trmv(Uplo::Lower, Op::Trans, Diag::Unit, V1, w);
+                //
+                // w := w + V2**T * b2
+                //
+                auto b2 = slice(A, pair{k + 1 + i, n}, i);
+                auto V2 = slice(A, pair{k + 1 + i, n}, pair{0, i});
+                gemv(Op::Trans, one, V2, b2, one, w);
+                //
+                // w := T**T * w
+                //
+                auto T2 = slice(T, pair{0, i}, pair{0, i});
+                trmv(Uplo::Upper, Op::Trans, Diag::NonUnit, T2, w);
+                //
+                // b2 := b2 - V2*w
+                //
+                gemv(Op::NoTrans, -one, V2, w, one, b2);
+                //
+                // b1 := b1 - V1*w
+                //
+                trmv(Uplo::Lower, Op::NoTrans, Diag::Unit, V1, w);
+                axpy(-one, w, b1);
+
+                A(k + i, i - 1) = ei;
+            }
+            auto v = slice(A, pair{k + i + 1, n}, i);
+            larfg(v, tau[i]);
+
+            // larf has been edited to not require A(k+i,i) = one
+            // this is for thread safety. Since we already modified
+            // A(k+i,i) before, this is not required here
+            ei = v[0];
+            v[0] = one;
+            //
+            // Compute  Y(K+1:N,I)
+            //
+            auto A2 = slice(A, pair{k + 1, n}, pair{i + 1, n - k});
+            auto y = slice(Y, pair{k + 1, n}, i);
+            gemv(Op::NoTrans, one, A2, v, zero, y);
+            auto t = slice(T, pair{0, i}, i);
+            auto A3 = slice(A, pair{k + i + 1, n}, pair{0, i});
+            gemv(Op::ConjTrans, one, A3, v, zero, t);
+            auto Y2 = slice(Y, pair{k + 1, n}, pair{0, i});
+            gemv(Op::NoTrans, -one, Y2, t, one, y);
+            scal(tau[i], y);
+            //
+            // Compute T(0:I+1,I)
+            //
+            scal(-tau[i], t);
+            auto T2 = slice(T, pair{0, i}, pair{0, i});
+            trmv(Uplo::Upper, Op::NoTrans, Diag::NonUnit, T2, t);
+            T(i, i) = tau[i];
+        }
+
+        return 0;
+    }
+
+} // lapack
+
+#endif // __LAHR2_HH__

--- a/include/plugins/tlapack_legacyArray.hpp
+++ b/include/plugins/tlapack_legacyArray.hpp
@@ -145,8 +145,10 @@ namespace blas {
     slice( const legacyMatrix<T,layout>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept {
         assert( rows.first >= 0 and rows.first < nrows(A));
         assert( rows.second >= 0 and rows.second <= nrows(A));
+        assert( rows.first <= rows.second );
         assert( cols.first >= 0 and cols.first < ncols(A));
         assert( cols.second >= 0 and cols.second <= ncols(A));
+        assert( cols.first <= cols.second );
         return legacyMatrix<T,layout>(
             rows.second-rows.first, cols.second-cols.first,
             &A(rows.first,cols.first), A.ldim
@@ -159,6 +161,10 @@ namespace blas {
     template< typename T, Layout layout, class SliceSpecCol >
     inline constexpr auto
     slice( const legacyMatrix<T,layout>& A, typename legacyMatrix<T>::idx_t rowIdx, SliceSpecCol&& cols ) noexcept {
+        assert( cols.first >= 0 and cols.first < ncols(A));
+        assert( cols.second >= 0 and cols.second <= ncols(A));
+        assert( cols.first <= cols.second );
+        assert( rowIdx >= 0 and rowIdx < nrows(A));
         using idx_t = typename legacyMatrix<T>::idx_t;
         return legacyVector<T,idx_t>( cols.second-cols.first, &A(rowIdx,cols.first), A.ldim );
     }
@@ -167,6 +173,10 @@ namespace blas {
     template< typename T, Layout layout, class SliceSpecRow >
     inline constexpr auto
     slice( const legacyMatrix<T,layout>& A, SliceSpecRow&& rows, typename legacyMatrix<T>::idx_t colIdx = 0 ) noexcept {
+        assert( rows.first >= 0 and rows.first < nrows(A));
+        assert( rows.second >= 0 and rows.second <= nrows(A));
+        assert( rows.first <= rows.second );
+        assert( colIdx >= 0 and colIdx < ncols(A));
         return legacyVector<T>( rows.second-rows.first, &A(rows.first,colIdx) );
     }
     
@@ -176,6 +186,7 @@ namespace blas {
     rows( const legacyMatrix<T,layout>& A, SliceSpec&& rows ) noexcept {
         assert( rows.first >= 0 and rows.first < nrows(A));
         assert( rows.second >= 0 and rows.second <= nrows(A));
+        assert( rows.first <= rows.second );
         return legacyMatrix<T,layout>(
             rows.second-rows.first, A.n,
             &A(rows.first,0), A.ldim

--- a/include/tlapack.hpp
+++ b/include/tlapack.hpp
@@ -52,6 +52,8 @@
 // ----------------
 
 #include "lapack/gehd2.hpp"
+#include "lapack/gehrd.hpp"
+#include "lapack/lahr2.hpp"
 #include "lapack/unghr.hpp"
 #include "lapack/lahqr.hpp"
 #include "lapack/lahqr_shiftcolumn.hpp"


### PR DESCRIPTION
Blocked Hessenberg reduction

Based on my unblocked eigenvalue PR, so that one should be merged first.

This also contains my attempt at making the options work for blocksize and workspace.

Advantage of this style for opts: clean, fully type checked, not complicated overloading to access options
Disadvantage: does not allow users to use one big 'opts' and use it for all their calls