### PR TITLE
Tries to mitigate the compilation time for the tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -237,7 +237,7 @@ jobs:
 
     # Mind that the job won't fail if only this step fails
     - name: Run BLASPP and LAPACKPP testers
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}/build/test
       continue-on-error: true
       run: |
         echo "Mind that the job won't fail if only this step fails."
@@ -246,45 +246,45 @@ jobs:
 
     # Mind that the job won't fail if only this step fails
     - name: Test InfNaN propagation
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}/build/test
       continue-on-error: true
       run: |
         echo "Mind that the job won't fail if only this step fails."
-        ./tester -# [#test_infNaN] -r compact
+        ./tester_testBLAS -# [#test_infNaN] -r compact
 
     # Mind that the job won't fail if only this step fails
     - name: Test InfNaN propagation on iamax
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}/build/test
       continue-on-error: true
       run: |
         echo "Mind that the job won't fail if only this step fails."
-        ./tester -# [#test_infNaN_iamax] -r compact
+        ./tester_testBLAS -# [#test_infNaN_iamax] -r compact
 
     # Mind that the job won't fail if only this step fails
     - name: Test InfNaN propagation on nrm2
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}/build/test
       continue-on-error: true
       run: |
         echo "Mind that the job won't fail if only this step fails."
-        ./tester -# [#test_infNaN_nrm2] -r compact
+        ./tester_testBLAS -# [#test_infNaN_nrm2] -r compact
 
     # Mind that the job won't fail if only this step fails
     - name: Test InfNaN propagation on trsv and trsm
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}/build/test
       continue-on-error: true
       run: |
         echo "Mind that the job won't fail if only this step fails."
-        ./tester -# [#test_infNaN_trsv_trsm] -r compact
+        ./tester_testBLAS -# [#test_infNaN_trsv_trsm] -r compact
 
     # Mind that the job won't fail if only this step fails
     - name: Test Corner Cases
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}/build/test
       continue-on-error: true
       run: |
         echo "Mind that the job won't fail if only this step fails."
-        ./tester -# [#test_corner_cases] -r compact
+        ./tester_testBLAS -# [#test_corner_cases] -r compact
       # echo "Total of:"
-      # ./tester -# [#test_corner_cases] -l | tail -n 2
+      # ./tester_testBLAS -# [#test_corner_cases] -l | tail -n 2
 
   build-test-performance:
     # Use GNU compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ endif()
 # Examples
 option( BUILD_EXAMPLES "Build examples" ON  )
 
+# Tests
+option( TLAPACK_BUILD_SINGLE_TESTER "Build one additional executable that contains all tests" OFF  )
+
 # Wrappers to <T>BLAS and <T>LAPACK
 option( C_WRAPPERS       "Build and install C wrappers"               OFF )
 option( CBLAS_WRAPPERS   "Build and install CBLAS wrappers to <T>BLAS" OFF )

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Here are the \<T\>LAPACK specific options and their default values
     BUILD_TESTING                       ON
     
         Build the testing tree
+    
+    TLAPACK_BUILD_SINGLE_TESTER         OFF
+    
+        Build one additional executable that contains all tests
         
     C_WRAPPERS                          OFF
     

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,15 +29,24 @@ FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "v2.13.1" )
 # Add folder with Catch.cmake to the CMAKE_MODULE_PATH
 set( CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${Catch2_SOURCE_DIR}/extras;${Catch2_SOURCE_DIR}/contrib" )
 
-#-------------------------------------------------------------------------------
-# Test sources
-file( GLOB test_sources
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/test_*.cpp" )
+add_subdirectory(src)
 
 #-------------------------------------------------------------------------------
 # tester: Program for tests
 
-add_executable( tester tests_main.cpp ${test_sources} )
+if( TLAPACK_BUILD_SINGLE_TESTER )# Test sources
+  file( GLOB test_sources "${CMAKE_CURRENT_SOURCE_DIR}/src/test_*.cpp" )
+  add_executable( tester tests_main.cpp ${test_sources} )
+  set_target_properties( tester
+    PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" )
+else()
+  add_executable( tester tests_main.cpp )
+  set_target_properties( tester
+    PROPERTIES
+      OUTPUT_NAME "tester_testBLAS"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
+endif()
 
 # Load testBLAS tests
 FetchPackage( "testBLAS" "https://github.com/tlapack/testBLAS.git" "master" )
@@ -49,10 +58,6 @@ if( TEST_MPFR )
   target_include_directories( tester PRIVATE ${MPFR_INCLUDES} ${GMP_INCLUDES} )
   target_link_libraries( tester PRIVATE ${MPFR_LIBRARIES} ${GMP_LIBRARIES} )
 endif()
-
-set_target_properties( tester
-PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" )
 
 # Add tests to CTest
 include(Catch)

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+#
+# This file is part of <T>LAPACK.
+# <T>LAPACK is free software: you can redistribute it and/or modify it under
+# the terms of the BSD 3-Clause license. See the accompanying LICENSE file
+
+include_directories( "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
+link_libraries( Catch2::Catch2 tlapack )
+if( TEST_MPFR )
+  include_directories( ${MPFR_INCLUDES} ${GMP_INCLUDES} )
+  link_libraries( ${MPFR_LIBRARIES} ${GMP_LIBRARIES} )
+endif()
+
+add_executable( test_blocked_francis test_blocked_francis.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_lasy2 test_lasy2.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_schur_move test_schur_move.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_transpose test_transpose.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_unmhr test_unmhr.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_gehrd test_gehrd.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_optBLAS test_optBLAS.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_schur_swap test_schur_swap.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_unblocked_francis test_unblocked_francis.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+add_executable( test_utils test_utils.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+
+set_target_properties( 
+  test_blocked_francis 
+  test_lasy2 
+  test_schur_move 
+  test_transpose 
+  test_unmhr 
+  test_gehrd 
+  test_optBLAS 
+  test_schur_swap 
+  test_unblocked_francis
+  test_utils
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
+  
+# Add tests to CTest
+if( NOT TLAPACK_BUILD_SINGLE_TESTER )
+  include(Catch)
+  catch_discover_tests(test_blocked_francis )
+  catch_discover_tests(test_lasy2 )
+  catch_discover_tests(test_schur_move )
+  catch_discover_tests(test_transpose )
+  catch_discover_tests(test_unmhr )
+  catch_discover_tests(test_gehrd )
+  catch_discover_tests(test_optBLAS )
+  catch_discover_tests(test_schur_swap )
+  catch_discover_tests(test_unblocked_francis)
+  catch_discover_tests(test_utils)
+endif()


### PR DESCRIPTION
Adds flag `TLAPACK_BUILD_SINGLE_TESTER` on CMake. Default is OFF. Builds testers separately on the build directory inside `test`.

__(After the modifications)__ To include a new test you should also modify the file `test/src/CMakeLists.txt` in the following way:
- Add `add_executable( test_YOURTEST test_YOURTEST.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )`.
- Add `test_YOURTEST` to the list in `set_target_properties`.
- Add `catch_discover_tests(test_YOURTEST)`.

I think I can improve it. But I have to look more into it.