### PR TITLE
Homogenize the check for arguments

### DIFF
--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -101,7 +101,6 @@ void run(size_t n)
     {
         // Hessenberg factorization
         int err = tlapack::gehrd(0, n, Q, tau);
-        // tlapack_check_false(tlapack::gehd2(0, n, Q, tau, work));
         tlapack_check_false(err);
     }
     // Record end time

--- a/include/base/exceptionHandling.hpp
+++ b/include/base/exceptionHandling.hpp
@@ -53,7 +53,7 @@ namespace tlapack {
     /**
      * @brief Throw an error if cond is false.
      * 
-     * ex: lapack_check( 1 > 2, -6 ); throws an error.
+     * ex: lapack_check( 1 > 2 ); throws an error.
      */
     #define tlapack_check( cond ) do { \
         if( !static_cast<bool>(cond) ) \
@@ -63,9 +63,9 @@ namespace tlapack {
     /**
      * @brief Throw an error if cond is true.
      * 
-     * ex: lapack_check( 1 < 2, -6 ); throws an error.
+     * ex: lapack_check( 1 < 2 ); throws an error.
      */
-    #define tlapack_check_false( cond, ... ) do { \
+    #define tlapack_check_false( cond ) do { \
         if( static_cast<bool>(cond) ) \
             throw tlapack::check_error( #cond ); \
     } while(false)
@@ -74,7 +74,7 @@ namespace tlapack {
 
     // <T>LAPACK does not check input parameters
 
-    #define tlapack_check_false( cond, ... ) \
+    #define tlapack_check_false( cond ) \
         ((void)0)
     #define tlapack_check( cond ) \
         ((void)0)

--- a/include/lapack/gehd2.hpp
+++ b/include/lapack/gehd2.hpp
@@ -66,10 +66,10 @@ int gehd2( size_type< matrix_t > ilo, size_type< matrix_t > ihi, matrix_t& A, ve
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false( access_denied( dense, write_policy(A) ), -3 );
-    tlapack_check_false( ncols(A) != nrows(A), -3 );
-    tlapack_check_false( (idx_t) size(tau)  < n-1, -4 );
-    tlapack_check_false( (idx_t) size(work) < n, -5 );
+    tlapack_check_false( access_denied( dense, write_policy(A) ) );
+    tlapack_check_false( ncols(A) != nrows(A) );
+    tlapack_check_false( (idx_t) size(tau)  < n-1 );
+    tlapack_check_false( (idx_t) size(work) < n );
 
     // quick return
     if (n <= 0) return 0;

--- a/include/lapack/gehrd.hpp
+++ b/include/lapack/gehrd.hpp
@@ -105,11 +105,11 @@ namespace tlapack
         idx_t nx = std::max( nb, nx_switch );
 
         // check arguments
-        tlapack_check_false((ilo < 0) or (ilo >= n), -1);
-        tlapack_check_false((ihi < 0) or (ihi > n), -2);
-        tlapack_check_false(access_denied(dense, write_policy(A)), -3);
-        tlapack_check_false(ncols(A) != nrows(A), -3);
-        tlapack_check_false((idx_t)size(tau) < n - 1, -4);
+        tlapack_check_false((ilo < 0) or (ilo >= n) );
+        tlapack_check_false((ihi < 0) or (ihi > n) );
+        tlapack_check_false(access_denied(dense, write_policy(A)) );
+        tlapack_check_false(ncols(A) != nrows(A) );
+        tlapack_check_false((idx_t)size(tau) < n - 1 );
 
         // quick return
         if (n <= 0)

--- a/include/lapack/gelq2.hpp
+++ b/include/lapack/gelq2.hpp
@@ -66,9 +66,9 @@ namespace tlapack
         const idx_t k = min(m, n);
 
         // check arguments
-        tlapack_check_false(access_denied(dense, write_policy(A)), -1);
-        tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n), -2);
-        tlapack_check_false((idx_t)size(work) < m, -3);
+        tlapack_check_false(access_denied(dense, write_policy(A)) );
+        tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n) );
+        tlapack_check_false((idx_t)size(work) < m );
 
         for (idx_t j = 0; j < k; ++j)
         {

--- a/include/lapack/gelqf.hpp
+++ b/include/lapack/gelqf.hpp
@@ -77,9 +77,9 @@ namespace tlapack
         const idx_t k = min(m, n);
 
         // check arguments
-        tlapack_check_false(access_denied(dense, write_policy(A)), -1);
-        tlapack_check_false( nrows(TT) < m || ncols(TT) < nb, -2);
-        tlapack_check_false((idx_t)size(work) < m, -3);
+        tlapack_check_false(access_denied(dense, write_policy(A)) );
+        tlapack_check_false( nrows(TT) < m || ncols(TT) < nb );
+        tlapack_check_false((idx_t)size(work) < m );
 
         for (idx_t j = 0; j < k; j += nb)
         {

--- a/include/lapack/geqr2.hpp
+++ b/include/lapack/geqr2.hpp
@@ -66,9 +66,9 @@ int geqr2( matrix_t& A, vector_t &tau, work_t &work )
     const idx_t k = std::min<idx_t>( m, n-1 );
 
     // check arguments
-    tlapack_check_false( access_denied( dense, write_policy(A) ), -1 );
-    tlapack_check_false( (idx_t) size(tau)  < std::min<idx_t>( m, n ), -2 );
-    tlapack_check_false( (idx_t) size(work) < n-1, -3 );
+    tlapack_check_false( access_denied( dense, write_policy(A) ) );
+    tlapack_check_false( (idx_t) size(tau)  < std::min<idx_t>( m, n ) );
+    tlapack_check_false( (idx_t) size(work) < n-1 );
 
     // quick return
     if (n <= 0) return 0;

--- a/include/lapack/lahqr.hpp
+++ b/include/lapack/lahqr.hpp
@@ -96,11 +96,11 @@ namespace tlapack
         const idx_t nh = ihi - ilo;
 
         // check arguments
-        tlapack_check_false(n != nrows(A), -5);
-        tlapack_check_false((idx_t)size(w) != n, -6);
+        tlapack_check_false(n != nrows(A) );
+        tlapack_check_false((idx_t)size(w) != n );
         if (want_z)
         {
-            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)), -7);
+            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)) );
         }
 
         // quick return
