### PR TITLE
Changes all identifiers starting with underscores and/or with double underscores

### DIFF
--- a/config/version.h.in
+++ b/config/version.h.in
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_VERSION_H__
-#define __TLAPACK_VERSION_H__
+#ifndef TLAPACK_VERSION_H
+#define TLAPACK_VERSION_H
 
 // the configured options and settings for <T>LAPACK
 #define TLAPACK_VERSION @TLAPACK_VERSION@
@@ -13,4 +13,4 @@
 #define TLAPACK_VERSION_MINOR @TLAPACK_VERSION_MINOR@
 #define TLAPACK_VERSION_PATCH @TLAPACK_VERSION_PATCH@
 
-#endif // __TLAPACK_VERSION_H__
+#endif // TLAPACK_VERSION_H

--- a/include/base/arrayTraits.hpp
+++ b/include/base/arrayTraits.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_ARRAY_TRAITS__
-#define __TLAPACK_ARRAY_TRAITS__
+#ifndef TLAPACK_ARRAY_TRAITS
+#define TLAPACK_ARRAY_TRAITS
 
 #include <type_traits>
 #include "base/types.hpp"
@@ -175,4 +175,4 @@ namespace tlapack {
     constexpr strictLower_t strictLower = { };
 }
 
-#endif // __TLAPACK_ARRAY_TRAITS__
+#endif // TLAPACK_ARRAY_TRAITS

--- a/include/base/constants.hpp
+++ b/include/base/constants.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_CONSTANTS_HH__
-#define __TLAPACK_CONSTANTS_HH__
+#ifndef TLAPACK_CONSTANTS_HH
+#define TLAPACK_CONSTANTS_HH
 
 #include <type_traits>
 #include <limits>
@@ -16,7 +16,7 @@ namespace tlapack {
 // -----------------------------------------------------------------------------
 // Macros to compute scaling constants
 //
-// __Further details__
+// @details
 //
 // Anderson E (2017) Algorithm 978: Safe scaling in the level 1 BLAS.
 // ACM Trans Math Softw 44:. https://doi.org/10.1145/3061665
@@ -176,4 +176,4 @@ inline constexpr real_t blue_scalingMax()
 
 } // namespace tlapack
 
-#endif // __TLAPACK_CONSTANTS_HH__
+#endif // TLAPACK_CONSTANTS_HH

--- a/include/base/exceptionHandling.hpp
+++ b/include/base/exceptionHandling.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_EXCEPTION_HH__
-#define __TLAPACK_EXCEPTION_HH__
+#ifndef TLAPACK_EXCEPTION_HH
+#define TLAPACK_EXCEPTION_HH
 
 #include <stdexcept>
 #include <string>
