### PR TITLE
Improve tests

### DIFF
--- a/include/lapack/schur_move.hpp
+++ b/include/lapack/schur_move.hpp
@@ -87,15 +87,28 @@ namespace tlapack
                 if (A(ilst, ilst - 1) != zero)
                     ilst = ilst - 1;
 
+        // Size of the final block, can be either 1, 2
+        idx_t nbl = 1;
+        if (!is_complex<T>::value)
+            if (ilst < n - 1)
+                if (A(ilst + 1, ilst) != zero)
+                    nbl = 2;
+
         idx_t here = ifst;
         if (ifst < ilst)
         {
+            if( nbf == 2 and nbl == 1 )
+                ilst = ilst - 1;
+            if( nbf == 1 and nbl == 2 )
+                ilst = ilst + 1;
+
+
             while (here != ilst)
             {
                 // Size of the next eigenvalue block
                 idx_t nbnext = 1;
                 if (!is_complex<T>::value)
-                    if (here + nbf + 1 < n - 1)
+                    if (here + nbf + 1 < n)
                         if (A(here + nbf + 1, here + nbf) != zero)
                             nbnext = 2;
 

--- a/include/lapack/schur_swap.hpp
+++ b/include/lapack/schur_swap.hpp
@@ -64,7 +64,7 @@ namespace tlapack
         assert(nrows(Q) == n);
         assert(ncols(Q) == n);
         assert(0 <= j0);
-        assert(j0 + n1 + n2 < n);
+        assert(j0 + n1 + n2 <= n);
         assert(n1 == 1 or n1 == 2);
         assert(n2 == 1 or n2 == 2);
 
@@ -434,7 +434,7 @@ namespace tlapack
             T cs, sn;
             std::complex<T> s1, s2;
             lahqr_schur22(A(j0_2, j0_2), A(j0_2, j1_2), A(j1_2, j0_2), A(j1_2, j1_2), s1, s2, cs, sn); // Apply transformation from the left
-            if (j2 < n)
+            if (j0_2 + 2 < n)
             {
                 auto row1 = slice(A, j0_2, pair{j0_2 + 2, n});
                 auto row2 = slice(A, j1_2, pair{j0_2 + 2, n});

--- a/include/lapack/unghr.hpp
+++ b/include/lapack/unghr.hpp
@@ -46,6 +46,7 @@ int unghr(
     const T one ( 1.0 );
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
+    const idx_t nh = ihi > ilo +1 ? ihi-1-ilo : 0;
 
     // check arguments
     lapack_error_if( (idx_t) size(tau)  < std::min<idx_t>( m, n ), -2 );
@@ -84,10 +85,11 @@ int unghr(
 
     // Now that the vectors are shifted, we can call orgqr to generate the matrix
     // orgqr is not yet implemented, so we call org2r instead
-    const idx_t nh = ihi-1-ilo;
-    auto A_s = slice( A, pair{ilo+1,ihi}, pair{ilo+1,ihi} );
-    auto tau_s = slice( tau, pair{ilo,ihi-1} );
-    ung2r( nh, A_s, tau_s, work );
+    if( nh > 0 ){
+        auto A_s = slice( A, pair{ilo+1,ihi}, pair{ilo+1,ihi} );
+        auto tau_s = slice( tau, pair{ilo,ihi-1} );
+        ung2r( nh, A_s, tau_s, work );
+    }
 
     return 0;
 }

--- a/include/plugins/tlapack_debugutils.hpp
+++ b/include/plugins/tlapack_debugutils.hpp
@@ -44,19 +44,35 @@ namespace tlapack
     // GDB doesn't handle templates well, so we explicitly define some versions of the functions
     // for common template arguments
     //
-    inline void print_matrix_r(const legacyMatrix<float, Layout::ColMajor> &A)
+    void print_matrix_r(const legacyMatrix<float, Layout::ColMajor> &A)
     {
         print_matrix(A);
     }
-    inline void print_matrix_d(const legacyMatrix<double, Layout::ColMajor> &A)
+    void print_matrix_d(const legacyMatrix<double, Layout::ColMajor> &A)
     {
         print_matrix(A);
     }
-    inline void print_matrix_c(const legacyMatrix<std::complex<float>, Layout::ColMajor> &A)
+    void print_matrix_c(const legacyMatrix<std::complex<float>, Layout::ColMajor> &A)
     {
         print_matrix(A);
     }
-    inline void print_matrix_z(const legacyMatrix<std::complex<double>, Layout::ColMajor> &A)
+    void print_matrix_z(const legacyMatrix<std::complex<double>, Layout::ColMajor> &A)
+    {
+        print_matrix(A);
+    }
+    void print_rowmajormatrix_r(const legacyMatrix<float, Layout::RowMajor> &A)
+    {
+        print_matrix(A);
+    }
+    void print_rowmajormatrix_d(const legacyMatrix<double, Layout::RowMajor> &A)
+    {
+        print_matrix(A);
+    }
+    void print_rowmajormatrix_c(const legacyMatrix<std::complex<float>, Layout::RowMajor> &A)
+    {
+        print_matrix(A);
+    }
+    void print_rowmajormatrix_z(const legacyMatrix<std::complex<double>, Layout::RowMajor> &A)
     {
         print_matrix(A);
     }
@@ -171,19 +187,35 @@ namespace tlapack
     // GDB doesn't handle templates well, so we explicitly define some versions of the functions
     // for common template arguments
     //
-    inline std::string visualize_matrix_r(const legacyMatrix<float, Layout::ColMajor> &A)
+    std::string visualize_matrix_r(const legacyMatrix<float, Layout::ColMajor> &A)
     {
         return visualize_matrix(A);
     }
-    inline std::string visualize_matrix_d(const legacyMatrix<double, Layout::ColMajor> &A)
+    std::string visualize_matrix_d(const legacyMatrix<double, Layout::ColMajor> &A)
     {
         return visualize_matrix(A);
     }
-    inline std::string visualize_matrix_c(const legacyMatrix<std::complex<float>, Layout::ColMajor> &A)
+    std::string visualize_matrix_c(const legacyMatrix<std::complex<float>, Layout::ColMajor> &A)
     {
         return visualize_matrix(A);
     }
-    inline std::string visualize_matrix_z(const legacyMatrix<std::complex<double>, Layout::ColMajor> &A)
+    std::string visualize_matrix_z(const legacyMatrix<std::complex<double>, Layout::ColMajor> &A)
+    {
+        return visualize_matrix(A);
+    }
+    std::string visualize_rowmajormatrix_r(const legacyMatrix<float, Layout::RowMajor> &A)
+    {
+        return visualize_matrix(A);
+    }
+    std::string visualize_rowmajormatrix_d(const legacyMatrix<double, Layout::RowMajor> &A)
+    {
+        return visualize_matrix(A);
+    }
+    std::string visualize_rowmajormatrix_c(const legacyMatrix<std::complex<float>, Layout::RowMajor> &A)
+    {
+        return visualize_matrix(A);
+    }
+    std::string visualize_rowmajormatrix_z(const legacyMatrix<std::complex<double>, Layout::RowMajor> &A)
     {
         return visualize_matrix(A);
     }

--- a/include/plugins/tlapack_debugutils.hpp
+++ b/include/plugins/tlapack_debugutils.hpp
@@ -1,4 +1,4 @@
-/// @file debug_utils.hpp
+/// @file tlapack_debugutils.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
 //
 // This file is part of <T>LAPACK.

--- a/include/plugins/tlapack_legacyArray.hpp
+++ b/include/plugins/tlapack_legacyArray.hpp
@@ -163,7 +163,7 @@ namespace tlapack {
         assert( cols.first <= cols.second );
         assert( rowIdx >= 0 and rowIdx < nrows(A));
         using idx_t = typename legacyMatrix<T>::idx_t;
-        return legacyVector<T,idx_t>( cols.second-cols.first, &A(rowIdx,cols.first), A.ldim );
+        return legacyVector<T,idx_t>( cols.second-cols.first, &A(rowIdx,cols.first), layout == Layout::ColMajor ? A.ldim : 1 );
     }
     
     // Slice
@@ -174,7 +174,8 @@ namespace tlapack {
         assert( rows.second >= 0 and rows.second <= nrows(A));
         assert( rows.first <= rows.second );
         assert( colIdx >= 0 and colIdx < ncols(A));
-        return legacyVector<T>( rows.second-rows.first, &A(rows.first,colIdx) );
+        using idx_t = typename legacyMatrix<T>::idx_t;
+        return legacyVector<T,idx_t>( rows.second-rows.first, &A(rows.first,colIdx), layout == Layout::RowMajor ? A.ldim : 1 );
     }
     
     // Rows

--- a/include/testutils.hpp
+++ b/include/testutils.hpp
@@ -41,7 +41,7 @@ namespace tlapack
      * @return frobenius norm of res
      *
      * @param[in] A n by n matrix
-     * @param[in] Q n by n matrix
+     * @param[in] Q n by n unitary matrix
      * @param[in] H n by n matrix
      * @param[out] res n by n matrix as defined above
      * @param[out] work n by n workspace matrix
@@ -59,7 +59,7 @@ namespace tlapack
         tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, work, Q, (T)-1.0, res);
 
         // Compute ||res||_F/||A||_F
-        return tlapack::lange(tlapack::frob_norm, res) / tlapack::lange(tlapack::frob_norm, A);
+        return tlapack::lange(tlapack::frob_norm, res);
     }
 
 }

--- a/include/testutils.hpp
+++ b/include/testutils.hpp
@@ -1,0 +1,65 @@
+/// @file testutils.hpp
+/// @brief Utility functions for the unit tests
+//
+// Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of testBLAS.
+// testBLAS is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <tlapack.hpp>
+#include <plugins/tlapack_debugutils.hpp>
+
+
+namespace tlapack
+{
+    /** Calculates res = Q'*Q - I and the frobenius norm of res
+     *
+     * @return frobenius norm of res
+     *
+     * @param[in] Q n by n (almost) orthogonal matrix
+     * @param[out] res n by n matrix as defined above
+     *
+     * @ingroup auxiliary
+     */
+    template <class matrix_t>
+    real_type<type_t<matrix_t>> check_orthogonality(matrix_t &Q, matrix_t &res)
+    {
+        using T = type_t<matrix_t>;
+
+        // res = I
+        tlapack::laset(tlapack::Uplo::Upper, (T)0.0, (T)1.0, res);
+        // res = Q'Q - I
+        tlapack::herk( tlapack::Uplo::Upper, tlapack::Op::ConjTrans, (real_type<T>)1.0, Q, (real_type<T>)-1.0, res );
+
+        // Compute ||res||_F
+        return tlapack::lanhe(tlapack::frob_norm, tlapack::Uplo::Upper, res);
+    }
+
+    /** Calculates res = Q'*A*Q - H and the frobenius norm of res relative to the norm of A
+     *
+     * @return frobenius norm of res
+     *
+     * @param[in] A n by n matrix
+     * @param[in] Q n by n matrix
+     * @param[in] H n by n matrix
+     * @param[out] res n by n matrix as defined above
+     * @param[out] work n by n workspace matrix
+     *
+     * @ingroup auxiliary
+     */
+    template <class matrix_t>
+    real_type<type_t<matrix_t>> check_similarity_transform(matrix_t &A, matrix_t &Q, matrix_t &H, matrix_t &res, matrix_t &work)
+    {
+        using T = type_t<matrix_t>;
+
+        // res = Q'*A*Q - H
+        tlapack::lacpy(Uplo::General, H, res);
+        tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, work, Q, (T)-1.0, res);
+
+        // Compute ||res||_F/||A||_F
+        return tlapack::lange(tlapack::frob_norm, res) / tlapack::lange(tlapack::frob_norm, A);
+    }
+
+}

