### PR TITLE
Fixes issue #83

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,6 +17,9 @@ env:
   FFLAGS: "-fimplicit-none -fcheck=all"
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  blaspp_DIR: ${{github.workspace}}/blaspp
+  lapackpp_DIR: ${{github.workspace}}/lapackpp
+  mdspan_DIR: ${{github.workspace}}/mdspan
 
 defaults:
   run:
@@ -32,10 +35,6 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
-    env:
-      blaspp_DIR: ${{github.workspace}}/blaspp
-      lapackpp_DIR: ${{github.workspace}}/lapackpp
-      mdspan_DIR: ${{github.workspace}}/mdspan
 
     strategy:
       fail-fast: false
@@ -158,6 +157,8 @@ jobs:
       run: cmake --build build --target install
 
   build-with-mpfr:
+    # Use GNU compilers
+
     runs-on: ubuntu-latest
     steps:     
     
@@ -192,9 +193,9 @@ jobs:
       run: cmake --build build --target install
 
   build-with-openblas:
+    # Use GNU compilers
+
     runs-on: ubuntu-latest
-    env:
-      blaspp_DIR: ${{github.workspace}}/blaspp
     steps:
     
     - name: Checkout <T>LAPACK
@@ -203,95 +204,65 @@ jobs:
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v3
 
+    - name: Install LAPACKE on Ubuntu
+      run: sudo apt install liblapacke-dev
+
     - name: Install OpenBLAS
       run: sudo apt install libopenblas-dev
 
-    - name: Checkout BLAS++
-      run: git clone https://bitbucket.org/weslleyspereira/blaspp ${{env.blaspp_DIR}}
+    - name: Checkout BLAS++ and LAPACK++
+      run: |
+        git clone https://bitbucket.org/weslleyspereira/blaspp ${{env.blaspp_DIR}}
+        git clone https://bitbucket.org/weslleyspereira/lapackpp ${{env.lapackpp_DIR}}
 
     - name: Build and install BLAS++
       working-directory: ${{env.blaspp_DIR}}
       run: |
         git checkout tlapack
-        mkdir build
         cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBLA_VENDOR=OpenBLAS -Dbuild_tests=OFF -DCMAKE_INSTALL_PREFIX=${{env.blaspp_DIR}}
+        cmake --build build --target install
+
+    - name: Build and install LAPACK++
+      working-directory: ${{env.lapackpp_DIR}}
+      run: |
+        git checkout tlapack
+        cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBLA_VENDOR=OpenBLAS -Dbuild_tests=OFF -DCMAKE_INSTALL_PREFIX=${{env.lapackpp_DIR}} -D CMAKE_CXX_FLAGS="${{env.CXXFLAGS}} -D LAPACK_FORTRAN_ADD_"
         cmake --build build --target install
 
     - name: Configure CMake for <T>LAPACK
       run: >
         cmake -B build -G Ninja
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -D CMAKE_INSTALL_PREFIX=${{github.workspace}}/tlapack_install
+        -D CMAKE_CXX_FLAGS="${{env.CXXFLAGS}} -D LAPACK_FORTRAN_ADD_"
         -D BUILD_SHARED_LIBS=ON
         -D BUILD_EXAMPLES=ON
         -D BUILD_TESTING=ON
         -D C_WRAPPERS=ON
         -D Fortran_WRAPPERS=ON
         -D CBLAS_WRAPPERS=ON
-        -D USE_BLASPP_WRAPPERS=ON
+        -D USE_LAPACKPP_WRAPPERS=ON
         -D BUILD_BLASPP_TESTS=ON
-        -D blaspp_DIR=${{env.blaspp_DIR}}
         -D blaspp_TEST_DIR=${{env.blaspp_DIR}}/test
+        -D BUILD_LAPACKPP_TESTS=ON
+        -D lapackpp_TEST_DIR=${{env.lapackpp_DIR}}/test
 
     - name: Build <T>LAPACK
       run: cmake --build build --config ${{env.BUILD_TYPE}}
 
     # Mind that the job won't fail if only this step fails
-    - name: Run BLASPP and LAPACKPP testers
-      working-directory: ${{github.workspace}}/build/test
+    - name: Run tests
+      working-directory: ${{github.workspace}}/build
       continue-on-error: true
