### PR TITLE
Fix a couple of copyright information

### DIFF
--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -3,8 +3,8 @@
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <legacy_api/legacyArray.hpp>

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -3,8 +3,8 @@
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <legacy_api/legacyArray.hpp>

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -3,8 +3,8 @@
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <catch2/catch.hpp>

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -3,8 +3,8 @@
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <catch2/catch.hpp>

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -3,8 +3,8 @@
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <catch2/catch.hpp>

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -3,8 +3,8 @@
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <catch2/catch.hpp>

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -3,8 +3,8 @@
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <catch2/catch.hpp>


### PR DESCRIPTION
Fix a couple of copyright information. This was caused by the copy-and-paste of files from the testBLAS project