### PR TITLE
Replace all std::complex<T> by complex_type<T>, except when T is float, double or long double

### DIFF
--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -368,31 +368,56 @@ namespace tlapack {
 
     /// define real_type<> type alias
     template< typename... Types >
-    using real_type = typename real_type_traits< Types... >::real_t;
-
-    /// define complex_type<> type alias
-    template< typename... Types >
-    using complex_type = std::complex< real_type< Types... > >;
+    using real_type = typename real_type_traits< Types... >::type;
 
     // for one type
     template< typename T >
     struct real_type_traits<T>
     {
-        using real_t = T;
+        using type = T;
     };
 
     // for one complex type, strip complex
     template< typename T >
     struct real_type_traits< std::complex<T> >
     {
-        using real_t = T;
+        using type = T;
     };
 
     // for two or more types
     template< typename T1, typename... Types >
     struct real_type_traits< T1, Types... >
     {
-        using real_t = scalar_type< real_type<T1>, real_type< Types... > >;
+        using type = scalar_type< real_type<T1>, real_type< Types... > >;
+    };
+
+    // for zero types
+    template< typename... Types >
+    struct complex_type_traits;
+
+    /// define complex_type<> type alias
+    template< typename... Types >
+    using complex_type = typename complex_type_traits< Types... >::type;
+
+    // for one type
+    template< typename T >
+    struct complex_type_traits<T>
+    {
+        using type = std::complex<T>;
+    };
+
+    // for one complex type, strip complex
+    template< typename T >
+    struct complex_type_traits< std::complex<T> >
+    {
+        using type = std::complex<T>;
+    };
+
+    // for two or more types
+    template< typename T1, typename... Types >
+    struct complex_type_traits< T1, Types... >
+    {
+        using type = scalar_type< complex_type<T1>, complex_type< Types... > >;
     };
 
 } // namespace tlapack

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -52,17 +52,11 @@ using std::enable_if_t;
 #endif
 
 //------------------------------------------------------------------------------
-/// True if T is std::complex<T2> for some type T2.
+/// True if T is complex_type<T>
 template <typename T>
-struct is_complex:
-    std::integral_constant<bool, false>
-{};
-
-/// specialize for std::complex
-template <typename T>
-struct is_complex< std::complex<T> >:
-    std::integral_constant<bool, true>
-{};
+struct is_complex {
+    static constexpr bool value = is_same_v< complex_type<T>, T >;
+};
 
 template <typename T, enable_if_t<!is_complex<T>::value,int> = 0>
 inline constexpr
