### PR TITLE
Add wrappers to all lv-3 BLAS

### DIFF
--- a/include/blas/gemv.hpp
+++ b/include/blas/gemv.hpp
@@ -45,7 +45,7 @@ template<
     class alpha_t, class beta_t >
 void gemv(
     Op trans,
-    const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
+    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
     const beta_t& beta, vectorY_t& y )
 {
     // data traits

--- a/include/blas/hemm.hpp
+++ b/include/blas/hemm.hpp
@@ -47,8 +47,20 @@ namespace tlapack {
  * @ingroup hemm
  */
 template<
-    class matrixA_t, class matrixB_t, class matrixC_t, 
-    class alpha_t, class beta_t >
+    class matrixA_t,
+    class matrixB_t,
+    class matrixC_t, 
+    class alpha_t,
+    class beta_t,
+    class T  = alpha_t,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    T >
+    > = 0
+>
 void hemm(
     Side side,
     Uplo uplo,

--- a/include/blas/hemv.hpp
+++ b/include/blas/hemv.hpp
@@ -42,7 +42,7 @@ template<
     class alpha_t, class beta_t >
 void hemv(
     Uplo uplo,
-    const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
+    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
     const beta_t& beta, vectorY_t& y )
 {
     // data traits

--- a/include/blas/her2k.hpp
+++ b/include/blas/her2k.hpp
@@ -57,7 +57,15 @@ template<
     enable_if_t<(
     /* Requires: */
         ! is_complex<beta_t>::value
-    ), int > = 0
+    ), int > = 0,
+    class T  = type_t<matrixA_t>,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    real_type<T> >
+    > = 0
 >
 void her2k(
     Uplo uplo,

--- a/include/blas/symm.hpp
+++ b/include/blas/symm.hpp
@@ -46,7 +46,16 @@ namespace tlapack {
  */
 template<
     class matrixA_t, class matrixB_t, class matrixC_t, 
-    class alpha_t, class beta_t >
+    class alpha_t, class beta_t,
+    class T  = alpha_t,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    T >
+    > = 0
+>
 void symm(
     Side side,
     Uplo uplo,

--- a/include/blas/symv.hpp
+++ b/include/blas/symv.hpp
@@ -40,7 +40,7 @@ template<
     class alpha_t, class beta_t >
 void symv(
     Uplo uplo,
-    const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
+    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
     const beta_t& beta, vectorY_t& y )
 {
     // data traits

--- a/include/blas/syr2k.hpp
+++ b/include/blas/syr2k.hpp
@@ -49,7 +49,16 @@ namespace tlapack {
  */
 template<
     class matrixA_t, class matrixB_t, class matrixC_t, 
-    class alpha_t, class beta_t >
+    class alpha_t, class beta_t,
+    class T  = alpha_t,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    T >
+    > = 0
+>
 void syr2k(
     Uplo uplo,
     Op trans,

--- a/include/blas/trmm.hpp
+++ b/include/blas/trmm.hpp
@@ -59,13 +59,20 @@ namespace tlapack {
  *
  * @ingroup trmm
  */
-template< class matrixA_t, class matrixB_t, class alpha_t >
+template< class matrixA_t, class matrixB_t, class alpha_t,
+    class T  = alpha_t,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
 void trmm(
     Side side,
     Uplo uplo,
     Op trans,
     Diag diag,
-    const alpha_t alpha,
+    const alpha_t& alpha,
     const matrixA_t& A,
     matrixB_t& B )
 {    

--- a/include/blas/trsm.hpp
+++ b/include/blas/trsm.hpp
@@ -76,7 +76,7 @@ void trsm(
     Uplo uplo,
     Op trans,
     Diag diag,
-    const alpha_t alpha,
+    const alpha_t& alpha,
     const matrixA_t& A,
     matrixB_t& B )
 {    

--- a/include/legacy_api/blas/wrappers.hpp
+++ b/include/legacy_api/blas/wrappers.hpp
@@ -48,10 +48,10 @@ inline
 void gemm(
     Op transA,
     Op transB,
-    alpha_t alpha,
+    const alpha_t alpha,
     const matrixA_t& A,
     const matrixB_t& B,
-    beta_t beta,
+    const beta_t beta,
     matrixC_t& C )
 {
     // Legacy objects
@@ -75,40 +75,74 @@ void gemm(
         _C.ptr, _C.ldim );
 }
 
-template< class matrixA_t, class matrixB_t, class alpha_t,
+/**
+ * Hermitian matrix-matrix multiply.
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see hemm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t& beta, matrixC_t& C )
+ * 
+ * @ingroup hemm
+ */
+template<
+    class matrixA_t,
+    class matrixB_t, 
+    class matrixC_t, 
+    class alpha_t, 
+    class beta_t,
     class T  = alpha_t,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,
-        pair< alpha_t,   T >
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    T >
     > = 0
 >
 inline
-void trsm(
+void hemm(
     Side side,
     Uplo uplo,
-    Op trans,
-    Diag diag,
-    const alpha_t alpha,
-    const matrixA_t& A,
-    matrixB_t& B )
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t beta, matrixC_t& C )
 {
     // Legacy objects
     auto _A = legacy_matrix(A);
     auto _B = legacy_matrix(B);
+    auto _C = legacy_matrix(C);
 
-    ::blas::trsm(
+    // Constants to forward
+    const auto& m = _C.m;
+    const auto& n = _C.n;
+
+    ::blas::hemm(
         (::blas::Layout) _A.layout,
-        (::blas::Side) side,
-        (::blas::Uplo) uplo,
-        (::blas::Op) trans,
-        (::blas::Diag) diag,
-        _B.m, _B.n,
+        (::blas::Side) side, (::blas::Uplo) uplo, 
+        m, n,
         alpha,
         _A.ptr, _A.ldim,
-        _B.ptr, _B.ldim );
+        _B.ptr, _B.ldim,
+        beta,
+        _C.ptr, _C.ldim );
 }
 
+/**
+ * Hermitian rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see herk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A,
+    const beta_t& beta, matrixC_t& C )
+ * 
+ * @ingroup herk
+ */
 template<
     class matrixA_t, class matrixC_t, 
     class alpha_t, class beta_t,
@@ -146,6 +180,131 @@ void herk(
         _C.ptr, _C.ldim );
 }
 
+/**
+ * Hermitian rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see her2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t& beta, matrixC_t& C )
+ * 
+ * @ingroup her2k
+ */
+template<
+    class matrixA_t, class matrixB_t, class matrixC_t, 
+    class alpha_t, class beta_t,
+    enable_if_t<(
+    /* Requires: */
+        ! is_complex<beta_t>::value
+    ), int > = 0,
+    class T  = type_t<matrixA_t>,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    real_type<T> >
+    > = 0
+>
+inline
+void her2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t beta, matrixC_t& C )
+{
+    // Legacy objects
+    auto _A = legacy_matrix(A);
+    auto _B = legacy_matrix(B);
+    auto _C = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& n = _C.n;
+    const auto& k = (trans == Op::NoTrans) ? _A.n : _A.m;
+
+    ::blas::her2k(
+        (::blas::Layout) _A.layout,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans, 
+        n, k,
+        alpha,
+        _A.ptr, _A.ldim,
+        _B.ptr, _B.ldim,
+        beta,
+        _C.ptr, _C.ldim );
+}
+
+/**
+ * Symmetric matrix-matrix multiply.
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see symm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t& beta, matrixC_t& C )
+ * 
+ * @ingroup symm
+ */
+template<
+    class matrixA_t,
+    class matrixB_t, 
+    class matrixC_t, 
+    class alpha_t, 
+    class beta_t,
+    class T  = alpha_t,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    T >
+    > = 0
+>
+inline
+void symm(
+    Side side,
+    Uplo uplo,
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t beta, matrixC_t& C )
+{
+    // Legacy objects
+    auto _A = legacy_matrix(A);
+    auto _B = legacy_matrix(B);
+    auto _C = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& m = _C.m;
+    const auto& n = _C.n;
+
+    ::blas::symm(
+        (::blas::Layout) _A.layout,
+        (::blas::Side) side, (::blas::Uplo) uplo, 
+        m, n,
+        alpha,
+        _A.ptr, _A.ldim,
+        _B.ptr, _B.ldim,
+        beta,
+        _C.ptr, _C.ldim );
+}
+
+/**
+ * Symmetric rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see syrk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A,
+    const beta_t& beta, matrixC_t& C )
+ * 
+ * @ingroup syrk
+ */
 template<
     class matrixA_t, class matrixC_t, 
     class alpha_t, class beta_t,
@@ -181,6 +340,151 @@ void syrk(
         _A.ptr, _A.ldim,
         beta,
         _C.ptr, _C.ldim );
+}
+
+/**
+ * Symmetric rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see syr2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t& beta, matrixC_t& C )
+ * 
+ * @ingroup syr2k
+ */
+template<
+    class matrixA_t, class matrixB_t, class matrixC_t, 
+    class alpha_t, class beta_t,
+    class T  = alpha_t,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >,
+        pair< beta_t,    T >
+    > = 0
+>
+inline
+void syr2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t beta, matrixC_t& C )
+{
+    // Legacy objects
+    auto _A = legacy_matrix(A);
+    auto _B = legacy_matrix(B);
+    auto _C = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& n = _C.n;
+    const auto& k = (trans == Op::NoTrans) ? _A.n : _A.m;
+
+    ::blas::syr2k(
+        (::blas::Layout) _A.layout,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans, 
+        n, k,
+        alpha,
+        _A.ptr, _A.ldim,
+        _B.ptr, _B.ldim,
+        beta,
+        _C.ptr, _C.ldim );
+}
+
+/**
+ * Triangular matrix-matrix multiply.
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see trmm(
+    Side side,
+    Uplo uplo,
+    Op trans,
+    Diag diag,
+    const alpha_t alpha,
+    const matrixA_t& A,
+    matrixB_t& B )
+ * 
+ * @ingroup trmm
+ */
+template< class matrixA_t, class matrixB_t, class alpha_t,
+    class T  = alpha_t,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void trmm(
+    Side side,
+    Uplo uplo,
+    Op trans,
+    Diag diag,
+    const alpha_t alpha,
+    const matrixA_t& A,
+    matrixB_t& B )
+{
+    // Legacy objects
+    auto _A = legacy_matrix(A);
+    auto _B = legacy_matrix(B);
+
+    // Constants to forward
+    const auto& m = _B.m;
+    const auto& n = _B.n;
+
+    ::blas::trmm(
+        (::blas::Layout) _A.layout,
+        (::blas::Side) side,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans,
+        (::blas::Diag) diag,
+        m, n,
+        alpha,
+        _A.ptr, _A.ldim,
+        _B.ptr, _B.ldim );
+}
+
+template< class matrixA_t, class matrixB_t, class alpha_t,
+    class T  = alpha_t,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void trsm(
+    Side side,
+    Uplo uplo,
+    Op trans,
+    Diag diag,
+    const alpha_t alpha,
+    const matrixA_t& A,
+    matrixB_t& B )
+{
+    // Legacy objects
+    auto _A = legacy_matrix(A);
+    auto _B = legacy_matrix(B);
+
+    // Constants to forward
+    const auto& m = _B.m;
+    const auto& n = _B.n;
+
+    ::blas::trsm(
+        (::blas::Layout) _A.layout,
+        (::blas::Side) side,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans,
+        (::blas::Diag) diag,
+        m, n,
+        alpha,
+        _A.ptr, _A.ldim,
+        _B.ptr, _B.ldim );
 }
 
 }  // namespace tlapack

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -129,7 +129,8 @@ TEMPLATE_LIST_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues
     DYNAMIC_SECTION("GEHRD with"
                     << " matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi << " nb = " << nb)
     {
-        gehrd_opts_t<idx_t, T> opts = {.nb = nb, .nx_switch = 2};
+        gehrd_opts_t<idx_t, T> opts;
+        opts.nb = nb; opts.nx_switch = 2;
         idx_t required_workspace = get_work_gehrd(ilo, ihi, A, tau, opts);
         std::unique_ptr<T[]> _work2(new T[required_workspace]);
         opts._work = &_work2[0];


### PR DESCRIPTION
This PR makes all lv-3 BLAS routines enable optimization via optmized BLAS (using BLAS++). The file 

https://github.com/weslleyspereira/tlapack/blob/try-all-lv3-blas-with-optmizedWrappers/include/legacy_api/blas/wrappers.hpp

has the lv-3 BLAS wrappers on \<T\>LAPACK.