### PR TITLE
Fix gemm legacy interface and propose a gemm with no beta

### DIFF
--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -200,8 +200,8 @@ void run(size_t n)
             for (size_t i = 0; i < n; ++i)
                 work(i, j) = static_cast<float>(0xABADBABC);
 
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, Q, H, (T)0.0, work);
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::ConjTrans, (T)1.0, work, Q, (T)0.0, H);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, Q, H, work);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::ConjTrans, (T)1.0, work, Q, H);
 
         for (size_t j = 0; j < n; ++j)
             for (size_t i = 0; i < n; ++i)
@@ -226,8 +226,8 @@ void run(size_t n)
             for (size_t i = 0; i < n; ++i)
                 work(i, j) = static_cast<float>(0xABADBABC);
 
-        tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, A, (T)0.0, work);
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, work, Q, (T)0.0, A);
+        tlapack::gemm(tlapack::Op::ConjTrans, tlapack::Op::NoTrans, (T)1.0, Q, A, work);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, work, Q, A);
 
         std::cout << std::endl
                     << "Q'AQ = ";

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -55,6 +55,61 @@
 
 namespace tlapack {
 
+    namespace internal {
+
+        /**
+         * @brief Auxiliary data type
+         * 
+         * Suppose x is of type T. Then:
+         * 
+         * 1. T(StrongZero()) is equivalent to T(0).
+         * 2. x *= StrongZero() is equivalent to x = T(0).
+         * 3. x += StrongZero() does not modify x.
+         * 
+         * This class satisfies:
+         * 
+         *      x * StrongZero() = StrongZero()
+         *      StrongZero() * x = StrongZero()
+         *      x + StrongZero() = x
+         *      StrongZero() + x = x 
+         * 
+         */
+        class StrongZero {
+
+            template<typename T>
+            constexpr operator T() const { return T(0); }
+
+            template<typename T>
+            friend constexpr
+            T& operator*=( T& lhs, const StrongZero& )
+            {
+                lhs = T(0);
+                return lhs;
+            }
+
+            template<typename T>
+            friend constexpr
+            const StrongZero operator*( const StrongZero&, const T& ) { return StrongZero(); }
+
+            template<typename T>
+            friend constexpr
+            const StrongZero operator*( const T&, const StrongZero& ) { return StrongZero(); }
+
+            template<typename T>
+            friend constexpr
+            const T& operator+=( const T& lhs, const StrongZero& ) { return lhs; }
+
+            template<typename T>
+            friend constexpr
+            const T operator+( const StrongZero&, const T& rhs ) { return rhs; }
+
+            template<typename T>
+            friend constexpr
+            const T operator+( const T& lhs, const StrongZero& ) { return lhs; }
+
+        };
+    }
+
     // -----------------------------------------------------------------------------
     // Layouts
 

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -74,10 +74,11 @@ namespace tlapack {
          *      StrongZero() + x = x 
          * 
          */
-        class StrongZero {
+        struct StrongZero {
 
             template<typename T>
-            constexpr operator T() const { return T(0); }
+            explicit constexpr
+            operator T() const { return T(0); }
 
             template<typename T>
             friend constexpr

--- a/include/tlapack/blas/hemm.hpp
+++ b/include/tlapack/blas/hemm.hpp
@@ -182,6 +182,62 @@ void hemm(
     }
 }
 
+/**
+ * Hermitian matrix-matrix multiply:
+ * \[
+ *     C := \alpha A B,
+ * \]
+ * or
+ * \[
+ *     C := \alpha B A,
+ * \]
+ * where alpha and beta are scalars, A is an m-by-m or n-by-n Hermitian matrix,
+ * and B and C are m-by-n matrices.
+ *
+ * @param[in] side
+ *     The side the matrix A appears on:
+ *     - Side::Left:  $C = \alpha A B$,
+ *     - Side::Right: $C = \alpha B A$.
+ *
+ * @param[in] uplo
+ *     What part of the matrix A is referenced:
+ *     - Uplo::Lower: only the lower triangular part of A is referenced.
+ *     - Uplo::Upper: only the upper triangular part of A is referenced.
+ *
+ * @param[in] alpha Scalar.
+ * @param[in] A
+ *     - If side = Left:  A m-by-m Hermitian matrix.
+ *     - If side = Right: A n-by-n Hermitian matrix.
+ *     Imaginary parts of the diagonal elements need not be set,
+ *     are assumed to be zero on entry, and are set to zero on exit.
+ * @param[in] B A m-by-n matrix.
+ * @param[out] C A m-by-n matrix.
+ *
+ * @ingroup hemm
+ */
+template<
+    class matrixA_t,
+    class matrixB_t,
+    class matrixC_t, 
+    class alpha_t,
+    class T = type_t<matrixC_t>,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void hemm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+{
+    return hemm( side, uplo, alpha, A, B, internal::StrongZero(), C );
+}
+
 }  // namespace tlapack
 
 #endif        //  #ifndef TLAPACK_BLAS_HEMM_HH

--- a/include/tlapack/blas/symm.hpp
+++ b/include/tlapack/blas/symm.hpp
@@ -177,6 +177,58 @@ void symm(
     }
 }
 
+/**
+ * Symmetric matrix-matrix multiply:
+ * \[
+ *     C := \alpha A B,
+ * \]
+ * or
+ * \[
+ *     C := \alpha B A,
+ * \]
+ * where alpha and beta are scalars, A is an m-by-m or n-by-n symmetric matrix,
+ * and B and C are m-by-n matrices.
+ *
+ * @param[in] side
+ *     The side the matrix A appears on:
+ *     - Side::Left:  $C = \alpha A B$,
+ *     - Side::Right: $C = \alpha B A$.
+ *
+ * @param[in] uplo
+ *     What part of the matrix A is referenced:
+ *     - Uplo::Lower: only the lower triangular part of A is referenced.
+ *     - Uplo::Upper: only the upper triangular part of A is referenced.
+ *
+ * @param[in] alpha Scalar.
+ * @param[in] A
+ *     - If side = Left:  A m-by-m symmetric matrix.
+ *     - If side = Right: A n-by-n symmetric matrix.
+ * @param[in] B A m-by-n matrix.
+ * @param[out] C A m-by-n matrix.
+ *
+ * @ingroup symm
+ */
+template<
+    class matrixA_t, class matrixB_t, class matrixC_t, 
+    class alpha_t,
+    class T = type_t<matrixC_t>,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void symm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+{
+    return symm( side, uplo, alpha, A, B, internal::StrongZero(), C );
+}
+
 }  // namespace tlapack
 
 #endif        //  #ifndef TLAPACK_BLAS_SYMM_HH