@@ -182,4 +182,4 @@ namespace tlapack {
         ((void)0)
 #endif
 
-#endif // __TLAPACK_EXCEPTION_HH__
+#endif // TLAPACK_EXCEPTION_HH

--- a/include/base/types.hpp
+++ b/include/base/types.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_TYPES_HH__
-#define __TLAPACK_TYPES_HH__
+#ifndef TLAPACK_TYPES_HH
+#define TLAPACK_TYPES_HH
 
 #include <complex>
 #include <type_traits>
@@ -330,4 +330,4 @@ namespace tlapack {
 #undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES
 #undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES
 
-#endif // __TLAPACK_TYPES_HH__
+#endif // TLAPACK_TYPES_HH

--- a/include/base/utils.hpp
+++ b/include/base/utils.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_UTILS_HH__
-#define __TLAPACK_UTILS_HH__
+#ifndef TLAPACK_UTILS_HH
+#define TLAPACK_UTILS_HH
 
 #include <limits>
 #include <cmath>
@@ -968,4 +968,4 @@ inline constexpr auto get_work( opts_t&& opts ) {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_UTILS_HH__
+#endif // TLAPACK_UTILS_HH

--- a/include/blas/asum.hpp
+++ b/include/blas/asum.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_ASUM_HH__
-#define __TLAPACK_BLAS_ASUM_HH__
+#ifndef TLAPACK_BLAS_ASUM_HH
+#define TLAPACK_BLAS_ASUM_HH
 
 #include "base/utils.hpp"
 
@@ -42,4 +42,4 @@ auto asum( vector_t const& x )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_ASUM_HH__
+#endif        //  #ifndef TLAPACK_BLAS_ASUM_HH

--- a/include/blas/axpy.hpp
+++ b/include/blas/axpy.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_AXPY_HH__
-#define __TLAPACK_BLAS_AXPY_HH__
+#ifndef TLAPACK_BLAS_AXPY_HH
+#define TLAPACK_BLAS_AXPY_HH
 
 #include "base/utils.hpp"
 
@@ -47,4 +47,4 @@ void axpy(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_AXPY_HH__
+#endif        //  #ifndef TLAPACK_BLAS_AXPY_HH

--- a/include/blas/copy.hpp
+++ b/include/blas/copy.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_COPY_HH__
-#define __TLAPACK_BLAS_COPY_HH__
+#ifndef TLAPACK_BLAS_COPY_HH
+#define TLAPACK_BLAS_COPY_HH
 
 #include "base/utils.hpp"
 
@@ -43,4 +43,4 @@ void copy( const vectorX_t& x, vectorY_t& y )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_COPY_HH__
+#endif        //  #ifndef TLAPACK_BLAS_COPY_HH

--- a/include/blas/dot.hpp
+++ b/include/blas/dot.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_DOT_HH__
-#define __TLAPACK_BLAS_DOT_HH__
+#ifndef TLAPACK_BLAS_DOT_HH
+#define TLAPACK_BLAS_DOT_HH
 
 #include "base/utils.hpp"
 
@@ -51,4 +51,4 @@ auto dot( const vectorX_t& x, const vectorY_t& y )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_DOT_HH__
+#endif        //  #ifndef TLAPACK_BLAS_DOT_HH

--- a/include/blas/dotu.hpp
+++ b/include/blas/dotu.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_DOTU_HH__
-#define __TLAPACK_BLAS_DOTU_HH__
+#ifndef TLAPACK_BLAS_DOTU_HH
+#define TLAPACK_BLAS_DOTU_HH
 
 #include "base/utils.hpp"
 
@@ -51,4 +51,4 @@ auto dotu( const vectorX_t& x, const vectorY_t& y )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_DOTU_HH__
+#endif        //  #ifndef TLAPACK_BLAS_DOTU_HH

--- a/include/blas/gemm.hpp
+++ b/include/blas/gemm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_GEMM_HH__
-#define __TLAPACK_BLAS_GEMM_HH__
+#ifndef TLAPACK_BLAS_GEMM_HH
+#define TLAPACK_BLAS_GEMM_HH
 
 #include "base/utils.hpp"
 
@@ -231,4 +231,4 @@ void gemm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_GEMM_HH__
+#endif        //  #ifndef TLAPACK_BLAS_GEMM_HH

--- a/include/blas/gemv.hpp
+++ b/include/blas/gemv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_GEMV_HH__
-#define __TLAPACK_BLAS_GEMV_HH__
+#ifndef TLAPACK_BLAS_GEMV_HH
+#define TLAPACK_BLAS_GEMV_HH
 
 #include "base/utils.hpp"
 
@@ -142,4 +142,4 @@ void gemv(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_GEMV_HH__
+#endif        //  #ifndef TLAPACK_BLAS_GEMV_HH

--- a/include/blas/ger.hpp
+++ b/include/blas/ger.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_GER_HH__
-#define __TLAPACK_BLAS_GER_HH__
+#ifndef TLAPACK_BLAS_GER_HH
+#define TLAPACK_BLAS_GER_HH
 
 #include "base/utils.hpp"
 
@@ -65,4 +65,4 @@ void ger(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_GER_HH__
+#endif        //  #ifndef TLAPACK_BLAS_GER_HH

--- a/include/blas/geru.hpp
+++ b/include/blas/geru.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_GERU_HH__
-#define __TLAPACK_BLAS_GERU_HH__
+#ifndef TLAPACK_BLAS_GERU_HH
+#define TLAPACK_BLAS_GERU_HH
 
 #include "base/utils.hpp"
 #include "blas/ger.hpp"
@@ -66,4 +66,4 @@ void geru(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_GER_HH__
+#endif        //  #ifndef TLAPACK_BLAS_GER_HH

--- a/include/blas/hemm.hpp
+++ b/include/blas/hemm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_HEMM_HH__
-#define __TLAPACK_BLAS_HEMM_HH__
+#ifndef TLAPACK_BLAS_HEMM_HH
+#define TLAPACK_BLAS_HEMM_HH
 
 #include "base/utils.hpp"
 
@@ -184,4 +184,4 @@ void hemm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_HEMM_HH__
+#endif        //  #ifndef TLAPACK_BLAS_HEMM_HH

--- a/include/blas/hemv.hpp
+++ b/include/blas/hemv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_HEMV_HH__
-#define __TLAPACK_BLAS_HEMV_HH__
+#ifndef TLAPACK_BLAS_HEMV_HH
+#define TLAPACK_BLAS_HEMV_HH
 
 #include "base/utils.hpp"
 
@@ -116,4 +116,4 @@ void hemv(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_HEMV_HH__
+#endif        //  #ifndef TLAPACK_BLAS_HEMV_HH

--- a/include/blas/her.hpp
+++ b/include/blas/her.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_HER_HH__
-#define __TLAPACK_BLAS_HER_HH__
+#ifndef TLAPACK_BLAS_HER_HH
+#define TLAPACK_BLAS_HER_HH
 
 #include "base/utils.hpp"
 
@@ -88,4 +88,4 @@ void her(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_HER_HH__
+#endif        //  #ifndef TLAPACK_BLAS_HER_HH

--- a/include/blas/her2.hpp
+++ b/include/blas/her2.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_HER2_HH__
-#define __TLAPACK_BLAS_HER2_HH__
+#ifndef TLAPACK_BLAS_HER2_HH
+#define TLAPACK_BLAS_HER2_HH
 
 #include "base/utils.hpp"
 
@@ -90,4 +90,4 @@ void her2(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_HER2_HH__
+#endif        //  #ifndef TLAPACK_BLAS_HER2_HH

--- a/include/blas/her2k.hpp
+++ b/include/blas/her2k.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_HER2K_HH__
-#define __TLAPACK_BLAS_HER2K_HH__
+#ifndef TLAPACK_BLAS_HER2K_HH
+#define TLAPACK_BLAS_HER2K_HH
 
 #include "base/utils.hpp"
 
@@ -188,4 +188,4 @@ void her2k(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_HER2K_HH__
+#endif        //  #ifndef TLAPACK_BLAS_HER2K_HH

--- a/include/blas/herk.hpp
+++ b/include/blas/herk.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_HERK_HH__
-#define __TLAPACK_BLAS_HERK_HH__
+#ifndef TLAPACK_BLAS_HERK_HH
+#define TLAPACK_BLAS_HERK_HH
 
 #include "base/utils.hpp"
 
@@ -172,4 +172,4 @@ void herk(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_HERK_HH__
+#endif        //  #ifndef TLAPACK_BLAS_HERK_HH

--- a/include/blas/iamax.hpp
+++ b/include/blas/iamax.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_IAMAX_HH__
-#define __TLAPACK_BLAS_IAMAX_HH__
+#ifndef TLAPACK_BLAS_IAMAX_HH
+#define TLAPACK_BLAS_IAMAX_HH
 
 #include "base/utils.hpp"
 #include "base/constants.hpp"
@@ -205,4 +205,4 @@ iamax( const vector_t& x, const ErrorCheck& ec = {} )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_IAMAX_HH__
+#endif        //  #ifndef TLAPACK_BLAS_IAMAX_HH

--- a/include/blas/nrm2.hpp
+++ b/include/blas/nrm2.hpp
@@ -13,8 +13,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_NRM2_HH__
-#define __TLAPACK_BLAS_NRM2_HH__
+#ifndef TLAPACK_BLAS_NRM2_HH
+#define TLAPACK_BLAS_NRM2_HH
 
 #include "base/utils.hpp"
 #include "base/constants.hpp"
@@ -122,4 +122,4 @@ auto nrm2( const vector_t& x )
 
 }  // namespace tlapack
 
-#endif        // #ifndef __TLAPACK_BLAS_NRM2_HH__
+#endif        // #ifndef TLAPACK_BLAS_NRM2_HH

--- a/include/blas/rot.hpp
+++ b/include/blas/rot.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_ROT_HH__
-#define __TLAPACK_BLAS_ROT_HH__
+#ifndef TLAPACK_BLAS_ROT_HH
+#define TLAPACK_BLAS_ROT_HH
 
 #include "base/utils.hpp"
 
@@ -65,4 +65,4 @@ void rot(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_ROT_HH__
+#endif        //  #ifndef TLAPACK_BLAS_ROT_HH

--- a/include/blas/rotg.hpp
+++ b/include/blas/rotg.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_ROTG_HH__
-#define __TLAPACK_BLAS_ROTG_HH__
+#ifndef TLAPACK_BLAS_ROTG_HH
+#define TLAPACK_BLAS_ROTG_HH
 
 #include "base/utils.hpp"
 
@@ -94,7 +94,7 @@ void rotg(
  * @param[out]    c Cosine of rotation; real.
  * @param[in]     s Sine of rotation; complex.
  *
- * __Further details__
+ * @details
  *
  * Anderson E (2017) Algorithm 978: Safe scaling in the level 1 BLAS.
  * ACM Trans Math Softw 44:. https://doi.org/10.1145/3061665
@@ -206,4 +206,4 @@ void rotg(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_ROTG_HH__
+#endif        //  #ifndef TLAPACK_BLAS_ROTG_HH

--- a/include/blas/rotm.hpp
+++ b/include/blas/rotm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_ROTM_HH__
-#define __TLAPACK_BLAS_ROTM_HH__
+#ifndef TLAPACK_BLAS_ROTM_HH
+#define TLAPACK_BLAS_ROTM_HH
 
 #include "base/utils.hpp"
 
@@ -107,4 +107,4 @@ void rotm( vectorX_t& x, vectorY_t& y, const T h[4] )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_ROTM_HH__
+#endif        //  #ifndef TLAPACK_BLAS_ROTM_HH

--- a/include/blas/rotmg.hpp
+++ b/include/blas/rotmg.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_ROTMG_HH__
-#define __TLAPACK_BLAS_ROTMG_HH__
+#ifndef TLAPACK_BLAS_ROTMG_HH
+#define TLAPACK_BLAS_ROTMG_HH
 
 #include "base/utils.hpp"
 
@@ -77,7 +77,7 @@ namespace tlapack {
  *      h = { h_{11}, h_{21}, h_{12}, h_{22} }.
  * \]
  *
- * __Further details__
+ * @details
  *
  * Hammarling, Sven. A note on modifications to the Givens plane rotation.
  * IMA Journal of Applied Mathematics, 13:215-218, 1974.
@@ -211,4 +211,4 @@ int rotmg( T& d1, T& d2, T& a, const T& b, T h[4] )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_ROTMG_HH__
+#endif        //  #ifndef TLAPACK_BLAS_ROTMG_HH

--- a/include/blas/scal.hpp
+++ b/include/blas/scal.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SCAL_HH__
-#define __TLAPACK_BLAS_SCAL_HH__
+#ifndef TLAPACK_BLAS_SCAL_HH
+#define TLAPACK_BLAS_SCAL_HH
 
 #include "base/utils.hpp"
 
@@ -40,4 +40,4 @@ void scal( const alpha_t& alpha, vector_t& x )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SCAL_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SCAL_HH

--- a/include/blas/swap.hpp
+++ b/include/blas/swap.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SWAP_HH__
-#define __TLAPACK_BLAS_SWAP_HH__
+#ifndef TLAPACK_BLAS_SWAP_HH
+#define TLAPACK_BLAS_SWAP_HH
 
 #include "base/utils.hpp"
 
@@ -46,4 +46,4 @@ void swap( vectorX_t& x, vectorY_t& y )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SWAP_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SWAP_HH

--- a/include/blas/symm.hpp
+++ b/include/blas/symm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SYMM_HH__
-#define __TLAPACK_BLAS_SYMM_HH__
+#ifndef TLAPACK_BLAS_SYMM_HH
+#define TLAPACK_BLAS_SYMM_HH
 
 #include "base/utils.hpp"
 
@@ -179,4 +179,4 @@ void symm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SYMM_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SYMM_HH

--- a/include/blas/symv.hpp
+++ b/include/blas/symv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SYMV_HH__
-#define __TLAPACK_BLAS_SYMV_HH__
+#ifndef TLAPACK_BLAS_SYMV_HH
+#define TLAPACK_BLAS_SYMV_HH
 
 #include "base/utils.hpp"
 
@@ -113,4 +113,4 @@ void symv(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SYMV_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SYMV_HH

--- a/include/blas/syr.hpp
+++ b/include/blas/syr.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SYR_HH__
-#define __TLAPACK_BLAS_SYR_HH__
+#ifndef TLAPACK_BLAS_SYR_HH
+#define TLAPACK_BLAS_SYR_HH
 
 #include "base/utils.hpp"
 
@@ -78,4 +78,4 @@ void syr(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SYR_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SYR_HH

--- a/include/blas/syr2.hpp
+++ b/include/blas/syr2.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SYR2_HH__
-#define __TLAPACK_BLAS_SYR2_HH__
+#ifndef TLAPACK_BLAS_SYR2_HH
+#define TLAPACK_BLAS_SYR2_HH
 
 #include "base/utils.hpp"
 
@@ -86,4 +86,4 @@ void syr2(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SYR2_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SYR2_HH

--- a/include/blas/syr2k.hpp
+++ b/include/blas/syr2k.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SYR2K_HH__
-#define __TLAPACK_BLAS_SYR2K_HH__
+#ifndef TLAPACK_BLAS_SYR2K_HH
+#define TLAPACK_BLAS_SYR2K_HH
 
 #include "base/utils.hpp"
 
@@ -164,4 +164,4 @@ void syr2k(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SYR2K_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SYR2K_HH

--- a/include/blas/syrk.hpp
+++ b/include/blas/syrk.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_SYRK_HH__
-#define __TLAPACK_BLAS_SYRK_HH__
+#ifndef TLAPACK_BLAS_SYRK_HH
+#define TLAPACK_BLAS_SYRK_HH
 
 #include "base/utils.hpp"
 
@@ -144,4 +144,4 @@ void syrk(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_SYRK_HH__
+#endif        //  #ifndef TLAPACK_BLAS_SYRK_HH

--- a/include/blas/trmm.hpp
+++ b/include/blas/trmm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_TRMM_HH__
-#define __TLAPACK_BLAS_TRMM_HH__
+#ifndef TLAPACK_BLAS_TRMM_HH
+#define TLAPACK_BLAS_TRMM_HH
 
 #include "base/utils.hpp"
 
@@ -288,4 +288,4 @@ void trmm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_TRMM_HH__
+#endif        //  #ifndef TLAPACK_BLAS_TRMM_HH

--- a/include/blas/trmv.hpp
+++ b/include/blas/trmv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_TRMV_HH__
-#define __TLAPACK_BLAS_TRMV_HH__
+#ifndef TLAPACK_BLAS_TRMV_HH
+#define TLAPACK_BLAS_TRMV_HH
 
 #include "base/utils.hpp"
 
@@ -196,4 +196,4 @@ void trmv(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_TRMV_HH__
+#endif        //  #ifndef TLAPACK_BLAS_TRMV_HH

--- a/include/blas/trsm.hpp
+++ b/include/blas/trsm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_TRSM_HH__
-#define __TLAPACK_BLAS_TRSM_HH__
+#ifndef TLAPACK_BLAS_TRSM_HH
+#define TLAPACK_BLAS_TRSM_HH
 
 #include "base/utils.hpp"
 
@@ -279,4 +279,4 @@ void trsm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_TRSM_HH__
+#endif        //  #ifndef TLAPACK_BLAS_TRSM_HH

--- a/include/blas/trsv.hpp
+++ b/include/blas/trsv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_TRSV_HH__
-#define __TLAPACK_BLAS_TRSV_HH__
+#ifndef TLAPACK_BLAS_TRSV_HH
+#define TLAPACK_BLAS_TRSV_HH
 
 #include "base/utils.hpp"
 
@@ -216,4 +216,4 @@ void trsv(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_BLAS_TRSV_HH__
+#endif        //  #ifndef TLAPACK_BLAS_TRSV_HH

--- a/include/lapack/agressive_early_deflation.hpp
+++ b/include/lapack/agressive_early_deflation.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __AED_HH__
-#define __AED_HH__
+#ifndef TLAPACK_AED_HH
+#define TLAPACK_AED_HH
 
 #include <complex>
 
@@ -424,4 +424,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __AED_HH__
+#endif // TLAPACK_AED_HH

--- a/include/lapack/gehd2.hpp
+++ b/include/lapack/gehd2.hpp
@@ -6,8 +6,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_GEHD2_HH__
-#define __TLAPACK_GEHD2_HH__
+#ifndef TLAPACK_GEHD2_HH
+#define TLAPACK_GEHD2_HH
 
 #include <iostream>
 
@@ -99,4 +99,4 @@ int gehd2( size_type< matrix_t > ilo, size_type< matrix_t > ihi, matrix_t& A, ve
 
 } // lapack
 
-#endif // __GEHD2_HH__
+#endif // TLAPACK_GEHD2_HH

--- a/include/lapack/gehrd.hpp
+++ b/include/lapack/gehrd.hpp
@@ -6,8 +6,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_GEHRD_HH__
-#define __TLAPACK_GEHRD_HH__
+#ifndef TLAPACK_GEHRD_HH
+#define TLAPACK_GEHRD_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "base/utils.hpp"
@@ -184,4 +184,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __GEHRD_HH__
+#endif // TLAPACK_GEHRD_HH

--- a/include/lapack/gelq2.hpp
+++ b/include/lapack/gelq2.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_GELQ2_HH__
-#define __TLAPACK_GELQ2_HH__
+#ifndef TLAPACK_GELQ2_HH
+#define TLAPACK_GELQ2_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -95,4 +95,4 @@ namespace tlapack
     }
 }
 
-#endif // __TLAPACK_GELQ2_HH__
+#endif // TLAPACK_GELQ2_HH

--- a/include/lapack/gelqf.hpp
+++ b/include/lapack/gelqf.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_GELQF_HH__
-#define __TLAPACK_GELQF_HH__
+#ifndef TLAPACK_GELQF_HH
+#define TLAPACK_GELQF_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -114,4 +114,4 @@ namespace tlapack
         return 0;
     }
 }
-#endif // __TLAPACK_GELQF_HH__
+#endif // TLAPACK_GELQF_HH

--- a/include/lapack/geqr2.hpp
+++ b/include/lapack/geqr2.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_GEQR2_HH__
-#define __TLAPACK_GEQR2_HH__
+#ifndef TLAPACK_GEQR2_HH
+#define TLAPACK_GEQR2_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -100,4 +100,4 @@ int geqr2( matrix_t& A, vector_t &tau, work_t &work )
 
 } // lapack
 
-#endif // __GEQR2_HH__
+#endif // TLAPACK_GEQR2_HH

--- a/include/lapack/lacpy.hpp
+++ b/include/lapack/lacpy.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LACPY_HH__
-#define __TLAPACK_LACPY_HH__
+#ifndef TLAPACK_LACPY_HH
+#define TLAPACK_LACPY_HH
 
 #include "base/types.hpp"
 
@@ -73,4 +73,4 @@ void lacpy( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
 
 }
 
-#endif // __LACPY_HH__
+#endif // TLAPACK_LACPY_HH

--- a/include/lapack/ladiv.hpp
+++ b/include/lapack/ladiv.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LADIV_HH__
-#define __TLAPACK_LADIV_HH__
+#ifndef TLAPACK_LADIV_HH
+#define TLAPACK_LADIV_HH
 
 #include "base/utils.hpp"
 
@@ -82,4 +82,4 @@ inline std::complex<real_t> ladiv(
 
 }
 
-#endif // __LADIV_HH__
+#endif // TLAPACK_LADIV_HH

--- a/include/lapack/lahqr.hpp
+++ b/include/lapack/lahqr.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAHQR_HH__
-#define __TLAPACK_LAHQR_HH__
+#ifndef TLAPACK_LAHQR_HH
+#define TLAPACK_LAHQR_HH
 
 #include <complex>
 #include <iostream>
@@ -709,4 +709,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __LAHQR_HH__
+#endif // TLAPACK_LAHQR_HH

--- a/include/lapack/lahqr_eig22.hpp
+++ b/include/lapack/lahqr_eig22.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAHQR_EIG22_HH__
-#define __TLAPACK_LAHQR_EIG22_HH__
+#ifndef TLAPACK_LAHQR_EIG22_HH
+#define TLAPACK_LAHQR_EIG22_HH
 
 #include <complex>
 
@@ -69,4 +69,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __LAHQR_EIG22_HH__
+#endif // TLAPACK_LAHQR_EIG22_HH

--- a/include/lapack/lahqr_schur22.hpp
+++ b/include/lapack/lahqr_schur22.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAHQR_SCHUR22_HH__
-#define __TLAPACK_LAHQR_SCHUR22_HH__
+#ifndef TLAPACK_LAHQR_SCHUR22_HH
+#define TLAPACK_LAHQR_SCHUR22_HH
 
 #include <complex>
 #include <cmath>
@@ -218,4 +218,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __LAHQR_SCHUR22_HH__
+#endif // TLAPACK_LAHQR_SCHUR22_HH

--- a/include/lapack/lahqr_shiftcolumn.hpp
+++ b/include/lapack/lahqr_shiftcolumn.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAHQR_SHIFTCOLUMN_HH__
-#define __TLAPACK_LAHQR_SHIFTCOLUMN_HH__
+#ifndef TLAPACK_LAHQR_SHIFTCOLUMN_HH
+#define TLAPACK_LAHQR_SHIFTCOLUMN_HH
 
 #include <complex>
 
@@ -173,4 +173,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __LAHQR_SHIFTCOLUMN_HH__
+#endif // TLAPACK_LAHQR_SHIFTCOLUMN_HH

--- a/include/lapack/lahr2.hpp
+++ b/include/lapack/lahr2.hpp
@@ -6,8 +6,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAHR2_HH__
-#define __TLAPACK_LAHR2_HH__
+#ifndef TLAPACK_LAHR2_HH
+#define TLAPACK_LAHR2_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -177,4 +177,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __LAHR2_HH__
+#endif // TLAPACK_LAHR2_HH

--- a/include/lapack/lange.hpp
+++ b/include/lapack/lange.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LANGE_HH__
-#define __TLAPACK_LANGE_HH__
+#ifndef TLAPACK_LANGE_HH
+#define TLAPACK_LANGE_HH
 
 #include "base/types.hpp"
 #include "lapack/lassq.hpp"
@@ -188,4 +188,4 @@ lange( norm_t normType, const matrix_t& A, work_t& work )
 
 } // lapack
 
-#endif // __LANGE_HH__
+#endif // TLAPACK_LANGE_HH

--- a/include/lapack/lanhe.hpp
+++ b/include/lapack/lanhe.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LANHE_HH__
-#define __TLAPACK_LANHE_HH__
+#ifndef TLAPACK_LANHE_HH
+#define TLAPACK_LANHE_HH
 
 #include "base/types.hpp"
 #include "lapack/lassq.hpp"
@@ -280,4 +280,4 @@ lanhe( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
 
 } // lapack
 
-#endif // __LANHE_HH__
+#endif // TLAPACK_LANHE_HH

--- a/include/lapack/lansy.hpp
+++ b/include/lapack/lansy.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LANSY_HH__
-#define __TLAPACK_LANSY_HH__
+#ifndef TLAPACK_LANSY_HH
+#define TLAPACK_LANSY_HH
 
 #include "base/types.hpp"
 #include "lapack/lassq.hpp"
@@ -252,4 +252,4 @@ lansy( norm_t normType, uplo_t uplo, const matrix_t& A, work_t& work )
 
 } // lapack
 
-#endif // __LANSY_HH__
+#endif // TLAPACK_LANSY_HH

--- a/include/lapack/lantr.hpp
+++ b/include/lapack/lantr.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LANTR_HH__
-#define __TLAPACK_LANTR_HH__
+#ifndef TLAPACK_LANTR_HH
+#define TLAPACK_LANTR_HH
 
 #include "base/types.hpp"
 #include "lapack/lassq.hpp"
@@ -371,4 +371,4 @@ lantr( norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A, work_t& wor
 
 } // lapack
 
-#endif // __LANTR_HH__
+#endif // TLAPACK_LANTR_HH

--- a/include/lapack/lapy2.hpp
+++ b/include/lapack/lapy2.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAPY2_HH__
-#define __TLAPACK_LAPY2_HH__
+#ifndef TLAPACK_LAPY2_HH
+#define TLAPACK_LAPY2_HH
 
 namespace tlapack {
 
@@ -56,4 +56,4 @@ real_type<TX,TY> lapy2( const TX& x, const TY& y )
 
 }
 
-#endif // __LAPY2_HH__
+#endif // TLAPACK_LAPY2_HH

--- a/include/lapack/lapy3.hpp
+++ b/include/lapack/lapy3.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAPY3_HH__
-#define __TLAPACK_LAPY3_HH__
+#ifndef TLAPACK_LAPY3_HH
+#define TLAPACK_LAPY3_HH
 
 #include "base/utils.hpp"
 
@@ -57,4 +57,4 @@ real_type<TX,TY,TZ> lapy3(
 
 }
 
-#endif // __LAPY3_HH__
+#endif // TLAPACK_LAPY3_HH

--- a/include/lapack/larf.hpp
+++ b/include/lapack/larf.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LARF_HH__
-#define __TLAPACK_LARF_HH__
+#ifndef TLAPACK_LARF_HH
+#define TLAPACK_LARF_HH
 
 #include "base/utils.hpp"
 
@@ -119,4 +119,4 @@ inline void larf(
 
 } // lapack
 
-#endif // __LARF_HH__
+#endif // TLAPACK_LARF_HH

--- a/include/lapack/larfb.hpp
+++ b/include/lapack/larfb.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LARFB_HH__
-#define __TLAPACK_LARFB_HH__
+#ifndef TLAPACK_LARFB_HH
+#define TLAPACK_LARFB_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -519,4 +519,4 @@ int larfb(
 
 }
 
-#endif // __LARFB_HH__
+#endif // TLAPACK_LARFB_HH

--- a/include/lapack/larfg.hpp
+++ b/include/lapack/larfg.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LARFG_HH__
-#define __TLAPACK_LARFG_HH__
+#ifndef TLAPACK_LARFG_HH
+#define TLAPACK_LARFG_HH
 
 #include "base/types.hpp"
 #include "lapack/lapy2.hpp"
@@ -130,4 +130,4 @@ void larfg( vector_t& v, tau_t& tau )
 
 }
 
-#endif // __LARFG_HH__
+#endif // TLAPACK_LARFG_HH

--- a/include/lapack/larft.hpp
+++ b/include/lapack/larft.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LARFT_HH__
-#define __TLAPACK_LARFT_HH__
+#ifndef TLAPACK_LARFT_HH
+#define TLAPACK_LARFT_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -258,4 +258,4 @@ int larft(
 
 }
 
-#endif // __LARFT_HH__
+#endif // TLAPACK_LARFT_HH

--- a/include/lapack/larnv.hpp
+++ b/include/lapack/larnv.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LARNV_HH__
-#define __TLAPACK_LARNV_HH__
+#ifndef TLAPACK_LARNV_HH
+#define TLAPACK_LARNV_HH
 
 #include <random>
 #include "base/types.hpp"
@@ -108,4 +108,4 @@ void larnv( Sseq& iseed, vector_t& x )
 
 }
 
-#endif // __LARNV_HH__
+#endif // TLAPACK_LARNV_HH

--- a/include/lapack/lascl.hpp
+++ b/include/lapack/lascl.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LASCL_HH__
-#define __TLAPACK_LASCL_HH__
+#ifndef TLAPACK_LASCL_HH
+#define TLAPACK_LASCL_HH
 
 #include "base/utils.hpp"
 
@@ -91,45 +91,45 @@ int lascl(
         return 0;
 
     bool done = false;
-    real_t _a = a, _b = b;
+    real_t a_ = a, b_ = b;
     while (!done)
     {
         real_t c, a1, b1 = b * small;
-        if (b1 == _b) {
+        if (b1 == b_) {
             // b is not finite:
             //  c is a correctly signed zero if a is finite,
             //  c is NaN otherwise.
-            c = _a / _b;
+            c = a_ / b_;
             done = true;
         }
         else { // b is finite
-            a1 = _a / big;
-            if (a1 == _a) {
+            a1 = a_ / big;
+            if (a1 == a_) {
                 // a is either 0 or an infinity number:
                 //  in both cases, c = a serves as the correct multiplication factor.
-                c = _a;
+                c = a_;
                 done = true;
             }
-            else if ( (abs(b1) > abs(_a)) && (_a != real_t(0)) ) {
+            else if ( (abs(b1) > abs(a_)) && (a_ != real_t(0)) ) {
                 // a is a non-zero finite number and abs(a/b) < small:
                 //  Set c = small as the multiplication factor,
                 //  Multiply b by the small factor.
                 c = small;
                 done = false;
-                _b = b1;
+                b_ = b1;
             }
-            else if (abs(a1) > abs(_b)) {
+            else if (abs(a1) > abs(b_)) {
                 // abs(a/b) > big:
                 //  Set c = big as the multiplication factor,
                 //  Divide a by the big factor.
                 c = big;
                 done = false;
-                _a = a1;
+                a_ = a1;
             }
             else {
                 // small <= abs(a/b) <= big:
                 //  Set c = a/b as the multiplication factor.
-                c = _a / _b;
+                c = a_ / b_;
                 done = true;
             }
         }
@@ -234,45 +234,45 @@ int lascl(
         return 0;
 
     bool done = false;
-    real_t _a = a, _b = b;
+    real_t a_ = a, b_ = b;
     while (!done)
     {
         real_t c, a1, b1 = b * small;
-        if (b1 == _b) {
+        if (b1 == b_) {
             // b is not finite:
             //  c is a correctly signed zero if a is finite,
             //  c is NaN otherwise.
-            c = _a / _b;
+            c = a_ / b_;
             done = true;
         }
         else { // b is finite
-            a1 = _a / big;
-            if (a1 == _a) {
+            a1 = a_ / big;
+            if (a1 == a_) {
                 // a is either 0 or an infinity number:
                 //  in both cases, c = a serves as the correct multiplication factor.
-                c = _a;
+                c = a_;
                 done = true;
             }
-            else if ( (abs(b1) > abs(_a)) && (_a != real_t(0)) ) {
+            else if ( (abs(b1) > abs(a_)) && (a_ != real_t(0)) ) {
                 // a is a non-zero finite number and abs(a/b) < small:
                 //  Set c = small as the multiplication factor,
                 //  Multiply b by the small factor.
                 c = small;
                 done = false;
-                _b = b1;
+                b_ = b1;
             }
-            else if (abs(a1) > abs(_b)) {
+            else if (abs(a1) > abs(b_)) {
                 // abs(a/b) > big:
                 //  Set c = big as the multiplication factor,
                 //  Divide a by the big factor.
                 c = big;
                 done = false;
-                _a = a1;
+                a_ = a1;
             }
             else {
                 // small <= abs(a/b) <= big:
                 //  Set c = a/b as the multiplication factor.
-                c = _a / _b;
+                c = a_ / b_;
                 done = true;
             }
         }
@@ -287,4 +287,4 @@ int lascl(
 
 }
 
-#endif // __LASCL_HH__
+#endif // TLAPACK_LASCL_HH

--- a/include/lapack/laset.hpp
+++ b/include/lapack/laset.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LASET_HH__
-#define __TLAPACK_LASET_HH__
+#ifndef TLAPACK_LASET_HH
+#define TLAPACK_LASET_HH
 
 #include "base/types.hpp"
 
@@ -88,4 +88,4 @@ void laset(
 
 }
 
-#endif // __LASET_HH__
+#endif // TLAPACK_LASET_HH

--- a/include/lapack/lassq.hpp
+++ b/include/lapack/lassq.hpp
@@ -12,8 +12,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LASSQ_HH__
-#define __TLAPACK_LASSQ_HH__
+#ifndef TLAPACK_LASSQ_HH
+#define TLAPACK_LASSQ_HH
 
 #include "base/utils.hpp"
 
@@ -198,4 +198,4 @@ void lassq(
 
 } // lapack
 
-#endif // __LASSQ_HH__
+#endif // TLAPACK_LASSQ_HH

--- a/include/lapack/lasy2.hpp
+++ b/include/lapack/lasy2.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LASY2_HH__
-#define __TLAPACK_LASY2_HH__
+#ifndef TLAPACK_LASY2_HH
+#define TLAPACK_LASY2_HH
 
 #include <complex>
 #include <memory>
@@ -245,4 +245,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __LASY2_HH__
+#endif // TLAPACK_LASY2_HH

--- a/include/lapack/lauum_recursive.hpp
+++ b/include/lapack/lauum_recursive.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAUUM_RECURSIVE__TLAPACK_
-#define __TLAPACK_LAUUM_RECURSIVE__TLAPACK_
+#ifndef TLAPACK_LAUUM_RECURSIVETLAPACK_
+#define TLAPACK_LAUUM_RECURSIVETLAPACK_
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -110,4 +110,4 @@ namespace tlapack
 
 } // namespace tlapack
 
-#endif // __TLAPACK_LAUUM_RECURSIVE__TLAPACK_
+#endif // TLAPACK_LAUUM_RECURSIVETLAPACK_

--- a/include/lapack/move_bulge.hpp
+++ b/include/lapack/move_bulge.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __MOVE_BULGE_HH__
-#define __MOVE_BULGE_HH__
+#ifndef TLAPACK_MOVE_BULGE_HH
+#define TLAPACK_MOVE_BULGE_HH
 
 
 #include <memory>
@@ -110,4 +110,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __MOVE_BULGE_HH__
+#endif // TLAPACK_MOVE_BULGE_HH

--- a/include/lapack/multishift_qr.hpp
+++ b/include/lapack/multishift_qr.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __MULTISHIFT_QR_HH__
-#define __MULTISHIFT_QR_HH__
+#ifndef TLAPACK_MULTISHIFT_QR_HH
+#define TLAPACK_MULTISHIFT_QR_HH
 
 #include <complex>
 #include <vector>
@@ -437,4 +437,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __MULTISHIFT_QR_HH__
+#endif // TLAPACK_MULTISHIFT_QR_HH

--- a/include/lapack/multishift_qr_sweep.hpp
+++ b/include/lapack/multishift_qr_sweep.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __QR_SWEEP_HH__
-#define __QR_SWEEP_HH__
+#ifndef TLAPACK_QR_SWEEP_HH
+#define TLAPACK_QR_SWEEP_HH
 
 #include <memory>
 #include <complex>
@@ -715,4 +715,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __QR_SWEEP_HH__
+#endif // TLAPACK_QR_SWEEP_HH

--- a/include/lapack/potrf.hpp
+++ b/include/lapack/potrf.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_POTRF_HH__
-#define __TLAPACK_POTRF_HH__
+#ifndef TLAPACK_POTRF_HH
+#define TLAPACK_POTRF_HH
 
 #include "base/utils.hpp"
 
@@ -186,4 +186,4 @@ int potrf( uplo_t uplo, matrix_t& A, const ErrorCheck& ec = {} )
 
 } // lapack
 
-#endif // __POTRF_HH__
+#endif // TLAPACK_POTRF_HH

--- a/include/lapack/potrf2.hpp
+++ b/include/lapack/potrf2.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_POTRF2_HH__
-#define __TLAPACK_POTRF2_HH__
+#ifndef TLAPACK_POTRF2_HH
+#define TLAPACK_POTRF2_HH
 
 #include "base/utils.hpp"
 #include "tblas.hpp"
@@ -161,4 +161,4 @@ int potrf2( uplo_t uplo, matrix_t& A, const ErrorCheck& ec = {} )
 
 } // lapack
 
-#endif // __POTRF2_HH__
+#endif // TLAPACK_POTRF2_HH

--- a/include/lapack/potrs.hpp
+++ b/include/lapack/potrs.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_POTRS_HH__
-#define __TLAPACK_POTRS_HH__
+#ifndef TLAPACK_POTRS_HH
+#define TLAPACK_POTRS_HH
 
 #include "base/utils.hpp"
 
@@ -81,4 +81,4 @@ int potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
 
 } // lapack
 
-#endif // __POTRS_HH__
+#endif // TLAPACK_POTRS_HH

--- a/include/lapack/schur_move.hpp
+++ b/include/lapack/schur_move.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_SCHUR_MOVE_HH__
-#define __TLAPACK_SCHUR_MOVE_HH__
+#ifndef TLAPACK_SCHUR_MOVE_HH
+#define TLAPACK_SCHUR_MOVE_HH
 
 #include <complex>
 #include <cmath>
@@ -145,4 +145,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __SCHUR_MOVE_HH__
+#endif // TLAPACK_SCHUR_MOVE_HH

--- a/include/lapack/schur_swap.hpp
+++ b/include/lapack/schur_swap.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_SCHUR_SWAP_HH__
-#define __TLAPACK_SCHUR_SWAP_HH__
+#ifndef TLAPACK_SCHUR_SWAP_HH
+#define TLAPACK_SCHUR_SWAP_HH
 
 #include <complex>
 #include <cmath>
@@ -277,8 +277,8 @@ namespace tlapack
         }
         if (n1 == 2 and n2 == 2)
         {
-            std::unique_ptr<T[]> _D(new T[4 * 4]);
-            auto D = internal::colmajor_matrix<T>(&_D[0], 4, 4);
+            std::unique_ptr<T[]> D_(new T[4 * 4]);
+            auto D = internal::colmajor_matrix<T>(&D_[0], 4, 4);
 
             auto AD_slice = slice(A, pair{j0, j0 + 4}, pair{j0, j0 + 4});
             lacpy(Uplo::General, AD_slice, D);
@@ -288,8 +288,8 @@ namespace tlapack
             const T small_num = safe_min<T>() / eps;
             T thresh = max(ten * eps * dnorm, small_num);
 
-            std::unique_ptr<T[]> _V(new T[4 * 2]);
-            auto V = internal::colmajor_matrix<T>(&_V[0], 4, 2);
+            std::unique_ptr<T[]> V_(new T[4 * 2]);
+            auto V = internal::colmajor_matrix<T>(&V_[0], 4, 2);
             auto X = slice(V, pair{0, 2}, pair{0, 2});
             auto TL = slice(D, pair{0, 2}, pair{0, 2});
             auto TR = slice(D, pair{2, 4}, pair{2, 4});
@@ -538,4 +538,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __SCHUR_SWAP_HH__
+#endif // TLAPACK_SCHUR_SWAP_HH

--- a/include/lapack/transpose.hpp
+++ b/include/lapack/transpose.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_TRANSPOSE_HH__
-#define __TLAPACK_TRANSPOSE_HH__
+#ifndef TLAPACK_TRANSPOSE_HH
+#define TLAPACK_TRANSPOSE_HH
 
 #include "base/utils.hpp"
 
@@ -139,4 +139,4 @@ namespace tlapack
 
 } // lapack
 
-#endif // __TLAPACK_TRANSPOSE_HH__
+#endif // TLAPACK_TRANSPOSE_HH

--- a/include/lapack/ung2r.hpp
+++ b/include/lapack/ung2r.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_UNG2R_HH__
-#define __TLAPACK_UNG2R_HH__
+#ifndef TLAPACK_UNG2R_HH
+#define TLAPACK_UNG2R_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -102,4 +102,4 @@ int ung2r(
 
 }
 
-#endif // __UNG2R_HH__
+#endif // TLAPACK_UNG2R_HH

--- a/include/lapack/unghr.hpp
+++ b/include/lapack/unghr.hpp
@@ -6,8 +6,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_UNGHR_HH__
-#define __TLAPACK_UNGHR_HH__
+#ifndef TLAPACK_UNGHR_HH
+#define TLAPACK_UNGHR_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -96,4 +96,4 @@ int unghr(
 
 }
 
-#endif // __UNGHR_HH__
+#endif // TLAPACK_UNGHR_HH

--- a/include/lapack/ungl2.hpp
+++ b/include/lapack/ungl2.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_UNGL2_HH__
-#define __TLAPACK_UNGL2_HH__
+#ifndef TLAPACK_UNGL2_HH
+#define TLAPACK_UNGL2_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -113,4 +113,4 @@ namespace tlapack
         return 0;
     }
 }
-#endif // __TLAPACK_UNGL2_HH__
+#endif // TLAPACK_UNGL2_HH

--- a/include/lapack/unm2r.hpp
+++ b/include/lapack/unm2r.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_UNM2R_HH__
-#define __TLAPACK_UNM2R_HH__
+#ifndef TLAPACK_UNM2R_HH
+#define TLAPACK_UNM2R_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -137,4 +137,4 @@ int unm2r(
 
 }
 
-#endif // __UNM2R_HH__
+#endif // TLAPACK_UNM2R_HH

--- a/include/lapack/unmhr.hpp
+++ b/include/lapack/unmhr.hpp
@@ -6,8 +6,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __UNMHR_HH__
-#define __UNMHR_HH__
+#ifndef TLAPACK_UNMHR_HH
+#define TLAPACK_UNMHR_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -66,4 +66,4 @@ namespace tlapack
 
 }
 
-#endif // __UNMHR_HH__
+#endif // TLAPACK_UNMHR_HH

--- a/include/lapack/unmqr.hpp
+++ b/include/lapack/unmqr.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_UNMQR_HH__
-#define __TLAPACK_UNMQR_HH__
+#ifndef TLAPACK_UNMQR_HH
+#define TLAPACK_UNMQR_HH
 
 #include "base/utils.hpp"
 #include "base/types.hpp"
@@ -170,4 +170,4 @@ int unmqr(
 
 }
 
-#endif // __UNMQR_HH__
+#endif // TLAPACK_UNMQR_HH

--- a/include/legacy_api/base/legacyArray.hpp
+++ b/include/legacy_api/base/legacyArray.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LEGACYARRAY_HH__
-#define __TLAPACK_LEGACY_LEGACYARRAY_HH__
+#ifndef TLAPACK_LEGACY_LEGACYARRAY_HH
+#define TLAPACK_LEGACY_LEGACYARRAY_HH
 
 #include "legacy_api/legacyArray.hpp"
 
@@ -90,4 +90,4 @@ namespace internal {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_LEGACY_LEGACYARRAY_HH__
+#endif // TLAPACK_LEGACY_LEGACYARRAY_HH

--- a/include/legacy_api/base/mdspan.hpp
+++ b/include/legacy_api/base/mdspan.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_MDSPAN_HH__
-#define __TLAPACK_LEGACY_MDSPAN_HH__
+#ifndef TLAPACK_LEGACY_MDSPAN_HH
+#define TLAPACK_LEGACY_MDSPAN_HH
 
 #include <experimental/mdspan> // Use mdspan for multidimensional arrays
 
@@ -199,4 +199,4 @@ namespace internal {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_LEGACY_MDSPAN_HH__
+#endif // TLAPACK_LEGACY_MDSPAN_HH

--- a/include/legacy_api/base/types.hpp
+++ b/include/legacy_api/base/types.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_TYPES_HH__
-#define __TLAPACK_LEGACY_TYPES_HH__
+#ifndef TLAPACK_LEGACY_TYPES_HH
+#define TLAPACK_LEGACY_TYPES_HH
 
 #include "base/types.hpp"
 
@@ -172,4 +172,4 @@ enum class RowCol {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_LEGACY_TYPES_HH__
+#endif // TLAPACK_LEGACY_TYPES_HH

--- a/include/legacy_api/base/utils.hpp
+++ b/include/legacy_api/base/utils.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_UTILS_HH__
-#define __TLAPACK_LEGACY_UTILS_HH__
+#ifndef TLAPACK_LEGACY_UTILS_HH
+#define TLAPACK_LEGACY_UTILS_HH
 
 #ifndef TLAPACK_USE_MDSPAN
 
@@ -115,4 +115,4 @@
     } while(false)
 #endif
 
-#endif // __TLAPACK_LEGACY_UTILS_HH__
+#endif // TLAPACK_LEGACY_UTILS_HH

--- a/include/legacy_api/blas.hpp
+++ b/include/legacy_api/blas.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_HH__
-#define __TLAPACK_BLAS_HH__
+#ifndef TLAPACK_BLAS_HH
+#define TLAPACK_BLAS_HH
 
 // Optimized BLAS
 
@@ -68,4 +68,4 @@
 #include "legacy_api/blas/trmm.hpp"
 #include "legacy_api/blas/trsm.hpp"
 
-#endif // __TLAPACK_BLAS_HH__
+#endif // TLAPACK_BLAS_HH

--- a/include/legacy_api/blas/asum.hpp
+++ b/include/legacy_api/blas/asum.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ASUM_HH__
-#define __TLAPACK_LEGACY_ASUM_HH__
+#ifndef TLAPACK_LEGACY_ASUM_HH
+#define TLAPACK_LEGACY_ASUM_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -42,11 +42,11 @@ real_type<T> asum( idx_t n, T const *x, int_t incx )
     if( n <= 0 ) return 0;
     
     tlapack_expr_with_vector_positiveInc(
-        _x, T, n, x, incx,
-        return asum( _x )
+        x_, T, n, x, incx,
+        return asum( x_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_ASUM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_ASUM_HH

--- a/include/legacy_api/blas/axpy.hpp
+++ b/include/legacy_api/blas/axpy.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_AXPY_HH__
-#define __TLAPACK_LEGACY_AXPY_HH__
+#ifndef TLAPACK_LEGACY_AXPY_HH
+#define TLAPACK_LEGACY_AXPY_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -57,12 +57,12 @@ void axpy(
     if( n <= 0 ) return;
     
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return axpy( alpha, _x, _y )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return axpy( alpha, x_, y_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_AXPY_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_AXPY_HH

--- a/include/legacy_api/blas/copy.hpp
+++ b/include/legacy_api/blas/copy.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_COPY_HH__
-#define __TLAPACK_LEGACY_COPY_HH__
+#ifndef TLAPACK_LEGACY_COPY_HH
+#define TLAPACK_LEGACY_COPY_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -51,12 +51,12 @@ void copy(
     if( n <= 0 ) return;
     
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return copy( _x, _y )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return copy( x_, y_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_COPY_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_COPY_HH

--- a/include/legacy_api/blas/dot.hpp
+++ b/include/legacy_api/blas/dot.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_DOT_HH__
-#define __TLAPACK_LEGACY_DOT_HH__
+#ifndef TLAPACK_LEGACY_DOT_HH
+#define TLAPACK_LEGACY_DOT_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -52,12 +52,12 @@ scalar_type<TX,TY> dot(
     if( n <= 0 ) return scalar_type<TX,TY>(0);
     
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return dot( _x, _y )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return dot( x_, y_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_DOT_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_DOT_HH

--- a/include/legacy_api/blas/dotu.hpp
+++ b/include/legacy_api/blas/dotu.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_DOTU_HH__
-#define __TLAPACK_LEGACY_DOTU_HH__
+#ifndef TLAPACK_LEGACY_DOTU_HH
+#define TLAPACK_LEGACY_DOTU_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -52,12 +52,12 @@ scalar_type<TX, TY> dotu(
     if( n <= 0 ) return scalar_type<TX,TY>(0);
     
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return dotu( _x, _y )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return dotu( x_, y_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_DOTU_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_DOTU_HH

--- a/include/legacy_api/blas/gemm.hpp
+++ b/include/legacy_api/blas/gemm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_GEMM_HH__
-#define __TLAPACK_LEGACY_GEMM_HH__
+#ifndef TLAPACK_LEGACY_GEMM_HH
+#define TLAPACK_LEGACY_GEMM_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -150,4 +150,4 @@ void gemm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_GEMM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_GEMM_HH

--- a/include/legacy_api/blas/gemv.hpp
+++ b/include/legacy_api/blas/gemv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_GEMV_HH__
-#define __TLAPACK_LEGACY_GEMV_HH__
+#ifndef TLAPACK_LEGACY_GEMV_HH
+#define TLAPACK_LEGACY_GEMV_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -123,12 +123,12 @@ void gemv(
     const auto A_ = colmajor_matrix<TA>( (TA*)A, m, n, lda );
 
     tlapack_expr_with_2vectors(
-        _x, TX, lenx, x, incx,
-        _y, TY, leny, y, incy,
-        return gemv( trans, alpha, A_, _x, beta, _y )
+        x_, TX, lenx, x, incx,
+        y_, TY, leny, y, incy,
+        return gemv( trans, alpha, A_, x_, beta, y_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_GEMV_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_GEMV_HH

--- a/include/legacy_api/blas/ger.hpp
+++ b/include/legacy_api/blas/ger.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_GER_HH__
-#define __TLAPACK_LEGACY_GER_HH__
+#ifndef TLAPACK_LEGACY_GER_HH
+#define TLAPACK_LEGACY_GER_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -89,9 +89,9 @@ void ger(
         auto A_ = colmajor_matrix<TA>( A, m, n, lda );
 
         tlapack_expr_with_2vectors(
-            _x, TX, m, x, incx,
-            _y, TY, n, y, incy,
-            return ger( alpha, _x, _y, A_ )
+            x_, TX, m, x, incx,
+            y_, TY, n, y, incy,
+            return ger( alpha, x_, y_, A_ )
         );
     }
     else
@@ -100,13 +100,13 @@ void ger(
         auto A_ = rowmajor_matrix<TA>( A, m, n, lda );
 
         tlapack_expr_with_2vectors(
-            _x, TX, m, x, incx,
-            _y, TY, n, y, incy,
-            return ger( alpha, _x, _y, A_ )
+            x_, TX, m, x, incx,
+            y_, TY, n, y, incy,
+            return ger( alpha, x_, y_, A_ )
         );
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_GER_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_GER_HH

--- a/include/legacy_api/blas/geru.hpp
+++ b/include/legacy_api/blas/geru.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_GERU_HH__
-#define __TLAPACK_LEGACY_GERU_HH__
+#ifndef TLAPACK_LEGACY_GERU_HH
+#define TLAPACK_LEGACY_GERU_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -88,9 +88,9 @@ void geru(
         auto A_ = colmajor_matrix<TA>( A, m, n, lda );
 
         tlapack_expr_with_2vectors(
-            _x, TX, m, x, incx,
-            _y, TY, n, y, incy,
-            return geru( alpha, _x, _y, A_ )
+            x_, TX, m, x, incx,
+            y_, TY, n, y, incy,
+            return geru( alpha, x_, y_, A_ )
         );
     }
     else
@@ -99,9 +99,9 @@ void geru(
         auto A_ = colmajor_matrix<TA>( A, n, m, lda );
 
         tlapack_expr_with_2vectors(
-            _y, TY, n, y, incy,
-            _x, TX, m, x, incx,
-            return geru( alpha, _y, _x, A_ )
+            y_, TY, n, y, incy,
+            x_, TX, m, x, incx,
+            return geru( alpha, y_, x_, A_ )
         );
     }
 
@@ -109,4 +109,4 @@ void geru(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_GER_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_GER_HH

--- a/include/legacy_api/blas/hemm.hpp
+++ b/include/legacy_api/blas/hemm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_HEMM_HH__
-#define __TLAPACK_LEGACY_HEMM_HH__
+#ifndef TLAPACK_LEGACY_HEMM_HH
+#define TLAPACK_LEGACY_HEMM_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -138,4 +138,4 @@ void hemm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_HEMM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_HEMM_HH

--- a/include/legacy_api/blas/hemv.hpp
+++ b/include/legacy_api/blas/hemv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_HEMV_HH__
-#define __TLAPACK_LEGACY_HEMV_HH__
+#ifndef TLAPACK_LEGACY_HEMV_HH
+#define TLAPACK_LEGACY_HEMV_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -97,21 +97,21 @@ void hemv(
     if(layout == Layout::ColMajor)
     {
         tlapack_expr_with_2vectors(
-            _x, TX, n, x, incx,
-            _y, TY, n, y, incy,
-            return hemv( uplo, alpha, colmajor_matrix<TA>( (TA*)A, n, n, lda ), _x, beta, _y )
+            x_, TX, n, x, incx,
+            y_, TY, n, y, incy,
+            return hemv( uplo, alpha, colmajor_matrix<TA>( (TA*)A, n, n, lda ), x_, beta, y_ )
         );
     }
     else
     {
         tlapack_expr_with_2vectors(
-            _x, TX, n, x, incx,
-            _y, TY, n, y, incy,
-            return hemv( uplo, alpha, rowmajor_matrix<TA>( (TA*)A, n, n, lda ), _x, beta, _y )
+            x_, TX, n, x, incx,
+            y_, TY, n, y, incy,
+            return hemv( uplo, alpha, rowmajor_matrix<TA>( (TA*)A, n, n, lda ), x_, beta, y_ )
         );
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_HEMV_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_HEMV_HH

--- a/include/legacy_api/blas/her.hpp
+++ b/include/legacy_api/blas/her.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_HER_HH__
-#define __TLAPACK_LEGACY_HER_HH__
+#ifndef TLAPACK_LEGACY_HER_HH
+#define TLAPACK_LEGACY_HER_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -88,9 +88,9 @@ void her(
     // Matrix views
     auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
-    tlapack_expr_with_vector( _x, TX, n, x, incx, her( uplo, alpha, _x, A_ ) );
+    tlapack_expr_with_vector( x_, TX, n, x, incx, her( uplo, alpha, x_, A_ ) );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_HER_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_HER_HH

--- a/include/legacy_api/blas/her2.hpp
+++ b/include/legacy_api/blas/her2.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_HER2_HH__
-#define __TLAPACK_LEGACY_HER2_HH__
+#ifndef TLAPACK_LEGACY_HER2_HH
+#define TLAPACK_LEGACY_HER2_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -98,12 +98,12 @@ void her2(
     auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return her2( uplo, alpha, _x, _y, A_ )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return her2( uplo, alpha, x_, y_, A_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_HER2_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_HER2_HH

--- a/include/legacy_api/blas/her2k.hpp
+++ b/include/legacy_api/blas/her2k.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_HER2K_HH__
-#define __TLAPACK_LEGACY_HER2K_HH__
+#ifndef TLAPACK_LEGACY_HER2K_HH
+#define TLAPACK_LEGACY_HER2K_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -161,4 +161,4 @@ void her2k(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_HER2K_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_HER2K_HH

--- a/include/legacy_api/blas/herk.hpp
+++ b/include/legacy_api/blas/herk.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_HERK_HH__
-#define __TLAPACK_LEGACY_HERK_HH__
+#ifndef TLAPACK_LEGACY_HERK_HH
+#define TLAPACK_LEGACY_HERK_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -140,4 +140,4 @@ void herk(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_HERK_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_HERK_HH

--- a/include/legacy_api/blas/iamax.hpp
+++ b/include/legacy_api/blas/iamax.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_IAMAX_HH__
-#define __TLAPACK_LEGACY_IAMAX_HH__
+#ifndef TLAPACK_LEGACY_IAMAX_HH
+#define TLAPACK_LEGACY_IAMAX_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -46,11 +46,11 @@ idx_t iamax( idx_t n, T const *x, int_t incx )
     if( n <= 0 ) return 0;
 
     tlapack_expr_with_vector_positiveInc(
-        _x, T, n, x, incx,
-        return iamax( _x )
+        x_, T, n, x, incx,
+        return iamax( x_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_IAMAX_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_IAMAX_HH

--- a/include/legacy_api/blas/nrm2.hpp
+++ b/include/legacy_api/blas/nrm2.hpp
@@ -13,8 +13,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_NRM2_HH__
-#define __TLAPACK_LEGACY_NRM2_HH__
+#ifndef TLAPACK_LEGACY_NRM2_HH
+#define TLAPACK_LEGACY_NRM2_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -48,11 +48,11 @@ real_type<T> nrm2( idx_t n, T const * x, int_t incx )
     if( n <= 0 ) return 0;
 
     tlapack_expr_with_vector_positiveInc(
-        _x, T, n, x, incx,
-        return nrm2( _x )
+        x_, T, n, x, incx,
+        return nrm2( x_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        // #ifndef __TLAPACK_LEGACY_NRM2_HH__
+#endif        // #ifndef TLAPACK_LEGACY_NRM2_HH

--- a/include/legacy_api/blas/rot.hpp
+++ b/include/legacy_api/blas/rot.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ROT_HH__
-#define __TLAPACK_LEGACY_ROT_HH__
+#ifndef TLAPACK_LEGACY_ROT_HH
+#define TLAPACK_LEGACY_ROT_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -67,12 +67,12 @@ void rot(
     if( n <= 0 ) return;
 
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return rot( _x, _y, c, s )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return rot( x_, y_, c, s )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_ROT_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_ROT_HH

--- a/include/legacy_api/blas/rotg.hpp
+++ b/include/legacy_api/blas/rotg.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ROTG_HH__
-#define __TLAPACK_LEGACY_ROTG_HH__
+#ifndef TLAPACK_LEGACY_ROTG_HH
+#define TLAPACK_LEGACY_ROTG_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -38,7 +38,7 @@ namespace tlapack {
  * @param[out] s
  *     Sine of rotation; scalar.
  *
- * __Further details__
+ * @details
  *
  * Anderson E (2017) Algorithm 978: Safe scaling in the level 1 BLAS.
  * ACM Trans Math Softw 44:. https://doi.org/10.1145/3061665
@@ -54,4 +54,4 @@ rotg ( T* a, T* b, real_type<T>* c, T* s )
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_ROTG_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_ROTG_HH

--- a/include/legacy_api/blas/rotm.hpp
+++ b/include/legacy_api/blas/rotm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ROTM_HH__
-#define __TLAPACK_LEGACY_ROTM_HH__
+#ifndef TLAPACK_LEGACY_ROTM_HH
+#define TLAPACK_LEGACY_ROTM_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -68,15 +68,15 @@ void rotm(
     if( n <= 0 ) return;
     
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        if      ( flag == -2 ) return rotm<-2>(_x,_y,h);
-        else if ( flag == -1 ) return rotm<-1>(_x,_y,h);
-        else if ( flag ==  0 ) return rotm< 0>(_x,_y,h);
-        else                   return rotm< 1>(_x,_y,h);
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        if      ( flag == -2 ) return rotm<-2>(x_,y_,h);
+        else if ( flag == -1 ) return rotm<-1>(x_,y_,h);
+        else if ( flag ==  0 ) return rotm< 0>(x_,y_,h);
+        else                   return rotm< 1>(x_,y_,h);
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_ROTM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_ROTM_HH

--- a/include/legacy_api/blas/rotmg.hpp
+++ b/include/legacy_api/blas/rotmg.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ROTMG_HH__
-#define __TLAPACK_LEGACY_ROTMG_HH__
+#ifndef TLAPACK_LEGACY_ROTMG_HH
+#define TLAPACK_LEGACY_ROTMG_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -88,7 +88,7 @@ namespace tlapack {
  *     Array of length 5 giving parameters of modified plane rotation,
  *     as described above.
  *
- * __Further details__
+ * @details
  *
  * Hammarling, Sven. A note on modifications to the Givens plane rotation.
  * IMA Journal of Applied Mathematics, 13:215-218, 1974.
@@ -113,4 +113,4 @@ void rotmg(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_ROTMG_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_ROTMG_HH

--- a/include/legacy_api/blas/scal.hpp
+++ b/include/legacy_api/blas/scal.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SCAL_HH__
-#define __TLAPACK_LEGACY_SCAL_HH__
+#ifndef TLAPACK_LEGACY_SCAL_HH
+#define TLAPACK_LEGACY_SCAL_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -45,11 +45,11 @@ void scal(
     if( n <= 0 ) return;
     
     tlapack_expr_with_vector_positiveInc(
-        _x, TX, n, x, incx,
-        return scal( alpha, _x )
+        x_, TX, n, x, incx,
+        return scal( alpha, x_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SCAL_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SCAL_HH

--- a/include/legacy_api/blas/swap.hpp
+++ b/include/legacy_api/blas/swap.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SWAP_HH__
-#define __TLAPACK_LEGACY_SWAP_HH__
+#ifndef TLAPACK_LEGACY_SWAP_HH
+#define TLAPACK_LEGACY_SWAP_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -52,12 +52,12 @@ void swap(
     if( n <= 0 ) return;
 
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return tlapack::swap( _x, _y );
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return tlapack::swap( x_, y_ );
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SWAP_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SWAP_HH

--- a/include/legacy_api/blas/symm.hpp
+++ b/include/legacy_api/blas/symm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SYMM_HH__
-#define __TLAPACK_LEGACY_SYMM_HH__
+#ifndef TLAPACK_LEGACY_SYMM_HH
+#define TLAPACK_LEGACY_SYMM_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -132,4 +132,4 @@ void symm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SYMM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/legacy_api/blas/symv.hpp
+++ b/include/legacy_api/blas/symv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SYMV_HH__
-#define __TLAPACK_LEGACY_SYMV_HH__
+#ifndef TLAPACK_LEGACY_SYMV_HH
+#define TLAPACK_LEGACY_SYMV_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -100,12 +100,12 @@ void symv(
     const auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
 
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return symv( uplo, alpha, A_, _x, beta, _y )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return symv( uplo, alpha, A_, x_, beta, y_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SYMV_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SYMV_HH

--- a/include/legacy_api/blas/syr.hpp
+++ b/include/legacy_api/blas/syr.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SYR_HH__
-#define __TLAPACK_LEGACY_SYR_HH__
+#ifndef TLAPACK_LEGACY_SYR_HH
+#define TLAPACK_LEGACY_SYR_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -86,9 +86,9 @@ void syr(
     // Matrix views
     auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
-    tlapack_expr_with_vector( _x, TX, n, x, incx, syr( uplo, alpha, _x, A_ ) );
+    tlapack_expr_with_vector( x_, TX, n, x, incx, syr( uplo, alpha, x_, A_ ) );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SYR_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SYR_HH

--- a/include/legacy_api/blas/syr2.hpp
+++ b/include/legacy_api/blas/syr2.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SYR2_HH__
-#define __TLAPACK_LEGACY_SYR2_HH__
+#ifndef TLAPACK_LEGACY_SYR2_HH
+#define TLAPACK_LEGACY_SYR2_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -96,12 +96,12 @@ void syr2(
     auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
     tlapack_expr_with_2vectors(
-        _x, TX, n, x, incx,
-        _y, TY, n, y, incy,
-        return syr2( uplo, alpha, _x, _y, A_ )
+        x_, TX, n, x, incx,
+        y_, TY, n, y, incy,
+        return syr2( uplo, alpha, x_, y_, A_ )
     );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SYR2_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SYR2_HH

--- a/include/legacy_api/blas/syr2k.hpp
+++ b/include/legacy_api/blas/syr2k.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SYR2K_HH__
-#define __TLAPACK_LEGACY_SYR2K_HH__
+#ifndef TLAPACK_LEGACY_SYR2K_HH
+#define TLAPACK_LEGACY_SYR2K_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -160,4 +160,4 @@ void syr2k(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SYMM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/legacy_api/blas/syrk.hpp
+++ b/include/legacy_api/blas/syrk.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_SYRK_HH__
-#define __TLAPACK_LEGACY_SYRK_HH__
+#ifndef TLAPACK_LEGACY_SYRK_HH
+#define TLAPACK_LEGACY_SYRK_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -139,4 +139,4 @@ void syrk(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_SYMM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/legacy_api/blas/trmm.hpp
+++ b/include/legacy_api/blas/trmm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_TRMM_HH__
-#define __TLAPACK_LEGACY_TRMM_HH__
+#ifndef TLAPACK_LEGACY_TRMM_HH
+#define TLAPACK_LEGACY_TRMM_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -145,4 +145,4 @@ void trmm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_TRMM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_TRMM_HH

--- a/include/legacy_api/blas/trmv.hpp
+++ b/include/legacy_api/blas/trmv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_TRMV_HH__
-#define __TLAPACK_LEGACY_TRMV_HH__
+#ifndef TLAPACK_LEGACY_TRMV_HH
+#define TLAPACK_LEGACY_TRMV_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -109,9 +109,9 @@ void trmv(
     // Matrix views
     const auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
 
-    tlapack_expr_with_vector( _x, TX, n, x, incx, return trmv( uplo, trans, diag, A_, _x ) );
+    tlapack_expr_with_vector( x_, TX, n, x, incx, return trmv( uplo, trans, diag, A_, x_ ) );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_TRMV_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_TRMV_HH

--- a/include/legacy_api/blas/trsm.hpp
+++ b/include/legacy_api/blas/trsm.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_TRSM_HH__
-#define __TLAPACK_LEGACY_TRSM_HH__
+#ifndef TLAPACK_LEGACY_TRSM_HH
+#define TLAPACK_LEGACY_TRSM_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -150,4 +150,4 @@ void trsm(
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_TRSM_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_TRSM_HH

--- a/include/legacy_api/blas/trsv.hpp
+++ b/include/legacy_api/blas/trsv.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_TRSV_HH__
-#define __TLAPACK_LEGACY_TRSV_HH__
+#ifndef TLAPACK_LEGACY_TRSV_HH
+#define TLAPACK_LEGACY_TRSV_HH
 
 #include "legacy_api/base/utils.hpp"
 #include "legacy_api/base/types.hpp"
@@ -113,9 +113,9 @@ void trsv(
     // Matrix views
     const auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
 
-    tlapack_expr_with_vector( _x, TX, n, x, incx, return trsv( uplo, trans, diag, A_, _x ) );
+    tlapack_expr_with_vector( x_, TX, n, x, incx, return trsv( uplo, trans, diag, A_, x_ ) );
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef __TLAPACK_LEGACY_TRSV_HH__
+#endif        //  #ifndef TLAPACK_LEGACY_TRSV_HH

--- a/include/legacy_api/lapack.hpp
+++ b/include/legacy_api/lapack.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_HH__
-#define __TLAPACK_LEGACY_HH__
+#ifndef TLAPACK_LEGACY_HH
+#define TLAPACK_LEGACY_HH
 
 // =============================================================================
 // Template LAPACK
@@ -40,4 +40,4 @@
 #include "legacy_api/lapack/potrf.hpp"
 #include "legacy_api/lapack/potrs.hpp"
 
-#endif // __TLAPACK_LEGACY_HH__
+#endif // TLAPACK_LEGACY_HH

--- a/include/legacy_api/lapack/geqr2.hpp
+++ b/include/legacy_api/lapack/geqr2.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_GEQR2_HH__
-#define __TLAPACK_LEGACY_GEQR2_HH__
+#ifndef TLAPACK_LEGACY_GEQR2_HH
+#define TLAPACK_LEGACY_GEQR2_HH
 
 #include "lapack/geqr2.hpp"
 
@@ -76,4 +76,4 @@ inline int geqr2(
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_GEQR2_HH__
+#endif // TLAPACK_LEGACY_GEQR2_HH

--- a/include/legacy_api/lapack/lacpy.hpp
+++ b/include/legacy_api/lapack/lacpy.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LACPY_HH__
-#define __TLAPACK_LEGACY_LACPY_HH__
+#ifndef TLAPACK_LEGACY_LACPY_HH
+#define TLAPACK_LEGACY_LACPY_HH
 
 #include "lapack/lacpy.hpp"
 
@@ -64,4 +64,4 @@ void inline lacpy(
 
 }
 
-#endif // __TLAPACK_LEGACY_LACPY_HH__
+#endif // TLAPACK_LEGACY_LACPY_HH

--- a/include/legacy_api/lapack/lange.hpp
+++ b/include/legacy_api/lapack/lange.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LANGE_HH__
-#define __TLAPACK_LEGACY_LANGE_HH__
+#ifndef TLAPACK_LEGACY_LANGE_HH
+#define TLAPACK_LEGACY_LANGE_HH
 
 #include "lapack/lange.hpp"
 
@@ -60,4 +60,4 @@ inline real_type<TA> lange(
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_LANGE_HH__
+#endif // TLAPACK_LEGACY_LANGE_HH

--- a/include/legacy_api/lapack/lanhe.hpp
+++ b/include/legacy_api/lapack/lanhe.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LANHE_HH__
-#define __TLAPACK_LEGACY_LANHE_HH__
+#ifndef TLAPACK_LEGACY_LANHE_HH
+#define TLAPACK_LEGACY_LANHE_HH
 
 #include <memory>
 
@@ -64,4 +64,4 @@ real_type<TA> lanhe(
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_LANHE_HH__
+#endif // TLAPACK_LEGACY_LANHE_HH

--- a/include/legacy_api/lapack/lansy.hpp
+++ b/include/legacy_api/lapack/lansy.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LANSY_HH__
-#define __TLAPACK_LEGACY_LANSY_HH__
+#ifndef TLAPACK_LEGACY_LANSY_HH
+#define TLAPACK_LEGACY_LANSY_HH
 
 #include <memory>
 
@@ -64,4 +64,4 @@ real_type<TA> lansy(
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_LANSY_HH__
+#endif // TLAPACK_LEGACY_LANSY_HH

--- a/include/legacy_api/lapack/lantr.hpp
+++ b/include/legacy_api/lapack/lantr.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LANTR_HH__
-#define __TLAPACK_LEGACY_LANTR_HH__
+#ifndef TLAPACK_LEGACY_LANTR_HH
+#define TLAPACK_LEGACY_LANTR_HH
 
 #include <memory>
 
@@ -72,4 +72,4 @@ real_type<TA> lantr(
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_LANTR_HH__
+#endif // TLAPACK_LEGACY_LANTR_HH

--- a/include/legacy_api/lapack/larf.hpp
+++ b/include/legacy_api/lapack/larf.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LARF_HH__
-#define __TLAPACK_LEGACY_LARF_HH__
+#ifndef TLAPACK_LEGACY_LARF_HH
+#define TLAPACK_LEGACY_LARF_HH
 
 #include "lapack/larf.hpp"
 #include <memory>
@@ -56,11 +56,11 @@ inline void larf(
     auto _work = vector( &work[0], lwork );
 
     tlapack_expr_with_vector(
-        _v, TV, lenv, v, incv,
-        return larf( side, _v, tau, C_, _work)
+        v_, TV, lenv, v, incv,
+        return larf( side, v_, tau, C_, _work)
     );
 }
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_LARF_HH__
+#endif // TLAPACK_LEGACY_LARF_HH

--- a/include/legacy_api/lapack/larfb.hpp
+++ b/include/legacy_api/lapack/larfb.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LARFB_HH__
-#define __TLAPACK_LEGACY_LARFB_HH__
+#ifndef TLAPACK_LEGACY_LARFB_HH
+#define TLAPACK_LEGACY_LARFB_HH
 
 #include "lapack/larfb.hpp"
 
@@ -162,4 +162,4 @@ int larfb(
 
 }
 
-#endif // __TLAPACK_LEGACY_LARFB_HH__
+#endif // TLAPACK_LEGACY_LARFB_HH

--- a/include/legacy_api/lapack/larfg.hpp
+++ b/include/legacy_api/lapack/larfg.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LARFG_HH__
-#define __TLAPACK_LEGACY_LARFG_HH__
+#ifndef TLAPACK_LEGACY_LARFG_HH
+#define TLAPACK_LEGACY_LARFG_HH
 
 #include "lapack/larfg.hpp"
 
@@ -19,7 +19,7 @@ template< typename T >
 void larfg(
     idx_t n, T &alpha, T *x, int_t incx, T &tau )
 {    
-    tlapack_expr_with_vector( _x, T, n-1, x, incx, return larfg( alpha, _x, tau ) );
+    tlapack_expr_with_vector( x_, T, n-1, x, incx, return larfg( alpha, x_, tau ) );
 }
 
 /** Generates a elementary Householder reflection.
@@ -37,4 +37,4 @@ void inline larfg(
 
 }
 
-#endif // __TLAPACK_LEGACY_LARFG_HH__
+#endif // TLAPACK_LEGACY_LARFG_HH

--- a/include/legacy_api/lapack/larft.hpp
+++ b/include/legacy_api/lapack/larft.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LARFT_HH__
-#define __TLAPACK_LEGACY_LARFT_HH__
+#ifndef TLAPACK_LEGACY_LARFT_HH
+#define TLAPACK_LEGACY_LARFT_HH
 
 #include "lapack/larft.hpp"
 
@@ -115,4 +115,4 @@ int larft(
 
 }
 
-#endif // __TLAPACK_LEGACY_LARFT_HH__
+#endif // TLAPACK_LEGACY_LARFT_HH

--- a/include/legacy_api/lapack/larnv.hpp
+++ b/include/legacy_api/lapack/larnv.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LARNV_HH__
-#define __TLAPACK_LEGACY_LARNV_HH__
+#ifndef TLAPACK_LEGACY_LARNV_HH
+#define TLAPACK_LEGACY_LARNV_HH
 
 #include "legacy_api/base/types.hpp"
 #include "lapack/larnv.hpp"
@@ -45,15 +45,15 @@ inline void larnv(
     idx_t n, T* x )
 {
     using internal::vector;
-    auto _x = vector( x, n );
+    auto x_ = vector( x, n );
 
-    if (idist == 1) return larnv<1>( *iseed, _x );
-    else if (idist == 2) return larnv<2>( *iseed, _x );
-    else if (idist == 3) return larnv<3>( *iseed, _x );
-    else if (idist == 4) return larnv<4>( *iseed, _x );
-    else if (idist == 5) return larnv<5>( *iseed, _x );
+    if (idist == 1) return larnv<1>( *iseed, x_ );
+    else if (idist == 2) return larnv<2>( *iseed, x_ );
+    else if (idist == 3) return larnv<3>( *iseed, x_ );
+    else if (idist == 4) return larnv<4>( *iseed, x_ );
+    else if (idist == 5) return larnv<5>( *iseed, x_ );
 }
 
 }
 
-#endif // __TLAPACK_LEGACY_LARNV_HH__
+#endif // TLAPACK_LEGACY_LARNV_HH

--- a/include/legacy_api/lapack/lascl.hpp
+++ b/include/legacy_api/lapack/lascl.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LASCL_HH__
-#define __TLAPACK_LEGACY_LASCL_HH__
+#ifndef TLAPACK_LEGACY_LASCL_HH
+#define TLAPACK_LEGACY_LASCL_HH
 
 #include "base/types.hpp"
 #include "lapack/lascl.hpp"
@@ -144,4 +144,4 @@ int lascl(
 
 }
 
-#endif // __LASCL_HH__
+#endif // TLAPACK_LEGACY_LASCL_HH

--- a/include/legacy_api/lapack/laset.hpp
+++ b/include/legacy_api/lapack/laset.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LASET_HH__
-#define __TLAPACK_LEGACY_LASET_HH__
+#ifndef TLAPACK_LEGACY_LASET_HH
+#define TLAPACK_LEGACY_LASET_HH
 
 #include "lapack/laset.hpp"
 
@@ -67,4 +67,4 @@ void inline laset(
 
 }
 
-#endif // __TLAPACK_LEGACY_LASET_HH__
+#endif // TLAPACK_LEGACY_LASET_HH

--- a/include/legacy_api/lapack/lassq.hpp
+++ b/include/legacy_api/lapack/lassq.hpp
@@ -12,8 +12,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_LASSQ_HH__
-#define __TLAPACK_LEGACY_LASSQ_HH__
+#ifndef TLAPACK_LEGACY_LASSQ_HH
+#define TLAPACK_LEGACY_LASSQ_HH
 
 #include "lapack/lassq.hpp"
 
@@ -61,9 +61,9 @@ void lassq(
     // quick return
     if( isnan(scl) || isnan(sumsq) || n <= 0 ) return;
 
-    tlapack_expr_with_vector( _x, TX, n, x, incx, return lassq( _x, scl, sumsq ) );
+    tlapack_expr_with_vector( x_, TX, n, x, incx, return lassq( x_, scl, sumsq ) );
 }
 
 } // lapack
 
-#endif // __LASSQ_HH__
+#endif // TLAPACK_LEGACY_LASSQ_HH

--- a/include/legacy_api/lapack/potrf.hpp
+++ b/include/legacy_api/lapack/potrf.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_POTRF_HH__
-#define __TLAPACK_LEGACY_POTRF_HH__
+#ifndef TLAPACK_LEGACY_POTRF_HH
+#define TLAPACK_LEGACY_POTRF_HH
 
 #include "lapack/potrf.hpp"
 
@@ -38,4 +38,4 @@ inline int potrf( uplo_t uplo, idx_t n, T* A, idx_t lda )
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_POTRF_HH__
+#endif // TLAPACK_LEGACY_POTRF_HH

--- a/include/legacy_api/lapack/potrs.hpp
+++ b/include/legacy_api/lapack/potrs.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_POTRS_HH__
-#define __TLAPACK_LEGACY_POTRS_HH__
+#ifndef TLAPACK_LEGACY_POTRS_HH
+#define TLAPACK_LEGACY_POTRS_HH
 
 #include "lapack/potrs.hpp"
 
@@ -41,4 +41,4 @@ inline int potrs(
 
 } // lapack
 
-#endif // __TLAPACK_LEGACY_POTRS_HH__
+#endif // TLAPACK_LEGACY_POTRS_HH

--- a/include/legacy_api/lapack/ung2r.hpp
+++ b/include/legacy_api/lapack/ung2r.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_UNG2R_HH__
-#define __TLAPACK_LEGACY_UNG2R_HH__
+#ifndef TLAPACK_LEGACY_UNG2R_HH
+#define TLAPACK_LEGACY_UNG2R_HH
 
 #include "lapack/ung2r.hpp"
 
@@ -72,4 +72,4 @@ inline int ung2r(
 
 }
 
-#endif // __TLAPACK_LEGACY_UNG2R_HH__
+#endif // TLAPACK_LEGACY_UNG2R_HH

--- a/include/legacy_api/lapack/unm2r.hpp
+++ b/include/legacy_api/lapack/unm2r.hpp
@@ -8,8 +8,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_UNM2R_HH__
-#define __TLAPACK_LEGACY_UNM2R_HH__
+#ifndef TLAPACK_LEGACY_UNM2R_HH
+#define TLAPACK_LEGACY_UNM2R_HH
 
 #include "lapack/unm2r.hpp"
 
@@ -92,4 +92,4 @@ inline int unm2r(
 
 }
 
-#endif // __TLAPACK_LEGACY_UNM2R_HH__
+#endif // TLAPACK_LEGACY_UNM2R_HH

--- a/include/legacy_api/lapack/unmqr.hpp
+++ b/include/legacy_api/lapack/unmqr.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_UNMQR_HH__
-#define __TLAPACK_LEGACY_UNMQR_HH__
+#ifndef TLAPACK_LEGACY_UNMQR_HH
+#define TLAPACK_LEGACY_UNMQR_HH
 
 #include <memory>
 #include "lapack/unmqr.hpp"
@@ -119,4 +119,4 @@ inline int unmqr(
 
 }
 
-#endif // __TLAPACK_LEGACY_UNMQR_HH__
+#endif // TLAPACK_LEGACY_UNMQR_HH

--- a/include/legacy_api/legacyArray.hpp
+++ b/include/legacy_api/legacyArray.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACY_ARRAY_HH__
-#define __TLAPACK_LEGACY_ARRAY_HH__
+#ifndef TLAPACK_LEGACY_ARRAY_HH
+#define TLAPACK_LEGACY_ARRAY_HH
 
 #include <cassert>
 
@@ -131,4 +131,4 @@ namespace tlapack {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_LEGACY_ARRAY_HH__
+#endif // TLAPACK_LEGACY_ARRAY_HH

--- a/include/optimized/wrappers.hpp
+++ b/include/optimized/wrappers.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LAPACKPP_WRAPPERS_HH__
-#define __TLAPACK_LAPACKPP_WRAPPERS_HH__
+#ifndef TLAPACK_LAPACKPP_WRAPPERS_HH
+#define TLAPACK_LAPACKPP_WRAPPERS_HH
 
 #include "lapack.hh" // from LAPACK++
 #include "base/utils.hpp"
@@ -22,8 +22,8 @@ template< class vector_t,
 inline
 auto asum( vector_t const& x )
 {
-    auto _x = legacy_vector(x);
-    return ::blas::asum( _x.n, _x.ptr, _x.inc );
+    auto x_ = legacy_vector(x);
+    return ::blas::asum( x_.n, x_.ptr, x_.inc );
 }
 
 template< class vectorX_t, class vectorY_t, class alpha_t,
@@ -42,15 +42,15 @@ void axpy(
     using idx_t = size_type< vectorX_t >;
 
     // Legacy objects
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
-    const idx_t& n = _x.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t& n = x_.n;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
-    return ::blas::axpy( n, alpha, _x.ptr, incx, _y.ptr, incy );
+    return ::blas::axpy( n, alpha, x_.ptr, incx, y_.ptr, incy );
 }
 
 template< class vectorX_t, class vectorY_t,
@@ -66,15 +66,15 @@ void copy( const vectorX_t& x, vectorY_t& y )
     using idx_t = size_type< vectorX_t >;
 
     // Legacy objects
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
-    const idx_t& n = _x.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t& n = x_.n;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
-    return ::blas::copy( n, _x.ptr, incx, _y.ptr, incy );
+    return ::blas::copy( n, x_.ptr, incx, y_.ptr, incy );
 }
 
 template< class vectorX_t, class vectorY_t,
@@ -90,15 +90,15 @@ auto dot( const vectorX_t& x, const vectorY_t& y )
     using idx_t = size_type< vectorX_t >;
 
     // Legacy objects
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
-    const idx_t& n = _x.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t& n = x_.n;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
-    return ::blas::dot( n, _x.ptr, incx, _y.ptr, incy );
+    return ::blas::dot( n, x_.ptr, incx, y_.ptr, incy );
 }
 
 template< class vectorX_t, class vectorY_t,
@@ -114,15 +114,15 @@ auto dotu( const vectorX_t& x, const vectorY_t& y )
     using idx_t = size_type< vectorX_t >;
 
     // Legacy objects
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
-    const idx_t& n = _x.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t& n = x_.n;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
-    return ::blas::dotu( n, _x.ptr, incx, _y.ptr, incy );
+    return ::blas::dotu( n, x_.ptr, incx, y_.ptr, incy );
 }
 
 template< class vector_t,
@@ -131,8 +131,8 @@ template< class vector_t,
 inline
 auto iamax( vector_t const& x )
 {
-    auto _x = legacy_vector(x);
-    return ::blas::iamax( _x.n, _x.ptr, _x.inc );
+    auto x_ = legacy_vector(x);
+    return ::blas::iamax( x_.n, x_.ptr, x_.inc );
 }
 
 template< class vector_t,
@@ -141,8 +141,8 @@ template< class vector_t,
 inline
 auto nrm2( vector_t const& x )
 {
-    auto _x = legacy_vector(x);
-    return ::blas::nrm2( _x.n, _x.ptr, _x.inc );
+    auto x_ = legacy_vector(x);
+    return ::blas::nrm2( x_.n, x_.ptr, x_.inc );
 }
 
 template<
@@ -164,15 +164,15 @@ void rot(
     using idx_t = size_type< vectorX_t >;
 
     // Legacy objects
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
-    const idx_t& n = _x.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t& n = x_.n;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
-    return ::blas::rot( n, _x.ptr, incx, _y.ptr, incy, c, s );
+    return ::blas::rot( n, x_.ptr, incx, y_.ptr, incy, c, s );
 }
 
 template <typename T,
@@ -230,16 +230,16 @@ void rotm( vectorX_t& x, vectorY_t& y, const T h[4] )
     using idx_t = size_type< vectorX_t >;
 
     // Legacy objects
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
-    const idx_t& n = _x.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
-    const T _h[] = { (T) flag, h[0], h[1], h[2], h[3] };
+    const idx_t& n = x_.n;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
+    const T h_[] = { (T) flag, h[0], h[1], h[2], h[3] };
 
-    return ::blas::rotm( n, _x.ptr, incx, _y.ptr, incy, _h );
+    return ::blas::rotm( n, x_.ptr, incx, y_.ptr, incy, h_ );
 }
 
 template< typename T,
@@ -270,8 +270,8 @@ template< class vector_t, class alpha_t,
 inline
 void scal( const alpha_t alpha, vector_t& x )
 {
-    auto _x = legacy_vector(x);
-    return ::blas::scal( _x.n, alpha, _x.ptr, _x.inc );
+    auto x_ = legacy_vector(x);
+    return ::blas::scal( x_.n, alpha, x_.ptr, x_.inc );
 }
 
 template< class vectorX_t, class vectorY_t,
@@ -287,15 +287,15 @@ void swap( vectorX_t& x, vectorY_t& y )
     using idx_t = size_type< vectorX_t >;
 
     // Legacy objects
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
-    const idx_t& n = _x.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t& n = x_.n;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
-    return ::blas::swap( n, _x.ptr, incx, _y.ptr, incy );
+    return ::blas::swap( n, x_.ptr, incx, y_.ptr, incy );
 }
 
 // =============================================================================
@@ -336,14 +336,14 @@ void gemv(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
     const idx_t& m = A_.m;
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
     return ::blas::gemv(
         (::blas::Layout) A_.layout,
@@ -351,9 +351,9 @@ void gemv(
         m, n,
         alpha,
         A_.ptr, A_.ldim,
-        _x.ptr, incx,
+        x_.ptr, incx,
         beta,
-        _y.ptr, incy );
+        y_.ptr, incy );
 }
 
 template<
@@ -378,21 +378,21 @@ void ger(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
     const idx_t& m = A_.m;
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
     return ::blas::ger(
         (::blas::Layout) A_.layout,
         m, n,
         alpha,
-        _x.ptr, incx,
-        _y.ptr, incy,
+        x_.ptr, incx,
+        y_.ptr, incy,
         A_.ptr, A_.ldim );
 }
 
@@ -418,21 +418,21 @@ void geru(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
     const idx_t& m = A_.m;
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
     return ::blas::geru(
         (::blas::Layout) A_.layout,
         m, n,
         alpha,
-        _x.ptr, incx,
-        _y.ptr, incy,
+        x_.ptr, incx,
+        y_.ptr, incy,
         A_.ptr, A_.ldim );
 }
 
@@ -459,13 +459,13 @@ void hemv(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
     return ::blas::hemv(
         (::blas::Layout) A_.layout,
@@ -473,9 +473,9 @@ void hemv(
         n,
         alpha,
         A_.ptr, A_.ldim,
-        _x.ptr, incx,
+        x_.ptr, incx,
         beta,
-        _y.ptr, incy );
+        y_.ptr, incy );
 }
 
 template<
@@ -500,18 +500,18 @@ void her(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
+    auto x_ = legacy_vector(x);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
     
     return ::blas::her(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
         n,
         alpha,
-        _x.ptr, incx,
+        x_.ptr, incx,
         A_.ptr, A_.ldim );
 }
 
@@ -538,21 +538,21 @@ void her2(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
     return ::blas::her2(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
         n,
         alpha,
-        _x.ptr, incx,
-        _y.ptr, incy,
+        x_.ptr, incx,
+        y_.ptr, incy,
         A_.ptr, A_.ldim );
 }
 
@@ -578,13 +578,13 @@ void symv(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
     return ::blas::symv(
         (::blas::Layout) A_.layout,
@@ -592,9 +592,9 @@ void symv(
         n,
         alpha,
         A_.ptr, A_.ldim,
-        _x.ptr, incx,
+        x_.ptr, incx,
         beta,
-        _y.ptr, incy );
+        y_.ptr, incy );
 }
 
 template<
@@ -619,18 +619,18 @@ void syr(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
+    auto x_ = legacy_vector(x);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
     
     return ::blas::syr(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
         n,
         alpha,
-        _x.ptr, incx,
+        x_.ptr, incx,
         A_.ptr, A_.ldim );
 }
 
@@ -657,21 +657,21 @@ void syr2(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
-    auto _y = legacy_vector(y);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
-    const idx_t incy = (_y.direction == Direction::Forward) ? _y.inc : -_y.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
+    const idx_t incy = (y_.direction == Direction::Forward) ? y_.inc : -y_.inc;
 
     return ::blas::syr2(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
         n,
         alpha,
-        _x.ptr, incx,
-        _y.ptr, incy,
+        x_.ptr, incx,
+        y_.ptr, incy,
         A_.ptr, A_.ldim );
 }
 
@@ -694,11 +694,11 @@ void trmv(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
+    auto x_ = legacy_vector(x);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
     
     return ::blas::trmv(
         (::blas::Layout) A_.layout,
@@ -707,7 +707,7 @@ void trmv(
         (::blas::Diag) diag,
         n,
         A_.ptr, A_.ldim,
-        _x.ptr, incx );
+        x_.ptr, incx );
 }
 
 template< class matrixA_t, class vectorX_t,
@@ -729,11 +729,11 @@ void trsv(
 
     // Legacy objects
     auto A_ = legacy_matrix(A);
-    auto _x = legacy_vector(x);
+    auto x_ = legacy_vector(x);
 
     // Constants to forward
     const idx_t& n = A_.n;
-    const idx_t incx = (_x.direction == Direction::Forward) ? _x.inc : -_x.inc;
+    const idx_t incx = (x_.direction == Direction::Forward) ? x_.inc : -x_.inc;
     
     return ::blas::trsv(
         (::blas::Layout) A_.layout,
@@ -742,7 +742,7 @@ void trsv(
         (::blas::Diag) diag,
         n,
         A_.ptr, A_.ldim,
-        _x.ptr, incx );
+        x_.ptr, incx );
 }
 
 // =============================================================================
@@ -1224,4 +1224,4 @@ void trsm(
 
 }  // namespace tlapack
 
-#endif // __TLAPACK_LAPACKPP_WRAPPERS_HH__
+#endif // TLAPACK_LAPACKPP_WRAPPERS_HH

--- a/include/plugins/tlapack_abstractArray.hpp
+++ b/include/plugins/tlapack_abstractArray.hpp
@@ -11,8 +11,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_ABSTRACT_ARRAY_HH__
-#define __TLAPACK_ABSTRACT_ARRAY_HH__
+#ifndef TLAPACK_ABSTRACT_ARRAY_HH
+#define TLAPACK_ABSTRACT_ARRAY_HH
 
 #include "base/arrayTraits.hpp"
 
@@ -313,4 +313,4 @@ namespace tlapack {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_ABSTRACT_ARRAY_HH__
+#endif // TLAPACK_ABSTRACT_ARRAY_HH

--- a/include/plugins/tlapack_debugutils.hpp
+++ b/include/plugins/tlapack_debugutils.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_DEBUG_UTILS_HH__
-#define __TLAPACK_DEBUG_UTILS_HH__
+#ifndef TLAPACK_DEBUG_UTILS_HH
+#define TLAPACK_DEBUG_UTILS_HH
 
 #include <iostream>
 #include <iomanip>
@@ -225,4 +225,4 @@ namespace tlapack
 
 }
 
-#endif // __TLAPACK_DEBUG_UTILS_HH
+#endif // TLAPACK_DEBUG_UTILS_HH

--- a/include/plugins/tlapack_eigen.hpp
+++ b/include/plugins/tlapack_eigen.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_EIGEN_HH__
-#define __TLAPACK_EIGEN_HH__
+#ifndef TLAPACK_EIGEN_HH
+#define TLAPACK_EIGEN_HH
 
 #include <Eigen/Core>
 #include "base/arrayTraits.hpp"
@@ -225,4 +225,4 @@ namespace tlapack{
 
 } // namespace tlapack
 
-#endif // __TLAPACK_EIGEN_HH__
+#endif // TLAPACK_EIGEN_HH

--- a/include/plugins/tlapack_legacyArray.hpp
+++ b/include/plugins/tlapack_legacyArray.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_LEGACYARRAY_HH__
-#define __TLAPACK_LEGACYARRAY_HH__
+#ifndef TLAPACK_LEGACYARRAY_HH
+#define TLAPACK_LEGACYARRAY_HH
 
 #include <utility>
 #include <type_traits>
@@ -250,4 +250,4 @@ namespace tlapack {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_LEGACYARRAY_HH__
+#endif // TLAPACK_LEGACYARRAY_HH

--- a/include/plugins/tlapack_mdspan.hpp
+++ b/include/plugins/tlapack_mdspan.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_MDSPAN_HH__
-#define __TLAPACK_MDSPAN_HH__
+#ifndef TLAPACK_MDSPAN_HH
+#define TLAPACK_MDSPAN_HH
 
 #include <experimental/mdspan>
 
@@ -201,4 +201,4 @@ namespace tlapack {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_MDSPAN_HH__
+#endif // TLAPACK_MDSPAN_HH

--- a/include/plugins/tlapack_mpreal.hpp
+++ b/include/plugins/tlapack_mpreal.hpp
@@ -5,8 +5,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_MPREAL_HH__
-#define __TLAPACK_MPREAL_HH__
+#ifndef TLAPACK_MPREAL_HH
+#define TLAPACK_MPREAL_HH
 
 #include <mpreal.h>
 #include <complex>
@@ -64,4 +64,4 @@ namespace tlapack {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_MPREAL_HH__
+#endif // TLAPACK_MPREAL_HH

--- a/include/plugins/tlapack_stdvector.hpp
+++ b/include/plugins/tlapack_stdvector.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_STDVECTOR_HH__
-#define __TLAPACK_STDVECTOR_HH__
+#ifndef TLAPACK_STDVECTOR_HH
+#define TLAPACK_STDVECTOR_HH
 
 #include <vector>
 #include "base/arrayTraits.hpp"
@@ -46,4 +46,4 @@ namespace tlapack {
 
 } // namespace tlapack
 
-#endif // __TLAPACK_STDVECTOR_HH__
+#endif // TLAPACK_STDVECTOR_HH

--- a/include/tblas.h.in
+++ b/include/tblas.h.in
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_BLAS_H__
-#define __TLAPACK_BLAS_H__
+#ifndef TLAPACK_BLAS_H
+#define TLAPACK_BLAS_H
 
 // -----------------------------------------------------------------------------
 #include <stdint.h>
@@ -1131,4 +1131,4 @@ void ztrsm(
 }
 #endif
 
-#endif // __TLAPACK_BLAS_H__
+#endif // TLAPACK_BLAS_H

--- a/include/tblas.hpp
+++ b/include/tblas.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_TBLAS_HH__
-#define __TLAPACK_TBLAS_HH__
+#ifndef TLAPACK_TBLAS_HH
+#define TLAPACK_TBLAS_HH
 
 // Optimized BLAS
 
@@ -68,4 +68,4 @@
 #include "blas/trmm.hpp"
 #include "blas/trsm.hpp"
 
-#endif // __TLAPACK_TBLAS_HH__
+#endif // TLAPACK_TBLAS_HH

--- a/include/tlapack.hpp
+++ b/include/tlapack.hpp
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_HH__
-#define __TLAPACK_HH__
+#ifndef TLAPACK_HH
+#define TLAPACK_HH
 
 // BLAS
 
@@ -82,4 +82,4 @@
 #include "lapack/agressive_early_deflation.hpp"
 #include "lapack/multishift_qr.hpp"
 
-#endif // __TLAPACK_HH__
+#endif // TLAPACK_HH

--- a/include/tlapack_cblas.h.in
+++ b/include/tlapack_cblas.h.in
@@ -4,8 +4,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TLAPACK_CBLAS_H__
-#define __TLAPACK_CBLAS_H__
+#ifndef TLAPACK_CBLAS_H
+#define TLAPACK_CBLAS_H
 
 // -----------------------------------------------------------------------------
 #include <stddef.h>
@@ -1132,4 +1132,4 @@ void cblas_ztrsm(
 }
 #endif
 
-#endif // __TLAPACK_CBLAS_H__
+#endif // TLAPACK_CBLAS_H

--- a/performancetests/multishift_qr/profile_aed.cpp
+++ b/performancetests/multishift_qr/profile_aed.cpp
@@ -95,15 +95,15 @@ void run(size_t n, size_t nw, bool use_fortran)
     size_t ldq = lda;
 
     // Arrays
-    std::unique_ptr<T[]> _A(new T[lda * n]); // m-by-n
-    std::unique_ptr<T[]> _H(new T[ldh * n]); // n-by-n
-    std::unique_ptr<T[]> _Q(new T[ldq * n]); // m-by-n
+    std::unique_ptr<T[]> A_(new T[lda * n]); // m-by-n
+    std::unique_ptr<T[]> H_(new T[ldh * n]); // n-by-n
+    std::unique_ptr<T[]> Q_(new T[ldq * n]); // m-by-n
     std::vector<T> tau(n);
 
     // Matrix views
-    auto A = colmajor_matrix<T>(&_A[0], n, n, lda);
-    auto H = colmajor_matrix<T>(&_H[0], n, n, ldh);
-    auto Q = colmajor_matrix<T>(&_Q[0], n, n, ldq);
+    auto A = colmajor_matrix<T>(&A_[0], n, n, lda);
+    auto H = colmajor_matrix<T>(&H_[0], n, n, ldh);
+    auto Q = colmajor_matrix<T>(&Q_[0], n, n, ldq);
 
     // Initialize arrays with junk
     for (size_t j = 0; j < n; ++j)
@@ -190,8 +190,8 @@ void run(size_t n, size_t nw, bool use_fortran)
 
     // 3) Compute ||QHQ* - A||_F / ||A||_F
 
-    std::unique_ptr<T[]> _H_copy(new T[n * n]);
-    auto H_copy = colmajor_matrix<T>(&_H_copy[0], n, n);
+    std::unique_ptr<T[]> H_copy_(new T[n * n]);
+    auto H_copy = colmajor_matrix<T>(&H_copy_[0], n, n);
     tlapack::lacpy(tlapack::Uplo::General, H, H_copy);
     {
         std::unique_ptr<T[]> _work(new T[n * n]);

--- a/performancetests/multishift_qr/profile_multishift_qr.cpp
+++ b/performancetests/multishift_qr/profile_multishift_qr.cpp
@@ -95,15 +95,15 @@ void run(size_t n, int seed, bool use_fortran)
     size_t ldq = lda;
 
     // Arrays
-    std::unique_ptr<T[]> _A(new T[lda * n]); // m-by-n
-    std::unique_ptr<T[]> _H(new T[ldh * n]); // n-by-n
-    std::unique_ptr<T[]> _Q(new T[ldq * n]); // m-by-n
+    std::unique_ptr<T[]> A_(new T[lda * n]); // m-by-n
+    std::unique_ptr<T[]> H_(new T[ldh * n]); // n-by-n
+    std::unique_ptr<T[]> Q_(new T[ldq * n]); // m-by-n
     std::vector<T> tau(n);
 
     // Matrix views
-    auto A = colmajor_matrix<T>(&_A[0], n, n, lda);
-    auto H = colmajor_matrix<T>(&_H[0], n, n, ldh);
-    auto Q = colmajor_matrix<T>(&_Q[0], n, n, ldq);
+    auto A = colmajor_matrix<T>(&A_[0], n, n, lda);
+    auto H = colmajor_matrix<T>(&H_[0], n, n, ldh);
+    auto Q = colmajor_matrix<T>(&Q_[0], n, n, ldq);
 
     // Initialize arrays with junk
     for (size_t j = 0; j < n; ++j)
@@ -235,8 +235,8 @@ void run(size_t n, int seed, bool use_fortran)
 
     // 3) Compute ||QHQ* - A||_F / ||A||_F
 
-    std::unique_ptr<T[]> _H_copy(new T[n * n]);
-    auto H_copy = colmajor_matrix<T>(&_H_copy[0], n, n);
+    std::unique_ptr<T[]> H_copy_(new T[n * n]);
+    auto H_copy = colmajor_matrix<T>(&H_copy_[0], n, n);
     tlapack::lacpy(tlapack::Uplo::General, H, H_copy);
     {
         std::unique_ptr<T[]> _work(new T[n * n]);

--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TESTDEFINITIONS_HH__
-#define __TESTDEFINITIONS_HH__
+#ifndef TLAPACK_TESTDEFINITIONS_HH
+#define TLAPACK_TESTDEFINITIONS_HH
 
 #include <legacy_api/legacyArray.hpp>
 #include <tlapack.hpp>
@@ -51,4 +51,4 @@ namespace tlapack
 
 }
 
-#endif // __TESTDEFINITIONS_HH__
+#endif // TLAPACK_TESTDEFINITIONS_HH

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -7,8 +7,8 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __TESTUTILS_HH__
-#define __TESTUTILS_HH__
+#ifndef TLAPACK_TESTUTILS_HH
+#define TLAPACK_TESTUTILS_HH
 
 #include <legacy_api/legacyArray.hpp>
 #include <tlapack.hpp>
@@ -201,4 +201,4 @@ namespace tlapack
 
 }
 
-#endif // __TESTUTILS_HH__
+#endif // TLAPACK_TESTUTILS_HH

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -60,14 +60,14 @@ TEMPLATE_LIST_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", types_t
     }
 
     // Define the matrices and vectors
-    std::unique_ptr<T[]> _A(new T[n * n]);
-    std::unique_ptr<T[]> _H(new T[n * n]);
-    std::unique_ptr<T[]> _Q(new T[n * n]);
+    std::unique_ptr<T[]> A_(new T[n * n]);
+    std::unique_ptr<T[]> H_(new T[n * n]);
+    std::unique_ptr<T[]> Q_(new T[n * n]);
 
     // This only works for legacy matrix, we really work on that construct_matrix function
-    auto A = legacyMatrix<T, layout<matrix_t>>(n, n, &_A[0], n);
-    auto H = legacyMatrix<T, layout<matrix_t>>(n, n, &_H[0], n);
-    auto Q = legacyMatrix<T, layout<matrix_t>>(n, n, &_Q[0], n);
+    auto A = legacyMatrix<T, layout<matrix_t>>(n, n, &A_[0], n);
+    auto H = legacyMatrix<T, layout<matrix_t>>(n, n, &H_[0], n);
+    auto Q = legacyMatrix<T, layout<matrix_t>>(n, n, &Q_[0], n);
 
     if (matrix_type == "Random")
     {

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -48,14 +48,14 @@ TEMPLATE_LIST_TEST_CASE("lahqr", "[eigenvalues][doubleshift_qr]", types_to_test)
     }
 
     // Define the matrices and vectors
-    std::unique_ptr<T[]> _A(new T[n * n]);
-    std::unique_ptr<T[]> _H(new T[n * n]);
-    std::unique_ptr<T[]> _Q(new T[n * n]);
+    std::unique_ptr<T[]> A_(new T[n * n]);
+    std::unique_ptr<T[]> H_(new T[n * n]);
+    std::unique_ptr<T[]> Q_(new T[n * n]);
 
     // This only works for legacy matrix, we really work on that construct_matrix function
-    auto A = legacyMatrix<T, layout<matrix_t>>(n, n, &_A[0], n);
-    auto H = legacyMatrix<T, layout<matrix_t>>(n, n, &_H[0], n);
-    auto Q = legacyMatrix<T, layout<matrix_t>>(n, n, &_Q[0], n);
+    auto A = legacyMatrix<T, layout<matrix_t>>(n, n, &A_[0], n);
+    auto H = legacyMatrix<T, layout<matrix_t>>(n, n, &H_[0], n);
+    auto Q = legacyMatrix<T, layout<matrix_t>>(n, n, &Q_[0], n);
 
     if (matrix_type == "Random")
     {

--- a/test/src/test_unmhr.cpp
+++ b/test/src/test_unmhr.cpp
@@ -40,14 +40,14 @@ TEMPLATE_LIST_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalu
     const real_type<T> tol = n * 1.0e2 * eps;
 
     // Define the matrices and vectors
-    std::unique_ptr<T[]> _H(new T[n * n]);
-    std::unique_ptr<T[]> _C(new T[m * n]);
-    std::unique_ptr<T[]> _C_copy(new T[m * n]);
+    std::unique_ptr<T[]> H_(new T[n * n]);
+    std::unique_ptr<T[]> C_(new T[m * n]);
+    std::unique_ptr<T[]> C_copy_(new T[m * n]);
 
     // This only works for legacy matrix, we really work on that construct_matrix function
-    auto H = legacyMatrix<T, layout<matrix_t>>(n, n, &_H[0], n);
-    auto C = legacyMatrix<T, layout<matrix_t>>(m, n, &_C[0], layout<matrix_t> == Layout::ColMajor ? m : n);
-    auto C_copy = legacyMatrix<T, layout<matrix_t>>(m, n, &_C_copy[0], layout<matrix_t> == Layout::ColMajor ? m : n);
+    auto H = legacyMatrix<T, layout<matrix_t>>(n, n, &H_[0], n);
+    auto C = legacyMatrix<T, layout<matrix_t>>(m, n, &C_[0], layout<matrix_t> == Layout::ColMajor ? m : n);
+    auto C_copy = legacyMatrix<T, layout<matrix_t>>(m, n, &C_copy_[0], layout<matrix_t> == Layout::ColMajor ? m : n);
     std::vector<T> tau(n);
     std::vector<T> work(std::max(n,m));
 


### PR DESCRIPTION
Closes #117

- Comprises with 17.4.3.1.2 Global names [lib.global.names].
- Also avoids underscores even if not followed by Uppercase to avoid problems
- On vscode, I used the following regular expressions to help find all names to change:

```
__(.*)__ # Identifiers limited by double underscore
([^\w|])_([A-Z]) # Identifiers that start with underscore
__ # All identifiers the contain double underscore
([^\w])_(\w)([, ;/\)\(.\[\]]) # Other identifiers that start with underscore
```