@@ -569,13 +563,17 @@ bool hasnan( const vector_t& x ) {
 /// @see https://en.cppreference.com/w/cpp/numeric/complex/abs
 /// but it may not propagate NaNs.
 ///
+template< typename T > auto abs ( const T& x );
+
+inline float abs( float x ) { return std::fabs( x ); }
+inline double abs( double x ) { return std::fabs( x ); }
+inline long double abs( long double x ) { return std::fabs( x ); }
+
 template< typename T >
-inline auto abs( const T& x ) {
-    if( is_complex<T>::value ) {
-        if( isnan(x) )
-            return std::numeric_limits< real_type<T> >::quiet_NaN();
-    }
-    return std::abs( x ); // Contains the 2-norm for the complex case
+inline auto abs( const std::complex<T>& x ) {
+    return ( isnan(x) )
+        ? std::numeric_limits<T>::quiet_NaN()
+        : std::abs( x );
 }
 
 // -----------------------------------------------------------------------------

--- a/include/tlapack/blas/herk.hpp
+++ b/include/tlapack/blas/herk.hpp
@@ -55,7 +55,7 @@ template<
     enable_if_t<(
     /* Requires: */
         !is_complex<alpha_t>::value &&
-        !is_complex<beta_t> ::value
+        !is_complex<beta_t>::value
     ), int > = 0,
     class T  = type_t<matrixC_t>,
     disable_if_allow_optblas_t<

--- a/include/tlapack/blas/rotg.hpp
+++ b/include/tlapack/blas/rotg.hpp
@@ -108,10 +108,10 @@ template <typename T,
 void rotg(
     T& a, const T& b,
     real_type<T>& c,
-    complex_type<T>& s )
+    T& s )
 {
     typedef real_type<T> real_t;
-    typedef complex_type<T> scalar_t;
+    typedef T scalar_t;
 
     // Constants
     const real_t r_one = 1;
@@ -237,7 +237,7 @@ void rotg(
         enable_if_allow_optblas_t< T > = 0
     >
     inline
-    void rotg( T& a, const T& b, real_type<T>& c, complex_type<T>& s )
+    void rotg( T& a, const T& b, real_type<T>& c, T& s )
     {
         T r;
         ::lapack::lartg( a, b, &c, &s, &r );

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -300,10 +300,10 @@ namespace tlapack
             else
             {
                 // 2x2 eigenvalue block
-                auto foo = abs(TW(ns - 1, ns - 1)) + sqrt(abs(TW(ns - 1, ns - 2))) * sqrt(abs(TW(ns - 2, ns - 1)));
+                auto foo = tlapack::abs(TW(ns - 1, ns - 1)) + sqrt(tlapack::abs(TW(ns - 1, ns - 2))) * sqrt(tlapack::abs(TW(ns - 2, ns - 1)));
                 if (foo == zero)
-                    foo = abs(s_spike);
-                if (max(abs(s_spike * V(0, ns - 1)), abs(s_spike * V(0, ns - 2))) <= max<real_t>(small_num, eps * foo))
+                    foo = tlapack::abs(s_spike);
+                if (max(tlapack::abs(s_spike * V(0, ns - 1)), tlapack::abs(s_spike * V(0, ns - 2))) <= max<real_t>(small_num, eps * foo))
                 {
                     // Eigenvalue pair is deflatable
                     ns = ns - 2;
@@ -377,11 +377,11 @@ namespace tlapack
                 if (n1 == 1)
                     ev1 = abs1(TW(i1, i1));
                 else
-                    ev1 = abs(TW(i1, i1)) + sqrt(abs(TW(i1 + 1, i1))) * sqrt(abs(TW(i1, i1 + 1)));
+                    ev1 = tlapack::abs(TW(i1, i1)) + sqrt(tlapack::abs(TW(i1 + 1, i1))) * sqrt(tlapack::abs(TW(i1, i1 + 1)));
                 if (n2 == 1)
                     ev2 = abs1(TW(i2, i2));
                 else
-                    ev2 = abs(TW(i2, i2)) + sqrt(abs(TW(i2 + 1, i2))) * sqrt(abs(TW(i2, i2 + 1)));
+                    ev2 = tlapack::abs(TW(i2, i2)) + sqrt(tlapack::abs(TW(i2 + 1, i2))) * sqrt(tlapack::abs(TW(i2, i2 + 1)));
 
                 if (ev1 > ev2)
                 {

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -68,16 +68,15 @@ void ladiv(
  * 
  * @ingroup auxiliary
  */
-template< typename real_t >
-inline std::complex<real_t> ladiv(
-    const std::complex<real_t>& x,
-    const std::complex<real_t>& y )
+template< typename T, enable_if_t< is_complex<T>::value ,int> = 0 >
+inline T ladiv(
+    const T& x,
+    const T& y )
 {
-
-    real_t zr, zi;
+    real_type<T> zr, zi;
     ladiv( real(x), imag(x), real(y), imag(y), zr, zi );
     
-    return std::complex<real_t>( zr, zi );
+    return T( zr, zi );
 }
 
 }

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -279,8 +279,8 @@ namespace tlapack
                 a01 = A(istop - 2, istop - 1);
                 a11 = A(istop - 1, istop - 1);
             }
-            std::complex<real_t> s1;
-            std::complex<real_t> s2;
+            complex_type<real_t> s1;
+            complex_type<real_t> s2;
             lahqr_eig22(a00, a01, a10, a11, s1, s2);
             if ((imag(s1) == rzero and imag(s2) == rzero) or is_complex<TA>::value)
             {
@@ -565,11 +565,11 @@ namespace tlapack
                 {
                     if (i >= ilo + 2)
                     {
-                        tst = tst + abs(A(i - 1, i - 2));
+                        tst = tst + tlapack::abs(A(i - 1, i - 2));
                     }
                     if (i < ihi)
                     {
-                        tst = tst + abs(A(i + 1, i));
+                        tst = tst + tlapack::abs(A(i + 1, i));
                     }
                 }
                 if (abs1(A(i, i - 1)) <= eps * tst)
@@ -614,9 +614,9 @@ namespace tlapack
             if (k_defl % non_convergence_limit == 0)
             {
                 // Exceptional shift
-                auto s = abs(A(istop - 1, istop - 2));
+                auto s = tlapack::abs(A(istop - 1, istop - 2));
                 if (istop > ilo + 2)
-                    s = s + abs(A(istop - 2, istop - 3));
+                    s = s + tlapack::abs(A(istop - 2, istop - 3));
                 a00 = dat1 * s + A(istop - 1, istop - 1);
                 a01 = dat2 * s;
                 a10 = s;
@@ -630,8 +630,8 @@ namespace tlapack
                 a01 = A(istop - 2, istop - 1);
                 a11 = A(istop - 1, istop - 1);
             }
-            std::complex<real_t> s1;
-            std::complex<real_t> s2;
+            complex_type<real_t> s1;
+            complex_type<real_t> s2;
             lahqr_eig22(a00, a01, a10, a11, s1, s2);
             if (abs1(s1 - A(istop - 1, istop - 1)) > abs1(s2 - A(istop - 1, istop - 1)))
                 s1 = s2;

--- a/include/tlapack/lapack/lahqr_eig22.hpp
+++ b/include/tlapack/lapack/lahqr_eig22.hpp
@@ -31,13 +31,11 @@ namespace tlapack
      *
      * @ingroup geev
      */
-    template <
-        typename T,
-        typename real_t = real_type<T>>
-    void lahqr_eig22(T a00, T a01, T a10, T a11, std::complex<real_t> &s1, std::complex<real_t> &s2)
+    template < typename T >
+    void lahqr_eig22(T a00, T a01, T a10, T a11, complex_type<T> &s1, complex_type<T> &s2)
     {
-
         // Using
+        using real_t = real_type<T>;
         
         // Constants
         const real_t rzero(0);
@@ -57,7 +55,7 @@ namespace tlapack
         a10 = a10 / s;
         a11 = a11 / s;
         auto tr = (a00 + a11) / two;
-        std::complex<real_t> det = (a00 - tr) * (a00 - tr) + a01 * a10;
+        complex_type<T> det = (a00 - tr) * (a00 - tr) + a01 * a10;
         auto rtdisc = sqrt(det);
 
         s1 = s*(tr + rtdisc);

--- a/include/tlapack/lapack/lahqr_schur22.hpp
+++ b/include/tlapack/lapack/lahqr_schur22.hpp
@@ -49,7 +49,7 @@ namespace tlapack
     template <
         typename T,
         enable_if_t<!is_complex<T>::value, bool> = true>
-    int lahqr_schur22(T &a, T &b, T &c, T &d, std::complex<T> &s1, std::complex<T> &s2, T &cs, T &sn)
+    int lahqr_schur22(T &a, T &b, T &c, T &d, complex_type<T> &s1, complex_type<T> &s2, T &cs, T &sn)
     {
 
         using std::copysign;
@@ -193,8 +193,8 @@ namespace tlapack
         if (c != zero)
         {
             auto temp = sqrt(abs(b)) * sqrt(abs(c));
-            s1 = std::complex<T>(a, temp);
-            s2 = std::complex<T>(d, -temp);
+            s1 = complex_type<T>(a, temp);
+            s2 = complex_type<T>(d, -temp);
         }
         else
         {

--- a/include/tlapack/lapack/multishift_qr.hpp
+++ b/include/tlapack/lapack/multishift_qr.hpp
@@ -461,7 +461,7 @@ namespace tlapack
                 {
                     if (imag(w[i_shifts]) == zero)
                     {
-                        if (abs(real(w[i_shifts]) - A(istop - 1, istop - 1)) < abs(real(w[i_shifts + 1]) - A(istop - 1, istop - 1)))
+                        if (tlapack::abs(real(w[i_shifts]) - A(istop - 1, istop - 1)) < tlapack::abs(real(w[i_shifts + 1]) - A(istop - 1, istop - 1)))
                             w[i_shifts + 1] = w[i_shifts];
                         else
                             w[i_shifts] = w[i_shifts + 1];

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -401,7 +401,7 @@ namespace tlapack
         if (n2 == 2)
         {
             T cs, sn;
-            std::complex<T> s1, s2;
+            complex_type<T> s1, s2;
             lahqr_schur22(A(j0, j0), A(j0, j1), A(j1, j0), A(j1, j1), s1, s2, cs, sn); // Apply transformation from the left
             if (j2 < n)
             {
@@ -429,7 +429,7 @@ namespace tlapack
             idx_t j1_2 = j0_2 + 1;
 
             T cs, sn;
-            std::complex<T> s1, s2;
+            complex_type<T> s1, s2;
             lahqr_schur22(A(j0_2, j0_2), A(j0_2, j1_2), A(j1_2, j0_2), A(j1_2, j1_2), s1, s2, cs, sn); // Apply transformation from the left
             if (j0_2 + 2 < n)
             {

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -65,7 +65,7 @@ namespace tlapack
         using real_t = real_type<T>;
         real_t r1 = static_cast<real_t>(gen()) / static_cast<real_t>(gen.max());
         real_t r2 = static_cast<real_t>(gen()) / static_cast<real_t>(gen.max());
-        return std::complex<real_t>(r1, r2);
+        return complex_type<real_t>(r1, r2);
     }
 
     template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
@@ -80,7 +80,7 @@ namespace tlapack
         using real_t = real_type<T>;
         real_t r1 = static_cast<real_t>(rand()) / static_cast<real_t>(RAND_MAX);
         real_t r2 = static_cast<real_t>(rand()) / static_cast<real_t>(RAND_MAX);
-        return std::complex<real_t>(r1, r2);
+        return complex_type<real_t>(r1, r2);
     }
 
     /** Calculates res = Q'*Q - I if m <= n or res = Q*Q' otherwise

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -30,7 +30,7 @@ TEMPLATE_LIST_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", types_t
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
     using real_t = real_type<T>;
-    using complex_t = std::complex<real_t>;
+    using complex_t = complex_type<real_t>;
 
     // Functor
     Create<matrix_t> new_matrix;

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -30,7 +30,7 @@ TEMPLATE_LIST_TEST_CASE("lahqr", "[eigenvalues][doubleshift_qr]", types_to_test)
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
     using real_t = real_type<T>;
-    using complex_t = std::complex<real_t>;
+    using complex_t = complex_type<real_t>;
 
     // Functor
     Create<matrix_t> new_matrix;


### PR DESCRIPTION
Closes #142 