--- a/include/tlapack/blas/syr2k.hpp
+++ b/include/tlapack/blas/syr2k.hpp
@@ -162,6 +162,62 @@ void syr2k(
     }
 }
 
+/**
+ * Symmetric rank-k update:
+ * \[
+ *     C := \alpha A B^T + \alpha B A^T,
+ * \]
+ * or
+ * \[
+ *     C := \alpha A^T B + \alpha B^T A,
+ * \]
+ * where alpha and beta are scalars, C is an n-by-n symmetric matrix,
+ * and A and B are n-by-k or k-by-n matrices.
+ *
+ * @param[in] uplo
+ *     What part of the matrix C is referenced,
+ *     the opposite triangle being assumed from symmetry:
+ *     - Uplo::Lower: only the lower triangular part of C is referenced.
+ *     - Uplo::Upper: only the upper triangular part of C is referenced.
+ *
+ * @param[in] trans
+ *     The operation to be performed:
+ *     - Op::NoTrans: $C = \alpha A B^T + \alpha B A^T$.
+ *     - Op::Trans:   $C = \alpha A^T B + \alpha B^T A$.
+ *
+ * @param[in] alpha Scalar.
+ * @param[in] A A n-by-k matrix.
+ *     - If trans = NoTrans: a n-by-k matrix.
+ *     - Otherwise:          a k-by-n matrix.
+ * @param[in] B A n-by-k matrix.
+ *     - If trans = NoTrans: a n-by-k matrix.
+ *     - Otherwise:          a k-by-n matrix.
+ * @param[in] beta Scalar.
+ * @param[out] C A n-by-n symmetric matrix.
+ *
+ * @ingroup syr2k
+ */
+template<
+    class matrixA_t, class matrixB_t, class matrixC_t, 
+    class alpha_t,
+    class T = type_t<matrixC_t>,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void syr2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+{
+    return syr2k( uplo, trans, alpha, A, B, internal::StrongZero(), C );
+}
+
 }  // namespace tlapack
 
 #endif        //  #ifndef TLAPACK_BLAS_SYR2K_HH

--- a/include/tlapack/blas/syrk.hpp
+++ b/include/tlapack/blas/syrk.hpp
@@ -142,6 +142,58 @@ void syrk(
     }
 }
 
