### PR TITLE
add out of place recursive transpose

### DIFF
--- a/include/base/types.hpp
+++ b/include/base/types.hpp
@@ -73,7 +73,7 @@ namespace tlapack {
 
     // Constants
     constexpr noTranspose_t noTranspose = { };
-    constexpr transpose_t transpose = { };
+    constexpr transpose_t Transpose = { };
     constexpr conjTranspose_t conjTranspose = { };
 
     // -----------------------------------------------------------------------------

--- a/include/lapack/transpose.hpp
+++ b/include/lapack/transpose.hpp
@@ -29,9 +29,7 @@ namespace tlapack
 
     /**
      *
-     * @brief Transpose a real matrix A into a real matrix B
-     *        or conjugate transpose a complex matrix A
-     *        into a complex matrix B.
+     * @brief conjugate transpose a matrix A into a matrix B.
      *
      * @param[in] A m-by-n matrix
      *      The matrix to be transposed
@@ -42,7 +40,7 @@ namespace tlapack
      * @ingroup util
      */
     template <class matrixA_t, class matrixB_t>
-    void transpose_matrix(matrixA_t &A, matrixB_t &B, const transpose_opts_t<size_type<matrixA_t>> &opts = {} )
+    void conjtranspose(matrixA_t &A, matrixB_t &B, const transpose_opts_t<size_type<matrixA_t>> &opts = {} )
     {
         using idx_t = size_type<matrixA_t>;
         using pair = std::pair<idx_t, idx_t>;
@@ -50,9 +48,9 @@ namespace tlapack
         const idx_t m = nrows(A);
         const idx_t n = ncols(A);
 
-        assert(m == ncols(B));
-        assert(n == nrows(B));
-        assert( opts.nx >= 2 );
+        tlapack_check(m == ncols(B));
+        tlapack_check(n == nrows(B));
+        tlapack_check( opts.nx >= 2 );
 
         if (min(m, n) <= opts.nx)
         {
@@ -77,10 +75,65 @@ namespace tlapack
             auto B10 = slice(B, pair(n1, n), pair(0, m1));
             auto B11 = slice(B, pair(n1, n), pair(m1, m));
 
-            transpose_matrix(A00, B00, opts);
-            transpose_matrix(A01, B10, opts);
-            transpose_matrix(A10, B01, opts);
-            transpose_matrix(A11, B11, opts);
+            conjtranspose(A00, B00, opts);
+            conjtranspose(A01, B10, opts);
+            conjtranspose(A10, B01, opts);
+            conjtranspose(A11, B11, opts);
+        }
+    }
+
+        /**
+     *
+     * @brief transpose a matrix A into a matrix B.
+     *
+     * @param[in] A m-by-n matrix
+     *      The matrix to be transposed
+     *
+     * @param[out] B n-by-m matrix
+     *      On exit, B = A**T
+     *
+     * @ingroup util
+     */
+    template <class matrixA_t, class matrixB_t>
+    void transpose(matrixA_t &A, matrixB_t &B, const transpose_opts_t<size_type<matrixA_t>> &opts = {} )
+    {
+        using idx_t = size_type<matrixA_t>;
+        using pair = std::pair<idx_t, idx_t>;
+
+        const idx_t m = nrows(A);
+        const idx_t n = ncols(A);
+
+        tlapack_check(m == ncols(B));
+        tlapack_check(n == nrows(B));
+        tlapack_check( opts.nx >= 2 );
+
+        if (min(m, n) <= opts.nx)
+        {
+            // The matrix is small, use direct method and end recursion
+            for (idx_t i = 0; i < m; ++i)
+                for (idx_t j = 0; j < n; ++j)
+                    B(j, i) = A(i, j);
+        }
+        else
+        {
+            // The matrix is large, split into subblocks and use recursion
+            const idx_t m1 = m / 2;
+            const idx_t n1 = n / 2;
+
+            auto A00 = slice(A, pair(0, m1), pair(0, n1));
+            auto A01 = slice(A, pair(0, m1), pair(n1, n));
+            auto A10 = slice(A, pair(m1, m), pair(0, n1));
+            auto A11 = slice(A, pair(m1, m), pair(n1, n));
+
+            auto B00 = slice(B, pair(0, n1), pair(0, m1));
+            auto B01 = slice(B, pair(0, n1), pair(m1, m));
+            auto B10 = slice(B, pair(n1, n), pair(0, m1));
+            auto B11 = slice(B, pair(n1, n), pair(m1, m));
+
+            transpose(A00, B00, opts);
+            transpose(A01, B10, opts);
+            transpose(A10, B01, opts);
+            transpose(A11, B11, opts);
         }
     }
 

--- a/include/lapack/transpose.hpp
+++ b/include/lapack/transpose.hpp
@@ -1,0 +1,89 @@
+/// @file transpose.hpp Out of place transpose
+/// @author Thijs Steel, KU Leuven, Belgium
+//
+// Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef __TLAPACK_TRANSPOSE_HH__
+#define __TLAPACK_TRANSPOSE_HH__
+
+#include "base/utils.hpp"
+
+#include "tblas.hpp"
+
+#include <cassert>
+
+namespace tlapack
+{
+
+    template <typename idx_t>
+    struct transpose_opts_t {
+        // Optimization parameter. Matrices smaller than nx will not
+        // be transposed using recursion. Must be at least 2.s
+        idx_t nx = 16;
+    };
+
+
+    /**
+     *
+     * @brief Transpose a real matrix A into a real matrix B
+     *        or conjugate transpose a complex matrix A
+     *        into a complex matrix B.
+     *
+     * @param[in] A m-by-n matrix
+     *      The matrix to be transposed
+     *
+     * @param[out] B n-by-m matrix
+     *      On exit, B = A**H
+     *
+     * @ingroup util
+     */
+    template <class matrixA_t, class matrixB_t>
+    void transpose_matrix(matrixA_t &A, matrixB_t &B, const transpose_opts_t<size_type<matrixA_t>> &opts = {} )
+    {
+        using idx_t = size_type<matrixA_t>;
+        using pair = std::pair<idx_t, idx_t>;
+
+        const idx_t m = nrows(A);
+        const idx_t n = ncols(A);
+
+        assert(m == ncols(B));
+        assert(n == nrows(B));
+        assert( opts.nx >= 2 );
+
+        if (min(m, n) <= opts.nx)
+        {
+            // The matrix is small, use direct method and end recursion
+            for (idx_t i = 0; i < m; ++i)
+                for (idx_t j = 0; j < n; ++j)
+                    B(j, i) = conj(A(i, j));
+        }
+        else
+        {
+            // The matrix is large, split into subblocks and use recursion
+            const idx_t m1 = m / 2;
+            const idx_t n1 = n / 2;
+
+            auto A00 = slice(A, pair(0, m1), pair(0, n1));
+            auto A01 = slice(A, pair(0, m1), pair(n1, n));
+            auto A10 = slice(A, pair(m1, m), pair(0, n1));
+            auto A11 = slice(A, pair(m1, m), pair(n1, n));
+
+            auto B00 = slice(B, pair(0, n1), pair(0, m1));
+            auto B01 = slice(B, pair(0, n1), pair(m1, m));
+            auto B10 = slice(B, pair(n1, n), pair(0, m1));
+            auto B11 = slice(B, pair(n1, n), pair(m1, m));
+
+            transpose_matrix(A00, B00, opts);
+            transpose_matrix(A01, B10, opts);
+            transpose_matrix(A10, B01, opts);
+            transpose_matrix(A11, B11, opts);
+        }
+    }
+
+} // lapack
+
+#endif // __TLAPACK_TRANSPOSE_HH__

--- a/include/legacy_api/base/legacyArray.hpp
+++ b/include/legacy_api/base/legacyArray.hpp
@@ -86,22 +86,6 @@ namespace internal {
         return legacyVector<T,one_t,Direction::Backward>{ n, x, one };
     }
 
-    // Transpose
-    template< typename T >
-    inline constexpr auto transpose(
-        const legacyMatrix<T,Layout::ColMajor>& A )
-    {
-        return legacyMatrix<T,Layout::RowMajor>{ A.n, A.m, A.ptr, A.ldim };
-    }
-
-    // Transpose
-    template< typename T >
-    inline constexpr auto transpose(
-        const legacyMatrix<T,Layout::RowMajor>& A )
-    {
-        return legacyMatrix<T,Layout::ColMajor>{ A.n, A.m, A.ptr, A.ldim };
-    }
-
 } // namespace internal
 
 } // namespace tlapack