--- a/include/testutils.hpp
+++ b/include/testutils.hpp
@@ -7,12 +7,23 @@
 // testBLAS is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+#include <legacy_api/legacyArray.hpp>
 #include <tlapack.hpp>
-#include <plugins/tlapack_debugutils.hpp>
-
 
 namespace tlapack
 {
+
+    using types_to_test = std::tuple<
+        legacyMatrix<float, Layout::ColMajor>,
+        legacyMatrix<double, Layout::ColMajor>,
+        legacyMatrix<std::complex<float>, Layout::ColMajor>,
+        legacyMatrix<std::complex<double>, Layout::ColMajor>,
+        legacyMatrix<float, Layout::RowMajor>,
+        legacyMatrix<double, Layout::RowMajor>,
+        legacyMatrix<std::complex<float>, Layout::RowMajor>,
+        legacyMatrix<std::complex<double>, Layout::RowMajor>
+    >;
+
     /** Calculates res = Q'*Q - I and the frobenius norm of res
      *
      * @return frobenius norm of res
@@ -28,12 +39,12 @@ namespace tlapack
         using T = type_t<matrix_t>;
 
         // res = I
-        tlapack::laset(tlapack::Uplo::Upper, (T)0.0, (T)1.0, res);
+        laset(Uplo::Upper, (T)0.0, (T)1.0, res);
         // res = Q'Q - I
-        tlapack::herk( tlapack::Uplo::Upper, tlapack::Op::ConjTrans, (real_type<T>)1.0, Q, (real_type<T>)-1.0, res );
+        herk(Uplo::Upper, Op::ConjTrans, (real_type<T>)1.0, Q, (real_type<T>)-1.0, res);
 
         // Compute ||res||_F
-        return tlapack::lanhe(tlapack::frob_norm, tlapack::Uplo::Upper, res);
+        return lanhe(frob_norm, Uplo::Upper, res);
     }
 
     /** Calculates res = Q'*A*Q - H and the frobenius norm of res relative to the norm of A
@@ -54,12 +65,12 @@ namespace tlapack
         using T = type_t<matrix_t>;
 
         // res = Q'*A*Q - H
-        tlapack::lacpy(Uplo::General, H, res);
-        tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, work, Q, (T)-1.0, res);
+        lacpy(Uplo::General, H, res);
+        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
+        gemm(Op::NoTrans, Op::NoTrans, (T)1.0, work, Q, (T)-1.0, res);
 
         // Compute ||res||_F/||A||_F
-        return tlapack::lange(tlapack::frob_norm, res);
+        return lange(frob_norm, res);
     }
 
 }

--- a/include/testutils.hpp
+++ b/include/testutils.hpp
@@ -13,6 +13,17 @@
 namespace tlapack
 {
 
+    using real_types_to_test = std::tuple<
+        legacyMatrix<float, Layout::ColMajor>,
+        legacyMatrix<double, Layout::ColMajor>,
+        legacyMatrix<float, Layout::RowMajor>,
+        legacyMatrix<double, Layout::RowMajor>>;
+
+    using complex_types_to_test = std::tuple<
+        legacyMatrix<std::complex<float>, Layout::ColMajor>,
+        legacyMatrix<std::complex<double>, Layout::ColMajor>,
+        legacyMatrix<std::complex<float>, Layout::RowMajor>,
+        legacyMatrix<std::complex<double>, Layout::RowMajor>>;
     using types_to_test = std::tuple<
         legacyMatrix<float, Layout::ColMajor>,
         legacyMatrix<double, Layout::ColMajor>,
@@ -21,8 +32,7 @@ namespace tlapack
         legacyMatrix<float, Layout::RowMajor>,
         legacyMatrix<double, Layout::RowMajor>,
         legacyMatrix<std::complex<float>, Layout::RowMajor>,
-        legacyMatrix<std::complex<double>, Layout::RowMajor>
-    >;
+        legacyMatrix<std::complex<double>, Layout::RowMajor>>;
 
     /** Calculates res = Q'*Q - I and the frobenius norm of res
      *

--- a/include/testutils.hpp
+++ b/include/testutils.hpp
@@ -57,25 +57,25 @@ namespace tlapack
         return lanhe(frob_norm, Uplo::Upper, res);
     }
 
-    /** Calculates res = Q'*A*Q - H and the frobenius norm of res relative to the norm of A
+    /** Calculates res = Q'*A*Q - B and the frobenius norm of res relative to the norm of A
      *
      * @return frobenius norm of res
      *
      * @param[in] A n by n matrix
      * @param[in] Q n by n unitary matrix
-     * @param[in] H n by n matrix
+     * @param[in] B n by n matrix
      * @param[out] res n by n matrix as defined above
      * @param[out] work n by n workspace matrix
      *
      * @ingroup auxiliary
      */
     template <class matrix_t>
-    real_type<type_t<matrix_t>> check_similarity_transform(matrix_t &A, matrix_t &Q, matrix_t &H, matrix_t &res, matrix_t &work)
+    real_type<type_t<matrix_t>> check_similarity_transform(matrix_t &A, matrix_t &Q, matrix_t &B, matrix_t &res, matrix_t &work)
     {
         using T = type_t<matrix_t>;
 
-        // res = Q'*A*Q - H
-        lacpy(Uplo::General, H, res);
+        // res = Q'*A*Q - B
+        lacpy(Uplo::General, B, res);
         gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
         gemm(Op::NoTrans, Op::NoTrans, (T)1.0, work, Q, (T)-1.0, res);
 

--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -1,0 +1,49 @@
+/// @file testdefinitions.hpp
+/// @brief Definitions for the unit tests
+//
+// Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of testBLAS.
+// testBLAS is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <legacy_api/legacyArray.hpp>
+#include <tlapack.hpp>
+
+namespace tlapack
+{
+
+    // 
+    // List of matrix types that will be tested
+    // 
+    using types_to_test = std::tuple<
+        legacyMatrix<float, Layout::ColMajor>,
+        legacyMatrix<double, Layout::ColMajor>,
+        legacyMatrix<std::complex<float>, Layout::ColMajor>,
+        legacyMatrix<std::complex<double>, Layout::ColMajor>,
+        legacyMatrix<float, Layout::RowMajor>,
+        legacyMatrix<double, Layout::RowMajor>,
+        legacyMatrix<std::complex<float>, Layout::RowMajor>,
+        legacyMatrix<std::complex<double>, Layout::RowMajor>>;
+        
+    // 
+    // The matrix types that will be tested for routines
+    // that only accept real matrices
+    // 
+    using real_types_to_test = std::tuple<
+        legacyMatrix<float, Layout::ColMajor>,
+        legacyMatrix<double, Layout::ColMajor>,
+        legacyMatrix<float, Layout::RowMajor>,
+        legacyMatrix<double, Layout::RowMajor>>;
+
+    // 
+    // The matrix types that will be tested for routines
+    // that only accept complex matrices
+    // 
+    using complex_types_to_test = std::tuple<
+        legacyMatrix<std::complex<float>, Layout::ColMajor>,
+        legacyMatrix<std::complex<double>, Layout::ColMajor>,
+        legacyMatrix<std::complex<float>, Layout::RowMajor>,
+        legacyMatrix<std::complex<double>, Layout::RowMajor>>;
+
+}

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -13,27 +13,6 @@
 namespace tlapack
 {
 
-    using real_types_to_test = std::tuple<
-        legacyMatrix<float, Layout::ColMajor>,
-        legacyMatrix<double, Layout::ColMajor>,
-        legacyMatrix<float, Layout::RowMajor>,
-        legacyMatrix<double, Layout::RowMajor>>;
-
-    using complex_types_to_test = std::tuple<
-        legacyMatrix<std::complex<float>, Layout::ColMajor>,
-        legacyMatrix<std::complex<double>, Layout::ColMajor>,
-        legacyMatrix<std::complex<float>, Layout::RowMajor>,
-        legacyMatrix<std::complex<double>, Layout::RowMajor>>;
-    using types_to_test = std::tuple<
-        legacyMatrix<float, Layout::ColMajor>,
-        legacyMatrix<double, Layout::ColMajor>,
-        legacyMatrix<std::complex<float>, Layout::ColMajor>,
-        legacyMatrix<std::complex<double>, Layout::ColMajor>,
-        legacyMatrix<float, Layout::RowMajor>,
-        legacyMatrix<double, Layout::RowMajor>,
-        legacyMatrix<std::complex<float>, Layout::RowMajor>,
-        legacyMatrix<std::complex<double>, Layout::RowMajor>>;
-
     /** Calculates res = Q'*Q - I and the frobenius norm of res
      *
      * @return frobenius norm of res

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -11,59 +11,11 @@
 #include <plugins/tlapack_stdvector.hpp>
 #include <plugins/tlapack_debugutils.hpp>
 #include <tlapack.hpp>
+#include <testutils.hpp>
 #include <iostream>
 #include <iomanip>
 
 using namespace tlapack;
-
-/** Calculates res = Q'*Q - I and the frobenius norm of res
- *
- * @return frobenius norm of res
- *
- * @param[in] Q n by n (almost) orthogonal matrix
- * @param[out] res n by n matrix as defined above
- *
- * @ingroup auxiliary
- */
-template <class matrix_t>
-real_type<type_t<matrix_t>> check_orthogonality(matrix_t &Q, matrix_t &res)
-{
-    using T = type_t<matrix_t>;
-
-    // res = I
-    tlapack::laset(tlapack::Uplo::General, (T)0.0, (T)1.0, res);
-    // res = Q'Q - I
-    tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, Q, (T)-1.0, res);
-
-    // Compute ||res||_F
-    return tlapack::lansy(tlapack::frob_norm, tlapack::Uplo::Upper, res);
-}
-
-/** Calculates res = Q'*A*Q - H and the frobenius norm of res relative to the norm of A
- *
- * @return frobenius norm of res
- *
- * @param[in] A n by n matrix
- * @param[in] Q n by n matrix
- * @param[in] H n by n matrix
- * @param[out] res n by n matrix as defined above
- * @param[out] work n by n workspace matrix
- *
- * @ingroup auxiliary
- */
-template <class matrix_t>
-real_type<type_t<matrix_t>> check_similarity_transform(matrix_t &A, matrix_t &Q, matrix_t &H, matrix_t &res, matrix_t &work)
-{
-    using T = type_t<matrix_t>;
-
-    // res = Q'*A*Q - H
-    tlapack::lacpy(Uplo::General, H, res);
-    tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
-    tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, work, Q, (T)-1.0, res);
-
-    // Compute ||res||_F/||A||_F
-    return tlapack::lange(tlapack::frob_norm, res) / tlapack::lange(tlapack::frob_norm, A);
-}
 
 TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", float, double, std::complex<float>, std::complex<double>)
 {

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -89,6 +89,7 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", f
         for (size_t j = 0; j < i; ++j)
             A(i, j) = (T)0.0;
     tlapack::lacpy(Uplo::General, A, H);
+    auto normA = tlapack::lange(tlapack::frob_norm, A);
 
     DYNAMIC_SECTION("GEHD2 with"
                     << " matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi)
@@ -109,7 +110,7 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", f
         CHECK(orth_res_norm <= tol);
 
         auto simil_res_norm = check_similarity_transform(A, Q, H, res, work);
-        CHECK(simil_res_norm <= tol);
+        CHECK(simil_res_norm <= tol*normA);
     }
     idx_t nb = GENERATE(2, 3);
     DYNAMIC_SECTION("GEHRD with"
@@ -135,6 +136,6 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", f
         CHECK(orth_res_norm <= tol);
 
         auto simil_res_norm = check_similarity_transform(A, Q, H, res, work);
-        CHECK(simil_res_norm <= tol);
+        CHECK(simil_res_norm <= tol*normA);
     }
 }

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -11,8 +11,7 @@
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>
-#include <iostream>
-#include <iomanip>
+#include <testdefinitions.hpp>
 
 using namespace tlapack;
 
@@ -54,7 +53,7 @@ void check_hess_reduction(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matr
     CHECK(simil_res_norm <= tol * normA);
 }
 
-TEMPLATE_LIST_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", types_to_test)
+TEMPLATE_LIST_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues][hessenberg]", types_to_test)
 {
     srand(1);
 

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -1,0 +1,147 @@
+/// @file test_gehrd.cpp
+/// @brief Test hessenberg reduction
+//
+// Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of testBLAS.
+// testBLAS is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <catch2/catch.hpp>
+#include <plugins/tlapack_stdvector.hpp>
+#include <plugins/tlapack_debugutils.hpp>
+#include <tlapack.hpp>
+#include <iostream>
+#include <iomanip>
+
+using namespace tlapack;
+
+/** Calculates res = Q'*Q - I and the frobenius norm of res
+ *
+ * @return frobenius norm of res
+ *
+ * @param[in] Q n by n (almost) orthogonal matrix
+ * @param[out] res n by n matrix as defined above
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t>
+real_type<type_t<matrix_t>> check_orthogonality(matrix_t &Q, matrix_t &res)
+{
+    using T = type_t<matrix_t>;
+
+    // res = I
+    tlapack::laset(tlapack::Uplo::General, (T)0.0, (T)1.0, res);
+    // res = Q'Q - I
+    tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, Q, (T)-1.0, res);
+
+    // Compute ||res||_F
+    return tlapack::lansy(tlapack::frob_norm, tlapack::Uplo::Upper, res);
+}
+
+/** Calculates res = Q'*A*Q - H and the frobenius norm of res relative to the norm of A
+ *
+ * @return frobenius norm of res
+ *
+ * @param[in] A n by n matrix
+ * @param[in] Q n by n matrix
+ * @param[in] H n by n matrix
+ * @param[out] res n by n matrix as defined above
+ * @param[out] work n by n workspace matrix
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t>
+real_type<type_t<matrix_t>> check_similarity_transform(matrix_t &A, matrix_t &Q, matrix_t &H, matrix_t &res, matrix_t &work)
+{
+    using T = type_t<matrix_t>;
+
+    // res = Q'*A*Q - H
+    tlapack::lacpy(Uplo::General, H, res);
+    tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
+    tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, work, Q, (T)-1.0, res);
+
+    // Compute ||res||_F/||A||_F
+    return tlapack::lange(tlapack::frob_norm, res) / tlapack::lange(tlapack::frob_norm, A);
+}
+
+TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", float, double, std::complex<float>, std::complex<double>)
+{
+
+    using T = TestType;
+    using idx_t = std::size_t;
+    using real_t = real_type<T>;
+    using tlapack::internal::colmajor_matrix;
+    using pair = pair<idx_t, idx_t>;
+
+    // Generate n
+    idx_t n = GENERATE(1, 2, 3, 5, 10);
+    // Generate ilo and ihi
+    idx_t ilo_offset = GENERATE(0, 1);
+    idx_t ihi_offset = GENERATE(0, 1);
+    idx_t ilo = n > 1 ? ilo_offset : 0;
+    idx_t ihi = n > 1 + ilo_offset ? n - ihi_offset : n;
+
+    const real_t eps = uroundoff<real_t>();
+    const real_t tol = n * 1.0e2 * eps;
+
+    // Define the matrices and vectors
+    std::unique_ptr<T[]> _A(new T[n * n]);
+    std::unique_ptr<T[]> _H(new T[n * n]);
+    std::unique_ptr<T[]> _Q(new T[n * n]);
+
+    auto A = colmajor_matrix<T>(&_A[0], n, n);
+    auto H = colmajor_matrix<T>(&_H[0], n, n);
+    auto Q = colmajor_matrix<T>(&_Q[0], n, n);
+    std::vector<T> tau(n);
+    std::vector<T> workv(n);
+
+    // Generate a random matrix in A
+    for (size_t j = 0; j < n; ++j)
+        for (size_t i = 0; i < n; ++i)
+            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    // Make sure ilo and ihi correspond to the actual matrix
+    for (size_t j = 0; j < ilo; ++j)
+        for (size_t i = j + 1; i < n; ++i)
+            A(i, j) = (T)0.0;
+    for (size_t i = ihi; i < n; ++i)
+        for (size_t j = 0; j < i; ++j)
+            A(i, j) = (T)0.0;
+    tlapack::lacpy(Uplo::General, A, H);
+
+    int use_gehd2_or_gehrd = GENERATE(0, 1);
+    if (use_gehd2_or_gehrd == 0)
+    {
+        tlapack::gehd2(ilo, ihi, H, tau, workv);
+    }
+    else
+    {
+        gehrd_opts_t<idx_t, T> opts = {.nb = 2, .nx_switch = 2};
+        idx_t required_workspace = get_work_gehrd(ilo, ihi, A, tau, opts);
+        std::unique_ptr<T[]> _work(new T[required_workspace]);
+        opts._work = &_work[0];
+        opts.lwork = required_workspace;
+        tlapack::gehrd(ilo, ihi, H, tau, opts);
+    }
+
+    // Generate orthogonal matrix Q
+    tlapack::lacpy(Uplo::General, H, Q);
+    tlapack::unghr(ilo, ihi, Q, tau, workv);
+
+    // Remove junk from lower half of H
+    for (size_t j = 0; j < n; ++j)
+        for (size_t i = j + 2; i < n; ++i)
+            H(i, j) = 0.0;
+
+    // Calculate residuals
+    std::unique_ptr<T[]> _res(new T[n * n]);
+    std::unique_ptr<T[]> _work(new T[n * n]);
+    auto res = colmajor_matrix<T>(&_res[0], n, n);
+    auto work = colmajor_matrix<T>(&_work[0], n, n);
+
+    auto orth_res_norm = check_orthogonality(Q, res);
+    CHECK(orth_res_norm <= tol);
+
+    auto simil_res_norm = check_similarity_transform(A, Q, H, res, work);
+    CHECK(simil_res_norm <= tol);
+}

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -17,12 +17,13 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", float, double, std::complex<float>, std::complex<double>)
+TEMPLATE_LIST_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", types_to_test)
 {
     srand(1);
 
-    using T = TestType;
-    using idx_t = std::size_t;
+    using matrix_t = TestType;
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
     using real_t = real_type<T>;
     using tlapack::internal::colmajor_matrix;
     using pair = pair<idx_t, idx_t>;
@@ -57,11 +58,12 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues]", f
     std::unique_ptr<T[]> _res(new T[n * n]);
     std::unique_ptr<T[]> _work(new T[n * n]);
 
-    auto A = colmajor_matrix<T>(&_A[0], n, n);
-    auto H = colmajor_matrix<T>(&_H[0], n, n);
-    auto Q = colmajor_matrix<T>(&_Q[0], n, n);
-    auto res = colmajor_matrix<T>(&_res[0], n, n);
-    auto work = colmajor_matrix<T>(&_work[0], n, n);
+    // This only works for legacy matrix, we really work on that construct_matrix function
+    auto A = legacyMatrix<T,layout<matrix_t>>(n, n, &_A[0], n);
+    auto H = legacyMatrix<T,layout<matrix_t>>(n, n, &_H[0], n);
+    auto Q = legacyMatrix<T,layout<matrix_t>>(n, n, &_Q[0], n);
+    auto res = legacyMatrix<T,layout<matrix_t>>(n, n, &_res[0], n);
+    auto work = legacyMatrix<T,layout<matrix_t>>(n, n, &_work[0], n);
     std::vector<T> tau(n);
     std::vector<T> workv(n);
 

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -9,7 +9,6 @@
 
 #include <catch2/catch.hpp>
 #include <plugins/tlapack_stdvector.hpp>
-#include <plugins/tlapack_debugutils.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>
 #include <iostream>

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -11,13 +11,11 @@
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>
-
-#include <iostream>
-#include <iomanip>
+#include <testdefinitions.hpp>
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("sylvester solver gives correct result", "[utils]", real_types_to_test)
+TEMPLATE_LIST_TEST_CASE("sylvester solver gives correct result", "[sylvester]", real_types_to_test)
 {
     srand(1);
 

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -8,137 +8,76 @@
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <catch2/catch.hpp>
+#include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
+#include <testutils.hpp>
+
 #include <iostream>
 #include <iomanip>
 
 using namespace tlapack;
 
-// This should really be moved to test utils or something
-template <typename matrix_t>
-inline void printMatrix(const matrix_t &A)
+TEMPLATE_LIST_TEST_CASE("sylvester solver gives correct result", "[utils]", real_types_to_test)
 {
-    using idx_t = size_type<matrix_t>;
-    const idx_t m = nrows(A);
-    const idx_t n = ncols(A);
+    srand(1);
 
-    for (idx_t i = 0; i < m; ++i)
+    using matrix_t = TestType;
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    typedef real_type<T> real_t;
+    typedef std::complex<real_t> complex_t;
+
+    const T zero(0);
+    const T one(1);
+    idx_t n1 = GENERATE(1, 2);
+    // Once 1x2 solver is finished, generate n2 independantly
+    idx_t n2 = n1;
+    const real_t eps = uroundoff<real_t>();
+    const real_t tol = 1.0e2 * eps;
+
+    std::unique_ptr<T[]> _TL(new T[n1 * n1]);
+    std::unique_ptr<T[]> _TR(new T[n2 * n2]);
+    std::unique_ptr<T[]> _B(new T[n1 * n2]);
+    std::unique_ptr<T[]> _X(new T[n1 * n2]);
+    std::unique_ptr<T[]> _X_exact(new T[n1 * n2]);
+
+    auto TL = legacyMatrix<T, layout<matrix_t>>(n1, n1, &_TL[0], n1);
+    auto TR = legacyMatrix<T, layout<matrix_t>>(n2, n2, &_TR[0], n2);
+    auto B = legacyMatrix<T, layout<matrix_t>>(n1, n2, &_B[0], layout<matrix_t> == Layout::ColMajor ? n1 : n2);
+    auto X = legacyMatrix<T, layout<matrix_t>>(n1, n2, &_X[0], layout<matrix_t> == Layout::ColMajor ? n1 : n2);
+    auto X_exact = legacyMatrix<T, layout<matrix_t>>(n1, n2, &_X_exact[0], layout<matrix_t> == Layout::ColMajor ? n1 : n2);
+
+    for (idx_t i = 0; i < n1; ++i)
+        for (idx_t j = 0; j < n1; ++j)
+            TL(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+
+    for (idx_t i = 0; i < n2; ++i)
+        for (idx_t j = 0; j < n2; ++j)
+            TR(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+
+    for (idx_t i = 0; i < n1; ++i)
+        for (idx_t j = 0; j < n2; ++j)
+            X_exact(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+
+    Op trans_l = Op::NoTrans;
+    Op trans_r = Op::NoTrans;
+
+    int sign = 1;
+
+    // Calculate op(TL)*X + ISGN*X*op(TR)
+    gemm(trans_l, Op::NoTrans, one, TL, X_exact, zero, B);
+    gemm(Op::NoTrans, trans_r, sign, X_exact, TR, one, B);
+
+
+    DYNAMIC_SECTION("n1 = " << n1 << " n2 =" << n2)
     {
-        std::cout << std::endl;
-        for (idx_t j = 0; j < n; ++j)
-            std::cout << std::setw(16) << A(i, j) << " ";
+        // Solve sylvester equation
+        T scale, xnorm;
+        lasy2(Op::NoTrans, Op::NoTrans, 1, TL, TR, B, scale, X, xnorm);
+
+        // Check that X_exact == X
+        for (idx_t i = 0; i < n1; ++i)
+            for (idx_t j = 0; j < n2; ++j)
+                CHECK(abs1(X_exact(i, j) - scale * X(i, j)) <= tol * X_exact(i, j));
     }
 }
-
-TEST_CASE( "1x1 sylvester solver gives correct result", "[utils]" ) {
-
-    typedef float T;
-    typedef std::size_t idx_t;
-    typedef real_type<T> real_t;
-    typedef std::complex<real_t> complex_t;
-
-    using internal::colmajor_matrix;
-
-    const T zero(0);
-    const T one(1);
-    const idx_t n1 = 1;
-    const idx_t n2 = 1;
-    const real_t eps = uroundoff<real_t>();
-
-    Op trans_l = Op::NoTrans;
-    Op trans_r = Op::NoTrans;
-
-    std::unique_ptr<T[]> _TL(new T[n1*n1]);
-    auto TL = colmajor_matrix<T>(&_TL[0], n1, n1);
-
-    std::unique_ptr<T[]> _TR(new T[n2*n2]);
-    auto TR = colmajor_matrix<T>(&_TR[0], n2, n2);
-
-    std::unique_ptr<T[]> _B(new T[n1*n2]);
-    auto B = colmajor_matrix<T>(&_B[0], n1, n2);
-
-    std::unique_ptr<T[]> _X(new T[n1 * n2]);
-    auto X = colmajor_matrix<T>(&_X[0], n1, n2);
-
-    std::unique_ptr<T[]> _X_exact(new T[n1 * n2]);
-    auto X_exact = colmajor_matrix<T>(&_X_exact[0], n1, n2);
-
-    TL(0,0) = 1.0;
-    TR(0,0) = 5.0;
-    X_exact(0,0) = 5.5;
-    int sign = 1;
-
-    // Calculate op(TL)*X + ISGN*X*op(TR)
-    gemm( trans_l, Op::NoTrans, one, TL, X_exact, zero, B );
-    gemm( Op::NoTrans, trans_r, sign, X_exact, TR, one, B );
-
-
-    T scale, xnorm;
-    lasy2( Op::NoTrans, Op::NoTrans, 1, TL, TR, B, scale, X, xnorm );
-
-    CHECK( X_exact(0,0) == Approx( scale * X(0,0) ) );
-
-}
-
-TEST_CASE( "2x2 sylvester solver gives correct result", "[utils]" ) {
-
-    typedef float T;
-    typedef std::size_t idx_t;
-    typedef real_type<T> real_t;
-    typedef std::complex<real_t> complex_t;
-
-    using internal::colmajor_matrix;
-
-    const T zero(0);
-    const T one(1);
-    const idx_t n1 = 2;
-    const idx_t n2 = 2;
-    const real_t eps = uroundoff<real_t>();
-
-    std::unique_ptr<T[]> _TL(new T[n1*n1]);
-    auto TL = colmajor_matrix<T>(&_TL[0], n1, n1);
-
-    std::unique_ptr<T[]> _TR(new T[n2*n2]);
-    auto TR = colmajor_matrix<T>(&_TR[0], n2, n2);
-
-    std::unique_ptr<T[]> _B(new T[n1*n2]);
-    auto B = colmajor_matrix<T>(&_B[0], n1, n2);
-
-    std::unique_ptr<T[]> _X(new T[n1 * n2]);
-    auto X = colmajor_matrix<T>(&_X[0], n1, n2);
-
-    std::unique_ptr<T[]> _X_exact(new T[n1 * n2]);
-    auto X_exact = colmajor_matrix<T>(&_X_exact[0], n1, n2);
-
-    for( idx_t i = 0; i < n1; ++i )
-        for( idx_t j = 0; j < n1; ++j )
-            TL(i,j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    for( idx_t i = 0; i < n2; ++i )
-        for( idx_t j = 0; j < n2; ++j )
-            TR(i,j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    for( idx_t i = 0; i < n1; ++i )
-        for( idx_t j = 0; j < n2; ++j )
-            X_exact(i,j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    Op trans_l = Op::NoTrans;
-    Op trans_r = Op::NoTrans;
-
-    int sign = 1;
-
-    // Calculate op(TL)*X + ISGN*X*op(TR)
-    gemm( trans_l, Op::NoTrans, one, TL, X_exact, zero, B );
-    gemm( Op::NoTrans, trans_r, sign, X_exact, TR, one, B );
-
-    // Solve sylvester equation
-    T scale, xnorm;
-    lasy2( Op::NoTrans, Op::NoTrans, 1, TL, TR, B, scale, X, xnorm );
-
-    // Check that X_exact == X
-    for( idx_t i = 0; i < n1; ++i )
-        for( idx_t j = 0; j < n2; ++j )
-            CHECK( X_exact(i,j) == Approx( scale * X(i,j) ) );
-
-}
-

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -11,10 +11,11 @@
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>
+#include <testdefinitions.hpp>
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("move of eigenvalue block gives correct results", "[utils]", types_to_test)
+TEMPLATE_LIST_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalues]", types_to_test)
 {
     srand(1);
 

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -14,7 +14,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("forward move of 1x1 block gives correct results", "[utils]", types_to_test)
+TEMPLATE_LIST_TEST_CASE("move of eigenvalue block gives correct results", "[utils]", types_to_test)
 {
     srand(1);
 
@@ -29,8 +29,8 @@ TEMPLATE_LIST_TEST_CASE("forward move of 1x1 block gives correct results", "[uti
     idx_t n = 10;
 
     idx_t n1, n2, ifst, ilst;
-    ifst = GENERATE(0, 1, 6, 9);
-    ilst = GENERATE(0, 1, 6, 9);
+    ifst = GENERATE(0, 2, 6, 9);
+    ilst = GENERATE(0, 2, 6, 9);
 
     if (is_complex<T>::value)
     {
@@ -42,6 +42,12 @@ TEMPLATE_LIST_TEST_CASE("forward move of 1x1 block gives correct results", "[uti
         n1 = GENERATE(1, 2);
         n2 = GENERATE(1, 2);
     }
+
+    // ifst and ilst point to the same block, n1 must be equal to n2 for
+    // the test to make sense.
+    if (ifst == ilst and n1 != n2)
+        n2 = n1;
+
     const real_t eps = uroundoff<real_t>();
     const real_t tol = 1.0e2 * n * eps;
 
@@ -79,7 +85,7 @@ TEMPLATE_LIST_TEST_CASE("forward move of 1x1 block gives correct results", "[uti
 
     if( !is_complex<T>::value ){
         // Put a 2x2 block in the middle
-        A(4, 3) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+        A(5, 4) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     }
 
     lacpy(Uplo::General, A, A_copy);

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -8,54 +8,52 @@
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <catch2/catch.hpp>
+#include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
-#include <iostream>
-#include <iomanip>
+#include <testutils.hpp>
 
 using namespace tlapack;
 
-// This should really be moved to test utils or something
-template <typename matrix_t>
-inline void printMatrix(const matrix_t &A)
+TEMPLATE_LIST_TEST_CASE("forward move of 1x1 block gives correct results", "[utils]", types_to_test)
 {
+    srand(1);
+
+    using matrix_t = TestType;
+    using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    const idx_t m = nrows(A);
-    const idx_t n = ncols(A);
-
-    for (idx_t i = 0; i < m; ++i)
-    {
-        std::cout << std::endl;
-        for (idx_t j = 0; j < n; ++j)
-            std::cout << std::setw(16) << A(i, j) << " ";
-    }
-}
-
-TEST_CASE("forward move of 1x1 block gives correct results", "[utils]")
-{
-
-    typedef float T;
-    typedef std::size_t idx_t;
     typedef real_type<T> real_t;
     typedef std::complex<real_t> complex_t;
 
-    using internal::colmajor_matrix;
-
     const T zero(0);
     const T one(1);
-    idx_t ifst = 1;
-    idx_t ilst = 6;
-    const idx_t n = 10;
+    idx_t n = 10;
+
+    idx_t n1, n2, ifst, ilst;
+    ifst = GENERATE(0, 1, 6, 9);
+    ilst = GENERATE(0, 1, 6, 9);
+
+    if (is_complex<T>::value)
+    {
+        n1 = 1;
+        n2 = 1;
+    }
+    else
+    {
+        n1 = GENERATE(1, 2);
+        n2 = GENERATE(1, 2);
+    }
     const real_t eps = uroundoff<real_t>();
+    const real_t tol = 1.0e2 * n * eps;
 
     std::unique_ptr<T[]> _A(new T[n * n]);
-    auto A = colmajor_matrix<T>(&_A[0], n, n);
-
     std::unique_ptr<T[]> _Q(new T[n * n]);
-    auto Q = colmajor_matrix<T>(&_Q[0], n, n);
-
     std::unique_ptr<T[]> _A_copy(new T[n * n]);
-    auto A_copy = colmajor_matrix<T>(&_A_copy[0], n, n);
 
+    auto A = legacyMatrix<T, layout<matrix_t>>(n, n, &_A[0], n);
+    auto Q = legacyMatrix<T, layout<matrix_t>>(n, n, &_Q[0], n);
+    auto A_copy = legacyMatrix<T, layout<matrix_t>>(n, n, &_A_copy[0], n);
+
+    // Generate random matrix in Schur form
     for (idx_t j = 0; j < n; ++j)
         for (idx_t i = 0; i < n; ++i)
             A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
@@ -64,379 +62,44 @@ TEST_CASE("forward move of 1x1 block gives correct results", "[utils]")
         for (idx_t i = j + 1; i < n; ++i)
             A(i, j) = zero;
 
-    A(4, 3) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    if (n1 == 2)
+    {
+        if (ifst < n - 1)
+            A(ifst + 1, ifst) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+        else
+            A(ifst, ifst - 1) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    }
+    if (n2 == 2)
+    {
+        if (ilst < n - 1)
+            A(ilst + 1, ilst) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+        else
+            A(ilst, ilst - 1) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    }
+
+    if( !is_complex<T>::value ){
+        // Put a 2x2 block in the middle
+        A(4, 3) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    }
 
     lacpy(Uplo::General, A, A_copy);
     laset(Uplo::General, zero, one, Q);
 
-    schur_move(true, A, Q, ifst, ilst);
-
-    T norm_orth_1, norm_repres_1;
-    const bool verbose = false;
-    // 2) Compute ||Q'Q - I||_F
+    DYNAMIC_SECTION("ifst = " << ifst << " n1 = " << n1 << " ilst = " << ilst << " n2 =" << n2)
     {
+        schur_move(true, A, Q, ifst, ilst);
+        // Calculate residuals
+
+        std::unique_ptr<T[]> _res(new T[n * n]);
         std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABE);
 
-        // work receives the identity n*n
-        laset(Uplo::General, (T)0.0, (T)1.0, work);
-        // work receives Q'Q - I
-        // syrk( Uplo::Upper, Op::ConjTrans, (T) 1.0, Q, (T) -1.0, work );
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, Q, (T)-1.0, work);
-
-        // Compute ||Q'Q - I||_F
-        norm_orth_1 = lansy(frob_norm, Uplo::Upper, work);
-
-        CHECK(norm_orth_1 <= 1.0e2 * eps);
-
-        if (verbose)
-        {
-            std::cout << std::endl
-                      << "Q'Q-I = ";
-            printMatrix(work);
-        }
-    }
-
-    // 3) Compute Q*A_copyQ
-
-    if (verbose)
-    {
-        std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABC);
-
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, A_copy, (T)0.0, work);
-        gemm(Op::NoTrans, Op::NoTrans, (T)1.0, work, Q, (T)0.0, A_copy);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ = ";
-        printMatrix(A_copy);
-
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                A_copy(i, j) -= A(i, j);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ - A = ";
-        printMatrix(A_copy);
-
-        // Compute ||Q'Q - I||_F
-        norm_repres_1 = lange(frob_norm, A_copy);
-
-        CHECK(norm_repres_1 <= 1.0e2 * eps);
-    }
-}
-
-TEST_CASE("forward move of 2x2 block gives correct results", "[utils]")
-{
-
-    typedef float T;
-    typedef std::size_t idx_t;
-    typedef real_type<T> real_t;
-    typedef std::complex<real_t> complex_t;
-
-    using internal::colmajor_matrix;
-
-    const T zero(0);
-    const T one(1);
-    idx_t ifst = 1;
-    idx_t ilst = 6;
-    const idx_t n = 10;
-    const real_t eps = uroundoff<real_t>();
-
-    std::unique_ptr<T[]> _A(new T[n * n]);
-    auto A = colmajor_matrix<T>(&_A[0], n, n);
-
-    std::unique_ptr<T[]> _Q(new T[n * n]);
-    auto Q = colmajor_matrix<T>(&_Q[0], n, n);
-
-    std::unique_ptr<T[]> _A_copy(new T[n * n]);
-    auto A_copy = colmajor_matrix<T>(&_A_copy[0], n, n);
-
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i)
-            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = j + 1; i < n; ++i)
-            A(i, j) = zero;
-
-    A(2, 1) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    A(4, 3) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    lacpy(Uplo::General, A, A_copy);
-    laset(Uplo::General, zero, one, Q);
-
-    schur_move(true, A, Q, ifst, ilst);
-
-    T norm_orth_1, norm_repres_1;
-    const bool verbose = false;
-    // 2) Compute ||Q'Q - I||_F
-    {
-        std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABE);
-
-        // work receives the identity n*n
-        laset(Uplo::General, (T)0.0, (T)1.0, work);
-        // work receives Q'Q - I
-        // syrk( Uplo::Upper, Op::ConjTrans, (T) 1.0, Q, (T) -1.0, work );
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, Q, (T)-1.0, work);
-
-        // Compute ||Q'Q - I||_F
-        norm_orth_1 = lansy(frob_norm, Uplo::Upper, work);
-
-        CHECK(norm_orth_1 <= 1.0e2 * eps);
-
-        if (verbose)
-        {
-            std::cout << std::endl
-                      << "Q'Q-I = ";
-            printMatrix(work);
-        }
-    }
-
-    // 3) Compute Q*A_copyQ
-
-    if (verbose)
-    {
-        std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABC);
-
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, A_copy, (T)0.0, work);
-        gemm(Op::NoTrans, Op::NoTrans, (T)1.0, work, Q, (T)0.0, A_copy);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ = ";
-        printMatrix(A_copy);
-
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                A_copy(i, j) -= A(i, j);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ - A = ";
-        printMatrix(A_copy);
-
-        // Compute ||Q'Q - I||_F
-        norm_repres_1 = lange(frob_norm, A_copy);
-
-        CHECK(norm_repres_1 <= 1.0e2 * eps);
-    }
-}
-
-TEST_CASE("backward move of 1x1 block gives correct results", "[utils]")
-{
-
-    typedef float T;
-    typedef std::size_t idx_t;
-    typedef real_type<T> real_t;
-    typedef std::complex<real_t> complex_t;
-
-    using internal::colmajor_matrix;
-
-    const T zero(0);
-    const T one(1);
-    idx_t ifst = 6;
-    idx_t ilst = 0;
-    const idx_t n = 10;
-    const real_t eps = uroundoff<real_t>();
-
-    std::unique_ptr<T[]> _A(new T[n * n]);
-    auto A = colmajor_matrix<T>(&_A[0], n, n);
-
-    std::unique_ptr<T[]> _Q(new T[n * n]);
-    auto Q = colmajor_matrix<T>(&_Q[0], n, n);
-
-    std::unique_ptr<T[]> _A_copy(new T[n * n]);
-    auto A_copy = colmajor_matrix<T>(&_A_copy[0], n, n);
-
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i)
-            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = j + 1; i < n; ++i)
-            A(i, j) = zero;
-
-    A(4, 3) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    lacpy(Uplo::General, A, A_copy);
-    laset(Uplo::General, zero, one, Q);
-
-    schur_move(true, A, Q, ifst, ilst);
-
-    T norm_orth_1, norm_repres_1;
-    const bool verbose = false;
-    // 2) Compute ||Q'Q - I||_F
-    {
-        std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABE);
-
-        // work receives the identity n*n
-        laset(Uplo::General, (T)0.0, (T)1.0, work);
-        // work receives Q'Q - I
-        // syrk( Uplo::Upper, Op::ConjTrans, (T) 1.0, Q, (T) -1.0, work );
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, Q, (T)-1.0, work);
-
-        // Compute ||Q'Q - I||_F
-        norm_orth_1 = lansy(frob_norm, Uplo::Upper, work);
-
-        CHECK(norm_orth_1 <= 1.0e2 * eps);
-
-        if (verbose)
-        {
-            std::cout << std::endl
-                      << "Q'Q-I = ";
-            printMatrix(work);
-        }
-    }
-
-    // 3) Compute Q*A_copyQ
-
-    if (verbose)
-    {
-        std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABC);
-
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, A_copy, (T)0.0, work);
-        gemm(Op::NoTrans, Op::NoTrans, (T)1.0, work, Q, (T)0.0, A_copy);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ = ";
-        printMatrix(A_copy);
-
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                A_copy(i, j) -= A(i, j);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ - A = ";
-        printMatrix(A_copy);
-
-        // Compute ||Q'Q - I||_F
-        norm_repres_1 = lange(frob_norm, A_copy);
-
-        CHECK(norm_repres_1 <= 1.0e2 * eps);
-    }
-}
-
-TEST_CASE("backward move of 2x2 block gives correct results", "[utils]")
-{
-
-    typedef float T;
-    typedef std::size_t idx_t;
-    typedef real_type<T> real_t;
-    typedef std::complex<real_t> complex_t;
-
-    using internal::colmajor_matrix;
-
-    const T zero(0);
-    const T one(1);
-    idx_t ifst = 6;
-    idx_t ilst = 0;
-    const idx_t n = 10;
-    const real_t eps = uroundoff<real_t>();
-
-    std::unique_ptr<T[]> _A(new T[n * n]);
-    auto A = colmajor_matrix<T>(&_A[0], n, n);
-
-    std::unique_ptr<T[]> _Q(new T[n * n]);
-    auto Q = colmajor_matrix<T>(&_Q[0], n, n);
-
-    std::unique_ptr<T[]> _A_copy(new T[n * n]);
-    auto A_copy = colmajor_matrix<T>(&_A_copy[0], n, n);
-
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i)
-            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = j + 1; i < n; ++i)
-            A(i, j) = zero;
-
-    A(4, 3) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-    A(7, 6) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-
-    lacpy(Uplo::General, A, A_copy);
-    laset(Uplo::General, zero, one, Q);
-
-    schur_move(true, A, Q, ifst, ilst);
-
-    T norm_orth_1, norm_repres_1;
-    const bool verbose = false;
-    // 2) Compute ||Q'Q - I||_F
-    {
-        std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABE);
-
-        // work receives the identity n*n
-        laset(Uplo::General, (T)0.0, (T)1.0, work);
-        // work receives Q'Q - I
-        // syrk( Uplo::Upper, Op::ConjTrans, (T) 1.0, Q, (T) -1.0, work );
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, Q, (T)-1.0, work);
-
-        // Compute ||Q'Q - I||_F
-        norm_orth_1 = lansy(frob_norm, Uplo::Upper, work);
-
-        CHECK(norm_orth_1 <= 1.0e2 * eps);
-
-        if (verbose)
-        {
-            std::cout << std::endl
-                      << "Q'Q-I = ";
-            printMatrix(work);
-        }
-    }
-
-    // 3) Compute Q*A_copyQ
-
-    if (verbose)
-    {
-        std::unique_ptr<T[]> _work(new T[n * n]);
-        auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = static_cast<float>(0xABADBABC);
-
-        gemm(Op::ConjTrans, Op::NoTrans, (T)1.0, Q, A_copy, (T)0.0, work);
-        gemm(Op::NoTrans, Op::NoTrans, (T)1.0, work, Q, (T)0.0, A_copy);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ = ";
-        printMatrix(A_copy);
-
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                A_copy(i, j) -= A(i, j);
-
-        std::cout << std::endl
-                  << "Q'A_copyQ - A = ";
-        printMatrix(A_copy);
-
-        // Compute ||Q'Q - I||_F
-        norm_repres_1 = lange(frob_norm, A_copy);
-
-        CHECK(norm_repres_1 <= 1.0e2 * eps);
+        auto res = legacyMatrix<T, layout<matrix_t>>(n, n, &_res[0], n);
+        auto work = legacyMatrix<T, layout<matrix_t>>(n, n, &_work[0], n);
+        auto orth_res_norm = check_orthogonality(Q, res);
+        CHECK(orth_res_norm <= tol);
+
+        auto normA = tlapack::lange(tlapack::frob_norm, A);
+        auto simil_res_norm = check_similarity_transform(A_copy, Q, A, res, work);
+        CHECK(simil_res_norm <= tol * normA);
     }
 }

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -12,10 +12,11 @@
 #include <plugins/tlapack_debugutils.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>
+#include <testdefinitions.hpp>
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("schur swap gives correct result", "[utils]", types_to_test)
+TEMPLATE_LIST_TEST_CASE("schur swap gives correct result", "[eigenvalues]", types_to_test)
 {    
     srand(1);
 


### PR DESCRIPTION
This PR adds a new test file for the Hessenberg reduction (and also fixes a few bugs i found while writing the tests)

It is a proposal for a pattern we can use for all tests. Several things I like:

- Template test cases to test 4 types with the same code
- Parameters are generated at the top of the file and reported in the dynamic sections. If a specific case fails, CATCH2 will then report the exact parameters used. You can then comment out the generator and replace it with a fixed value to run a single case. I have also made an issue in CATCH2 to maybe support only running a single dynamic section with a command line argument.