@@ -490,11 +490,11 @@ namespace tlapack
         const idx_t nh = ihi - ilo;
 
         // check arguments
-        tlapack_check_false(n != nrows(A), -5);
-        tlapack_check_false((idx_t)size(w) != n, -6);
+        tlapack_check_false(n != nrows(A) );
+        tlapack_check_false((idx_t)size(w) != n );
         if (want_z)
         {
-            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)), -7);
+            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)) );
         }
 
         // quick return

--- a/include/lapack/lahqr_shiftcolumn.hpp
+++ b/include/lapack/lahqr_shiftcolumn.hpp
@@ -55,9 +55,9 @@ namespace tlapack
       const real_t zero(0);
 
       // Check arguments
-      tlapack_check_false((n != 2 and n != 3), -1);
-      tlapack_check_false(n != nrows(H), -1);
-      tlapack_check_false((idx_t)size(v) != n, -2);
+      tlapack_check_false((n != 2 and n != 3) );
+      tlapack_check_false(n != nrows(H) );
+      tlapack_check_false((idx_t)size(v) != n );
 
       if (n == 2)
       {
@@ -131,9 +131,9 @@ namespace tlapack
       const TH zero(0);
 
       // Check arguments
-      tlapack_check_false((n != 2 and n != 3), -1);
-      tlapack_check_false(n != nrows(H), -1);
-      tlapack_check_false((idx_t)size(v) != n, -2);
+      tlapack_check_false((n != 2 and n != 3) );
+      tlapack_check_false(n != nrows(H) );
+      tlapack_check_false((idx_t)size(v) != n );
 
       if (n == 2)
       {

--- a/include/lapack/larfb.hpp
+++ b/include/lapack/larfb.hpp
@@ -115,36 +115,36 @@ int larfb(
 
     // check arguments
     tlapack_check_false(    side != Side::Left &&
-                        side != Side::Right, -1 );
+                        side != Side::Right );
     tlapack_check_false(    trans != Op::NoTrans &&
                         trans != Op::ConjTrans &&
                         (
                             (trans != Op::Trans) ||
                             is_complex< type_t< matrixV_t > >::value
-                        ), -2 );
+                        ) );
     tlapack_check_false(    direction != Direction::Backward &&
-                        direction != Direction::Forward, -3 );
+                        direction != Direction::Forward );
     tlapack_check_false(    storeMode != StoreV::Columnwise &&
-                        storeMode != StoreV::Rowwise, -4 );
+                        storeMode != StoreV::Rowwise );
 
     if( direction == Direction::Forward )
     {
         if( storeMode == StoreV::Columnwise )
-            tlapack_check_false( access_denied( strictLower, read_policy(V) ), -5 );
+            tlapack_check_false( access_denied( strictLower, read_policy(V) ) );
         else
-            tlapack_check_false( access_denied( strictUpper, read_policy(V) ), -5 );
+            tlapack_check_false( access_denied( strictUpper, read_policy(V) ) );
 
-        tlapack_check_false( access_denied( Uplo::Upper, read_policy(T) ), -6 );
+        tlapack_check_false( access_denied( Uplo::Upper, read_policy(T) ) );
     }
     else
     {
-        tlapack_check_false( access_denied( dense, read_policy(V) ), -5 );
+        tlapack_check_false( access_denied( dense, read_policy(V) ) );
 
-        tlapack_check_false( access_denied( Uplo::Lower, read_policy(T) ), -6 );
+        tlapack_check_false( access_denied( Uplo::Lower, read_policy(T) ) );
     }
 
