### PR TITLE
Closes #19

### DIFF
--- a/include/legacy_api/blas/asum.hpp
+++ b/include/legacy_api/blas/asum.hpp
@@ -14,11 +14,11 @@
 namespace blas {
 
 /**
+ * Wrapper to asum( vector_t const& x ).
+ * 
  * @return 1-norm of vector,
  *     $|| Re(x) ||_1 + || Im(x) ||_1
  *         = \sum_{i=0}^{n-1} |Re(x_i)| + |Im(x_i)|$.
- *
- * Generic implementation for arbitrary data types.
  *
  * @param[in] n
  *     Number of elements in x. n >= 0.
@@ -33,13 +33,14 @@ namespace blas {
  */
 template< typename T >
 inline
-real_type<T>
-asum(
-    blas::idx_t n,
-    T const *x, blas::int_t incx )
+auto asum( idx_t n, T const *x, int_t incx )
 {
     blas_error_if( incx <= 0 );
-    tlapack_expr_with_vector( _x, T, n, x, incx, return asum( _x ) );
+    
+    tlapack_expr_with_vector_positiveInc(
+        _x, T, n, x, incx,
+        return asum( _x )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/axpy.hpp
+++ b/include/legacy_api/blas/axpy.hpp
@@ -15,8 +15,10 @@ namespace blas {
 
 /**
  * Add scaled vector, $y = \alpha x + y$.
- *
- * Generic implementation for arbitrary data types.
+ * 
+ * Wrapper to axpy(
+    const alpha_t& alpha,
+    const vectorX_t& x, vectorY_t& y ).
  *
  * @param[in] n
  *     Number of elements in x and y. n >= 0.
@@ -31,7 +33,7 @@ namespace blas {
  *     Stride between elements of x. incx must not be zero.
  *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
  *
- * @param[in, out] y
+ * @param[in,out] y
  *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
  *
  * @param[in] incy
@@ -47,20 +49,13 @@ void axpy(
     TX const *x, blas::int_t incx,
     TY       *y, blas::int_t incy )
 {
-    typedef blas::scalar_type<TX, TY> scalar_t;
-
-    // check arguments
     blas_error_if( incx == 0 );
     blas_error_if( incy == 0 );
-
-    // quick return
-    if (alpha == scalar_t(0))
-        return;
-
+    
     tlapack_expr_with_2vectors(
         _x, TX, n, x, incx,
         _y, TY, n, y, incy,
-        axpy( alpha, _x, _y )
+        return axpy( alpha, _x, _y )
     );
 }
 

--- a/include/legacy_api/blas/copy.hpp
+++ b/include/legacy_api/blas/copy.hpp
@@ -15,8 +15,8 @@ namespace blas {
 
 /**
  * Copy vector, $y = x$.
- *
- * Generic implementation for arbitrary data types.
+ * 
+ * Wrapper to copy( const vectorX_t& x, vectorY_t& y ).
  *
  * @param[in] n
  *     Number of elements in x and y. n >= 0.
@@ -42,22 +42,15 @@ void copy(
     blas::idx_t n,
     TX const *x, blas::int_t incx,
     TY       *y, blas::int_t incy )
-{
-    using internal::vector;
-    
-    // check arguments
+{    
     blas_error_if( incx == 0 );
     blas_error_if( incy == 0 );
-
-    // Views
-    const auto _x = vector<TX>(
-        (TX*) &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    auto _y = vector<TY>(
-        &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
-
-    copy( _x, _y );
+    
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        return copy( _x, _y )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/dot.hpp
+++ b/include/legacy_api/blas/dot.hpp
@@ -39,26 +39,19 @@ namespace blas {
  * @ingroup dot
  */
 template< typename TX, typename TY >
-scalar_type<TX, TY> dot(
+auto dot(
     blas::idx_t n,
     TX const *x, blas::int_t incx,
     TY const *y, blas::int_t incy )
 {
-    using internal::vector;
-
-    // check arguments
     blas_error_if( incx == 0 );
     blas_error_if( incy == 0 );
-
-    // Views
-    const auto _x = vector<TX>(
-        (TX*) &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    const auto _y = vector<TY>(
-        (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
-
-    return dot( _x, _y );
+    
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        return dot( _x, _y )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/dotu.hpp
+++ b/include/legacy_api/blas/dotu.hpp
@@ -44,21 +44,14 @@ scalar_type<TX, TY> dotu(
     TX const *x, blas::int_t incx,
     TY const *y, blas::int_t incy )
 {
-    using internal::vector;
-
-    // check arguments
     blas_error_if( incx == 0 );
     blas_error_if( incy == 0 );
-
-    // Views
-    const auto _x = vector<TX>(
-        (TX*) &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    const auto _y = vector<TY>(
-        (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
-
-    return dotu( _x, _y );
+    
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        return dotu( _x, _y )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/gemm.hpp
+++ b/include/legacy_api/blas/gemm.hpp
@@ -148,7 +148,7 @@ void gemm(
             : colmajor_matrix<TB>( (TB*)B, n, k, ldb );
     auto _C = colmajor_matrix<TC>( C, m, n, ldc );
 
-    gemm( transA, transB, alpha, _A, _B, beta, _C );
+    return gemm( transA, transB, alpha, _A, _B, beta, _C );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/gemv.hpp
+++ b/include/legacy_api/blas/gemv.hpp
@@ -64,7 +64,7 @@ namespace blas {
  * @param[in] beta
  *     Scalar beta. If beta is zero, y need not be set on input.
  *
- * @param[in, out] y
+ * @param[in,out] y
  *     - If trans = NoTrans:
  *       the m-element vector y, in an array of length (m-1)*abs(incy) + 1.
  *     - Otherwise:
@@ -87,12 +87,7 @@ void gemv(
     blas::scalar_type<TA, TX, TY> beta,
     TY *y, blas::int_t incy )
 {
-    typedef blas::scalar_type<TA, TX, TY> scalar_t;
     using blas::internal::colmajor_matrix;
-    
-    // constants
-    const scalar_t zero( 0.0 );
-    const scalar_t one( 1.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -107,7 +102,7 @@ void gemv(
     blas_error_if( incy == 0 );
 
     // quick return
-    if (m == 0 || n == 0 || (alpha == zero && beta == one))
+    if (m == 0 || n == 0)
         return;
 
     // Transpose if Row Major
@@ -129,7 +124,7 @@ void gemv(
     tlapack_expr_with_2vectors(
         _x, TX, lenx, x, incx,
         _y, TY, leny, y, incy,
-        gemv( trans, alpha, _A, _x, beta, _y )
+        return gemv( trans, alpha, _A, _x, beta, _y )
     );
 }
 

--- a/include/legacy_api/blas/ger.hpp
+++ b/include/legacy_api/blas/ger.hpp
@@ -49,7 +49,7 @@ namespace blas {
  *     Stride between elements of y. incy must not be zero.
  *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
  *
- * @param[in, out] A
+ * @param[in,out] A
  *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor: m-by-lda].
  *
  * @param[in] lda
@@ -66,12 +66,8 @@ void ger(
     TY const *y, blas::int_t incy,
     TA *A, blas::idx_t lda )
 {
-    typedef blas::scalar_type<TA, TX, TY> scalar_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-    
-    // constants
-    const scalar_t zero( 0.0 );
+    using blas::internal::rowmajor_matrix;
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -83,40 +79,30 @@ void ger(
     blas_error_if( lda < ((layout == Layout::ColMajor) ? m : n) );
 
     // quick return
-    if (m == 0 || n == 0 || alpha == zero)
+    if (m == 0 || n == 0)
         return;
 
-    if( layout == Layout::ColMajor ) {
-    
+    if( layout == Layout::ColMajor )
+    {
         // Matrix views
         auto _A = colmajor_matrix<TA>( A, m, n, lda );
-        const auto _x = vector<TX>(
-            (TX*) &x[(incx > 0 ? 0 : (-m + 1)*incx)],
-            m, incx );
-        const auto _y = vector<TY>(
-            (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-            n, incy );
 
-        ger( alpha, _x, _y, _A );
+        tlapack_expr_with_2vectors(
+            _x, TX, m, x, incx,
+            _y, TY, n, y, incy,
+            return ger( alpha, _x, _y, _A )
+        );
     }
-    else {
-        
+    else
+    {
         // Matrix views
-        auto _A = colmajor_matrix<TA>( A, n, m, lda );
-        auto _x = vector<TX>(
-            (TX*) &x[(incx > 0 ? 0 : (-m + 1)*incx)],
-            m, incx );
-        auto _y = vector<TY>(
-            (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-            n, incy );
+        auto _A = rowmajor_matrix<TA>( A, m, n, lda );
 
-        for (idx_t i = 0; i < m; ++i) _x[i] = conj( _x[i] );
-        for (idx_t i = 0; i < n; ++i) _y[i] = conj( _y[i] );
-
-        ger( alpha, _y, _x, _A );
-
-        for (idx_t i = 0; i < m; ++i) _x[i] = conj( _x[i] );
-        for (idx_t i = 0; i < n; ++i) _y[i] = conj( _y[i] );
+        tlapack_expr_with_2vectors(
+            _x, TX, m, x, incx,
+            _y, TY, n, y, incy,
+            return ger( alpha, _x, _y, _A )
+        );
     }
 }
 

--- a/include/legacy_api/blas/geru.hpp
+++ b/include/legacy_api/blas/geru.hpp
@@ -49,7 +49,7 @@ namespace blas {
  *     Stride between elements of y. incy must not be zero.
  *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
  *
- * @param[in, out] A
+ * @param[in,out] A
  *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor: m-by-lda].
  *
  * @param[in] lda
@@ -66,12 +66,7 @@ void geru(
     TY const *y, blas::int_t incy,
     TA *A, blas::idx_t lda )
 {
-    typedef blas::scalar_type<TA, TX, TY> scalar_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-    
-    // constants
-    const scalar_t zero( 0.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor );
@@ -82,35 +77,32 @@ void geru(
     blas_error_if( lda < ((layout == Layout::ColMajor) ? m : n) );
 
     // quick return
-    if (m == 0 || n == 0 || alpha == zero)
+    if (m == 0 || n == 0)
         return;
 
-    if( layout == Layout::ColMajor ) {
-    
+    if( layout == Layout::ColMajor )
+    {
         // Matrix views
         auto _A = colmajor_matrix<TA>( A, m, n, lda );
-        const auto _x = vector<TX>(
-            (TX*) &x[(incx > 0 ? 0 : (-m + 1)*incx)],
-            m, incx );
-        const auto _y = vector<TY>(
-            (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-            n, incy );
 
-        geru( alpha, _x, _y, _A );
+        tlapack_expr_with_2vectors(
+            _x, TX, m, x, incx,
+            _y, TY, n, y, incy,
+            return geru( alpha, _x, _y, _A )
+        );
     }
-    else {
-        
+    else
+    {
         // Matrix views
         auto _A = colmajor_matrix<TA>( A, n, m, lda );
-        auto _x = vector<TX>(
-            (TX*) &x[(incx > 0 ? 0 : (-m + 1)*incx)],
-            m, incx );
-        auto _y = vector<TY>(
-            (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-            n, incy );
 
-        geru( alpha, _y, _x, _A );
+        tlapack_expr_with_2vectors(
+            _y, TY, n, y, incy,
+            _x, TX, m, x, incx,
+            return geru( alpha, _y, _x, _A )
+        );
     }
+
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/hemm.hpp
+++ b/include/legacy_api/blas/hemm.hpp
@@ -93,12 +93,7 @@ void hemm(
     scalar_type<TA, TB, TC> beta,
     TC       *C, blas::idx_t ldc )
 {    
-    typedef blas::scalar_type<TA, TB, TC> scalar_t;
     using blas::internal::colmajor_matrix;
-            
-    // constants
-    const scalar_t zero( 0.0 );
-    const scalar_t one( 1.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -135,24 +130,7 @@ void hemm(
                   ? colmajor_matrix<TA>( (TA*)A, m, m, lda )
                   : colmajor_matrix<TA>( (TA*)A, n, n, lda );
     const auto _B = colmajor_matrix<TB>( (TB*)B, m, n, ldb );
-          auto _C = colmajor_matrix<TC>( C, m, n, ldc );
-
-    // alpha == zero
-    if (alpha == zero) {
-        if (beta == zero) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i)
-                    _C(i,j) = zero;
-            }
-        }
-        else if (beta != one) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i)
-                    _C(i,j) *= beta;
-            }
-        }
-        return;
-    }
+    auto _C = colmajor_matrix<TC>( C, m, n, ldc );
 
     hemm( side, uplo, alpha, _A, _B, beta, _C );
 }

--- a/include/legacy_api/blas/hemv.hpp
+++ b/include/legacy_api/blas/hemv.hpp
@@ -56,7 +56,7 @@ namespace blas {
  * @param[in] beta
  *     Scalar beta. If beta is zero, y need not be set on input.
  *
- * @param[in, out] y
+ * @param[in,out] y
  *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
  *
  * @param[in] incy
@@ -76,14 +76,8 @@ void hemv(
     blas::scalar_type<TA, TX, TY> beta,
     TY *y, blas::int_t incy )
 {
-    typedef blas::scalar_type<TA, TX, TY> scalar_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-    using blas::internal::transpose;
-    
-    // constants
-    const scalar_t zero( 0.0 );
-    const scalar_t one( 1.0 );
+    using blas::internal::rowmajor_matrix;
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -96,36 +90,25 @@ void hemv(
     blas_error_if( incy == 0 );
 
     // quick return
-    if (n == 0 || (alpha == zero && beta == one))
+    if (n == 0)
         return;
-
-    // Views
-    const auto _x = vector<TX>(
-        (TX*) &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    auto _y = vector<TY>(
-        &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
-
-    if (alpha == zero){
-        // form y = beta*y
-        if (beta != one) {
-            if (beta == zero) {
-                for (idx_t i = 0; i < n; ++i)
-                    _y[i] = zero;
-            }
-            else {
-                for (idx_t i = 0; i < n; ++i)
-                    _y[i] *= beta;
-            }
-        }
-        return;
-    }
 
     if(layout == Layout::ColMajor)
-        hemv( uplo, alpha, colmajor_matrix<TA>( (TA*)A, n, n, lda ), _x, beta, _y );
+    {
+        tlapack_expr_with_2vectors(
+            _x, TX, n, x, incx,
+            _y, TY, n, y, incy,
+            return hemv( uplo, alpha, colmajor_matrix<TA>( (TA*)A, n, n, lda ), _x, beta, _y )
+        );
+    }
     else
-        hemv( uplo, alpha, transpose(colmajor_matrix<TA>( (TA*)A, n, n, lda )), _x, beta, _y );
+    {
+        tlapack_expr_with_2vectors(
+            _x, TX, n, x, incx,
+            _y, TY, n, y, incy,
+            return hemv( uplo, alpha, rowmajor_matrix<TA>( (TA*)A, n, n, lda ), _x, beta, _y )
+        );
+    }
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/her.hpp
+++ b/include/legacy_api/blas/her.hpp
@@ -45,7 +45,7 @@ namespace blas {
  *     Stride between elements of x. incx must not be zero.
  *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
  *
- * @param[in, out] A
+ * @param[in,out] A
  *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
  *     Imaginary parts of the diagonal elements need not be set,
  *     are assumed to be zero on entry, and are set to zero on exit.
@@ -64,11 +64,7 @@ void her(
     TX const *x, blas::int_t incx,
     TA       *A, blas::idx_t lda )
 {
-    typedef blas::real_type<TA, TX> real_t;
     using blas::internal::colmajor_matrix;
-    
-    // constants
-    const real_t zero( 0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -80,7 +76,7 @@ void her(
     blas_error_if( lda < n );
 
     // quick return
-    if (n == 0 || alpha == zero)
+    if (n == 0)
         return;
 
     // for row major, swap lower <=> upper
@@ -91,7 +87,7 @@ void her(
     // Matrix views
     auto _A = colmajor_matrix<TA>( A, n, n, lda );
 
-    tlapack_expr_with_vector( _x, TX, n, x, incx, (her( uplo, alpha, _x, _A )) );
+    tlapack_expr_with_vector( _x, TX, n, x, incx, her( uplo, alpha, _x, _A ) );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/her2.hpp
+++ b/include/legacy_api/blas/her2.hpp
@@ -52,7 +52,7 @@ namespace blas {
  *     Stride between elements of y. incy must not be zero.
  *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
  *
- * @param[in, out] A
+ * @param[in,out] A
  *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
  *     Imaginary parts of the diagonal elements need not be set,
  *     are assumed to be zero on entry, and are set to zero on exit.
@@ -72,12 +72,7 @@ void her2(
     TY const *y, blas::int_t incy,
     TA *A, blas::idx_t lda )
 {
-    typedef blas::scalar_type<TA, TX, TY> scalar_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-
-    // constants
-    const scalar_t zero( 0.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -90,7 +85,7 @@ void her2(
     blas_error_if( lda < n );
 
     // quick return
-    if (n == 0 || alpha == zero)
+    if (n == 0)
         return;
 
     // for row major, swap lower <=> upper
@@ -100,14 +95,12 @@ void her2(
     
     // Matrix views
     auto _A = colmajor_matrix<TA>( A, n, n, lda );
-    const auto _x = vector<TX>(
-        (TX*) &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    const auto _y = vector<TY>(
-        (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
 
-    her2( uplo, alpha, _x, _y, _A );
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        return her2( uplo, alpha, _x, _y, _A )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/her2k.hpp
+++ b/include/legacy_api/blas/her2k.hpp
@@ -99,15 +99,7 @@ void her2k(
     real_type<TA, TB, TC> beta,  // note: real
     TC       *C, blas::idx_t ldc )
 {
-    typedef blas::scalar_type<TA, TB, TC> scalar_t;
-    typedef blas::real_type<TA, TB, TC> real_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-
-    // constants
-    const real_t rzero( 0.0 );
-    const scalar_t zero( 0.0 );
-    const scalar_t one( 1.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -162,55 +154,6 @@ void her2k(
                   ? colmajor_matrix<TB>( (TB*)B, n, k, ldb )
                   : colmajor_matrix<TB>( (TB*)B, k, n, ldb );
     auto _C = colmajor_matrix<TC>( C, n, n, ldc );
-
-    // alpha == zero
-    if (alpha == zero) {
-        if (beta == rzero) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i <= j; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = j; i < n; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < n; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-        } else if (beta != one) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < j; ++i)
-                        _C(i,j) *= beta;
-                    _C(j,j) = beta * real( _C(j,j) );
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    _C(j,j) = beta * real( _C(j,j) );
-                    for(idx_t i = j+1; i < n; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < j; ++i)
-                        _C(i,j) *= beta;
-                    _C(j,j) = beta * real( _C(j,j) );
-                    for(idx_t i = j+1; i < n; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-        }
-        return;
-    }
 
     her2k( uplo, trans, alpha, _A, _B, beta, _C );
 }

--- a/include/legacy_api/blas/herk.hpp
+++ b/include/legacy_api/blas/herk.hpp
@@ -84,17 +84,11 @@ void herk(
     blas::Op trans,
     blas::idx_t n, blas::idx_t k,
     real_type<TA, TC> alpha,  // note: real
-    TA const *A_, blas::idx_t lda,
+    TA const *A, blas::idx_t lda,
     real_type<TA, TC> beta,  // note: real
-    TC       *C_, blas::idx_t ldc )
+    TC       *C, blas::idx_t ldc )
 {
-    typedef blas::real_type<TA, TC> real_t;
     using blas::internal::colmajor_matrix;
-
-    // constants
-    const TC szero( 0 );
-    const real_t zero( 0 );
-    const real_t one( 1 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -134,63 +128,14 @@ void herk(
             : Op::NoTrans;
         alpha = conj(alpha);
     }
-        
+
     // Matrix views
-    const auto A = (trans == Op::NoTrans)
-                 ? colmajor_matrix<TA>( (TA*)A_, n, k, lda )
-                 : colmajor_matrix<TA>( (TA*)A_, k, n, lda );
-    auto C = colmajor_matrix<TC>( C_, n, n, ldc );
+    const auto _A = (trans == Op::NoTrans)
+                 ? colmajor_matrix<TA>( (TA*)A, n, k, lda )
+                 : colmajor_matrix<TA>( (TA*)A, k, n, lda );
+    auto _C = colmajor_matrix<TC>( C, n, n, ldc );
 
-    // alpha == zero
-    if (alpha == zero) {
-        if (beta == zero) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i <= j; ++i)
-                        C(i,j) = szero;
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = j; i < n; ++i)
-                        C(i,j) = szero;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < n; ++i)
-                        C(i,j) = szero;
-                }
-            }
-        } else if (beta != one) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < j; ++i)
-                        C(i,j) *= beta;
-                    C(j,j) = beta * real( C(j,j) );
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    C(j,j) = beta * real( C(j,j) );
-                    for(idx_t i = j+1; i < n; ++i)
-                        C(i,j) *= beta;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < j; ++i)
-                        C(i,j) *= beta;
-                    C(j,j) = beta * real( C(j,j) );
-                    for(idx_t i = j+1; i < n; ++i)
-                        C(i,j) *= beta;
-                }
-            }
-        }
-        return;
-    }
-
-    herk( uplo, trans, alpha, A, beta, C );
+    herk( uplo, trans, alpha, _A, beta, _C );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/iamax.hpp
+++ b/include/legacy_api/blas/iamax.hpp
@@ -41,13 +41,11 @@ inline idx_t
 iamax(
     idx_t n, T const *x, blas::int_t incx )
 {
-    using internal::vector;
-
-    // check arguments
     blas_error_if( incx <= 0 );
-
-    const auto _x = vector<T>( (T*) x, n, incx );
-    return iamax( _x );
+    tlapack_expr_with_vector_positiveInc(
+        _x, T, n, x, incx,
+        return iamax( _x )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/nrm2.hpp
+++ b/include/legacy_api/blas/nrm2.hpp
@@ -44,13 +44,11 @@ nrm2(
     blas::idx_t n,
     T const * x, blas::int_t incx )
 {
-    using internal::vector;
-
-    // check arguments
     blas_error_if( incx <= 0 );
-
-    const auto _x = vector<T>( (T*) x, n, incx );
-    return nrm2( _x );
+    tlapack_expr_with_vector_positiveInc(
+        _x, T, n, x, incx,
+        return nrm2( _x )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/rot.hpp
+++ b/include/legacy_api/blas/rot.hpp
@@ -28,14 +28,14 @@ namespace blas {
  * @param[in] n
  *     Number of elements in x and y. n >= 0.
  *
- * @param[in, out] x
+ * @param[in,out] x
  *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
  *
  * @param[in] incx
  *     Stride between elements of x. incx must not be zero.
  *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
  *
- * @param[in, out] y
+ * @param[in,out] y
  *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
  *
  * @param[in] incy
@@ -58,26 +58,15 @@ void rot(
     const blas::real_type<TX, TY>&   c,
     const blas::scalar_type<TX, TY>& s )
 {
-    typedef scalar_type<TX, TY> scalar_t;
-    using internal::vector;
-
     // check arguments
     blas_error_if( incx == 0 );
     blas_error_if( incy == 0 );
 
-    // quick return
-    if ( n == 0 || (c == 1 && s == scalar_t(0)) )
-        return;
-
-    // Views
-    auto _x = vector<TX>(
-        &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    auto _y = vector<TY>(
-        &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
-
-    rot( _x, _y, c, s );
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        return rot( _x, _y, c, s )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/rotg.hpp
+++ b/include/legacy_api/blas/rotg.hpp
@@ -25,10 +25,10 @@ namespace blas {
  *
  * Generic implementation for arbitrary data types.
  *
- * @param[in, out] a
+ * @param[in,out] a
  *     On entry, scalar a. On exit, set to r.
  *
- * @param[in, out] b
+ * @param[in,out] b
  *     On entry, scalar b. On exit, set to s, 1/c, or 0.
  *
  * @param[out] c
@@ -62,10 +62,10 @@ rotg (
  *
  * Generic implementation for arbitrary data types.
  *
- * @param[in, out] a
+ * @param[in,out] a
  *     On entry, scalar a. On exit, set to r.
  *
- * @param[in, out] b
+ * @param[in,out] b
  *     On entry, scalar b. On exit, set to s, 1/c, or 0.
  *
  * @param[out] c
@@ -86,7 +86,10 @@ inline void
 rotg (
     T* a, T* b,
     real_type<T>* c,
-    complex_type<T>* s ) { return rotg(*a,*b,*c,*s); }
+    complex_type<T>* s )
+{
+    return rotg(*a,*b,*c,*s);
+}
 
 }  // namespace blas
 

--- a/include/legacy_api/blas/rotm.hpp
+++ b/include/legacy_api/blas/rotm.hpp
@@ -28,14 +28,14 @@ namespace blas {
  * @param[in] n
  *     Number of elements in x and y. n >= 0.
  *
- * @param[in, out] x
+ * @param[in,out] x
  *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
  *
  * @param[in] incx
  *     Stride between elements of x. incx must not be zero.
  *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
  *
- * @param[in, out] y
+ * @param[in,out] y
  *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
  *
  * @param[in] incy
@@ -48,41 +48,30 @@ namespace blas {
  * @ingroup rotm
  */
 template< typename TX, typename TY >
+inline
 void rotm(
     blas::idx_t n,
     TX *x, blas::int_t incx,
     TY *y, blas::int_t incy,
     blas::scalar_type<TX, TY> const param[5] )
 {
-    using internal::vector;
-
     // constants
     const int flag = (int) param[0];
+    auto h = &param[1];
 
     // check arguments
     blas_error_if( incx == 0 );
     blas_error_if( incy == 0 );
-
-    // quick return
-    if ( n == 0 || flag == -2 )
-        return;
-
-    // Views
-    auto _x = vector<TX>(
-        &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    auto _y = vector<TY>(
-        &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
-
-    switch (flag) {
-    case -2: return rotm<-2>(_x,_y,&param[1]);
-    case -1: return rotm<-1>(_x,_y,&param[1]);
-    case  0: return rotm< 0>(_x,_y,&param[1]);
-    case  1: return rotm< 1>(_x,_y,&param[1]);
-    default:
-        throw Error("Invalid flag in blas::rotm");
-    }
+    blas_error_if( flag < -2 && flag > 1 );
+    
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        if      ( flag == -2 ) return rotm<-2>(_x,_y,h);
+        else if ( flag == -1 ) return rotm<-1>(_x,_y,h);
+        else if ( flag ==  0 ) return rotm< 0>(_x,_y,h);
+        else                   return rotm< 1>(_x,_y,h);
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/rotmg.hpp
+++ b/include/legacy_api/blas/rotmg.hpp
@@ -71,13 +71,13 @@ namespace blas {
  *
  * Generic implementation for arbitrary data types.
  *
- * @param[in, out] d1
+ * @param[in,out] d1
  *     sqrt(d1) is scaling factor for vector x.
  *
- * @param[in, out] d2
+ * @param[in,out] d2
  *     sqrt(d2) is scaling factor for vector y.
  *
- * @param[in, out] a
+ * @param[in,out] a
  *     On entry, scalar a. On exit, set to z.
  *
  * @param[in] b

--- a/include/legacy_api/blas/scal.hpp
+++ b/include/legacy_api/blas/scal.hpp
@@ -38,13 +38,11 @@ void scal(
     const TA& alpha,
     TX* x, blas::int_t incx )
 {
-    using internal::vector;
-
-    // check arguments
     blas_error_if( incx <= 0 );
-
-    auto _x = vector<TX>( x, n, incx );
-    return scal( alpha, _x );
+    tlapack_expr_with_vector_positiveInc(
+        _x, TX, n, x, incx,
+        return scal( alpha, _x )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/swap.hpp
+++ b/include/legacy_api/blas/swap.hpp
@@ -28,7 +28,7 @@ namespace blas {
  *     Stride between elements of x. incx must not be zero.
  *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
  *
- * @param[in, out] y
+ * @param[in,out] y
  *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
  *
  * @param[in] incy
@@ -43,21 +43,15 @@ void swap(
     TX *x, blas::int_t incx,
     TY *y, blas::int_t incy )
 {
-    using internal::vector;
-
     // check arguments
     blas_error_if( incx == 0 );
     blas_error_if( incy == 0 );
 
-    // Views
-    auto _x = vector<TX>(
-        &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    auto _y = vector<TY>(
-        &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
-        
-    blas::swap( _x, _y );
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        return blas::swap( _x, _y );
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/symm.hpp
+++ b/include/legacy_api/blas/symm.hpp
@@ -86,13 +86,8 @@ void symm(
     TB const *B, blas::idx_t ldb,
     scalar_type<TA, TB, TC> beta,
     TC       *C, blas::idx_t ldc )
-{
-    typedef blas::scalar_type<TA, TB, TC> scalar_t;
+{    
     using blas::internal::colmajor_matrix;
-
-    // constants
-    const scalar_t zero( 0.0 );
-    const scalar_t one( 1.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -123,30 +118,13 @@ void symm(
             uplo = Uplo::Lower;
         std::swap( m , n );
     }
-        
+    
     // Matrix views
     const auto _A = (side == Side::Left)
                   ? colmajor_matrix<TA>( (TA*)A, m, m, lda )
                   : colmajor_matrix<TA>( (TA*)A, n, n, lda );
     const auto _B = colmajor_matrix<TB>( (TB*)B, m, n, ldb );
     auto _C = colmajor_matrix<TC>( C, m, n, ldc );
-
-    // alpha == zero
-    if (alpha == zero) {
-        if (beta == zero) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i)
-                    _C(i,j) = zero;
-            }
-        }
-        else if (beta != one) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i)
-                    _C(i,j) *= beta;
-            }
-        }
-        return;
-    }
 
     symm( side, uplo, alpha, _A, _B, beta, _C );
 }

--- a/include/legacy_api/blas/syr.hpp
+++ b/include/legacy_api/blas/syr.hpp
@@ -45,7 +45,7 @@ namespace blas {
  *     Stride between elements of x. incx must not be zero.
  *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
  *
- * @param[in, out] A
+ * @param[in,out] A
  *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
  *
  * @param[in] lda
@@ -62,12 +62,7 @@ void syr(
     TX const *x, blas::int_t incx,
     TA       *A, blas::idx_t lda )
 {
-    typedef blas::scalar_type<TA, TX> scalar_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-
-    // constants
-    const scalar_t zero( 0.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -79,22 +74,18 @@ void syr(
     blas_error_if( lda < n );
 
     // quick return
-    if (n == 0 || alpha == zero)
+    if (n == 0)
         return;
 
     // for row major, swap lower <=> upper
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
-        
+    
     // Matrix views
     auto _A = colmajor_matrix<TA>( A, n, n, lda );
-    const auto _x = vector<TX>(
-        (TX*) &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
 
-    syr( uplo, alpha, _x, _A );
-
+    tlapack_expr_with_vector( _x, TX, n, x, incx, syr( uplo, alpha, _x, _A ) );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/syr2.hpp
+++ b/include/legacy_api/blas/syr2.hpp
@@ -52,7 +52,7 @@ namespace blas {
  *     Stride between elements of y. incy must not be zero.
  *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
  *
- * @param[in, out] A
+ * @param[in,out] A
  *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
  *
  * @param[in] lda
@@ -70,12 +70,7 @@ void syr2(
     TY const *y, blas::int_t incy,
     TA *A, blas::idx_t lda )
 {
-    typedef blas::scalar_type<TA, TX, TY> scalar_t;
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-
-    // constants
-    const scalar_t zero( 0.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -88,7 +83,7 @@ void syr2(
     blas_error_if( lda < n );
 
     // quick return
-    if (n == 0 || alpha == zero)
+    if (n == 0)
         return;
 
     // for row major, swap lower <=> upper
@@ -98,14 +93,12 @@ void syr2(
     
     // Matrix views
     auto _A = colmajor_matrix<TA>( A, n, n, lda );
-    const auto _x = vector<TX>(
-        (TX*) &x[(incx > 0 ? 0 : (-n + 1)*incx)],
-        n, incx );
-    const auto _y = vector<TY>(
-        (TY*) &y[(incy > 0 ? 0 : (-n + 1)*incy)],
-        n, incy );
 
-    syr2( uplo, alpha, _x, _y, _A );
+    tlapack_expr_with_2vectors(
+        _x, TX, n, x, incx,
+        _y, TY, n, y, incy,
+        return syr2( uplo, alpha, _x, _y, _A )
+    );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/syr2k.hpp
+++ b/include/legacy_api/blas/syr2k.hpp
@@ -98,14 +98,8 @@ void syr2k(
     TB const *B, blas::idx_t ldb,
     scalar_type<TA, TB, TC> beta,
     TC       *C, blas::idx_t ldc )
-{    
-    typedef blas::scalar_type<TA, TB, TC> scalar_t;
+{
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
-
-    // constants
-    const scalar_t zero( 0.0 );
-    const scalar_t one( 1.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -159,51 +153,6 @@ void syr2k(
                   ? colmajor_matrix<TB>( (TB*)B, n, k, ldb )
                   : colmajor_matrix<TB>( (TB*)B, k, n, ldb );
     auto _C = colmajor_matrix<TC>( C, n, n, ldc );
-
-    // alpha == zero
-    if (alpha == zero) {
-        if (beta == zero) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i <= j; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = j; i < n; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < n; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-        }
-        else if (beta != one) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i <= j; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = j; i < n; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < n; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-        }
-        return;
-    }
 
     syr2k( uplo, trans, alpha, _A, _B, beta, _C );
 }

--- a/include/legacy_api/blas/syrk.hpp
+++ b/include/legacy_api/blas/syrk.hpp
@@ -88,12 +88,7 @@ void syrk(
     scalar_type<TA, TC> beta,
     TC       *C, blas::idx_t ldc )
 {
-    typedef blas::scalar_type<TA, TC> scalar_t;
     using blas::internal::colmajor_matrix;
-
-    // constants
-    const scalar_t zero( 0 );
-    const scalar_t one( 1 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -139,51 +134,6 @@ void syrk(
                   : colmajor_matrix<TA>( (TA*)A, k, n, lda );
     auto _C = colmajor_matrix<TC>( C, n, n, ldc );
 
-    // alpha == zero
-    if (alpha == zero) {
-        if (beta == zero) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i <= j; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = j; i < n; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < n; ++i)
-                        _C(i,j) = zero;
-                }
-            }
-        }
-        else if (beta != one) {
-            if (uplo != Uplo::Upper) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i <= j; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-            else if (uplo != Uplo::Lower) {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = j; i < n; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-            else {
-                for(idx_t j = 0; j < n; ++j) {
-                    for(idx_t i = 0; i < n; ++i)
-                        _C(i,j) *= beta;
-                }
-            }
-        }
-        return;
-    }
-    
     syrk( uplo, trans, alpha, _A, beta, _C );
 }
 

--- a/include/legacy_api/blas/trmm.hpp
+++ b/include/legacy_api/blas/trmm.hpp
@@ -77,7 +77,7 @@ namespace blas {
  *     - If side = left:  lda >= max(1, m).
  *     - If side = right: lda >= max(1, n).
  *
- * @param[in, out] B
+ * @param[in,out] B
  *     The m-by-n matrix B, stored in an ldb-by-n array [RowMajor: m-by-ldb].
  *
  * @param[in] ldb
@@ -97,12 +97,8 @@ void trmm(
     blas::scalar_type<TA, TB> alpha,
     TA const *A, blas::idx_t lda,
     TB       *B, blas::idx_t ldb )
-{    
-    typedef blas::scalar_type<TA, TB> scalar_t;
+{
     using blas::internal::colmajor_matrix;
-
-    // constants
-    const scalar_t zero( 0.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -143,16 +139,6 @@ void trmm(
                   : colmajor_matrix<TA>( (TA*)A, n, n, lda );
     auto _B = colmajor_matrix<TB>( B, m, n, ldb );
 
-    // alpha == zero
-    if (alpha == zero) {
-        for(idx_t j = 0; j < n; ++j) {
-            for(idx_t i = 0; i < m; ++i)
-                _B(i,j) = TB(0);
-        }
-        return;
-    }
-
-    // alpha != zero
     trmm( side, uplo, trans, diag, alpha, _A, _B );
 }
 

--- a/include/legacy_api/blas/trmv.hpp
+++ b/include/legacy_api/blas/trmv.hpp
@@ -57,7 +57,7 @@ namespace blas {
  * @param[in] lda
  *     Leading dimension of A. lda >= max(1, n).
  *
- * @param[in, out] x
+ * @param[in,out] x
  *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
  *
  * @param[in] incx
@@ -77,7 +77,6 @@ void trmv(
     TX       *x, blas::int_t incx )
 {
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -108,9 +107,8 @@ void trmv(
         
     // Matrix views
     const auto _A = colmajor_matrix<TA>( (TA*)A, n, n, lda );
-    auto _x = vector<TX>( &x[(incx > 0 ? 0 : (-n + 1)*incx)], n, incx );
 
-    trmv( uplo, trans, diag, _A, _x );
+    tlapack_expr_with_vector( _x, TX, n, x, incx, return trmv( uplo, trans, diag, _A, _x ) );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/trsm.hpp
+++ b/include/legacy_api/blas/trsm.hpp
@@ -80,7 +80,7 @@ namespace blas {
  *     - If side = left:  lda >= max(1, m).
  *     - If side = right: lda >= max(1, n).
  *
- * @param[in, out] B
+ * @param[in,out] B
  *     On entry,
  *     the m-by-n matrix B, stored in an ldb-by-n array [RowMajor: m-by-ldb].
  *     On exit, overwritten by the solution matrix X.
@@ -103,12 +103,8 @@ void trsm(
     blas::scalar_type<TA, TB> alpha,
     TA const *A, blas::idx_t lda,
     TB       *B, blas::idx_t ldb )
-{    
-    typedef blas::scalar_type<TA, TB> scalar_t;
+{
     using blas::internal::colmajor_matrix;
-
-    // constants
-    const scalar_t zero( 0.0 );
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -149,16 +145,6 @@ void trsm(
                   : colmajor_matrix<TA>( (TA*)A, n, n, lda );
     auto _B = colmajor_matrix<TB>( B, m, n, ldb );
 
-    // alpha == zero
-    if (alpha == zero) {
-        for(idx_t j = 0; j < n; ++j) {
-            for(idx_t i = 0; i < m; ++i)
-                _B(i,j) = TB(0);
-        }
-        return;
-    }
-
-    // alpha != zero
     trsm( side, uplo, trans, diag, alpha, _A, _B );
 }
 

--- a/include/legacy_api/blas/trsv.hpp
+++ b/include/legacy_api/blas/trsv.hpp
@@ -61,7 +61,7 @@ namespace blas {
  * @param[in] lda
  *     Leading dimension of A. lda >= max(1, n).
  *
- * @param[in, out] x
+ * @param[in,out] x
  *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
  *
  * @param[in] incx
@@ -81,7 +81,6 @@ void trsv(
     TX       *x, blas::int_t incx )
 {
     using blas::internal::colmajor_matrix;
-    using blas::internal::vector;
 
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
@@ -112,9 +111,8 @@ void trsv(
         
     // Matrix views
     const auto _A = colmajor_matrix<TA>( (TA*)A, n, n, lda );
-    auto _x = vector<TX>( &x[(incx > 0 ? 0 : (-n + 1)*incx)], n, incx );
 
-    trsv( uplo, trans, diag, _A, _x );
+    tlapack_expr_with_vector( _x, TX, n, x, incx, return trsv( uplo, trans, diag, _A, _x ) );
 }
 
 }  // namespace blas

--- a/include/legacy_api/blas/utils.hpp
+++ b/include/legacy_api/blas/utils.hpp
@@ -13,8 +13,8 @@
     #include "plugins/tlapack_legacyArray.hpp" // Loads LegacyArray plugin
 
     #define tlapack_expr_with_2vectors( x, TX, n, X, incx, ... ) do { \
-        using internal::vector; \
-        using internal::backward_vector; \
+        using blas::internal::vector; \
+        using blas::internal::backward_vector; \
         if( incx == 1 ) { \
             auto x = vector( (TX*) X, n ); \
             tlapack_expr_with_vector( __VA_ARGS__ ); \
@@ -34,8 +34,8 @@
     } while(false)
 
     #define tlapack_expr_with_vector( x, TX, n, X, incx, expr ) do { \
-        using internal::vector; \
-        using internal::backward_vector; \
+        using blas::internal::vector; \
+        using blas::internal::backward_vector; \
         if( incx == 1 ) { \
             auto x = vector( (TX*) X, n ); \
             expr; \
@@ -55,7 +55,7 @@
     } while(false)
 
     #define tlapack_expr_with_vector_positiveInc( x, TX, n, X, incx, expr ) do { \
-        using internal::vector; \
+        using blas::internal::vector; \
         if( incx == 1 ) { \
             auto x = vector( (TX*) X, n ); \
             expr; \
@@ -71,7 +71,7 @@
     #include "plugins/tlapack_mdspan.hpp" // Loads mdspan plugin
 
     #define tlapack_expr_with_2vectors( x, TX, n, X, incx, ... ) do { \
-        using internal::vector; \
+        using blas::internal::vector; \
         if( incx == 1 ) { \
             auto x = vector( (TX*) X, n ); \
             tlapack_expr_with_vector( __VA_ARGS__ ); \
@@ -87,7 +87,7 @@
     } while(false)
 
     #define tlapack_expr_with_vector( x, TX, n, X, incx, expr ) do { \
-        using internal::vector; \
+        using blas::internal::vector; \
         if( incx == 1 ) { \
             auto x = vector( (TX*) X, n ); \
             expr; \
@@ -103,7 +103,7 @@
     } while(false)
 
     #define tlapack_expr_with_vector_positiveInc( x, TX, n, X, incx, expr ) do { \
-        using internal::vector; \
+        using blas::internal::vector; \
         if( incx == 1 ) { \
             auto x = vector( (TX*) X, n ); \
             expr; \

--- a/include/legacy_api/lapack/larf.hpp
+++ b/include/legacy_api/lapack/larf.hpp
@@ -53,14 +53,12 @@ inline void larf(
     
     // Matrix views
     auto _C = colmajor_matrix<TC>( C, m, n, ldC );
-    const auto _v = vector<TV>(
-        (TV*) &v[(incv > 0 ? 0 : (-lenv + 1)*incv)],
-        lenv, incv );
-    auto _work = vector<scalar_t>( &work[0], lwork, 1 );
+    auto _work = vector( &work[0], lwork );
 
-    larf( side, _v, tau, _C, _work);
-        
-    // delete[] work;
+    tlapack_expr_with_vector(
+        _v, TV, lenv, v, incv,
+        return larf( side, _v, tau, _C, _work)
+    );
 }
 
 } // lapack

--- a/include/legacy_api/lapack/larfg.hpp
+++ b/include/legacy_api/lapack/larfg.hpp
@@ -18,15 +18,8 @@ namespace lapack {
 template< typename T >
 void larfg(
     blas::idx_t n, T &alpha, T *x, blas::int_t incx, T &tau )
-{
-    using blas::internal::vector;
-
-    // Views
-    auto _x = vector<T>(
-        &x[(incx > 0 ? 0 : (-n + 2)*incx)],
-        n-1, incx );
-    
-    larfg( alpha, _x, tau );
+{    
+    tlapack_expr_with_vector( _x, T, n-1, x, incx, return larfg( alpha, _x, tau ) );
 }
 
 /** Generates a elementary Householder reflection.

--- a/include/legacy_api/lapack/larft.hpp
+++ b/include/legacy_api/lapack/larft.hpp
@@ -107,7 +107,7 @@ int larft(
     auto _V = (storeV == StoreV::Columnwise)
             ? colmajor_matrix<scalar_t>( (scalar_t*)V, n, k, ldV )
             : colmajor_matrix<scalar_t>( (scalar_t*)V, k, n, ldV );
-    auto _tau = vector<scalar_t>( (scalar_t*)tau, k, 1 );
+    auto _tau = vector( (scalar_t*)tau, k );
     auto _T = colmajor_matrix<scalar_t>( T, k, k, ldT );
 
     return larft( direction, storeV, _V, _tau, _T);

--- a/include/legacy_api/lapack/lassq.hpp
+++ b/include/legacy_api/lapack/lassq.hpp
@@ -58,28 +58,12 @@ void lassq(
     real_type<TX> &scl,
     real_type<TX> &sumsq)
 {
-    using real_t = real_type<TX>;
-    using blas::internal::vector;
     using blas::isnan;
 
-    // constants
-    const real_t zero( 0 );
-    const real_t one( 1 );
-
     // quick return
-    if( isnan(scl) || isnan(sumsq) ) return;
+    if( isnan(scl) || isnan(sumsq) || n <= 0 ) return;
 
-    if( sumsq == zero ) scl = one;
-    if( scl == zero ) {
-        scl = one;
-        sumsq = zero;
-    }
-
-    // quick return
-    if( n <= 0 ) return;
-
-    const auto _x = vector<TX>( (TX*) x, n, incx );
-    lassq( _x, scl, sumsq );
+    tlapack_expr_with_vector( _x, TX, n, x, incx, return lassq( _x, scl, sumsq ) );
 }
 
 } // lapack

--- a/include/legacy_api/lapack/ung2r.hpp
+++ b/include/legacy_api/lapack/ung2r.hpp
@@ -63,8 +63,8 @@ inline int ung2r(
 
     // Matrix views
     auto _A    = colmajor_matrix<TA>( A, m, n, lda );
-    auto _tau  = vector<Ttau>( (Ttau*)tau, std::min<blas::idx_t>( m, n ), 1 );
-    auto _work = vector<TA>  ( work, n-1, 1 );
+    auto _tau  = vector( (Ttau*)tau, std::min<blas::idx_t>( m, n ) );
+    auto _work = vector( work, n-1 );
     
     info = ung2r( k, _A, _tau, _work );
 

--- a/include/legacy_api/lapack/unm2r.hpp
+++ b/include/legacy_api/lapack/unm2r.hpp
@@ -80,9 +80,9 @@ inline int unm2r(
 
     // Matrix views
     const auto _A = colmajor_matrix<TA>( (TA*)A, q, k, lda );
-    const auto _tau = vector<TA>( (TA*)tau, k );
+    const auto _tau = vector( (TA*)tau, k );
     auto _C = colmajor_matrix<TC>( C, m, n, ldc );
-    auto _work = vector<TC>( work, q );
+    auto _work = vector( work, q );
 
     int info = unm2r( side, trans, A, _tau, _C, _work );
 

--- a/include/legacy_api/lapack/unmqr.hpp
+++ b/include/legacy_api/lapack/unmqr.hpp
@@ -104,7 +104,7 @@ inline int unmqr(
     const auto _A = (side == Side::Left)
             ? colmajor_matrix<TA>( (TA*)A, m, k, lda )
             : colmajor_matrix<TA>( (TA*)A, n, k, lda );
-    const auto _tau = vector<TA>( (TA*)tau, k, 1 );
+    const auto _tau = vector( (TA*)tau, k );
     auto _C = colmajor_matrix<TC>( C, m, n, ldc );
     auto _W = colmajor_matrix<scalar_t>( &_work[0], nb, nw+nb );
 

--- a/test/lapackpp/test.cpp
+++ b/test/lapackpp/test.cpp
@@ -674,7 +674,7 @@ int main( int argc, char** argv )
 
     int status = 0;
     try {
-        printf( "Running tests from https://bitbucket.org/icl/lapackpp/src/master/test\n" );
+        printf( "Running tests from https://bitbucket.org/weslleyspereira/lapackpp/src/tlapack/test \n" );
 
         // print input so running `test [input] > out.txt` documents input
         printf( "input: %s", argv[0] );


### PR DESCRIPTION
Closes #19

This PR:
1. hides the complexity of negative increment and unitary increment to [`utils.hpp`](https://github.com/tlapack/tlapack/blob/c48d1a872ce129111455b4889a901bc849dd6089/include/legacy_api/blas/utils.hpp)
2. allows for the optimization with unitary increment in the same way as in Reference BLAS.
3. allows for negative increments on level 2 and level 3 BLAS routines on \<T\>LAPACK, e.g., hemm and her.

This PR also:
1. Removes quick returns that prevented inf and nan propagation from the wrappers.