### PR TITLE
Deduces the type and size type automatically for matrices and vectors

### DIFF
--- a/include/base/arrayTraits.hpp
+++ b/include/base/arrayTraits.hpp
@@ -173,50 +173,6 @@ namespace tlapack {
     constexpr lowerTriangle_t lowerTriangle = { };
     constexpr strictUpper_t strictUpper = { };
     constexpr strictLower_t strictLower = { };
-
-    /**
-     * @brief Data type trait. Type of the entries of the array class.
-     * 
-     * The data type is defined on @c type_trait<array_t>::type.
-     * 
-     * @tparam array_t Array class.
-     */
-    template< class array_t > struct type_trait {
-        using type = void;
-    };
-    
-    /**
-     * @brief Size type trait. Index type used in the array class.
-     * 
-     * The size type is defined on @c sizet_trait<array_t>::type.
-     * 
-     * @tparam array_t Array class.
-     */
-    template< class array_t > struct sizet_trait {
-        using type = void;
-    };
-
-    /**
-     * @brief Trait to determine if a given list of data allows optimization
-     * using a optimized BLAS library.
-     */
-    template<class...>
-    struct allow_optblas {
-        static constexpr bool value = false; ///< True if the list of types
-                                             ///< allows optimized BLAS library.
-    };
-
-    /// Alias for @c type_trait<>::type.
-    template< class array_t >
-    using type_t = typename type_trait< array_t >::type;
-
-    /// Alias for @c sizet_trait<>::type.
-    template< class array_t >
-    using size_type = typename sizet_trait< array_t >::type;
-
-    /// Alias for @c allow_optblas<>::value.
-    template<class... Ts>
-    constexpr bool allow_optblas_v = allow_optblas< Ts... >::value;
 }
 
 #endif // __TLAPACK_ARRAY_TRAITS__

--- a/include/plugins/tlapack_debugutils.hpp
+++ b/include/plugins/tlapack_debugutils.hpp
@@ -15,7 +15,7 @@
 #include <fstream>
 
 #include "legacy_api/legacyArray.hpp"