-    tlapack_check_false(    access_denied( dense, write_policy(C) ), -7 );
-    tlapack_check_false(    access_denied( dense, write_policy(work) ), -8 );
+    tlapack_check_false(    access_denied( dense, write_policy(C) ) );
+    tlapack_check_false(    access_denied( dense, write_policy(work) ) );
 
     // Quick return
     if (m <= 0 || n <= 0 || k <= 0) return 0;

--- a/include/lapack/larft.hpp
+++ b/include/lapack/larft.hpp
@@ -102,30 +102,30 @@ int larft(
 
     // check arguments
     tlapack_check_false(    direction != Direction::Backward &&
-                        direction != Direction::Forward, -1 );
+                        direction != Direction::Forward );
     tlapack_check_false(    storeMode != StoreV::Columnwise &&
-                        storeMode != StoreV::Rowwise, -2 );
+                        storeMode != StoreV::Rowwise );
 
     if( direction == Direction::Forward )
     {
         if( storeMode == StoreV::Columnwise )
-            tlapack_check_false( access_denied( strictLower, read_policy(V) ), -3 );
+            tlapack_check_false( access_denied( strictLower, read_policy(V) ) );
         else
-            tlapack_check_false( access_denied( strictUpper, read_policy(V) ), -3 );
+            tlapack_check_false( access_denied( strictUpper, read_policy(V) ) );
     }
     else
     {
-        tlapack_check_false( access_denied( dense, read_policy(V) ), -3 );
+        tlapack_check_false( access_denied( dense, read_policy(V) ) );
     }
     tlapack_check_false( k > ( (storeMode == StoreV::Columnwise)
                             ? ncols( V )
-                            : nrows( V ) ), -3 );
+                            : nrows( V ) ) );
 
     if( direction == Direction::Forward )
-        tlapack_check_false( access_denied( Uplo::Upper, read_policy(T) ), -5 );
+        tlapack_check_false( access_denied( Uplo::Upper, read_policy(T) ) );
     else
-        tlapack_check_false( access_denied( Uplo::Lower, read_policy(T) ), -5 );
-    tlapack_check_false(    nrows( T ) < k || ncols( T ) < k, -5 );
+        tlapack_check_false( access_denied( Uplo::Lower, read_policy(T) ) );
+    tlapack_check_false(    nrows( T ) < k || ncols( T ) < k );
 
     // Quick return
     if (n == 0 || k == 0)

--- a/include/lapack/lascl.hpp
+++ b/include/lapack/lascl.hpp
@@ -81,10 +81,10 @@ int lascl(
         (accessType != MatrixAccessPolicy::UpperTriangle) && 
         (accessType != MatrixAccessPolicy::LowerTriangle) && 
         (accessType != MatrixAccessPolicy::StrictUpper) && 
-        (accessType != MatrixAccessPolicy::StrictLower), -1 );
-    tlapack_check_false( access_denied( accessType, write_policy(A) ), -1 );
-    tlapack_check_false( (b == b_type(0)) || isnan(b), -2 );
-    tlapack_check_false( isnan(a), -3 );
+        (accessType != MatrixAccessPolicy::StrictLower) );
+    tlapack_check_false( access_denied( accessType, write_policy(A) ) );
+    tlapack_check_false( (b == b_type(0)) || isnan(b) );
+    tlapack_check_false( isnan(a) );
 
     // quick return
     if( m <= 0 || n <= 0 )