-      run: |
-        echo "Mind that the job won't fail if only this step fails."
-        ctest -C ${{env.BUILD_TYPE}} --output-on-failure -R blaspp_test
-        ctest -C ${{env.BUILD_TYPE}} --output-on-failure -R lapackpp_test
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
-    # Mind that the job won't fail if only this step fails
-    - name: Test InfNaN propagation
-      working-directory: ${{github.workspace}}/build/test
-      continue-on-error: true
-      run: |
-        echo "Mind that the job won't fail if only this step fails."
-        ./tester_testBLAS -# [#test_infNaN] -r compact
-
-    # Mind that the job won't fail if only this step fails
-    - name: Test InfNaN propagation on iamax
-      working-directory: ${{github.workspace}}/build/test
-      continue-on-error: true
-      run: |
-        echo "Mind that the job won't fail if only this step fails."
-        ./tester_testBLAS -# [#test_infNaN_iamax] -r compact
-
-    # Mind that the job won't fail if only this step fails
-    - name: Test InfNaN propagation on nrm2
-      working-directory: ${{github.workspace}}/build/test
-      continue-on-error: true
-      run: |
-        echo "Mind that the job won't fail if only this step fails."
-        ./tester_testBLAS -# [#test_infNaN_nrm2] -r compact
-
-    # Mind that the job won't fail if only this step fails
-    - name: Test InfNaN propagation on trsv and trsm
-      working-directory: ${{github.workspace}}/build/test
-      continue-on-error: true
-      run: |
-        echo "Mind that the job won't fail if only this step fails."
-        ./tester_testBLAS -# [#test_infNaN_trsv_trsm] -r compact
-
-    # Mind that the job won't fail if only this step fails
-    - name: Test Corner Cases
-      working-directory: ${{github.workspace}}/build/test
-      continue-on-error: true
-      run: |
-        echo "Mind that the job won't fail if only this step fails."
-        ./tester_testBLAS -# [#test_corner_cases] -r compact
-      # echo "Total of:"
-      # ./tester_testBLAS -# [#test_corner_cases] -l | tail -n 2
+    - name: Install
+      run: cmake --build build --target install
 
   build-test-performance:
     # Use GNU compilers
   
     runs-on: ubuntu-latest
-    env:
-      blaspp_DIR: ${{github.workspace}}/blaspp
 
     strategy:
       fail-fast: false
@@ -304,15 +275,23 @@ jobs:
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v3
 
-    - name: Checkout BLAS++
+    - name: Checkout BLAS++ and LAPACK++
       run: |
         git clone https://bitbucket.org/weslleyspereira/blaspp ${{env.blaspp_DIR}}
+        git clone https://bitbucket.org/weslleyspereira/lapackpp ${{env.lapackpp_DIR}}
 
     - name: Build and install BLAS++
       working-directory: ${{env.blaspp_DIR}}
       run: |
         git checkout tlapack
         cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dbuild_tests=OFF -DCMAKE_INSTALL_PREFIX=${{env.blaspp_DIR}}
+        cmake --build build --target install
+
+    - name: Build and install LAPACK++
+      working-directory: ${{env.lapackpp_DIR}}
+      run: |
+        git checkout tlapack
+        cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dbuild_tests=OFF -DCMAKE_INSTALL_PREFIX=${{env.lapackpp_DIR}}
         cmake --build build --target install
 
     - name: Configure CMake
@@ -323,7 +302,7 @@ jobs:
         -D BUILD_SHARED_LIBS=ON
         -D BUILD_EXAMPLES=OFF
         -D BUILD_TESTING=OFF
-        -D USE_BLASPP_WRAPPERS=ON
+        -D USE_LAPACKPP_WRAPPERS=ON
         -D TLAPACK_CHECK_INPUT=OFF
 
     - name: Build and Install
@@ -341,11 +320,15 @@ jobs:
         ./build/example_potrf
 
   build-with-mkl:
+    # Use Intel compilers
+
     runs-on: ubuntu-latest
     env:
-      blaspp_DIR: ${{github.workspace}}/blaspp
       CXX: icpx
     steps:
+
+    - name: Install LAPACKE on Ubuntu
+      run: sudo apt install liblapacke-dev
 
     - name: Intel Apt repository
       timeout-minutes: 1
@@ -371,40 +354,50 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
 
-    - name: Checkout BLAS++
-      run: git clone https://bitbucket.org/weslleyspereira/blaspp ${{env.blaspp_DIR}}
+    - name: Checkout BLAS++ and LAPACK++
+      run: |
+        git clone https://bitbucket.org/weslleyspereira/blaspp ${{env.blaspp_DIR}}
+        git clone https://bitbucket.org/weslleyspereira/lapackpp ${{env.lapackpp_DIR}}
 
     - name: Build and install BLAS++
       working-directory: ${{env.blaspp_DIR}}
       run: |
         git checkout tlapack