+/**
+ * Symmetric rank-k update:
+ * \[
+ *     C := \alpha A A^T,
+ * \]
+ * or
+ * \[
+ *     C := \alpha A^T A,
+ * \]
+ * where alpha and beta are scalars, C is an n-by-n symmetric matrix,
+ * and A is an n-by-k or k-by-n matrix.
+ *
+ * @param[in] uplo
+ *     What part of the matrix C is referenced,
+ *     the opposite triangle being assumed from symmetry:
+ *     - Uplo::Lower: only the lower triangular part of C is referenced.
+ *     - Uplo::Upper: only the upper triangular part of C is referenced.
+ *
+ * @param[in] trans
+ *     The operation to be performed:
+ *     - Op::NoTrans: $C = \alpha A A^T$.
+ *     - Op::Trans:   $C = \alpha A^T A$.
+ *
+ * @param[in] alpha Scalar.
+ * @param[in] A A n-by-k matrix.
+ *     - If trans = NoTrans: a n-by-k matrix.
+ *     - Otherwise:          a k-by-n matrix.
+ * @param[in] beta Scalar.
+ * @param[out] C A n-by-n symmetric matrix.
+ *
+ * @ingroup syrk
+ */
+template<
+    class matrixA_t, class matrixC_t, 
+    class alpha_t,
+    class T = type_t<matrixC_t>,
+    disable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void syrk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A,
+    matrixC_t& C )
+{
+    return syrk( uplo, trans, alpha, A, internal::StrongZero(), C );
+}
+
 }  // namespace tlapack
 
 #endif        //  #ifndef TLAPACK_BLAS_SYRK_HH

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -386,7 +386,7 @@ namespace tlapack
                 idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
                 auto A_slice = slice(A, pair{kwtop, ihi}, pair{i, i + iblock});
                 auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                gemm(Op::ConjTrans, Op::NoTrans, one, V, A_slice, zero, WH_slice);
+                gemm(Op::ConjTrans, Op::NoTrans, one, V, A_slice, WH_slice);
                 lacpy(Uplo::General, WH_slice, A_slice);
                 i = i + iblock;
             }
@@ -400,7 +400,7 @@ namespace tlapack
                 idx_t iblock = std::min<idx_t>(kwtop - i, nrows(WV));
                 auto A_slice = slice(A, pair{i, i + iblock}, pair{kwtop, ihi});
                 auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, V, zero, WV_slice);
+                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, V, WV_slice);
                 lacpy(Uplo::General, WV_slice, A_slice);
                 i = i + iblock;
             }
@@ -414,7 +414,7 @@ namespace tlapack
                 idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
                 auto Z_slice = slice(Z, pair{i, i + iblock}, pair{kwtop, ihi});
                 auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, V, zero, WV_slice);
+                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, V, WV_slice);
                 lacpy(Uplo::General, WV_slice, Z_slice);
                 i = i + iblock;
             }

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -260,7 +260,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
                     auto A_slice = slice(A, pair{ilo, ilo + n_block}, pair{i, i + iblock});
                     auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, zero, WH_slice);
+                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
                     lacpy(Uplo::General, WH_slice, A_slice);
                     i = i + iblock;
                 }
@@ -274,7 +274,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(ilo - i, nrows(WV));
                     auto A_slice = slice(A, pair{i, i + iblock}, pair{ilo, ilo + n_block});
                     auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, zero, WV_slice);
+                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
                     lacpy(Uplo::General, WV_slice, A_slice);
                     i = i + iblock;
                 }
@@ -288,7 +288,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
                     auto Z_slice = slice(Z, pair{i, i + iblock}, pair{ilo, ilo + n_block});
                     auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, zero, WV_slice);
+                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
                     lacpy(Uplo::General, WV_slice, Z_slice);
                     i = i + iblock;
                 }
@@ -446,7 +446,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
                     auto A_slice = slice(A, pair{i_pos_block, i_pos_block + n_block}, pair{i, i + iblock});
                     auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, zero, WH_slice);
+                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
                     lacpy(Uplo::General, WH_slice, A_slice);
                     i = i + iblock;
                 }
@@ -460,7 +460,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
                     auto A_slice = slice(A, pair{i, i + iblock}, pair{i_pos_block, i_pos_block + n_block});
                     auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, zero, WV_slice);
+                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
                     lacpy(Uplo::General, WV_slice, A_slice);
                     i = i + iblock;
                 }
@@ -474,7 +474,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
                     auto Z_slice = slice(Z, pair{i, i + iblock}, pair{i_pos_block, i_pos_block + n_block});
                     auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, zero, WV_slice);
+                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
                     lacpy(Uplo::General, WV_slice, Z_slice);
                     i = i + iblock;
                 }
@@ -676,7 +676,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
                     auto A_slice = slice(A, pair{i_pos_block, ihi}, pair{i, i + iblock});
                     auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, zero, WH_slice);
+                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
                     lacpy(Uplo::General, WH_slice, A_slice);
                     i = i + iblock;
                 }
@@ -690,7 +690,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
                     auto A_slice = slice(A, pair{i, i + iblock}, pair{i_pos_block, ihi});
                     auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, zero, WV_slice);