@@ -224,10 +224,10 @@ int lascl(
     const real_t big   = safe_max<real_t>();
     
     // check arguments
-    tlapack_check_false( (kl < 0) || (kl >= m) || (ku < 0) || (ku >= n), -1 );
-    tlapack_check_false( access_denied( accessType, write_policy(A) ), -1 );
-    tlapack_check_false( (b == b_type(0)) || isnan(b), -2 );
-    tlapack_check_false( isnan(a), -3 );
+    tlapack_check_false( (kl < 0) || (kl >= m) || (ku < 0) || (ku >= n) );
+    tlapack_check_false( access_denied( accessType, write_policy(A) ) );
+    tlapack_check_false( (b == b_type(0)) || isnan(b) );
+    tlapack_check_false( isnan(a) );
 
     // quick return
     if( m <= 0 || n <= 0 )

--- a/include/lapack/lauum_recursive.hpp
+++ b/include/lapack/lauum_recursive.hpp
@@ -54,10 +54,9 @@ namespace tlapack
 
         // check arguments
         tlapack_check_false(uplo != Uplo::Lower &&
-                                uplo != Uplo::Upper,
-                            -1);
-        tlapack_check_false(access_denied(uplo, write_policy(C)), -1);
-        tlapack_check_false(nrows(C) != ncols(C), -2);
+                                uplo != Uplo::Upper );
+        tlapack_check_false(access_denied(uplo, write_policy(C)) );
+        tlapack_check_false(nrows(C) != ncols(C) );
 
         // Quick return
         if (n <= 0)

--- a/include/lapack/multishift_qr.hpp
+++ b/include/lapack/multishift_qr.hpp
@@ -168,11 +168,11 @@ namespace tlapack
         int n_shifts_total = 0;
 
         // check arguments
-        tlapack_check_false(n != nrows(A), -5);
-        tlapack_check_false((idx_t)size(w) != n, -6);
+        tlapack_check_false(n != nrows(A) );
+        tlapack_check_false((idx_t)size(w) != n );
         if (want_z)
         {
-            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)), -7);
+            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)) );
         }
 
         // quick return

--- a/include/lapack/potrf2.hpp
+++ b/include/lapack/potrf2.hpp
@@ -81,9 +81,9 @@ int potrf2( uplo_t uplo, matrix_t& A, const ErrorCheck& ec = {} )
 
     // check arguments
     tlapack_check_false(    uplo != Uplo::Lower &&
-                            uplo != Uplo::Upper, -1 );
-    tlapack_check_false(    access_denied( uplo, write_policy(A) ), -1 );
-    tlapack_check_false(    nrows(A) != ncols(A), -2 );
+                            uplo != Uplo::Upper );
+    tlapack_check_false(    access_denied( uplo, write_policy(A) ) );
+    tlapack_check_false(    nrows(A) != ncols(A) );
 
     // Quick return
     if (n <= 0)

