### PR TITLE
Fix bug in allow_optblas for matrices and vectors.

### DIFF
--- a/include/blas/axpy.hpp
+++ b/include/blas/axpy.hpp
@@ -22,9 +22,11 @@ namespace tlapack {
  * @ingroup axpy
  */
 template< class vectorX_t, class vectorY_t, class alpha_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 void axpy(

--- a/include/blas/copy.hpp
+++ b/include/blas/copy.hpp
@@ -21,9 +21,10 @@ namespace tlapack {
  * @ingroup copy
  */
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 void copy( const vectorX_t& x, vectorY_t& y )

--- a/include/blas/dot.hpp
+++ b/include/blas/dot.hpp
@@ -22,14 +22,15 @@ namespace tlapack {
  * @ingroup dot
  */
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 auto dot( const vectorX_t& x, const vectorY_t& y )
 {
-    using T = scalar_type<
+    using return_t = scalar_type<
         type_t< vectorX_t >,
         type_t< vectorY_t >
     >;
@@ -41,7 +42,7 @@ auto dot( const vectorX_t& x, const vectorY_t& y )
     // check arguments
     tlapack_check_false( size(y) != n );
 
-    T result( 0.0 );
+    return_t result( 0.0 );
     for (idx_t i = 0; i < n; ++i)
         result += conj(x[i]) * y[i];
 

--- a/include/blas/dotu.hpp
+++ b/include/blas/dotu.hpp
@@ -22,14 +22,15 @@ namespace tlapack {
  * @ingroup dotu
  */
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 auto dotu( const vectorX_t& x, const vectorY_t& y )
 {
-    using T = scalar_type<
+    using return_t = scalar_type<
         type_t< vectorX_t >,
         type_t< vectorY_t >
     >;
@@ -41,7 +42,7 @@ auto dotu( const vectorX_t& x, const vectorY_t& y )
     // check arguments
     tlapack_check_false( size(y) != n );
 
-    T result( 0.0 );
+    return_t result( 0.0 );
     for (idx_t i = 0; i < n; ++i)
         result += x[i] * y[i];
 

--- a/include/blas/gemm.hpp
+++ b/include/blas/gemm.hpp
@@ -50,7 +50,7 @@ template<
     class matrixC_t,
     class alpha_t,
     class beta_t,
-    class T  = alpha_t,
+    class T = type_t<matrixC_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/blas/gemv.hpp
+++ b/include/blas/gemv.hpp
@@ -43,11 +43,13 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t, 
     class alpha_t, class beta_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >,
-        pair< beta_t,    alpha_t >
+        pair< alpha_t,    T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >,
+        pair< beta_t,    T >
     > = 0
 >
 void gemv(

--- a/include/blas/ger.hpp
+++ b/include/blas/ger.hpp
@@ -31,10 +31,12 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 void ger(

--- a/include/blas/geru.hpp
+++ b/include/blas/geru.hpp
@@ -32,10 +32,12 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 void geru(

--- a/include/blas/hemm.hpp
+++ b/include/blas/hemm.hpp
@@ -52,7 +52,7 @@ template<
     class matrixC_t, 
     class alpha_t,
     class beta_t,
-    class T  = alpha_t,
+    class T = type_t<matrixC_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/blas/hemv.hpp
+++ b/include/blas/hemv.hpp
@@ -40,11 +40,13 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t, 
     class alpha_t, class beta_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >,
-        pair< beta_t,    alpha_t >
+        pair< alpha_t,   T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >,
+        pair< beta_t,    T >
     > = 0
 >
 void hemv(

--- a/include/blas/her.hpp
+++ b/include/blas/her.hpp
@@ -41,10 +41,11 @@ template< class matrixA_t, class vectorX_t, class alpha_t,
     /* Requires: */
         ! is_complex<alpha_t>::value
     ), int > = 0,
+    class T = type_t<matrixA_t>,
     disable_if_allow_optblas_t<
-        pair< alpha_t, real_type<type_t<matrixA_t>> >,
-        pair< matrixA_t, type_t<matrixA_t> >,
-        pair< vectorX_t, type_t<matrixA_t> >
+        pair< alpha_t, real_type<T> >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 void her(

--- a/include/blas/her2.hpp
+++ b/include/blas/her2.hpp
@@ -39,10 +39,12 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 void her2(

--- a/include/blas/her2k.hpp
+++ b/include/blas/her2k.hpp
@@ -58,7 +58,7 @@ template<
     /* Requires: */
         ! is_complex<beta_t>::value
     ), int > = 0,
-    class T  = type_t<matrixA_t>,
+    class T  = type_t<matrixC_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/blas/herk.hpp
+++ b/include/blas/herk.hpp
@@ -57,7 +57,7 @@ template<
         !is_complex<alpha_t>::value &&
         !is_complex<beta_t> ::value
     ), int > = 0,
-    class T  = type_t<matrixA_t>,
+    class T  = type_t<matrixC_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixC_t, T >,

--- a/include/blas/rot.hpp
+++ b/include/blas/rot.hpp
@@ -32,13 +32,12 @@ namespace tlapack {
 template<
     class vectorX_t, class vectorY_t,
     class c_type, class s_type,
-    class T = vectorX_t,
-    class real_t = real_type< T >,
+    class T = type_t<vectorX_t>,
     disable_if_allow_optblas_t<
         pair< vectorX_t, T >,
         pair< vectorY_t, T >,
-        pair< c_type, real_t >,
-        pair< s_type, real_t >
+        pair< c_type, real_type<T> >,
+        pair< s_type, real_type<T> >
     > = 0
 >
 void rot(

--- a/include/blas/rotg.hpp
+++ b/include/blas/rotg.hpp
@@ -29,26 +29,25 @@ namespace tlapack {
  *
  * @ingroup rotg
  */
-template <typename real_t,
-    disable_if_allow_optblas_t<
-        pair< real_t, real_type<real_t> >
-    > = 0
+template <typename T,
+    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
+    disable_if_allow_optblas_t< T > = 0
 >
 void rotg(
-    real_t& a, real_t& b,
-    real_t& c, real_t& s )
+    T& a, T& b,
+    T& c, T& s )
 {
     // Constants
-    const real_t one  = 1;
-    const real_t zero = 0;
+    const T one  = 1;
+    const T zero = 0;
 
     // Scaling constants
-    const real_t safmin = safe_min<real_t>();
-    const real_t safmax = safe_max<real_t>();
+    const T safmin = safe_min<T>();
+    const T safmax = safe_max<T>();
 
     // Norms
-    const real_t anorm = tlapack::abs(a);
-    const real_t bnorm = tlapack::abs(b);
+    const T anorm = tlapack::abs(a);
+    const T bnorm = tlapack::abs(b);
 
     // quick return
     if ( bnorm == zero ) {
@@ -63,11 +62,11 @@ void rotg(
         b = one;
     }
     else {
-        real_t scl = min( safmax, max(safmin, anorm, bnorm) );
-        real_t sigma = (anorm > bnorm)
+        T scl = min( safmax, max(safmin, anorm, bnorm) );
+        T sigma = (anorm > bnorm)
             ? sgn(a)
             : sgn(b);
-        real_t r = sigma * scl * sqrt( (a/scl) * (a/scl) + (b/scl) * (b/scl) );
+        T r = sigma * scl * sqrt( (a/scl) * (a/scl) + (b/scl) * (b/scl) );
         c = a / r;
         s = b / r;
         a = r;
@@ -103,6 +102,7 @@ void rotg(
  * @ingroup rotg
  */
 template <typename T,
+    enable_if_t< !is_same_v< T, real_type<T> >, int > = 0,
     disable_if_allow_optblas_t< T > = 0
 >
 void rotg(

--- a/include/blas/rotm.hpp
+++ b/include/blas/rotm.hpp
@@ -63,15 +63,16 @@ namespace tlapack {
  */
 template<
     int flag,
-    class vectorX_t, class vectorY_t, class real_t,
+    class vectorX_t, class vectorY_t,
     enable_if_t<((-2 <= flag) && (flag <= 1)), int > = 0,
+    class T = type_t<vectorX_t>,
+    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
     disable_if_allow_optblas_t<
-        pair< real_t, real_type<real_t> >,
-        pair< vectorX_t, real_t >,
-        pair< vectorY_t, real_t >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
-void rotm( vectorX_t& x, vectorY_t& y, const real_t h[4] )
+void rotm( vectorX_t& x, vectorY_t& y, const T h[4] )
 {
     using idx_t = size_type< vectorX_t >;
 

--- a/include/blas/rotmg.hpp
+++ b/include/blas/rotmg.hpp
@@ -86,23 +86,19 @@ namespace tlapack {
  *
  * @ingroup rotmg
  */
-template< typename real_t,
-    disable_if_allow_optblas_t<
-        pair< real_t, real_type<real_t> >
-    > = 0
+template< typename T,
+    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
+    disable_if_allow_optblas_t< T > = 0
 >
-int rotmg(
-    real_t& d1, real_t& d2,
-    real_t& a, const real_t& b,
-    real_t h[4] )
+int rotmg( T& d1, T& d2, T& a, const T& b, T h[4] )
 {
     // check arguments
     tlapack_check_false( d1 <= 0 );
 
     // Constants
-    const real_t zero( 0 );
-    const real_t one( 1 );
-    const real_t gam( 4096 );
+    const T zero( 0 );
+    const T one( 1 );
+    const T gam( 4096 );
     const auto gamsq  = gam*gam;
     const auto rgamsq = one/gamsq;
 

--- a/include/blas/scal.hpp
+++ b/include/blas/scal.hpp
@@ -21,8 +21,10 @@ namespace tlapack {
  * @ingroup scal
  */
 template< class vector_t, class alpha_t,
+    class T = type_t<vector_t>,
     disable_if_allow_optblas_t<
-        pair< vector_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< vector_t, T >
     > = 0
 >
 void scal( const alpha_t& alpha, vector_t& x )

--- a/include/blas/swap.hpp
+++ b/include/blas/swap.hpp
@@ -21,9 +21,10 @@ namespace tlapack {
  * @ingroup swap
  */
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 void swap( vectorX_t& x, vectorY_t& y )

--- a/include/blas/symm.hpp
+++ b/include/blas/symm.hpp
@@ -47,7 +47,7 @@ namespace tlapack {
 template<
     class matrixA_t, class matrixB_t, class matrixC_t, 
     class alpha_t, class beta_t,
-    class T  = alpha_t,
+    class T = type_t<matrixC_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/blas/symv.hpp
+++ b/include/blas/symv.hpp
@@ -38,12 +38,13 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t, 
     class alpha_t, class beta_t,
+    class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< alpha_t, real_type<alpha_t> >,
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >,
-        pair< beta_t,    alpha_t >
+        pair< alpha_t, real_type<T> >, // Standard BLAS does not support csymv or zsymv
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >,
+        pair< beta_t,    T >
     > = 0
 >
 void symv(

--- a/include/blas/syr.hpp
+++ b/include/blas/syr.hpp
@@ -33,9 +33,11 @@ namespace tlapack {
  * @ingroup syr
  */
 template< class matrixA_t, class vectorX_t, class alpha_t,
+    class T = type_t<matrixA_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 void syr(

--- a/include/blas/syr2.hpp
+++ b/include/blas/syr2.hpp
@@ -37,10 +37,12 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 void syr2(

--- a/include/blas/syr2k.hpp
+++ b/include/blas/syr2k.hpp
@@ -50,7 +50,7 @@ namespace tlapack {
 template<
     class matrixA_t, class matrixB_t, class matrixC_t, 
     class alpha_t, class beta_t,
-    class T  = alpha_t,
+    class T = type_t<matrixC_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/blas/syrk.hpp
+++ b/include/blas/syrk.hpp
@@ -47,7 +47,7 @@ namespace tlapack {
 template<
     class matrixA_t, class matrixC_t, 
     class alpha_t, class beta_t,
-    class T  = alpha_t,
+    class T = type_t<matrixC_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixC_t, T >,

--- a/include/blas/trmm.hpp
+++ b/include/blas/trmm.hpp
@@ -60,7 +60,7 @@ namespace tlapack {
  * @ingroup trmm
  */
 template< class matrixA_t, class matrixB_t, class alpha_t,
-    class T  = alpha_t,
+    class T = type_t<matrixB_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/blas/trmv.hpp
+++ b/include/blas/trmv.hpp
@@ -49,9 +49,10 @@ namespace tlapack {
  * @ingroup trmv
  */
 template< class matrixA_t, class vectorX_t,
+    class T = type_t<vectorX_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, type_t< matrixA_t > >,
-        pair< vectorX_t, type_t< matrixA_t > >
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 void trmv(

--- a/include/blas/trsm.hpp
+++ b/include/blas/trsm.hpp
@@ -64,7 +64,7 @@ namespace tlapack {
  * @ingroup trsm
  */
 template< class matrixA_t, class matrixB_t, class alpha_t,
-    class T  = alpha_t,
+    class T = type_t<matrixB_t>,
     disable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/blas/trsv.hpp
+++ b/include/blas/trsv.hpp
@@ -53,9 +53,10 @@ namespace tlapack {
  * @ingroup trsv
  */
 template< class matrixA_t, class vectorX_t,
+    class T = type_t<vectorX_t>,
     disable_if_allow_optblas_t<
-        pair< matrixA_t, type_t< matrixA_t > >,
-        pair< vectorX_t, type_t< matrixA_t > >
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 void trsv(

--- a/include/optimized/wrappers.hpp
+++ b/include/optimized/wrappers.hpp
@@ -27,9 +27,11 @@ auto asum( vector_t const& x )
 }
 
 template< class vectorX_t, class vectorY_t, class alpha_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
@@ -52,9 +54,10 @@ void axpy(
 }
 
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
@@ -75,9 +78,10 @@ void copy( const vectorX_t& x, vectorY_t& y )
 }
 
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
@@ -98,9 +102,10 @@ auto dot( const vectorX_t& x, const vectorY_t& y )
 }
 
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
@@ -143,13 +148,12 @@ auto nrm2( vector_t const& x )
 template<
     class vectorX_t, class vectorY_t,
     class c_type, class s_type,
-    class T = vectorX_t,
-    class real_t = real_type< T >,
+    class T = type_t<vectorX_t>,
     enable_if_allow_optblas_t<
         pair< vectorX_t, T >,
         pair< vectorY_t, T >,
-        pair< c_type, real_t >,
-        pair< s_type, real_t >
+        pair< c_type, real_type<T> >,
+        pair< s_type, real_type<T> >
     > = 0
 >
 inline
@@ -182,16 +186,17 @@ void rotg( T& a, const T& b, real_type<T>& c, T& s )
 
 template<
     int flag,
-    class vectorX_t, class vectorY_t, class real_t,
+    class vectorX_t, class vectorY_t,
     enable_if_t<((-2 <= flag) && (flag <= 1)), int > = 0,
+    class T = type_t<vectorX_t>,
+    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
     enable_if_allow_optblas_t<
-        pair< real_t, real_type<real_t> >,
-        pair< vectorX_t, real_t >,
-        pair< vectorY_t, real_t >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
-void rotm( vectorX_t& x, vectorY_t& y, const real_t h[4] )
+void rotm( vectorX_t& x, vectorY_t& y, const T h[4] )
 {
     using idx_t = size_type< vectorX_t >;
 
@@ -203,23 +208,19 @@ void rotm( vectorX_t& x, vectorY_t& y, const real_t h[4] )
     const idx_t& n = _x.n;
     const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
     const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
-    const real_t _h[] = { (real_t) flag, h[0], h[1], h[2], h[3] };
+    const T _h[] = { (T) flag, h[0], h[1], h[2], h[3] };
 
     return ::blas::rotm( n, _x.ptr, incx, _y.ptr, incy, _h );
 }
 
-template< typename real_t,
-    enable_if_allow_optblas_t<
-        pair< real_t, real_type<real_t> >
-    > = 0
+template< typename T,
+    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
+    enable_if_allow_optblas_t< T > = 0
 >
 inline
-int rotmg(
-    real_t& d1, real_t& d2,
-    real_t& a, const real_t b,
-    real_t h[4] )
+int rotmg( T& d1, T& d2, T& a, const T b, T h[4] )
 {
-    real_t param[5];
+    T param[5];
     ::blas::rotmg( &d1, &d2, &a, b, param );
     
     h[0] = param[1];
@@ -231,8 +232,10 @@ int rotmg(
 }
 
 template< class vector_t, class alpha_t,
+    class T = type_t<vector_t>,
     enable_if_allow_optblas_t<
-        pair< vector_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< vector_t, T >
     > = 0
 >
 inline
@@ -243,9 +246,10 @@ void scal( const alpha_t alpha, vector_t& x )
 }
 
 template< class vectorX_t, class vectorY_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< vectorX_t, type_t< vectorX_t > >,
-        pair< vectorY_t, type_t< vectorX_t > >
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
@@ -284,11 +288,13 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t, 
     class alpha_t, class beta_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >,
-        pair< beta_t,    alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >,
+        pair< beta_t,    T >
     > = 0
 >
 inline
@@ -325,15 +331,17 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
 void ger(
-    const alpha_t& alpha,
+    const alpha_t alpha,
     const vectorX_t& x, const vectorY_t& y,
     matrixA_t& A )
 {
@@ -363,15 +371,17 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
 void geru(
-    const alpha_t& alpha,
+    const alpha_t alpha,
     const vectorX_t& x, const vectorY_t& y,
     matrixA_t& A )
 {
@@ -401,18 +411,20 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t, 
     class alpha_t, class beta_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >,
-        pair< beta_t,    alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >,
+        pair< beta_t,    T >
     > = 0
 >
 inline
 void hemv(
     Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    const beta_t& beta, vectorY_t& y )
+    const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
+    const beta_t beta, vectorY_t& y )
 {
     using idx_t = size_type< matrixA_t >;
 
@@ -441,16 +453,17 @@ template<
     class matrixA_t,
     class vectorX_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     enable_if_allow_optblas_t<
-        pair< alpha_t, real_type<type_t<matrixA_t>> >,
-        pair< matrixA_t, type_t<matrixA_t> >,
-        pair< vectorX_t, type_t<matrixA_t> >
+        pair< alpha_t, real_type<T> >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 inline
 void her(
     Uplo  uplo,
-    const alpha_t& alpha,
+    const alpha_t alpha,
     const vectorX_t& x,
     matrixA_t& A )
 {
@@ -477,16 +490,18 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
 void her2(
     Uplo  uplo,
-    const alpha_t& alpha,
+    const alpha_t alpha,
     const vectorX_t& x, const vectorY_t& y,
     matrixA_t& A )
 {
@@ -516,19 +531,20 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t, 
     class alpha_t, class beta_t,
+    class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<
-        pair< alpha_t, real_type<alpha_t> >,
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >,
-        pair< beta_t,    alpha_t >
+        pair< alpha_t, real_type<T> >, // Standard BLAS does not support csymv or zsymv
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >,
+        pair< beta_t,    T >
     > = 0
 >
 inline
 void symv(
     Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    const beta_t& beta, vectorY_t& y )
+    const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
+    const beta_t beta, vectorY_t& y )
 {
     using idx_t = size_type< matrixA_t >;
 
@@ -557,15 +573,17 @@ template<
     class matrixA_t,
     class vectorX_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 inline
 void syr(
     Uplo  uplo,
-    const alpha_t& alpha,
+    const alpha_t alpha,
     const vectorX_t& x,
     matrixA_t& A )
 {
@@ -592,16 +610,18 @@ template<
     class matrixA_t,
     class vectorX_t, class vectorY_t,
     class alpha_t,
+    class T = type_t<matrixA_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, alpha_t >,
-        pair< vectorX_t, alpha_t >,
-        pair< vectorY_t, alpha_t >
+        pair< alpha_t, T >,
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >,
+        pair< vectorY_t, T >
     > = 0
 >
 inline
 void syr2(
     Uplo  uplo,
-    const alpha_t& alpha,
+    const alpha_t alpha,
     const vectorX_t& x, const vectorY_t& y,
     matrixA_t& A )
 {
@@ -628,9 +648,10 @@ void syr2(
 }
 
 template< class matrixA_t, class vectorX_t,
+    class T = type_t<vectorX_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, type_t< matrixA_t > >,
-        pair< vectorX_t, type_t< matrixA_t > >
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 inline
@@ -662,9 +683,10 @@ void trmv(
 }
 
 template< class matrixA_t, class vectorX_t,
+    class T = type_t<vectorX_t>,
     enable_if_allow_optblas_t<
-        pair< matrixA_t, type_t< matrixA_t > >,
-        pair< vectorX_t, type_t< matrixA_t > >
+        pair< matrixA_t, T >,
+        pair< vectorX_t, T >
     > = 0
 >
 inline
@@ -720,7 +742,7 @@ template<
     class matrixC_t, 
     class alpha_t, 
     class beta_t,
-    class T  = alpha_t,
+    class T  = type_t<matrixC_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,
@@ -779,7 +801,7 @@ template<
     class matrixC_t, 
     class alpha_t, 
     class beta_t,
-    class T  = alpha_t,
+    class T  = type_t<matrixC_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,
@@ -831,7 +853,7 @@ void hemm(
 template<
     class matrixA_t, class matrixC_t, 
     class alpha_t, class beta_t,
-    class T  = type_t<matrixA_t>,
+    class T  = type_t<matrixC_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixC_t, T >,
@@ -885,7 +907,7 @@ template<
     /* Requires: */
         ! is_complex<beta_t>::value
     ), int > = 0,
-    class T  = type_t<matrixA_t>,
+    class T  = type_t<matrixC_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,
@@ -941,7 +963,7 @@ template<
     class matrixC_t, 
     class alpha_t, 
     class beta_t,
-    class T  = alpha_t,
+    class T  = type_t<matrixC_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,
@@ -993,7 +1015,7 @@ void symm(
 template<
     class matrixA_t, class matrixC_t, 
     class alpha_t, class beta_t,
-    class T  = alpha_t,
+    class T  = type_t<matrixC_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixC_t, T >,
@@ -1043,7 +1065,7 @@ void syrk(
 template<
     class matrixA_t, class matrixB_t, class matrixC_t, 
     class alpha_t, class beta_t,
-    class T  = alpha_t,
+    class T  = type_t<matrixC_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,
@@ -1097,7 +1119,7 @@ void syr2k(
  * @ingroup trmm
  */
 template< class matrixA_t, class matrixB_t, class alpha_t,
-    class T  = alpha_t,
+    class T  = type_t<matrixB_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,
@@ -1135,7 +1157,7 @@ void trmm(
 }
 
 template< class matrixA_t, class matrixB_t, class alpha_t,
-    class T  = alpha_t,
+    class T  = type_t<matrixB_t>,
     enable_if_allow_optblas_t<
         pair< matrixA_t, T >,
         pair< matrixB_t, T >,

--- a/include/plugins/tlapack_mdspan.hpp
+++ b/include/plugins/tlapack_mdspan.hpp
@@ -182,22 +182,22 @@ namespace tlapack {
     //         has_blas_type_v<type> && ;
     // };
 
-    template< class ET, class Exts, class LP, class AP,
-        std::enable_if_t<
-        /* Requires: */
-            LP::template mapping<Exts>::is_always_strided() &&
-            Exts::rank() == 2
-        , bool > = true
-    >
-    inline constexpr auto
-    legacy_matrix( const mdspan<ET,Exts,LP,AP>& A ) {
-        if( A.stride(0) == 1 )
-            return legacyMatrix<ET,Layout::ColMajor>( A.extent(0), A.extent(1), A.data(), A.stride(1) );
-        else if( A.stride(1) == 1 )
-            return legacyMatrix<ET,Layout::RowMajor>( A.extent(0), A.extent(1), A.data(), A.stride(0) );
-        else
-            return legacyMatrix<ET>( 0, 0, nullptr, 0 );
-    }
+    // template< class ET, class Exts, class LP, class AP,
+    //     std::enable_if_t<
+    //     /* Requires: */
+    //         LP::template mapping<Exts>::is_always_strided() &&
+    //         Exts::rank() == 2
+    //     , bool > = true
+    // >
+    // inline constexpr auto
+    // legacy_matrix( const mdspan<ET,Exts,LP,AP>& A ) {
+    //     if( A.stride(0) == 1 )
+    //         return legacyMatrix<ET,Layout::ColMajor>( A.extent(0), A.extent(1), A.data(), A.stride(1) );
+    //     else if( A.stride(1) == 1 )
+    //         return legacyMatrix<ET,Layout::RowMajor>( A.extent(0), A.extent(1), A.data(), A.stride(0) );
+    //     else
+    //         return legacyMatrix<ET>( 0, 0, nullptr, 0 );
+    // }
 
 } // namespace tlapack
 

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -10,6 +10,8 @@
 #include <catch2/catch.hpp>
 #include <tlapack.hpp>
 
+#include "testdefinitions.hpp"
+
 using namespace tlapack;
 
 TEST_CASE( "MatrixAccessPolicy can be cast to Uplo", "[utils]" ) {
@@ -57,4 +59,26 @@ TEST_CASE( "MatrixAccessPolicy can be cast to Uplo", "[utils]" ) {
 
     CHECK( dense == (Uplo) runtimeAccess );
     CHECK( dense == (MatrixAccessPolicy) uplo );
+}
+
+TEMPLATE_LIST_TEST_CASE("is_matrix works", "[utils]", types_to_test)
+{
+    using matrix_t  = TestType;
+
+    CHECK( is_matrix<matrix_t> );
+}
+
+TEST_CASE("is_matrix and is_vector work", "[utils]")
+{
+    CHECK( !is_matrix< std::vector<float> > );
+    CHECK( !is_matrix< legacyVector<float> > );
+
+    CHECK( is_vector< std::vector<float> > );
+    CHECK( is_vector< legacyVector<float> > );
+
+    CHECK( !is_matrix< float > );
+    CHECK( !is_matrix< std::complex<double> > );
+
+    CHECK( !is_vector< float > );
+    CHECK( !is_vector< std::complex<double> > );
 }


### PR DESCRIPTION
The bug prevented the identification of optBLAS for matrices and vectors. Bug introduced in #78.

- Adds tests for the bug.

- New behavior. Ex.: `axpy(1,x,y)` trigger optBLAS as well as `axpy(1.0,x,y)` and `axpy(1.0f,x,y)`.