### PR TITLE
Changes from Catch v2 to v3

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -93,6 +93,7 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: >
         cmake -B build -G Ninja
+        -D BUILD_TESTING=ON
         -D BUILD_BLASPP_TESTS=ON
         -D blaspp_DIR=${{env.blaspp_DIR}}/build
         -D blaspp_TEST_DIR=${{env.blaspp_DIR}}/test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/testBLAS"]
+	path = test/testBLAS
+	url = https://github.com/tlapack/testBLAS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,27 @@ else()
   endif()
 endif()
 
+# Option GIT_SUBMODULE
+find_package(Git QUIET)
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+# Update submodules as needed
+  option(GIT_SUBMODULE "Check submodules during build" ON)
+  if(GIT_SUBMODULE)
+    message(STATUS "Submodule update")
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+      message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    endif()
+  endif()
+endif()
+
+cmake_dependent_option( BUILD_testBLAS_TESTS "Build testBLAS tests"
+  ON "BUILD_TESTING" # Default value when condition is true
+  OFF # Value when condition is false 
+)
+
 #-------------------------------------------------------------------------------
 # Modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,9 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.7)
 # VERSION 3.3: IN_LIST for if() operator
+# VERSION 3.7: VERSION_GREATER_EQUAL
 
 #-------------------------------------------------------------------------------
 # Read project version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ target_link_libraries( tlapack INTERFACE tblas )
 # Includes CMAKE_DEPENDENT_OPTION
 include(CMakeDependentOption)
 
+# Includes BUILD_TESTING option
+include(CTest)
+
 # LAPACK++ interface
 option( USE_LAPACKPP_WRAPPERS "Use LAPACK++ wrappers to link with optimized BLAS and LAPACK libraries" OFF )
 
@@ -216,7 +219,6 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Include tests
-include(CTest)
 if( BUILD_TESTING )
   add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Here are the \<T\>LAPACK specific options and their default values
         Build LAPACK++ tests. Not used if BUILD_TESTING is OFF. If it is ON, you also need to inform lapackpp_TEST_DIR,
         which is the path for the test sources of LAPACK++.
 
+    BUILD_testBLAS_TESTS                ON
+
+        Build testBLAS tests.
+
     TLAPACK_NDEBUG                      OFF
 
         Disable all error checks from <T>LAPACK.

--- a/cmake/FetchPackage.cmake
+++ b/cmake/FetchPackage.cmake
@@ -1,7 +1,6 @@
 # FetchPackage tries to load ${pkg} using:
 # 1. The usual CMake find_package
-# 2. Via the environment variable ${pkg}_DIR
-# 3. An online Git repository via the CMake FetchContent module
+# 2. An online Git repository via the CMake FetchContent module
 #
 # Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
 #
@@ -14,15 +13,7 @@ macro( FetchPackage pkg pkgURL gitTag )
   find_package( ${pkg} QUIET ) # Try to load ${pkg} from the system
   if( NOT ${pkg}_FOUND )
 
-    if( EXISTS "$ENV{${pkg}_DIR}" )
-
-      get_property( docString CACHE ${pkg}_DIR PROPERTY HELPSTRING )
-      set( ${pkg}_DIR $ENV{${pkg}_DIR} CACHE STRING "${docString}" FORCE )
-
-      add_subdirectory( ${${pkg}_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${pkg} )
-      message( STATUS "Using ${pkg} from ${${pkg}_DIR}" )
-
-    elseif( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14" )
+    if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14" )
 
       message( STATUS "${pkg} not found. Trying to fetch from ${pkgURL}. "
                       "It may take a while." )
@@ -37,9 +28,9 @@ macro( FetchPackage pkg pkgURL gitTag )
 
       # Test if the fetch was successful
       if( EXISTS "${${pkg}_SOURCE_DIR}" )
-      message( STATUS "Using ${pkg} from ${pkgURL}." )
+        message( STATUS "Using ${pkg} from ${pkgURL}." )
       else()
-      message( FATAL_ERROR "Failed in fetching ${pkg} from ${pkgURL}." )
+        message( FATAL_ERROR "Failed in fetching ${pkg} from ${pkgURL}." )
       endif()
 
       # Hide ${pkg}_DIR and FETCHCONTENT_ options
@@ -53,8 +44,7 @@ macro( FetchPackage pkg pkgURL gitTag )
 
     else()
       message( FATAL_ERROR "${pkg} not found. Set \"${pkg}_DIR\" to a directory containing "
-                      "one of the files: ${pkg}Config.cmake, ${pkg}-config.cmake; or "
-                      "containing the root of the project ${pkg}." )
+                      "one of the files: ${pkg}Config.cmake, ${pkg}-config.cmake." )
     endif()
 
   endif( NOT ${pkg}_FOUND )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,11 +23,8 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Load Catch2
-FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "v2.13.1" )
-
-#-------------------------------------------------------------------------------
-# Add folder with Catch.cmake to the CMAKE_MODULE_PATH
-set( CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${Catch2_SOURCE_DIR}/extras;${Catch2_SOURCE_DIR}/contrib" )
+FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "devel" )
+list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")
 
 add_subdirectory(src)
 