--- a/include/lapack/potrs.hpp
+++ b/include/lapack/potrs.hpp
@@ -61,10 +61,10 @@ int potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
 
     // Check arguments
     tlapack_check_false(    uplo != Uplo::Lower &&
-                        uplo != Uplo::Upper, -1 );
-    tlapack_check_false(    access_denied( uplo, write_policy(A) ), -1 );
-    tlapack_check_false(    nrows(A) != ncols(A), -2 );
-    tlapack_check_false(    nrows(B) != ncols(A), -3 );
+                        uplo != Uplo::Upper );
+    tlapack_check_false(    access_denied( uplo, write_policy(A) ) );
+    tlapack_check_false(    nrows(A) != ncols(A) );
+    tlapack_check_false(    nrows(B) != ncols(A) );
 
     if( uplo == Uplo::Upper ) {
         // Solve A*X = B where A = U**H *U.

--- a/include/lapack/ung2r.hpp
+++ b/include/lapack/ung2r.hpp
@@ -58,10 +58,10 @@ int ung2r(
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false( k < 0 || k > n, -1 );
-    tlapack_check_false( access_denied( dense, write_policy(A) ), -2 );
-    tlapack_check_false( (idx_t) size(tau)  < k, -3 );
-    tlapack_check_false( (idx_t) size(work) < n-1, -4 );
+    tlapack_check_false( k < 0 || k > n );
+    tlapack_check_false( access_denied( dense, write_policy(A) ) );
+    tlapack_check_false( (idx_t) size(tau)  < k );
+    tlapack_check_false( (idx_t) size(work) < n-1 );
 
     // quick return
     if (n <= 0) return 0;

--- a/include/lapack/unghr.hpp
+++ b/include/lapack/unghr.hpp
@@ -49,8 +49,8 @@ int unghr(
     const idx_t nh = ihi > ilo +1 ? ihi-1-ilo : 0;
 
     // check arguments
-    tlapack_check_false( (idx_t) size(tau)  < std::min<idx_t>( m, n ), -2 );
-    tlapack_check_false( (idx_t) size(work) < n-1, -3 );
+    tlapack_check_false( (idx_t) size(tau)  < std::min<idx_t>( m, n ) );
+    tlapack_check_false( (idx_t) size(work) < n-1 );
 
 
     // Shift the vectors which define the elementary reflectors one

--- a/include/lapack/ungl2.hpp
+++ b/include/lapack/ungl2.hpp
@@ -59,9 +59,9 @@ namespace tlapack
         const idx_t t = min(k, m);  // desired number of Householder reflectors to use
 
         // check arguments
-        tlapack_check_false(access_denied(dense, write_policy(Q)), -1);
-        tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n), -2);
-        tlapack_check_false((idx_t)size(work) < t, -3);
+        tlapack_check_false(access_denied(dense, write_policy(Q)) );
+        tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n) );
+        tlapack_check_false((idx_t)size(work) < t );
 
         // Initialise columns t:k-1 to rows of the unit matrix
         if (k > m)

--- a/include/lapack/unm2r.hpp
+++ b/include/lapack/unm2r.hpp
@@ -93,14 +93,14 @@ int unm2r(
 
     // check arguments
     tlapack_check_false( side != Side::Left &&
-                     side != Side::Right, -1 );
+                     side != Side::Right );
     tlapack_check_false( trans != Op::NoTrans &&
                      trans != Op::Trans &&
-                     trans != Op::ConjTrans, -2 );
-    tlapack_check_false( trans == Op::Trans && is_complex<matrixA_t>::value, -2 );
-    tlapack_check_false( access_denied( lowerTriangle, read_policy(A)  ), -3 );
-    tlapack_check_false( access_denied( band_t(0,0),   write_policy(A) ), -3 );
-    tlapack_check_false( access_denied( dense, write_policy(C) ), -5 );
+                     trans != Op::ConjTrans );
+    tlapack_check_false( trans == Op::Trans && is_complex<matrixA_t>::value );
+    tlapack_check_false( access_denied( lowerTriangle, read_policy(A)  ) );
+    tlapack_check_false( access_denied( band_t(0,0),   write_policy(A) ) );
+    tlapack_check_false( access_denied( dense, write_policy(C) ) );
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0))

--- a/include/lapack/unmqr.hpp
+++ b/include/lapack/unmqr.hpp
@@ -118,14 +118,14 @@ int unmqr(
 
     // check arguments
     tlapack_check_false( side != Side::Left &&
-                     side != Side::Right, -1 );
+                     side != Side::Right );
     tlapack_check_false( trans != Op::NoTrans &&
                      trans != Op::Trans &&
-                     trans != Op::ConjTrans, -2 );
-    tlapack_check_false( trans == Op::Trans && is_complex<matrixA_t>::value, -2 );
+                     trans != Op::ConjTrans );
+    tlapack_check_false( trans == Op::Trans && is_complex<matrixA_t>::value );
     
-    tlapack_check_false( access_denied( strictLower, read_policy(A) ), -3 );
-    tlapack_check_false( access_denied( dense, write_policy(C) ), -5 );
+    tlapack_check_false( access_denied( strictLower, read_policy(A) ) );
+    tlapack_check_false( access_denied( dense, write_policy(C) ) );
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0))