+                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
                     lacpy(Uplo::General, WV_slice, A_slice);
                     i = i + iblock;
                 }
@@ -704,7 +704,7 @@ namespace tlapack
                     idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
                     auto Z_slice = slice(Z, pair{i, i + iblock}, pair{i_pos_block, ihi});
                     auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, zero, WV_slice);
+                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
                     lacpy(Uplo::General, WV_slice, Z_slice);
                     i = i + iblock;
                 }

--- a/include/tlapack/legacy_api/blas/gemm.hpp
+++ b/include/tlapack/legacy_api/blas/gemm.hpp
@@ -134,8 +134,8 @@ void gemm(
     tlapack_check_false( ldc < m );
 
     // quick return
-    if (m == 0 || n == 0)
-        return;
+    if ( m == 0 || n == 0 || 
+        ((alpha == scalar_t(0) || k == 0 ) && (beta == scalar_t(1))) ) return;
 
     // Matrix views
     const auto A_ = (transA == Op::NoTrans)
@@ -146,7 +146,7 @@ void gemm(
             : colmajor_matrix<TB>( (TB*)B, n, k, ldb );
     auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
 
-    if( alpha == scalar_t(0) )
+    if( alpha == scalar_t(0) ) {
         if( beta == scalar_t(0) ) {
             for(idx_t j = 0; j < n; ++j)
                 for(idx_t i = 0; i < m; ++i)
@@ -157,11 +157,13 @@ void gemm(
                 for(idx_t i = 0; i < m; ++i)
                     C_(i,j) *= beta;
         }
-    else
+    }
+    else {
         if( beta == scalar_t(0) )
             gemm( transA, transB, alpha, A_, B_, C_ );
         else
             gemm( transA, transB, alpha, A_, B_, beta, C_ );
+    }
 }
 
 }  // namespace tlapack

--- a/include/tlapack/legacy_api/blas/gemm.hpp
+++ b/include/tlapack/legacy_api/blas/gemm.hpp
@@ -101,6 +101,7 @@ void gemm(
     TC       *C, idx_t ldc )
 {
     using internal::colmajor_matrix;
+    using scalar_t = scalar_type<TA, TB, TC>;
 
     // redirect if row major
     if (layout == Layout::RowMajor) {
@@ -145,7 +146,22 @@ void gemm(
             : colmajor_matrix<TB>( (TB*)B, n, k, ldb );
     auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
 
-    return gemm( transA, transB, alpha, A_, B_, beta, C_ );
+    if( alpha == scalar_t(0) )
+        if( beta == scalar_t(0) ) {
+            for(idx_t j = 0; j < n; ++j)
+                for(idx_t i = 0; i < m; ++i)
+                    C_(i,j) = TC(0);
+        }
+        else {
+            for(idx_t j = 0; j < n; ++j)
+                for(idx_t i = 0; i < m; ++i)
+                    C_(i,j) *= beta;
+        }
+    else
+        if( beta == scalar_t(0) )
+            gemm( transA, transB, alpha, A_, B_, C_ );
+        else
+            gemm( transA, transB, alpha, A_, B_, beta, C_ );
 }
 
 }  // namespace tlapack

--- a/include/tlapack/legacy_api/blas/hemm.hpp
+++ b/include/tlapack/legacy_api/blas/hemm.hpp
@@ -95,6 +95,7 @@ void hemm(
     TC       *C, idx_t ldc )
 {    
     using internal::colmajor_matrix;
+    using scalar_t = scalar_type<TA, TB, TC>;
 
     // check arguments
     tlapack_check_false( layout != Layout::ColMajor &&
@@ -111,8 +112,8 @@ void hemm(
     tlapack_check_false( ldc < ((layout == Layout::RowMajor) ? n : m) );
 
     // quick return
-    if (m == 0 || n == 0)
-        return;
+    if ( m == 0 || n == 0 ||
+        ((alpha == scalar_t(0)) && (beta == scalar_t(1))) ) return;
 
     // adapt if row major
     if (layout == Layout::RowMajor) {
@@ -133,7 +134,24 @@ void hemm(
     const auto B_ = colmajor_matrix<TB>( (TB*)B, m, n, ldb );
     auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
 
-    hemm( side, uplo, alpha, A_, B_, beta, C_ );
+    if( alpha == scalar_t(0) ) {
+        if( beta == scalar_t(0) ) {
+            for(idx_t j = 0; j < n; ++j)
+                for(idx_t i = 0; i < m; ++i)
+                    C_(i,j) = TC(0);
+        }
+        else {
+            for(idx_t j = 0; j < n; ++j)
+                for(idx_t i = 0; i < m; ++i)
+                    C_(i,j) *= beta;
+        }
+    }
+    else {
+        if( beta == scalar_t(0) )
+            hemm( side, uplo, alpha, A_, B_, C_ );
+        else
+            hemm( side, uplo, alpha, A_, B_, beta, C_ );
+    }
 }
 
 }  // namespace tlapack

--- a/include/tlapack/legacy_api/blas/syrk.hpp
+++ b/include/tlapack/legacy_api/blas/syrk.hpp
@@ -89,6 +89,7 @@ void syrk(
     TC       *C, idx_t ldc )
 {
     using internal::colmajor_matrix;
+    using scalar_t = scalar_type<TA, TC>;
 
     // check arguments
     tlapack_check_false( layout != Layout::ColMajor &&
@@ -111,8 +112,8 @@ void syrk(
     tlapack_check_false( ldc < n );
 
     // quick return
-    if (n == 0)
-        return;
+    if ( n == 0 ||
+        ((alpha == scalar_t(0) || k == 0 ) && (beta == scalar_t(1))) ) return;
 
     // This algorithm only works with Op::NoTrans or Op::Trans
     if(trans == Op::ConjTrans) trans = Op::Trans;
@@ -134,7 +135,24 @@ void syrk(
                   : colmajor_matrix<TA>( (TA*)A, k, n, lda );
     auto C_ = colmajor_matrix<TC>( C, n, n, ldc );
 
-    syrk( uplo, trans, alpha, A_, beta, C_ );
+    if( alpha == scalar_t(0) ) {
+        if( beta == scalar_t(0) ) {
+            for(idx_t j = 0; j < n; ++j)
+                for(idx_t i = 0; i < n; ++i)
+                    C_(i,j) = TC(0);
+        }
+        else {
+            for(idx_t j = 0; j < n; ++j)
+                for(idx_t i = 0; i < n; ++i)
+                    C_(i,j) *= beta;
+        }
+    }
+    else {
+        if( beta == scalar_t(0) )
+            syrk( uplo, trans, alpha, A_, C_ );
+        else
+            syrk( uplo, trans, alpha, A_, beta, C_ );
+    }
 }
 
 }  // namespace tlapack

--- a/include/tlapack/legacy_api/blas/trmm.hpp
+++ b/include/tlapack/legacy_api/blas/trmm.hpp
@@ -100,6 +100,7 @@ void trmm(
     TB       *B, idx_t ldb )
 {
     using internal::colmajor_matrix;
+    using scalar_t = scalar_type<TA, TB>;
 
     // check arguments
     tlapack_check_false( layout != Layout::ColMajor &&
@@ -140,7 +141,12 @@ void trmm(
                   : colmajor_matrix<TA>( (TA*)A, n, n, lda );
     auto B_ = colmajor_matrix<TB>( B, m, n, ldb );
 
-    trmm( side, uplo, trans, diag, alpha, A_, B_ );
+    if( alpha == scalar_t(0) )
+        for(idx_t j = 0; j < n; ++j)
+            for(idx_t i = 0; i < m; ++i)
+                B_(i,j) = TB(0);
+    else
+        trmm( side, uplo, trans, diag, alpha, A_, B_ );
 }
 
 }  // namespace tlapack

--- a/include/tlapack/legacy_api/blas/trsm.hpp
+++ b/include/tlapack/legacy_api/blas/trsm.hpp
@@ -105,6 +105,7 @@ void trsm(
     TB       *B, idx_t ldb )
 {
     using internal::colmajor_matrix;
+    using scalar_t = scalar_type<TA, TB>;
 
     // check arguments
     tlapack_check_false( layout != Layout::ColMajor &&
@@ -145,7 +146,12 @@ void trsm(
                   : colmajor_matrix<TA>( (TA*)A, n, n, lda );
     auto B_ = colmajor_matrix<TB>( B, m, n, ldb );
 
-    trsm( side, uplo, trans, diag, alpha, A_, B_ );
+    if( alpha == scalar_t(0) )
+        for(idx_t j = 0; j < n; ++j)
+            for(idx_t i = 0; i < m; ++i)
+                B_(i,j) = TB(0);
+    else
+        trsm( side, uplo, trans, diag, alpha, A_, B_ );
 }
 
 }  // namespace tlapack

--- a/include/tlapack/optimized/wrappers.hpp
+++ b/include/tlapack/optimized/wrappers.hpp
@@ -815,6 +815,21 @@ void gemm(
         C_.ptr, C_.ldim );
 }
 
+/**
+ * General matrix-matrix multiply.
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see gemm(
+    Op transA,
+    Op transB,
+    const alpha_t& alpha,
+    const matrixA_t& A,
+    const matrixB_t& B,
+    matrixC_t& C )
+ * 
+ * @ingroup gemm
+ */
 template<
     class matrixA_t,
     class matrixB_t,
@@ -905,6 +920,11 @@ void hemm(
     const auto& m = C_.m;
     const auto& n = C_.n;
 
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if( beta == beta_t(0) )
+        tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
+
     return ::blas::hemm(
         (::blas::Layout) A_.layout,
         (::blas::Side) side, (::blas::Uplo) uplo, 
@@ -913,6 +933,62 @@ void hemm(
         A_.ptr, A_.ldim,
         B_.ptr, B_.ldim,
         beta,
+        C_.ptr, C_.ldim );
+}
+
+/**
+ * Hermitian matrix-matrix multiply.
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see hemm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+ * 
+ * @ingroup hemm
+ */
+template<
+    class matrixA_t,
+    class matrixB_t, 
+    class matrixC_t, 
+    class alpha_t,
+    class T  = type_t<matrixC_t>,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void hemm(
+    Side side,
+    Uplo uplo,
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& m = C_.m;
+    const auto& n = C_.n;
+
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+
+    return ::blas::hemm(
+        (::blas::Layout) A_.layout,
+        (::blas::Side) side, (::blas::Uplo) uplo, 
+        m, n,
+        alpha,
+        A_.ptr, A_.ldim,
+        B_.ptr, B_.ldim,
+        T(0),
         C_.ptr, C_.ldim );
 }
 
@@ -955,6 +1031,11 @@ void herk(
     const auto& n = C_.n;
     const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A will not propagate to C on output" );
+    if( beta == beta_t(0) )
+        tlapack_warning( -5, "Infs and NaNs in C on input will not propagate to C on output" );
+
     return ::blas::herk(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
@@ -963,6 +1044,58 @@ void herk(
         alpha,
         A_.ptr, A_.ldim,
         beta,
+        C_.ptr, C_.ldim );
+}
+
+/**
+ * Hermitian rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see herk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A,
+    matrixC_t& C )
+ * 
+ * @ingroup herk
+ */
+template<
+    class matrixA_t, class matrixC_t, 
+    class alpha_t,
+    class T  = type_t<matrixC_t>,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   real_type<T> >
+    > = 0
+>
+inline
+void herk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t alpha, const matrixA_t& A,
+    matrixC_t& C )
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+
+    return ::blas::herk(
+        (::blas::Layout) A_.layout,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans, 
+        n, k,
+        alpha,
+        A_.ptr, A_.ldim,
+        real_type<T>(0),
         C_.ptr, C_.ldim );
 }
 
@@ -1011,6 +1144,11 @@ void her2k(
     const auto& n = C_.n;
     const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if( beta == beta_t(0) )
+        tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
+
     return ::blas::her2k(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
@@ -1020,6 +1158,61 @@ void her2k(
         A_.ptr, A_.ldim,
         B_.ptr, B_.ldim,
         beta,
+        C_.ptr, C_.ldim );
+}
+
+/**
+ * Hermitian rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see her2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+ * 
+ * @ingroup her2k
+ */
+template<
+    class matrixA_t, class matrixB_t, class matrixC_t, 
+    class alpha_t,
+    class T  = type_t<matrixC_t>,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void her2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+
+    return ::blas::her2k(
+        (::blas::Layout) A_.layout,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans, 
+        n, k,
+        alpha,
+        A_.ptr, A_.ldim,
+        B_.ptr, B_.ldim,
+        real_type<T>(0),
         C_.ptr, C_.ldim );
 }
 
@@ -1067,6 +1260,11 @@ void symm(
     const auto& m = C_.m;
     const auto& n = C_.n;
 
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if( beta == beta_t(0) )
+        tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
+
     return ::blas::symm(
         (::blas::Layout) A_.layout,
         (::blas::Side) side, (::blas::Uplo) uplo, 
@@ -1075,6 +1273,62 @@ void symm(
         A_.ptr, A_.ldim,
         B_.ptr, B_.ldim,
         beta,
+        C_.ptr, C_.ldim );
+}
+
+/**
+ * Symmetric matrix-matrix multiply.
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see symm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+ * 
+ * @ingroup symm
+ */
+template<
+    class matrixA_t,
+    class matrixB_t, 
+    class matrixC_t, 
+    class alpha_t,
+    class T  = type_t<matrixC_t>,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void symm(
+    Side side,
+    Uplo uplo,
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& m = C_.m;
+    const auto& n = C_.n;
+
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+
+    return ::blas::symm(
+        (::blas::Layout) A_.layout,
+        (::blas::Side) side, (::blas::Uplo) uplo, 
+        m, n,
+        alpha,
+        A_.ptr, A_.ldim,
+        B_.ptr, B_.ldim,
+        T(0),
         C_.ptr, C_.ldim );
 }
 
@@ -1117,6 +1371,11 @@ void syrk(
     const auto& n = C_.n;
     const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A will not propagate to C on output" );
+    if( beta == beta_t(0) )
+        tlapack_warning( -5, "Infs and NaNs in C on input will not propagate to C on output" );
+
     return ::blas::syrk(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
@@ -1125,6 +1384,58 @@ void syrk(
         alpha,
         A_.ptr, A_.ldim,
         beta,
+        C_.ptr, C_.ldim );
+}
+
+/**
+ * Symmetric rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see syrk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A,
+    matrixC_t& C )
+ * 
+ * @ingroup syrk
+ */
+template<
+    class matrixA_t, class matrixC_t, 
+    class alpha_t,
+    class T  = type_t<matrixC_t>,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void syrk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t alpha, const matrixA_t& A,
+    matrixC_t& C )
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+
+    return ::blas::syrk(
+        (::blas::Layout) A_.layout,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans, 
+        n, k,
+        alpha,
+        A_.ptr, A_.ldim,
+        T(0),
         C_.ptr, C_.ldim );
 }
 
@@ -1169,6 +1480,11 @@ void syr2k(
     const auto& n = C_.n;
     const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if( beta == beta_t(0) )
+        tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
+
     return ::blas::syr2k(
         (::blas::Layout) A_.layout,
         (::blas::Uplo) uplo,
@@ -1178,6 +1494,61 @@ void syr2k(
         A_.ptr, A_.ldim,
         B_.ptr, B_.ldim,
         beta,
+        C_.ptr, C_.ldim );
+}
+
+/**
+ * Symmetric rank-k update
+ * 
+ * Wrapper to optimized BLAS.
+ * 
+ * @see syr2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+ * 
+ * @ingroup syr2k
+ */
+template<
+    class matrixA_t, class matrixB_t, class matrixC_t, 
+    class alpha_t,
+    class T  = type_t<matrixC_t>,
+    enable_if_allow_optblas_t<
+        pair< matrixA_t, T >,
+        pair< matrixB_t, T >,
+        pair< matrixC_t, T >,
+        pair< alpha_t,   T >
+    > = 0
+>
+inline
+void syr2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+
+    return ::blas::syr2k(
+        (::blas::Layout) A_.layout,
+        (::blas::Uplo) uplo,
+        (::blas::Op) trans, 
+        n, k,
+        alpha,
+        A_.ptr, A_.ldim,
+        B_.ptr, B_.ldim,
+        T(0),
         C_.ptr, C_.ldim );
 }
 
@@ -1223,6 +1594,9 @@ void trmm(
     const auto& m = B_.m;
     const auto& n = B_.n;
 
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -5, "Infs and NaNs in A or B will not propagate to B on output" );
+
     return ::blas::trmm(
         (::blas::Layout) A_.layout,
         (::blas::Side) side,
@@ -1260,6 +1634,9 @@ void trsm(
     // Constants to forward
     const auto& m = B_.m;
     const auto& n = B_.n;
+
+    if( alpha == alpha_t(0) )
+        tlapack_warning( -5, "Infs and NaNs in A or B will not propagate to B on output" );
 
     return ::blas::trsm(
         (::blas::Layout) A_.layout,

--- a/performancetests/multishift_qr/profile_aed.cpp
+++ b/performancetests/multishift_qr/profile_aed.cpp
@@ -196,12 +196,9 @@ void run(size_t n, size_t nw, bool use_fortran)
     {
         std::unique_ptr<T[]> _work(new T[n * n]);
         auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = (T)0.0;
 
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, Q, H, (T)0.0, work);
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::ConjTrans, (T)1.0, work, Q, (T)0.0, H);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, Q, H, work);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::ConjTrans, (T)1.0, work, Q, H);
 
         for (size_t j = 0; j < n; ++j)
             for (size_t i = 0; i < n; ++i)

--- a/performancetests/multishift_qr/profile_multishift_qr.cpp
+++ b/performancetests/multishift_qr/profile_multishift_qr.cpp
@@ -241,12 +241,9 @@ void run(size_t n, int seed, bool use_fortran)
     {
         std::unique_ptr<T[]> _work(new T[n * n]);
         auto work = colmajor_matrix<T>(&_work[0], n, n);
-        for (size_t j = 0; j < n; ++j)
-            for (size_t i = 0; i < n; ++i)
-                work(i, j) = (T) 0.0;
 
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, Q, H, (T)0.0, work);
-        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::ConjTrans, (T)1.0, work, Q, (T)0.0, H);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, (T)1.0, Q, H, work);
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::ConjTrans, (T)1.0, work, Q, H);
 
         for (size_t j = 0; j < n; ++j)
             for (size_t i = 0; i < n; ++i)

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -167,7 +167,7 @@ namespace tlapack
 
         // res = Q'*A*Q - B
         lacpy(Uplo::General, B, res);
-        gemm(Op::ConjTrans, Op::NoTrans, (real_t)1.0, Q, A, (real_t)0.0, work);
+        gemm(Op::ConjTrans, Op::NoTrans, (real_t)1.0, Q, A, work);
         gemm(Op::NoTrans, Op::NoTrans, (real_t)1.0, work, Q, (real_t)-1.0, res);
 
         // Compute ||res||_F

--- a/test/src/test_gelq2.cpp
+++ b/test/src/test_gelq2.cpp
@@ -84,10 +84,9 @@ TEMPLATE_LIST_TEST_CASE("LQ factorization of a general m-by-n matrix", "[lqf]", 
             // R stores the product of L and Q
             std::unique_ptr<T[]> R_(new T[min(k, m) * n]);
             auto R = legacyMatrix<T, layout<matrix_t>>(min(k, m), n, &R_[0], layout<matrix_t> == Layout::ColMajor ? min(k, m) : n);
-            laset(Uplo::General, zero, zero, R);
 
             // Test A = L * Q
-            gemm(Op::NoTrans, Op::NoTrans, real_t(1.), L, Q, real_t(0.), R);
+            gemm(Op::NoTrans, Op::NoTrans, real_t(1.), L, Q, R);
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < min(m, k); ++i)
                     A_copy(i, j) -= R(i, j);

--- a/test/src/test_gelqf.cpp
+++ b/test/src/test_gelqf.cpp
@@ -96,10 +96,9 @@ TEMPLATE_LIST_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked", 
             // R stores the product of L and Q
             std::unique_ptr<T[]> R_(new T[min(k, m) * n]);
             auto R = legacyMatrix<T, layout<matrix_t>>(min(k, m), n, &R_[0], layout<matrix_t> == Layout::ColMajor ? min(k, m) : n);
-            laset(Uplo::General, zero, zero, R);
 
             // Test A = L * Q
-            gemm(Op::NoTrans, Op::NoTrans, real_t(1.), L, Q, real_t(0.), R);
+            gemm(Op::NoTrans, Op::NoTrans, real_t(1.), L, Q, R);
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < min(m, k); ++i)
                     A_copy(i, j) -= R(i, j);

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -25,7 +25,6 @@ TEMPLATE_LIST_TEST_CASE("sylvester solver gives correct result", "[sylvester]", 
     using idx_t = size_type<matrix_t>;
     typedef real_type<T> real_t;
 
-    const T zero(0);
     const T one(1);
     idx_t n1 = GENERATE(1, 2);
     // Once 1x2 solver is finished, generate n2 independantly
@@ -63,7 +62,7 @@ TEMPLATE_LIST_TEST_CASE("sylvester solver gives correct result", "[sylvester]", 
     int sign = 1;
 
     // Calculate op(TL)*X + ISGN*X*op(TR)
-    gemm(trans_l, Op::NoTrans, one, TL, X_exact, zero, B);
+    gemm(trans_l, Op::NoTrans, one, TL, X_exact, B);
     gemm(Op::NoTrans, trans_r, sign, X_exact, TR, one, B);
 
 


### PR DESCRIPTION
- gemm is the interface from BLAS. Since the interface in T-LAPACK is different, it makes sense to rename it.
- Also, by renaming it we could make different design choices.

`matrix_multiply` has two versions: one with and one without beta.
1. The first version computes `C := alpha*A*B + beta*C`;
2. The second computes `C := alpha*A*B`.
They are semantically different: in the first, C is [in,out]; in the second, C is [out] only.
Legacy `gemm` covers both functionalities depending on the value of beta (if beta is zero, use second expression).
The problem with the strategy adopted in `gemm` is: if beta evaluates to zero in some part of an algorithm and there are Infs or NaNs in C, those will not propagate.

The proposal is: if one wants to obtain the same behavior of gemm and
- `alpha=0` and `beta=0`: just use `laset` to set the matrix C to 0.
- `alpha=0` and `beta` is not zero: just use `lascl` to scale the matrix C.
- `alpha` is not zero and `beta=0`: use the version of `matrix_multiply` that considers C as output only.
- otherwise, use `matrix_multiply` that considers C as input and output.

This PR also introduces the StrongZero internal data type. This is to avoid code duplication.
Also, it solves failing tests in https://github.com/tlapack/testBLAS/runs/7583337777.