### PR TITLE
Fix bug in example geqr2

### DIFF
--- a/examples/geqr2/example_geqr2.cpp
+++ b/examples/geqr2/example_geqr2.cpp
@@ -95,13 +95,13 @@ void run( size_t m, size_t n )
         std::vector<real_t> work( n-1 );
     
         // QR factorization
-        blas_error_if( lapack::geqr2( Q, tau, work ) );
+        lapack::geqr2( Q, tau, work );
 
         // Save the R matrix
         lapack::lacpy( lapack::upperTriangle, Q, R );
 
         // Generates Q = H_1 H_2 ... H_n
-        blas_error_if( lapack::ung2r( n, Q, tau, work ) );
+        lapack::ung2r( n, Q, tau, work );
     }
     // Record end time
     auto endQR = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Closes #18
Thanks to @thijssteel !

__[edited:]__
What was happening:

```c++
    #define blas_error_if( cond ) \
        ((void)0)
```

when the flag `NDEBUG` is defined. So `blas_error_if( foo(...) )` is optimized to `((void)0)`.

Thus, `blas_error_if` should be used for parameter checking only.