--- a/include/tlapack.hpp
+++ b/include/tlapack.hpp
@@ -32,6 +32,7 @@
 #include "lapack/larnv.hpp"
 #include "lapack/lascl.hpp"
 #include "lapack/lassq.hpp"
+#include "lapack/transpose.hpp"
 
 // QR factorization
 // ----------------

--- a/test/src/test_transpose.cpp
+++ b/test/src/test_transpose.cpp
@@ -1,5 +1,5 @@
-/// @file test_gehrd.cpp
-/// @brief Test hessenberg reduction
+/// @file test_transpose.cpp
+/// @brief Test transpose
 //
 // Copyright (c) 2022, University of Colorado Denver. All rights reserved.
 //

--- a/test/src/test_transpose.cpp
+++ b/test/src/test_transpose.cpp
@@ -15,7 +15,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("Transpose gives correct result", "[util]", types_to_test)
+TEMPLATE_LIST_TEST_CASE("Conjugate Transpose gives correct result", "[util]", types_to_test)
 {
     srand(1);
 
@@ -41,15 +41,56 @@ TEMPLATE_LIST_TEST_CASE("Transpose gives correct result", "[util]", types_to_tes
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 
-    DYNAMIC_SECTION("Transpose with" << " m = " << m << " n = " << n)
+    DYNAMIC_SECTION("Conjugate Transpose with"
+                    << " m = " << m << " n = " << n)
     {
         transpose_opts_t<idx_t> opts;
         // Set nx to a small value so that the blocked algorithm gets tested even for small n and m;
         opts.nx = 3;
-        transpose_matrix( A, B, opts);
+        conjtranspose(A, B, opts);
 
         for (idx_t i = 0; i < m; ++i)
             for (idx_t j = 0; j < n; ++j)
-                CHECK( B(j, i) == conj(A(i, j)));
+                CHECK(B(j, i) == conj(A(i, j)));
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("Conjugate Transpose gives correct result", "[util]", types_to_test)
+{
+    srand(1);
+
+    using matrix_t = TestType;
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+
+    // Generate n
+    idx_t n = GENERATE(1, 2, 3, 5, 10);
+    // Generate m
+    idx_t m = GENERATE(1, 2, 3, 5, 10);
+
+    // Define the matrices and vectors
+    std::unique_ptr<T[]> A_(new T[n * m]);
+    std::unique_ptr<T[]> B_(new T[n * m]);
+
+    // This only works for legacy matrix, we really work on that construct_matrix function
+    auto A = legacyMatrix<T, layout<matrix_t>>(m, n, &A_[0], layout<matrix_t> == Layout::ColMajor ? m : n);
+    auto B = legacyMatrix<T, layout<matrix_t>>(n, m, &B_[0], layout<matrix_t> == Layout::ColMajor ? n : m);
+
+    // Generate a random matrix in A
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = 0; i < m; ++i)
+            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+
+    DYNAMIC_SECTION("Transpose with"
+                    << " m = " << m << " n = " << n)
+    {
+        transpose_opts_t<idx_t> opts;
+        // Set nx to a small value so that the blocked algorithm gets tested even for small n and m;
+        opts.nx = 3;
+        transpose(A, B, opts);
+
+        for (idx_t i = 0; i < m; ++i)
+            for (idx_t j = 0; j < n; ++j)
+                CHECK(B(j, i) == A(i, j));
     }
 }

--- a/test/src/test_transpose.cpp
+++ b/test/src/test_transpose.cpp
@@ -1,0 +1,55 @@
+/// @file test_gehrd.cpp
+/// @brief Test hessenberg reduction
+//
+// Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <catch2/catch.hpp>
+#include <plugins/tlapack_stdvector.hpp>
+#include <tlapack.hpp>
+#include <testutils.hpp>
+#include <testdefinitions.hpp>
+
+using namespace tlapack;
+
+TEMPLATE_LIST_TEST_CASE("Transpose gives correct result", "[util]", types_to_test)
+{
+    srand(1);
+
+    using matrix_t = TestType;
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+
+    // Generate n
+    idx_t n = GENERATE(1, 2, 3, 5, 10);
+    // Generate m
+    idx_t m = GENERATE(1, 2, 3, 5, 10);
+
+    // Define the matrices and vectors
+    std::unique_ptr<T[]> A_(new T[n * m]);
+    std::unique_ptr<T[]> B_(new T[n * m]);
+
+    // This only works for legacy matrix, we really work on that construct_matrix function
+    auto A = legacyMatrix<T, layout<matrix_t>>(m, n, &A_[0], layout<matrix_t> == Layout::ColMajor ? m : n);
+    auto B = legacyMatrix<T, layout<matrix_t>>(n, m, &B_[0], layout<matrix_t> == Layout::ColMajor ? n : m);
+
+    // Generate a random matrix in A
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = 0; i < m; ++i)
+            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+
+    DYNAMIC_SECTION("Transpose with" << " m = " << m << " n = " << n)
+    {
+        transpose_opts_t<idx_t> opts;
+        // Set nx to a small value so that the blocked algorithm gets tested even for small n and m;
+        opts.nx = 3;
+        transpose_matrix( A, B, opts);
+
+        for (idx_t i = 0; i < m; ++i)
+            for (idx_t j = 0; j < n; ++j)
+                CHECK( B(j, i) == conj(A(i, j)));
+    }
+}


### PR DESCRIPTION
Adds an out of place transpose.
Uses recursion for efficiency.
Includes tests and nice documentation of the function.

I am well aware that transpose is usually avoided, but that does not mean we should limit the user. They may wish to have a transpose for testing.