-#include "base/types.hpp"
+#include "base/utils.hpp"
 
 namespace tlapack
 {

--- a/include/plugins/tlapack_eigen.hpp
+++ b/include/plugins/tlapack_eigen.hpp
@@ -9,58 +9,9 @@
 #define __TLAPACK_EIGEN_HH__
 
 #include <Eigen/Core>
-#include <type_traits>
 #include "base/arrayTraits.hpp"
 
 namespace tlapack{
-
-    // // -----------------------------------------------------------------------------
-    // // is_EigenBlock
-    
-    // template< class >
-    // struct is_EigenBlock : public std::false_type {};
-
-    // template< typename T, int R, int C, bool P >
-    // struct is_EigenBlock< Eigen::Block<T,R,C,P> > : public std::true_type {};
-
-    // -----------------------------------------------------------------------------
-    // Data traits for Eigen
-
-    // Data type
-    template<typename Scalar_, int Rows_, int Cols_, int Options_, int MaxRows_, int MaxCols_>
-    struct type_trait< Eigen::Matrix<Scalar_, Rows_, Cols_, Options_, MaxRows_, MaxCols_> > {
-        using type = Scalar_;
-    };
-    template<typename XprType, int BlockRows, int BlockCols, bool InnerPanel>
-    struct type_trait< Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel> > {
-        using type = typename XprType::Scalar;
-    };
-    template<class T>
-    struct type_trait< Eigen::VectorBlock<T> > {
-        using type = typename T::Scalar;
-    };
-    template<class T, int idx>
-    struct type_trait< Eigen::Diagonal<T,idx> > {
-        using type = typename T::Scalar;
-    };
-
-    // Size type
-    template<typename Scalar_, int Rows_, int Cols_, int Options_, int MaxRows_, int MaxCols_>
-    struct sizet_trait< Eigen::Matrix<Scalar_, Rows_, Cols_, Options_, MaxRows_, MaxCols_> > {
-        using type = Eigen::Index;
-    };
-    template<typename XprType, int BlockRows, int BlockCols, bool InnerPanel>
-    struct sizet_trait< Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel> > {
-        using type = Eigen::Index;
-    };
-    template<class T>
-    struct sizet_trait< Eigen::VectorBlock<T> > {
-        using type = Eigen::Index;
-    };
-    template<class T, int idx>
-    struct sizet_trait< Eigen::Diagonal<T,idx> > {
-        using type = Eigen::Index;
-    };
 
     // -----------------------------------------------------------------------------
     // blas functions to access Eigen properties

--- a/include/plugins/tlapack_legacyArray.hpp
+++ b/include/plugins/tlapack_legacyArray.hpp
@@ -19,42 +19,10 @@ namespace tlapack {
     // -----------------------------------------------------------------------------
     // Data traits
 
-    // Data type
-    template< typename T, Layout layout >
-    struct type_trait< legacyMatrix<T,layout> > { using type = T; };
-    // Size type
-    template< typename T, Layout layout >
-    struct sizet_trait< legacyMatrix<T,layout> > { using type = typename legacyMatrix<T>::idx_t; };
     // Layout
     template< typename T, Layout L >
     constexpr Layout layout< legacyMatrix<T,L> > = L;
-    
-    /// Specialization of has_blas_type for arrays.
-    template< typename T, Layout L >
-    struct allow_optblas< legacyMatrix<T,L> > {
-        static constexpr bool value = allow_optblas_v<T>;
-    };
 
-    // Data type
-    template< typename T, typename int_t, Direction direction >
-    struct type_trait< legacyVector<T,int_t,direction> > { using type = T; };
-    // Size type
-    template< typename T, typename int_t, Direction direction >
-    struct sizet_trait< legacyVector<T,int_t,direction> > { using type = typename legacyVector<T>::idx_t; };
-    
-    /// Specialization of has_blas_type for arrays.
-    template< typename T, typename int_t, Direction direction >
-    struct allow_optblas< legacyVector<T,int_t,direction> > {
-        using type = T;
-        static constexpr bool value = allow_optblas_v<type>;
-    };
-
-    // Data type
-    template< typename T >
-    struct type_trait< legacyBandedMatrix<T> > { using type = T; };
-    // Size type
-    template< typename T >
-    struct sizet_trait< legacyBandedMatrix<T> > { using type = typename legacyBandedMatrix<T>::idx_t; };
     // Layout
     template< typename T >
     constexpr Layout layout< legacyBandedMatrix<T> > = Layout::BandStorage;

--- a/include/plugins/tlapack_mdspan.hpp
+++ b/include/plugins/tlapack_mdspan.hpp
@@ -8,7 +8,6 @@
 #define __TLAPACK_MDSPAN_HH__
 
 #include <experimental/mdspan>
-#include <type_traits>
 
 #include "base/arrayTraits.hpp"
 #include "legacy_api/legacyArray.hpp"
@@ -16,20 +15,6 @@
 namespace tlapack {
 
     using std::experimental::mdspan;
-
-    // -----------------------------------------------------------------------------
-    // Data traits for mdspan
-
-    // Data type
-    template< class ET, class Exts, class LP, class AP >
-    struct type_trait< mdspan<ET,Exts,LP,AP> > {
-        using type = ET;
-    };
-    // Size type
-    template< class ET, class Exts, class LP, class AP >
-    struct sizet_trait< mdspan<ET,Exts,LP,AP> > {
-        using type = typename mdspan<ET,Exts,LP,AP>::size_type;
-    };
 
     // -----------------------------------------------------------------------------
     // blas functions to access mdspan properties

--- a/include/plugins/tlapack_stdvector.hpp
+++ b/include/plugins/tlapack_stdvector.hpp
@@ -19,20 +19,6 @@
 namespace tlapack {
 
     // -----------------------------------------------------------------------------
-    // Data traits for std::vector
-
-    // Data type
-    template< class T, class Allocator >
-    struct type_trait< std::vector<T,Allocator> > {
-        using type = T;
-    };
-    // Size type
-    template< class T, class Allocator >
-    struct sizet_trait< std::vector<T,Allocator> > {
-        using type = typename std::vector<T,Allocator>::size_type;
-    };
-
-    // -----------------------------------------------------------------------------
     // blas functions to access std::vector properties
 
     // Size


### PR DESCRIPTION
implements the ideas from: https://github.com/tlapack/tlapack/discussions/51.

- Now `type_trait`, sizet_trait` and `allow_optblas` are deduced automatically.
- Hide some utilities into the namespace `internal`.
- Add the alias `tlapack::range<idx_t>` for `std::pair<idx_t,idx_t>`. Not using anywhere so far, but it should reduce wordiness.

We need tests for the utility functions! I open a new issue to relate this.