@@ -36,12 +33,12 @@ add_subdirectory(src)
 
 if( TLAPACK_BUILD_SINGLE_TESTER )# Test sources
   file( GLOB test_sources "${CMAKE_CURRENT_SOURCE_DIR}/src/test_*.cpp" )
-  add_executable( tester tests_main.cpp ${test_sources} )
+  add_executable( tester ${test_sources} )
   set_target_properties( tester
     PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" )
 else()
-  add_executable( tester tests_main.cpp )
+  add_executable( tester )
   set_target_properties( tester
     PROPERTIES
       OUTPUT_NAME "tester_testBLAS"
@@ -51,9 +48,9 @@ endif()
 # Load testBLAS tests
 FetchPackage( "testBLAS" "https://github.com/tlapack/testBLAS.git" "master" )
 
+# Configurations
 target_include_directories( tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-target_link_libraries( tester PRIVATE Catch2::Catch2 tlapack )
-
+target_link_libraries( tester PRIVATE Catch2::Catch2WithMain tlapack )
 if( TEST_MPFR )
   target_include_directories( tester PRIVATE ${MPFR_INCLUDES} ${GMP_INCLUDES} )
   target_link_libraries( tester PRIVATE ${MPFR_LIBRARIES} ${GMP_LIBRARIES} )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,19 @@
 include( "${TLAPACK_SOURCE_DIR}/cmake/FetchPackage.cmake" )
 
 #-------------------------------------------------------------------------------
+# Load Catch2
+FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "devel" )
+if( EXISTS "${Catch2_SOURCE_DIR}" )
+  list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")
+else()
+  list(APPEND CMAKE_MODULE_PATH "${Catch2_DIR}")
+endif()
+
+#-------------------------------------------------------------------------------
+# Build tests in the src directory
+add_subdirectory(src)
+
+#-------------------------------------------------------------------------------
 # Build BLAS++ tests
 if( BUILD_BLASPP_TESTS )
   add_subdirectory( blaspp )
@@ -18,44 +31,29 @@ if( BUILD_LAPACKPP_TESTS )
   add_subdirectory( lapackpp )
 endif()
 
-#########################
-## Tests from <T>LAPACK :
+#-------------------------------------------------------------------------------
+# Build testBLAS tests
+if( BUILD_testBLAS_TESTS )
+
+  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/testBLAS/CMakeLists.txt")
+    message(FATAL_ERROR "The testBLAS submodule was not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules or -Duse BUILD_testBLAS_TESTS=OFF and try again.")
+  endif()
+
+  add_subdirectory( testBLAS )
+
+endif()
 
 #-------------------------------------------------------------------------------
-# Load Catch2
-FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "devel" )
-list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")
+# Create a single-file tester with all tests
 
-add_subdirectory(src)
+if( TLAPACK_BUILD_SINGLE_TESTER )
 
-#-------------------------------------------------------------------------------
-# tester: Program for tests
-
-if( TLAPACK_BUILD_SINGLE_TESTER )# Test sources
   file( GLOB test_sources "${CMAKE_CURRENT_SOURCE_DIR}/src/test_*.cpp" )
   add_executable( tester ${test_sources} )
-  set_target_properties( tester
-    PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" )
-else()
-  add_executable( tester )
-  set_target_properties( tester
-    PROPERTIES
-      OUTPUT_NAME "tester_testBLAS"
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
+
+  if( BUILD_testBLAS_TESTS )
+    file( GLOB test_sources "${CMAKE_CURRENT_SOURCE_DIR}/testBLAS/src/test_*.cpp" )
+    target_sources( tester PRIVATE ${test_sources} )
+  endif()
+
 endif()
-
-# Load testBLAS tests
-FetchPackage( "testBLAS" "https://github.com/tlapack/testBLAS.git" "master" )
-
-# Configurations
-target_include_directories( tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-target_link_libraries( tester PRIVATE Catch2::Catch2WithMain tlapack )
-if( TEST_MPFR )
-  target_include_directories( tester PRIVATE ${MPFR_INCLUDES} ${GMP_INCLUDES} )
-  target_link_libraries( tester PRIVATE ${MPFR_LIBRARIES} ${GMP_LIBRARIES} )
-endif()
-
-# Add tests to CTest
-include(Catch)
-catch_discover_tests(tester)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ include( "${TLAPACK_SOURCE_DIR}/cmake/FetchPackage.cmake" )
 
 #-------------------------------------------------------------------------------
 # Load Catch2
-FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "devel" )
+FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "v3.0.1" )
 if( EXISTS "${Catch2_SOURCE_DIR}" )
   list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")
 else()

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -34,11 +34,10 @@ add_executable( test_gelq2 test_gelq2.cpp )
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${TLAPACK_RUNTIME_OUTPUT_DIRECTORY}" )
   
 # Add tests to CTest
-if( NOT TLAPACK_BUILD_SINGLE_TESTER )
-  include(Catch)
-  
-  get_property( DIRECTORY_BUILDSYSTEM_TARGETS DIRECTORY PROPERTY BUILDSYSTEM_TARGETS )
-  foreach(target ${DIRECTORY_BUILDSYSTEM_TARGETS})
-    catch_discover_tests( ${target} )
-  endforeach()
-endif()
+
+include(Catch)
+
+get_property( DIRECTORY_BUILDSYSTEM_TARGETS DIRECTORY PROPERTY BUILDSYSTEM_TARGETS )
+foreach(target ${DIRECTORY_BUILDSYSTEM_TARGETS})
+  catch_discover_tests( ${target} )
+endforeach()

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -6,8 +6,7 @@
 
 # Configurations
 include_directories( "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
-link_libraries( Catch2::Catch2 tlapack )
-add_definitions( -DCATCH_CONFIG_MAIN ) # Defines that each tester is a single executable
+link_libraries( Catch2::Catch2WithMain tlapack )
 if( TEST_MPFR )
   include_directories( ${MPFR_INCLUDES} ${GMP_INCLUDES} )
   link_libraries( ${MPFR_LIBRARIES} ${GMP_LIBRARIES} )

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -7,7 +7,7 @@
 // testBLAS is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_gelq2.cpp
+++ b/test/src/test_gelq2.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <plugins/tlapack_legacyArray.hpp>
 #include <tlapack.hpp>

--- a/test/src/test_gelqf.cpp
+++ b/test/src/test_gelqf.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <plugins/tlapack_legacyArray.hpp>
 #include <tlapack.hpp>

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_lauum.cpp
+++ b/test/src/test_lauum.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_optBLAS.cpp
+++ b/test/src/test_optBLAS.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <testdefinitions.hpp>
 
 #include <complex>

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <plugins/tlapack_debugutils.hpp>
 #include <tlapack.hpp>

--- a/test/src/test_transpose.cpp
+++ b/test/src/test_transpose.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -7,7 +7,7 @@
 // testBLAS is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_unmhr.cpp
+++ b/test/src/test_unmhr.cpp
@@ -7,7 +7,7 @@
 // testBLAS is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <plugins/tlapack_stdvector.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -7,7 +7,7 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tlapack.hpp>
 #include <testutils.hpp>
 

--- a/test/tests_main.cpp
+++ b/test/tests_main.cpp
@@ -1,8 +1,0 @@
-// Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
-//
-// This file is part of <T>LAPACK.
-// <T>LAPACK is free software: you can redistribute it and/or modify it under
-// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>


### PR DESCRIPTION
Closes #115 

From https://github.com/catchorg/Catch2/blob/devel/docs/migrate-v2-to-v3.md :

> There are many reasons why we decided to go from the old single-header distribution model to a more standard library distribution model. The big one is compile-time performance, but moving over to a split header distribution model also improves the future maintainability and extendability of the codebase.

This PR also removes the inconsistent option in the FetchPackage CMake module:
```cmake
    if( EXISTS "$ENV{${pkg}_DIR}" )

      get_property( docString CACHE ${pkg}_DIR PROPERTY HELPSTRING )
      set( ${pkg}_DIR $ENV{${pkg}_DIR} CACHE STRING "${docString}" FORCE )

      add_subdirectory( ${${pkg}_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${pkg} )
      message( STATUS "Using ${pkg} from ${${pkg}_DIR}" )
```