-        mkdir build
         cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dbuild_tests=OFF -DCMAKE_INSTALL_PREFIX=${{env.blaspp_DIR}}
+        cmake --build build --target install
+
+    - name: Build and install LAPACK++
+      working-directory: ${{env.lapackpp_DIR}}
+      run: |
+        git checkout tlapack
+        cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dbuild_tests=OFF -DCMAKE_INSTALL_PREFIX=${{env.lapackpp_DIR}}
         cmake --build build --target install
 
     - name: Configure CMake for <T>LAPACK
       run: >
         cmake -B build -G Ninja
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -D CMAKE_INSTALL_PREFIX=${{github.workspace}}/tlapack_install
         -D BUILD_SHARED_LIBS=ON
         -D BUILD_EXAMPLES=ON
         -D BUILD_TESTING=ON
         -D C_WRAPPERS=ON
         -D Fortran_WRAPPERS=ON
         -D CBLAS_WRAPPERS=ON
-        -D USE_BLASPP_WRAPPERS=ON
+        -D USE_LAPACKPP_WRAPPERS=ON
         -D BUILD_BLASPP_TESTS=ON
-        -D blaspp_DIR=${{env.blaspp_DIR}}
         -D blaspp_TEST_DIR=${{env.blaspp_DIR}}/test
+        -D BUILD_LAPACKPP_TESTS=ON
+        -D lapackpp_TEST_DIR=${{env.lapackpp_DIR}}/test
 
     - name: Build <T>LAPACK
       run: cmake --build build --config ${{env.BUILD_TYPE}}
 
     # Mind that the job won't fail if only this step fails
-    - name: Run BLASPP and LAPACKPP testers
+    - name: Run tests
       working-directory: ${{github.workspace}}/build
       continue-on-error: true
-      run: |
-        echo "Mind that the job won't fail if only this step fails."
-        ctest -C ${{env.BUILD_TYPE}} --output-on-failure -R blaspp_test
-        ctest -C ${{env.BUILD_TYPE}} --output-on-failure -R lapackpp_test
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
+
+    - name: Install
+      run: cmake --build build --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,8 @@ target_link_libraries( tlapack INTERFACE tblas )
 # Includes CMAKE_DEPENDENT_OPTION
 include(CMakeDependentOption)
 