--- a/include/legacy_api/lapack/geqr2.hpp
+++ b/include/legacy_api/lapack/geqr2.hpp
@@ -45,9 +45,9 @@ inline int geqr2(
     using work_t = scalar_type<TA,Ttau>;
 
     // check arguments
-    tlapack_check_false( m < 0, -1 );
-    tlapack_check_false( n < 0, -2 );
-    tlapack_check_false( lda < m, -4 );
+    tlapack_check_false( m < 0 );
+    tlapack_check_false( n < 0 );
+    tlapack_check_false( lda < m );
 
     // quick return
     if (n <= 0) return 0;

--- a/include/legacy_api/lapack/larfb.hpp
+++ b/include/legacy_api/lapack/larfb.hpp
@@ -126,17 +126,17 @@ int larfb(
 
     // check arguments
     tlapack_check_false(    side != Side::Left &&
-                        side != Side::Right, -1 );
+                        side != Side::Right );
     tlapack_check_false(    trans != Op::NoTrans &&
                         trans != Op::ConjTrans &&
                         (
                             (trans != Op::Trans) ||
                             is_complex< TV >::value
-                        ), -2 );
+                        ) );
     tlapack_check_false(    direct != Direction::Backward &&
-                        direct != Direction::Forward, -3 );
+                        direct != Direction::Forward );
     tlapack_check_false(    storeV != StoreV::Columnwise &&
-                        storeV != StoreV::Rowwise, -4 );
+                        storeV != StoreV::Rowwise );
 
     // Quick return
     if (m <= 0 || n <= 0) return 0;

--- a/include/legacy_api/lapack/larft.hpp
+++ b/include/legacy_api/lapack/larft.hpp
@@ -91,13 +91,13 @@ int larft(
 
     // check arguments
     tlapack_check_false( direction != Direction::Forward &&
-                     direction != Direction::Backward, -1 );
+                     direction != Direction::Backward );
     tlapack_check_false( storeV != StoreV::Columnwise &&
-                     storeV != StoreV::Rowwise, -2 );
-    tlapack_check_false( n < 0, -3 );
-    tlapack_check_false( k < 1, -4 );
-    tlapack_check_false( ldV < ((storeV == StoreV::Columnwise) ? n : k), -6 );
-    tlapack_check_false( ldT < k, -9 );
+                     storeV != StoreV::Rowwise );
+    tlapack_check_false( n < 0 );
+    tlapack_check_false( k < 1 );
+    tlapack_check_false( ldV < ((storeV == StoreV::Columnwise) ? n : k) );
+    tlapack_check_false( ldT < k );
 
     // Quick return
     if (n == 0 || k == 0)

--- a/include/legacy_api/lapack/lascl.hpp
+++ b/include/legacy_api/lapack/lascl.hpp
@@ -74,7 +74,7 @@ int lascl(
         (matrixtype != MatrixType::Hessenberg) && 
         (matrixtype != MatrixType::LowerBand) && 
         (matrixtype != MatrixType::UpperBand) && 
-        (matrixtype != MatrixType::Band), -1 );
+        (matrixtype != MatrixType::Band) );
     tlapack_check_false( (
             (matrixtype == MatrixType::LowerBand) ||
             (matrixtype == MatrixType::UpperBand) || 
@@ -82,7 +82,7 @@ int lascl(
         ) && (
             (kl < 0) ||
             (kl > max(m-1, idx_t(0)))
-        ), -2 );
+        ) );
     tlapack_check_false( (
             (matrixtype == MatrixType::LowerBand) ||
             (matrixtype == MatrixType::UpperBand) || 
@@ -90,20 +90,20 @@ int lascl(
         ) && (
             (ku < 0) ||
             (ku > max(n-1, idx_t(0)))
-        ), -3 );
+        ) );
     tlapack_check_false( (
             (matrixtype == MatrixType::LowerBand) ||
             (matrixtype == MatrixType::UpperBand)
-        ) && ( kl != ku ), -3 );
-    tlapack_check_false( m < 0, -6 );
+        ) && ( kl != ku ) );
+    tlapack_check_false( m < 0 );
     tlapack_check_false( (lda < m) && (
         (matrixtype == MatrixType::General) || 
         (matrixtype == MatrixType::Lower) ||
         (matrixtype == MatrixType::Upper) ||
-        (matrixtype == MatrixType::Hessenberg) ), -9 );
-    tlapack_check_false( (matrixtype == MatrixType::LowerBand) && (lda < kl + 1), -9);
-    tlapack_check_false( (matrixtype == MatrixType::UpperBand) && (lda < ku + 1), -9);
-    tlapack_check_false( (matrixtype == MatrixType::Band) && (lda < 2 * kl + ku + 1), -9);
+        (matrixtype == MatrixType::Hessenberg) ) );
+    tlapack_check_false( (matrixtype == MatrixType::LowerBand) && (lda < kl + 1) );
+    tlapack_check_false( (matrixtype == MatrixType::UpperBand) && (lda < ku + 1) );
+    tlapack_check_false( (matrixtype == MatrixType::Band) && (lda < 2 * kl + ku + 1) );
 
     if (matrixtype == MatrixType::LowerBand)
     {

--- a/include/legacy_api/lapack/potrf.hpp
+++ b/include/legacy_api/lapack/potrf.hpp
@@ -28,7 +28,7 @@ inline int potrf( uplo_t uplo, idx_t n, T* A, idx_t lda )
 
     // check arguments
     tlapack_check_false(    uplo != Uplo::Lower &&
-                        uplo != Uplo::Upper, -1 );
+                        uplo != Uplo::Upper );
 
     // Matrix views
     auto A_ = colmajor_matrix( A, n, n, lda );

