### PR TITLE
Put more automation in the cmakelists.txt inside test/src

### DIFF
--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -4,48 +4,40 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file
 
+# Configurations
 include_directories( "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
 link_libraries( Catch2::Catch2 tlapack )
+add_definitions( -DCATCH_CONFIG_MAIN ) # Defines that each tester is a single executable
 if( TEST_MPFR )
   include_directories( ${MPFR_INCLUDES} ${GMP_INCLUDES} )
   link_libraries( ${MPFR_LIBRARIES} ${GMP_LIBRARIES} )
 endif()
 
-add_executable( test_blocked_francis test_blocked_francis.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_lasy2 test_lasy2.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_schur_move test_schur_move.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_transpose test_transpose.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_unmhr test_unmhr.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_gehrd test_gehrd.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_optBLAS test_optBLAS.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_schur_swap test_schur_swap.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_unblocked_francis test_unblocked_francis.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
-add_executable( test_utils test_utils.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../tests_main.cpp" )
+# Set the directory where to put testers
+set( TLAPACK_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" )
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
 
-set_target_properties( 
-  test_blocked_francis 
-  test_lasy2 
-  test_schur_move 
-  test_transpose 
-  test_unmhr 
-  test_gehrd 
-  test_optBLAS 
-  test_schur_swap 
-  test_unblocked_francis
-  test_utils
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
+# Testers
+add_executable( test_blocked_francis test_blocked_francis.cpp )
+add_executable( test_lasy2 test_lasy2.cpp )
+add_executable( test_schur_move test_schur_move.cpp )
+add_executable( test_transpose test_transpose.cpp )
+add_executable( test_unmhr test_unmhr.cpp )
+add_executable( test_gehrd test_gehrd.cpp )
+add_executable( test_optBLAS test_optBLAS.cpp )
+add_executable( test_schur_swap test_schur_swap.cpp )
+add_executable( test_unblocked_francis test_unblocked_francis.cpp )
+add_executable( test_utils test_utils.cpp )
+
+# Reset the output directory
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${TLAPACK_RUNTIME_OUTPUT_DIRECTORY}" )
   
 # Add tests to CTest
 if( NOT TLAPACK_BUILD_SINGLE_TESTER )
   include(Catch)
-  catch_discover_tests(test_blocked_francis )
-  catch_discover_tests(test_lasy2 )
-  catch_discover_tests(test_schur_move )
-  catch_discover_tests(test_transpose )
-  catch_discover_tests(test_unmhr )
-  catch_discover_tests(test_gehrd )
-  catch_discover_tests(test_optBLAS )
-  catch_discover_tests(test_schur_swap )
-  catch_discover_tests(test_unblocked_francis)
-  catch_discover_tests(test_utils)
+  
+  get_property( DIRECTORY_BUILDSYSTEM_TARGETS DIRECTORY PROPERTY BUILDSYSTEM_TARGETS )
+  foreach(target ${DIRECTORY_BUILDSYSTEM_TARGETS})
+    catch_discover_tests( ${target} )
+  endforeach()
 endif()


### PR DESCRIPTION
Now it should be easier (once more) to add new tests.
To add a new tester `my_new_test`:
1. Add your source file (`my_new_test.cpp`) to `test/src`.
2. Add a line to `test/src/CMakeLists.txt`:

```cmake
set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )

# New line for the tester:
add_executable( my_new_test my_new_test.cpp )

set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${TLAPACK_RUNTIME_OUTPUT_DIRECTORY}" )
``` 