-# BLAS++ and LAPACK++ interface
-option( USE_BLASPP_WRAPPERS   "Use BLAS++ wrappers to link with an optimized BLAS library"     OFF )
-option( USE_LAPACKPP_WRAPPERS "Use LAPACK++ wrappers to link with an optimized LAPACK library" OFF )
+# LAPACK++ interface
+option( USE_LAPACKPP_WRAPPERS "Use LAPACK++ wrappers to link with optimized BLAS and LAPACK libraries" OFF )
 
 cmake_dependent_option( BUILD_BLASPP_TESTS   "Build BLAS++ tests. Please inform blaspp_TEST_DIR if BUILD_BLASPP_TESTS=ON"
   OFF "BUILD_TESTING" # Default value when condition is true
@@ -143,14 +142,6 @@ endif()
 #-------------------------------------------------------------------------------
 # Modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-
-#-------------------------------------------------------------------------------
-# Search for BLAS++ library if it is needed
-if( USE_BLASPP_WRAPPERS )
-  find_package( blaspp REQUIRED )
-  target_compile_definitions( tblas INTERFACE USE_BLASPP_WRAPPERS )
-  target_link_libraries( tblas INTERFACE blaspp )
-endif()
 
 #-------------------------------------------------------------------------------
 # Search for LAPACK++ library if it is needed

--- a/README.md
+++ b/README.md
@@ -97,15 +97,13 @@ Here are the \<T\>LAPACK specific options and their default values
     
         Build and install CBLAS wrappers to <T>BLAS
     
-    USE_BLASPP_WRAPPERS                 OFF
-
-        Use BLAS++ wrappers to link with an optimized BLAS library.
-        Branch compatible with \<T>LAPACK:
-            https://bitbucket.org/weslleyspereira/blaspp/branch/tlapack
-    
     USE_LAPACKPP_WRAPPERS               OFF
 
         Use LAPACK++ wrappers to link with an optimized LAPACK library.
+        Mind that LAPACK++ needs BLAS++.
+        Branches compatible with \<T>LAPACK:
+            https://bitbucket.org/weslleyspereira/blaspp/branch/tlapack
+            https://bitbucket.org/weslleyspereira/lapackpp/branch/tlapack
     
     TLAPACK_INT_T                       int64_t
     

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,11 +2,6 @@
 
 include( CMakeFindDependencyMacro )
 
-set( USE_BLASPP_WRAPPERS "@USE_BLASPP_WRAPPERS@" )
-if( USE_BLASPP_WRAPPERS )
-    find_dependency( blaspp )
-endif()
-
 set( USE_LAPACKPP_WRAPPERS "@USE_LAPACKPP_WRAPPERS@" )
 if( USE_LAPACKPP_WRAPPERS )
     find_dependency( lapackpp )

--- a/include/base/utils.hpp
+++ b/include/base/utils.hpp
@@ -742,7 +742,7 @@ using disable_if_allow_optblas_t = enable_if_t<(
     }
 
     /// Optimized types
-    #ifdef USE_BLASPP_WRAPPERS
+    #ifdef USE_LAPACKPP_WRAPPERS
         TLAPACK_OPT_TYPE(float)
         TLAPACK_OPT_TYPE(double)
         TLAPACK_OPT_TYPE(std::complex<float>)

--- a/include/blas/symv.hpp
+++ b/include/blas/symv.hpp
@@ -40,7 +40,6 @@ template<
     class alpha_t, class beta_t,
     class T = type_t<vectorY_t>,
     disable_if_allow_optblas_t<
-        pair< alpha_t, real_type<T> >, // Standard BLAS does not support csymv or zsymv
         pair< matrixA_t, T >,
         pair< vectorX_t, T >,
         pair< vectorY_t, T >,

--- a/include/legacy_api/base/types.hpp
+++ b/include/legacy_api/base/types.hpp
@@ -15,7 +15,7 @@
 #include <cstdint> // Defines std::int64_t
 #include <cstddef> // Defines std::size_t
 
-#if defined(USE_BLASPP_WRAPPERS) || defined(USE_LAPACKPP_WRAPPERS)
+#ifdef USE_LAPACKPP_WRAPPERS
     #ifndef TLAPACK_SIZE_T
         #define TLAPACK_SIZE_T std::int64_t
     #endif

--- a/include/legacy_api/blas.hpp
+++ b/include/legacy_api/blas.hpp
@@ -9,7 +9,7 @@
 
 // Optimized BLAS
 
-#ifdef USE_BLASPP_WRAPPERS
+#ifdef USE_LAPACKPP_WRAPPERS
     #include "optimized/wrappers.hpp"
 #endif
 

--- a/include/legacy_api/lapack/ung2r.hpp
+++ b/include/legacy_api/lapack/ung2r.hpp
@@ -13,8 +13,6 @@
 
 #include "lapack/ung2r.hpp"
 
-#include "tblas.hpp"
-
 namespace tlapack {
 
 /** Generates a m-by-n matrix Q with orthogonal columns.

--- a/include/tblas.hpp
+++ b/include/tblas.hpp
@@ -9,7 +9,7 @@
 
 // Optimized BLAS
 
-#ifdef USE_BLASPP_WRAPPERS
+#ifdef USE_LAPACKPP_WRAPPERS
     #include "optimized/wrappers.hpp"
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,7 @@ set_property( CACHE TLAPACK_SIZE_T
 #-------------------------------------------------------------------------------
 # Force options when using BLAS++ or LAPACK++ wrappers
 
-if( USE_BLASPP_WRAPPERS OR USE_LAPACKPP_WRAPPERS )
+if( USE_LAPACKPP_WRAPPERS )
   mark_as_advanced( FORCE TLAPACK_INT_T TLAPACK_SIZE_T )
   get_property( docString CACHE TLAPACK_INT_T PROPERTY HELPSTRING )
   set( TLAPACK_INT_T int64_t CACHE STRING "${docString}" FORCE )

--- a/test/blaspp/blas/defines.h
+++ b/test/blaspp/blas/defines.h
@@ -16,7 +16,7 @@
 #undef assert_throw
 #define assert_throw( expr, exception_type ) ((void)0)
 
-#undef USE_BLASPP_WRAPPERS // Disable BLAS++ wrappers
+#undef USE_LAPACKPP_WRAPPERS // Disable BLAS++ wrappers
 #define TLAPACK_ERROR_NDEBUG // Don't test corner cases
 
 #endif        //  #ifndef BLAS_DEFINES_H


### PR DESCRIPTION
Resolves #83 by using wrappers from LAPACK++. Then we can use `lartg` directly. Also, enables support to `csymv` and `zsymv`.