--- a/include/legacy_api/lapack/potrs.hpp
+++ b/include/legacy_api/lapack/potrs.hpp
@@ -30,7 +30,7 @@ inline int potrs(
 
     // Check arguments
     tlapack_check_false(    uplo != Uplo::Lower &&
-                        uplo != Uplo::Upper, -1 );
+                        uplo != Uplo::Upper );
 
     // Matrix views
     const auto A_ = colmajor_matrix<T>( (T*) A, n, n, lda );

--- a/include/legacy_api/lapack/ung2r.hpp
+++ b/include/legacy_api/lapack/ung2r.hpp
@@ -47,10 +47,10 @@ inline int ung2r(
     using internal::vector;
 
     // check arguments
-    tlapack_check_false( m < 0, -1 );
-    tlapack_check_false( n < 0 || n > m, -2 );
-    tlapack_check_false( k < 0 || k > n, -3 );
-    tlapack_check_false( lda < m, -5 );
+    tlapack_check_false( m < 0 );
+    tlapack_check_false( n < 0 || n > m );
+    tlapack_check_false( k < 0 || k > n );
+    tlapack_check_false( lda < m );
 
     // quick return
     if (n <= 0) return 0;

--- a/include/legacy_api/lapack/unm2r.hpp
+++ b/include/legacy_api/lapack/unm2r.hpp
@@ -61,16 +61,16 @@ inline int unm2r(
 
     // check arguments
     tlapack_check_false( side != Side::Left &&
-                     side != Side::Right, -1 );
+                     side != Side::Right );
     tlapack_check_false( trans != Op::NoTrans &&
                      trans != Op::Trans &&
-                     trans != Op::ConjTrans, -2 );
-    tlapack_check_false( m < 0, -3 );
-    tlapack_check_false( n < 0, -4 );
+                     trans != Op::ConjTrans );
+    tlapack_check_false( m < 0 );
+    tlapack_check_false( n < 0 );
     const idx_t q = (side == Side::Left) ? m : n;
-    tlapack_check_false( k < 0 || k > q, -5 );
-    tlapack_check_false( lda < q, -7 );
-    tlapack_check_false( ldc < m, -10 );
+    tlapack_check_false( k < 0 || k > q );
+    tlapack_check_false( lda < q );
+    tlapack_check_false( ldc < m );
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0))

--- a/include/legacy_api/lapack/unmqr.hpp
+++ b/include/legacy_api/lapack/unmqr.hpp
@@ -92,10 +92,10 @@ inline int unmqr(
 
     // check arguments
     tlapack_check_false( side != Side::Left &&
-                     side != Side::Right, -1 );
+                     side != Side::Right );
     tlapack_check_false( trans != Op::NoTrans &&
                      trans != Op::Trans &&
-                     trans != Op::ConjTrans, -2 );
+                     trans != Op::ConjTrans );
     
     // Allocate work
     std::unique_ptr<scalar_t[]> _work( new scalar_t[ nb * (nw + nb) ] );


### PR DESCRIPTION
Goes in the same line of thought of https://github.com/tlapack/tlapack/discussions/48#discussioncomment-2601890,
i.e., programming errors don't need to return a code, they instead generate exceptions for the programmer.

Also, the changes here avoid contradicting the standard up to C++17: `the number of arguments must not be less than the number of parameters (counting ...). Otherwise the program is ill-formed`. This rule changed with C++20 to `the number of arguments must not be less than the number of parameters (__not__ counting ...). Otherwise the program is ill-formed`.

See https://en.cppreference.com/w/cpp/preprocessor/replace