### PR TITLE
Improve tests and workspace queries

### DIFF
--- a/include/tlapack/blas/swap.hpp
+++ b/include/tlapack/blas/swap.hpp
@@ -49,7 +49,7 @@ void swap( vectorX_t& x, vectorY_t& y )
  * 
  * @see swap( vectorX_t& x, vectorY_t& y )
  * 
- * @note This overload avoids conflicts with the STD library.
+ * @note This overload avoids unexpected behavior as follows.
  *      Without it, the unspecialized call `swap( x, y )` using arrays with
  *      `std::complex` entries would call `std::swap`, while `swap( x, y )`
  *      using arrays with float or double entries would call `tlapack::swap`.

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -31,7 +31,9 @@ namespace tlapack
     /** Worspace query.
      * @see agressive_early_deflation
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template <
         class matrix_t,
@@ -64,10 +66,8 @@ namespace tlapack
         auto TW = slice(A, pair{0,jw}, pair{0,jw});
 
         // quick return
-        if( n < 9 || nw <= 1 || ihi <= 1+ilo ) {
-            workinfo = {};
+        if( n < 9 || nw <= 1 || ihi <= 1+ilo )
             return;
-        }
 
         if( jw >= opts.nmin )
         {
@@ -77,15 +77,12 @@ namespace tlapack
             multishift_qr_worksize(true, true, 0, jw, TW, s_window, V, workinfo, opts);
         }
 
-        workinfo_t workinfo2;
         if( jw != ihi-ilo )
         {
             // Hessenberg reduction
             auto tau = slice(A, pair{0,jw}, 0);
-            gehrd_worksize(0, jw, TW, tau, workinfo2);
+            gehrd_worksize(0, jw, TW, tau, workinfo);
         }
-        
-        workinfo.minMax( workinfo2 );
     }
 
     /** agressive_early_deflation accepts as input an upper Hessenberg matrix

--- a/include/tlapack/lapack/gebd2.hpp
+++ b/include/tlapack/lapack/gebd2.hpp
@@ -27,7 +27,9 @@ namespace tlapack
     /** Worspace query.
      * @see gebd2
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template <typename matrix_t, class vector_t>
     inline constexpr 
@@ -46,17 +48,12 @@ namespace tlapack
             
             if( m > 1 )
             {
-                workinfo_t workinfo2;
                 auto B11 = rows( A11, range<idx_t>{1,m} );
                 auto row0 = slice(A,0,range<idx_t>{1,n});
                 
-                larf_worksize( right_side, row0, tauw[0], B11, workinfo2, opts );
-                
-                workinfo.minMax( workinfo2 );
+                larf_worksize( right_side, row0, tauw[0], B11, workinfo, opts );
             }
         }
-        else
-            workinfo = {};
     }
 
     /** Reduces a complex general m by n matrix A to an upper

--- a/include/tlapack/lapack/gehd2.hpp
+++ b/include/tlapack/lapack/gehd2.hpp
@@ -18,7 +18,9 @@ namespace tlapack {
 /** Worspace query.
  * @see gehd2
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class matrix_t, class vector_t >
 inline constexpr
@@ -35,18 +37,13 @@ void gehd2_worksize(
 
     if( ilo+1 < ihi ) {
         const auto v = slice( A, pair{ilo+1,ihi}, ilo );
-        workinfo_t workinfo2;
         
         auto C = slice( A, pair{0,ihi}, pair{ilo+1,ihi} );
         larf_worksize( right_side, v, tau[0], C, workinfo, opts );
         
         C = slice( A, pair{ilo+1,ihi}, pair{ilo+1,n} );
-        larf_worksize( left_side, v, tau[0], C, workinfo2, opts );
-                
-        workinfo.minMax( workinfo2 );
+        larf_worksize( left_side, v, tau[0], C, workinfo, opts );
     }
-    else
-        workinfo = {};
 }
 
 /** Reduces a general square matrix to upper Hessenberg form

--- a/include/tlapack/lapack/gehrd.hpp
+++ b/include/tlapack/lapack/gehrd.hpp
@@ -35,7 +35,9 @@ namespace tlapack
     /** Worspace query.
      * @see gehrd
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template < class matrix_t, class vector_t >
     void gehrd_worksize(
@@ -53,8 +55,8 @@ namespace tlapack
         const idx_t n = ncols(A);
         const idx_t nb = std::min( opts.nb, ihi-ilo-1 );
 
-        workinfo.m = sizeof(T) * (n+nb);
-        workinfo.n = nb;
+        const workinfo_t myWorkinfo( sizeof(T)*(n+nb), nb );
+        workinfo.minMax( myWorkinfo );
     }
 
     /** Reduces a general square matrix to upper Hessenberg form

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -21,7 +21,9 @@ namespace tlapack
     /** Worspace query.
      * @see gelq2
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template< class matrix_t, class vector_t >
     inline constexpr
@@ -37,8 +39,7 @@ namespace tlapack
         if( m > 1 ) {
             auto C = rows( A, range<idx_t>{1,m} );
             larf_worksize( right_side, row(A,0), tauw[0], C, workinfo, opts );
-        } else
-            workinfo = {};
+        }
     }
     
     /** Computes an LQ factorization of a complex m-by-n matrix A using

--- a/include/tlapack/lapack/gelqf.hpp
+++ b/include/tlapack/lapack/gelqf.hpp
@@ -34,7 +34,9 @@ namespace tlapack
     /** Worspace query.
      * @see gelqf
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template< typename matrix_t >
     inline constexpr

--- a/include/tlapack/lapack/geqr2.hpp
+++ b/include/tlapack/lapack/geqr2.hpp
@@ -20,7 +20,9 @@ namespace tlapack {
 /** Worspace query.
  * @see geqr2
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class matrix_t, class vector_t >
 inline constexpr
@@ -37,8 +39,6 @@ void geqr2_worksize(
         auto C = cols( A, range<idx_t>{1,n} );
         larf_worksize( left_side, col(A,0), tau[0], C, workinfo, opts );
     }
-    else
-        workinfo = {};
 }
 
 /** Computes a QR factorization of a matrix A.

--- a/include/tlapack/lapack/getri.hpp
+++ b/include/tlapack/lapack/getri.hpp
@@ -37,8 +37,6 @@ namespace tlapack {
     {
         if( opts.variant == GetriVariant::UXLI )
             getri_uxli_worksize( A, workinfo, opts );
-        else
-            workinfo = {};
     }
 
     /** getri computes inverse of a general n-by-n matrix A

--- a/include/tlapack/lapack/getri_uxli.hpp
+++ b/include/tlapack/lapack/getri_uxli.hpp
@@ -24,8 +24,8 @@ void getri_uxli_worksize( matrix_t& A, workinfo_t& workinfo, const workspace_opt
 {
     using T = type_t< matrix_t >;
 
-    workinfo.m = sizeof(T);
-    workinfo.n = ncols(A)-1;
+    const workinfo_t myWorkinfo( sizeof(T), ncols(A)-1 );
+    workinfo.minMax( myWorkinfo );
 }
 
 /** getri computes inverse of a general n-by-n matrix A

--- a/include/tlapack/lapack/lange.hpp
+++ b/include/tlapack/lapack/lange.hpp
@@ -19,22 +19,23 @@ namespace tlapack {
 /** Worspace query.
  * @see lange
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< typename norm_t, typename matrix_t >
 inline constexpr
 void lange_worksize(
     norm_t normType,
     const matrix_t& A,
-    workinfo_t& workinfo )
-{
-    workinfo = {};
-}
+    workinfo_t& workinfo ) { }
 
 /** Worspace query.
  * @see lange
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< typename norm_t, typename matrix_t >
 inline constexpr
@@ -48,11 +49,9 @@ void lange_worksize(
 
     if ( normType == Norm::Inf  )
     {
-        workinfo.m = sizeof(T);
-        workinfo.n = nrows(A);
+        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
+        workinfo.minMax( myWorkinfo );
     }
-    else
-        workinfo = {};
 }
 
 /** Calculates the norm of a matrix.

--- a/include/tlapack/lapack/lanhe.hpp
+++ b/include/tlapack/lapack/lanhe.hpp
@@ -19,7 +19,9 @@ namespace tlapack {
 /** Worspace query.
  * @see lanhe
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class norm_t, class uplo_t, class matrix_t >
 inline constexpr
@@ -27,15 +29,14 @@ void lanhe_worksize(
     norm_t normType,
     uplo_t uplo,
     const matrix_t& A,
-    workinfo_t& workinfo )
-{
-    workinfo = {};
-}
+    workinfo_t& workinfo ) { }
 
 /** Worspace query.
  * @see lanhe
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class norm_t, class uplo_t, class matrix_t >
 inline constexpr
@@ -50,11 +51,9 @@ void lanhe_worksize(
 
     if ( normType == Norm::Inf || normType == Norm::One )
     {
-        workinfo.m = sizeof(T);
-        workinfo.n = nrows(A);
+        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
+        workinfo.minMax( myWorkinfo );
     }
-    else
-        workinfo = {};
 }
 
 /** Calculates the norm of a hermitian matrix.

--- a/include/tlapack/lapack/lansy.hpp
+++ b/include/tlapack/lapack/lansy.hpp
@@ -19,7 +19,9 @@ namespace tlapack {
 /** Worspace query.
  * @see lansy
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class norm_t, class uplo_t, class matrix_t >
 inline constexpr
@@ -27,15 +29,14 @@ void lansy_worksize(
     norm_t normType,
     uplo_t uplo,
     const matrix_t& A,
-    workinfo_t& workinfo )
-{
-    workinfo = {};
-}
+    workinfo_t& workinfo ) { }
 
 /** Worspace query.
  * @see lansy
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class norm_t, class uplo_t, class matrix_t >
 inline constexpr
@@ -50,11 +51,9 @@ void lansy_worksize(
 
     if ( normType == Norm::Inf || normType == Norm::One )
     {
-        workinfo.m = sizeof(T);
-        workinfo.n = nrows(A);
+        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
+        workinfo.minMax( myWorkinfo );
     }
-    else
-        workinfo = {};
 }
 
 /** Calculates the norm of a symmetric matrix.

--- a/include/tlapack/lapack/lantr.hpp
+++ b/include/tlapack/lapack/lantr.hpp
@@ -19,7 +19,9 @@ namespace tlapack {
 /** Worspace query.
  * @see lantr
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template<
     class norm_t, 
@@ -32,15 +34,14 @@ void lantr_worksize(
     uplo_t uplo,
     diag_t diag,
     const matrix_t& A,
-    workinfo_t& workinfo )
-{
-    workinfo = {};
-}
+    workinfo_t& workinfo ) { }
 
 /** Worspace query.
  * @see lantr
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template<
     class norm_t, 
@@ -60,11 +61,9 @@ void lantr_worksize(
 
     if ( normType == Norm::Inf )
     {
-        workinfo.m = sizeof(T);
-        workinfo.n = nrows(A);
+        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
+        workinfo.minMax( myWorkinfo );
     }
-    else
-        workinfo = {};
 }
 
 /** Calculates the norm of a symmetric matrix.
@@ -337,7 +336,6 @@ lantr(
     uplo_t uplo,
     diag_t diag,
     const matrix_t& A,
-    workinfo_t& workinfo,
     const workspace_opts_t<>& opts )
 {
     using T      = type_t< matrix_t >;

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -19,7 +19,9 @@ namespace tlapack {
 
 /** Worspace query.
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class side_t, class vector_t, class tau_t, class matrix_t >
 inline constexpr
@@ -36,8 +38,8 @@ void larf_worksize(
     const idx_t m = nrows(C);
     const idx_t n = ncols(C);
 
-    workinfo.m = sizeof(T);
-    workinfo.n = (side == Side::Left) ? n : m;
+    const workinfo_t myWorkinfo( sizeof(T), (side == Side::Left) ? n : m );
+    workinfo.minMax( myWorkinfo );
 }
 
 /** Applies an elementary reflector H to a m-by-n matrix C.

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -21,7 +21,9 @@ namespace tlapack {
 /** Worspace query.
  * @see larfb
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template<
     class matrixV_t, class matrixT_t, class matrixC_t,
@@ -49,16 +51,19 @@ void larfb_worksize(
     const idx_t n = ncols(C);
     const idx_t k = nrows(Tmatrix);
 
+    workinfo_t myWorkinfo;
     if( layout<matrixW_t> == Layout::RowMajor )
     {
-        workinfo.m = (side == Side::Left) ? k : m;
-        workinfo.n = sizeof(T) * ((side == Side::Left) ? n : k);
+        myWorkinfo.m = (side == Side::Left) ? k : m;
+        myWorkinfo.n = sizeof(T) * ((side == Side::Left) ? n : k);
     }
     else
     {
-        workinfo.m = sizeof(T) * ((side == Side::Left) ? k : m);
-        workinfo.n = (side == Side::Left) ? n : k;
+        myWorkinfo.m = sizeof(T) * ((side == Side::Left) ? k : m);
+        myWorkinfo.n = (side == Side::Left) ? n : k;
     }
+
+    workinfo.minMax( myWorkinfo );
 }
 
 /** Applies a block reflector $H$ or its conjugate transpose $H^H$ to a

--- a/include/tlapack/lapack/multishift_qr.hpp
+++ b/include/tlapack/lapack/multishift_qr.hpp
@@ -81,7 +81,9 @@ namespace tlapack
     /** Worspace query.
      * @see multishift_qr
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template <
         class matrix_t,
@@ -109,10 +111,7 @@ namespace tlapack
 
         // quick return
         if ( ilo + 1 >= ihi || n < opts.nmin || nh <= 0 )
-        {
-            workinfo = {};
             return;
-        }
 
         {
             const idx_t nw_max = (n - 3) / 3;
@@ -121,15 +120,12 @@ namespace tlapack
             agressive_early_deflation_worksize(want_t, want_z, ilo, ihi, nw_max, A, w, Z, ls, ld, workinfo, opts);
         }
 
-        workinfo_t workinfo2;
         {
             const idx_t nsr = opts.nshift_recommender(n, nh);
             const auto shifts = slice(w, pair{0,nsr});
 
-            multishift_QR_sweep_worksize(want_t, want_z, ilo, ihi, A, shifts, Z, workinfo2, opts);
+            multishift_QR_sweep_worksize(want_t, want_z, ilo, ihi, A, shifts, Z, workinfo, opts);
         }
-        
-        workinfo.minMax( workinfo2 );
     }
 
     /** multishift_qr computes the eigenvalues and optionally the Schur

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -20,7 +20,9 @@ namespace tlapack
     /** Worspace query.
      * @see multishift_QR_sweep 
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template <
         class matrix_t,
@@ -40,9 +42,9 @@ namespace tlapack
         const workspace_opts_t<> &opts = {} )
     {
         using T  = type_t< matrix_t >;
-        
-        workinfo.m = sizeof(T)*3;
-        workinfo.n = size(s)/2;
+
+        const workinfo_t myWorkinfo( sizeof(T)*3, size(s)/2 );
+        workinfo.minMax( myWorkinfo );
     }
 
     /** multishift_QR_sweep performs a single small-bulge multi-shift QR sweep.

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -20,7 +20,9 @@ namespace tlapack {
 /** Worspace query.
  * @see ung2r
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class matrix_t, class vector_t >
 inline constexpr
@@ -37,8 +39,6 @@ void ung2r_worksize(
         auto C = cols( A, range<idx_t>{1,n} );
         larf_worksize( left_side, col(A,0), tau[0], C, workinfo, opts );
     }
-    else
-        workinfo = {};
 }
 
 /**

--- a/include/tlapack/lapack/unghr.hpp
+++ b/include/tlapack/lapack/unghr.hpp
@@ -96,7 +96,9 @@ int unghr(
 /** Worspace query.
  * @see unghr
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template< class matrix_t, class vector_t >
 inline constexpr
@@ -107,15 +109,10 @@ void unghr_worksize(
     vector_t& tau,
     workinfo_t& workinfo, const workspace_opts_t<>& opts = {} )
 {
-    using T      = type_t< matrix_t >;
-    using idx_t  = size_type< matrix_t >;
+    using idx_t = size_type< matrix_t >;
     using pair  = pair<idx_t,idx_t>;
     
     // constants
-    const T zero( 0.0 );
-    const T one ( 1.0 );
-    const idx_t m = nrows(A);
-    const idx_t n = ncols(A);
     const idx_t nh = (ihi > ilo +1) ? ihi-1-ilo : 0;
 
     if( nh > 0 && ilo+1 < ihi ) {
@@ -123,8 +120,6 @@ void unghr_worksize(
         auto tau_s = slice( tau, pair{ilo,ihi-1} );
         ung2r_worksize( nh, A_s, tau_s, workinfo, opts );
     }
-    else
-        workinfo = {};
 }
 
 }

--- a/include/tlapack/lapack/ungl2.hpp
+++ b/include/tlapack/lapack/ungl2.hpp
@@ -20,7 +20,9 @@ namespace tlapack
     /** Worspace query.
      * @see ungl2
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template< class matrix_t, class vector_t >
     inline constexpr
@@ -37,8 +39,6 @@ namespace tlapack
             auto C = rows( Q, range<idx_t>{1,k} );
             larf_worksize( right_side, row(Q,0), tauw[0], C, workinfo, opts );
         }
-        else
-            workinfo = {};
     }
     
     /**

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -19,7 +19,9 @@ namespace tlapack {
 /** Worspace query.
  * @see unm2r
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  */
 template<
     class matrixA_t, class matrixC_t, class tau_t,

--- a/include/tlapack/lapack/unmhr.hpp
+++ b/include/tlapack/lapack/unmhr.hpp
@@ -69,7 +69,9 @@ namespace tlapack
     /** Worspace query.
      * @see unmhr
      * 
-     * @param[out] workinfo On return, contains the required workspace sizes.
+     * @param[in,out] workinfo
+     *      On output, the amount workspace required. It is larger than or equal
+     *      to that given on input.
      */
     template < class matrix_t, class vector_t >
     inline constexpr

--- a/include/tlapack/lapack/unmqr.hpp
+++ b/include/tlapack/lapack/unmqr.hpp
@@ -31,7 +31,9 @@ struct unmqr_opts_t : public workspace_opts_t<workT_t>
 /** Worspace query.
  * @see unmqr
  * 
- * @param[out] workinfo On return, contains the required workspace sizes.
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
  * 
  * @see unmqr
  */
@@ -62,11 +64,9 @@ void unmqr_worksize(
     const idx_t nb = min<idx_t>( opts.nb, k );
 
     // Local workspace sizes
-    workinfo.m = nb*sizeof(T);
-    workinfo.n = nb;
+    const workinfo_t myWorkinfo( nb*sizeof(T), nb );
 
     // larfb:
-    workinfo_t workinfo2;
     {
         // Constants
         const idx_t m = nrows(C);
@@ -81,11 +81,11 @@ void unmqr_worksize(
         const auto matrixT = new_matrix( nullptr, nb, nb );
 
         // Internal workspace queries
-        larfb_worksize( side, trans, forward, columnwise_storage, V, matrixT, C, workinfo2, opts );
+        larfb_worksize( side, trans, forward, columnwise_storage, V, matrixT, C, workinfo, opts );
     }
     
     // Additional workspace needed inside the routine
-    workinfo.minMax( workinfo2 );
+    workinfo += myWorkinfo;
 }
 
 /** Applies orthogonal matrix op(Q) to a matrix C using a blocked code.

--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -10,44 +10,39 @@
 #ifndef TLAPACK_TESTDEFINITIONS_HH
 #define TLAPACK_TESTDEFINITIONS_HH
 
+#include <complex>
 #include <tlapack/plugins/legacyArray.hpp>
 
-namespace tlapack
-{
+// 
+// The matrix types that will be tested for routines
+// that only accept real matrices
+// 
+#ifndef TLAPACK_REAL_TYPES_TO_TEST
+    #define TLAPACK_REAL_TYPES_TO_TEST \
+        (legacyMatrix<float,std::size_t,Layout::ColMajor>), \
+        (legacyMatrix<double,std::size_t,Layout::ColMajor>), \
+        (legacyMatrix<float,std::size_t,Layout::RowMajor>), \
+        (legacyMatrix<double,std::size_t,Layout::RowMajor>)
+#endif
 
-    // 
-    // List of matrix types that will be tested
-    // 
-    using types_to_test = std::tuple<
-        legacyMatrix<float, std::size_t, Layout::ColMajor>,
-        legacyMatrix<double, std::size_t, Layout::ColMajor>,
-        legacyMatrix<std::complex<float>, std::size_t, Layout::ColMajor>,
-        legacyMatrix<std::complex<double>, std::size_t, Layout::ColMajor>,
-        legacyMatrix<float, std::size_t, Layout::RowMajor>,
-        legacyMatrix<double, std::size_t, Layout::RowMajor>,
-        legacyMatrix<std::complex<float>, std::size_t, Layout::RowMajor>,
-        legacyMatrix<std::complex<double>, std::size_t, Layout::RowMajor>>;
-        
-    // 
-    // The matrix types that will be tested for routines
-    // that only accept real matrices
-    // 
-    using real_types_to_test = std::tuple<
-        legacyMatrix<float, std::size_t, Layout::ColMajor>,
-        legacyMatrix<double, std::size_t, Layout::ColMajor>,
-        legacyMatrix<float, std::size_t, Layout::RowMajor>,
-        legacyMatrix<double, std::size_t, Layout::RowMajor>>;
+// 
+// The matrix types that will be tested for routines
+// that only accept complex matrices
+// 
+#ifndef TLAPACK_COMPLEX_TYPES_TO_TEST
+    #define TLAPACK_COMPLEX_TYPES_TO_TEST \
+        (legacyMatrix<std::complex<float>,std::size_t,Layout::ColMajor>), \
+        (legacyMatrix<std::complex<double>,std::size_t,Layout::ColMajor>), \
+        (legacyMatrix<std::complex<float>,std::size_t,Layout::RowMajor>), \
+        (legacyMatrix<std::complex<double>,std::size_t,Layout::RowMajor>)
+#endif
 
-    // 
-    // The matrix types that will be tested for routines
-    // that only accept complex matrices
-    // 
-    using complex_types_to_test = std::tuple<
-        legacyMatrix<std::complex<float>, std::size_t, Layout::ColMajor>,
-        legacyMatrix<std::complex<double>, std::size_t, Layout::ColMajor>,
-        legacyMatrix<std::complex<float>, std::size_t, Layout::RowMajor>,
-        legacyMatrix<std::complex<double>, std::size_t, Layout::RowMajor>>;
-
-}
+// 
+// List of matrix types that will be tested
+// 
+#ifndef TLAPACK_TYPES_TO_TEST
+    #define TLAPACK_TYPES_TO_TEST \
+        TLAPACK_REAL_TYPES_TO_TEST, TLAPACK_COMPLEX_TYPES_TO_TEST
+#endif
 
 #endif // TLAPACK_TESTDEFINITIONS_HH

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -23,7 +23,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", types_to_test)
+TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPES_TO_TEST)
 {
 
     using matrix_t = TestType;
@@ -129,8 +129,7 @@ TEMPLATE_LIST_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", types_t
     idx_t ns = GENERATE(4, 2);
     idx_t nw = GENERATE(4, 2);
 
-    DYNAMIC_SECTION("Multishift QR with"
-                    << " matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi << " ns = " << ns << " nw = " << nw << " seed = " << seed)
+    INFO("matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi << " ns = " << ns << " nw = " << nw << " seed = " << seed);
     {
 
         francis_opts_t<> opts;

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -40,12 +40,9 @@ void check_hess_reduction(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matr
     std::vector<T> res_; auto res = new_matrix( res_, n, n );
     std::vector<T> work_; auto work = new_matrix( work_, n, n );
 
-    vectorOfBytes workVec;
-    workspace_opts_t<> workOpts( alloc_workspace( workVec, n*sizeof(T) ) );
-
     // Generate orthogonal matrix Q
     tlapack::lacpy(Uplo::General, H, Q);
-    tlapack::unghr(ilo, ihi, Q, tau, workOpts);
+    tlapack::unghr(ilo, ihi, Q, tau);
 
     // Remove junk from lower half of H
     for (idx_t j = 0; j < n; ++j)
@@ -61,7 +58,7 @@ void check_hess_reduction(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matr
     CHECK(simil_res_norm <= tol * normA);
 }
 
-TEMPLATE_LIST_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues][hessenberg]", types_to_test)
+TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues][hessenberg]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -126,20 +123,20 @@ TEMPLATE_LIST_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues
             A(i, j) = (T)0.0;
     tlapack::lacpy(Uplo::General, A, H);
 
-    DYNAMIC_SECTION("GEHD2 with"
-                    << " matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi)
-    {
-        vectorOfBytes workVec;
-        workspace_opts_t<> workOpts( alloc_workspace( workVec, n*sizeof(T) ) );
-
-        tlapack::gehd2(ilo, ihi, H, tau, workOpts);
+    INFO("matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi);
+    
+    SECTION("GEHD2")
+    {    
+        tlapack::gehd2(ilo, ihi, H, tau);
 
         check_hess_reduction(ilo, ihi, H, tau, A);
     }
-    idx_t nb = GENERATE(2, 3);
-    DYNAMIC_SECTION("GEHRD with"
-                    << " matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi << " nb = " << nb)
+    
+    SECTION("GEHRD")
     {
+        idx_t nb = GENERATE(2, 3);
+        INFO("nb = " << nb);
+        
         gehrd_opts_t<idx_t> opts;
         opts.nb = nb;
         opts.nx_switch = 2;

--- a/test/src/test_getrf.cpp
+++ b/test/src/test_getrf.cpp
@@ -23,7 +23,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("LU factorization of a general m-by-n matrix", "[getrf]", types_to_test)
+TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix", "[getrf]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;

--- a/test/src/test_getri.cpp
+++ b/test/src/test_getri.cpp
@@ -22,7 +22,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("Inversion of a general m-by-n matrix", "[getri]", types_to_test)
+TEMPLATE_TEST_CASE("Inversion of a general m-by-n matrix", "[getri]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -18,7 +18,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("sylvester solver gives correct result", "[sylvester]", real_types_to_test)
+TEMPLATE_TEST_CASE("sylvester solver gives correct result", "[sylvester]", TLAPACK_REAL_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -65,7 +65,7 @@ TEMPLATE_LIST_TEST_CASE("sylvester solver gives correct result", "[sylvester]", 
     gemm(Op::NoTrans, trans_r, sign, X_exact, TR, one, B);
 
 
-    DYNAMIC_SECTION("n1 = " << n1 << " n2 =" << n2)
+    INFO("n1 = " << n1 << " n2 =" << n2);
     {
         // Solve sylvester equation
         T scale, xnorm;

--- a/test/src/test_lauum.cpp
+++ b/test/src/test_lauum.cpp
@@ -21,7 +21,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("LAUUM is stable", "[lauum]", types_to_test)
+TEMPLATE_TEST_CASE("LAUUM is stable", "[lauum]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -49,7 +49,7 @@ TEMPLATE_LIST_TEST_CASE("LAUUM is stable", "[lauum]", types_to_test)
 
     lacpy(Uplo::General, A, C);
 
-    DYNAMIC_SECTION("n = " << n << " uplo = " << (uplo == Uplo::Upper ? "upper" : "lower"))
+    INFO("n = " << n << " uplo = " << uplo);
     {
         lauum_recursive(uplo, A);
 

--- a/test/src/test_lu_mult.cpp
+++ b/test/src/test_lu_mult.cpp
@@ -22,7 +22,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("lu multiplication is backward stable", "[lu check][lu][qrt]", types_to_test)
+TEMPLATE_TEST_CASE("lu multiplication is backward stable", "[lu check][lu][qrt]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -36,8 +36,8 @@ TEMPLATE_LIST_TEST_CASE("lu multiplication is backward stable", "[lu check][lu][
 
     idx_t n, nx;
 
-    n = GENERATE(1, 2, 6, 9);
-    nx = GENERATE(1, 2, 4, 5);
+    n = GENERATE(1, 2, 6, 9); INFO("n = " << n);
+    nx = GENERATE(1, 2, 4, 5); INFO("nx = " << nx);
 
     if(nx <= n){
 
@@ -61,7 +61,6 @@ TEMPLATE_LIST_TEST_CASE("lu multiplication is backward stable", "[lu check][lu][
 
         real_t norma = lange(max_norm, A);
 
-        DYNAMIC_SECTION("n = " << n)
         {
             lu_mult(A);
 

--- a/test/src/test_optBLAS.cpp
+++ b/test/src/test_optBLAS.cpp
@@ -47,7 +47,7 @@ TEST_CASE("allow_optblas_v does not allow bool, int, long int, char", "[optBLAS]
     CHECK(!allow_optblas_v<char> );
 }
 
-TEMPLATE_LIST_TEST_CASE("legacy_matrix() exists", "[utils]", types_to_test)
+TEMPLATE_TEST_CASE("legacy_matrix() exists", "[utils]", TLAPACK_TYPES_TO_TEST)
 {
     using matrix_t = TestType;
     using legacy_t = decltype( legacy_matrix( std::declval<matrix_t>() ) );
@@ -55,7 +55,7 @@ TEMPLATE_LIST_TEST_CASE("legacy_matrix() exists", "[utils]", types_to_test)
     CHECK ( is_same_v< matrix_t, legacy_t > );
 }
 
-TEMPLATE_LIST_TEST_CASE("allow_optblas_v gives the correct result", "[optBLAS]", types_to_test)
+TEMPLATE_TEST_CASE("allow_optblas_v gives the correct result", "[optBLAS]", TLAPACK_TYPES_TO_TEST)
 {
     using matrix_t  = TestType;
     using T = type_t<matrix_t>;

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -21,7 +21,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalues]", types_to_test)
+TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalues]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -96,7 +96,7 @@ TEMPLATE_LIST_TEST_CASE("move of eigenvalue block gives correct results", "[eige
     lacpy(Uplo::General, A, A_copy);
     laset(Uplo::General, zero, one, Q);
 
-    DYNAMIC_SECTION("ifst = " << ifst << " n1 = " << n1 << " ilst = " << ilst << " n2 =" << n2)
+    INFO("ifst = " << ifst << " n1 = " << n1 << " ilst = " << ilst << " n2 =" << n2);
     {
         schur_move(true, A, Q, ifst, ilst);
         // Calculate residuals

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -21,7 +21,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("schur swap gives correct result", "[eigenvalues]", types_to_test)
+TEMPLATE_TEST_CASE("schur swap gives correct result", "[eigenvalues]", TLAPACK_TYPES_TO_TEST)
 {    
     srand(1);
 
@@ -74,7 +74,7 @@ TEMPLATE_LIST_TEST_CASE("schur swap gives correct result", "[eigenvalues]", type
     lacpy(Uplo::General, A, A_copy);
     laset(Uplo::General, zero, one, Q);
 
-    DYNAMIC_SECTION("j = " << j << " n1 = " << n1 << " n2 =" << n2)
+    INFO("j = " << j << " n1 = " << n1 << " n2 =" << n2);
     {
         schur_swap(true, A, Q, j, n1, n2);
         // Calculate residuals

--- a/test/src/test_transpose.cpp
+++ b/test/src/test_transpose.cpp
@@ -16,7 +16,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("Conjugate Transpose gives correct result", "[util]", types_to_test)
+TEMPLATE_TEST_CASE("Conjugate Transpose gives correct result", "[util]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -41,8 +41,7 @@ TEMPLATE_LIST_TEST_CASE("Conjugate Transpose gives correct result", "[util]", ty
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 
-    DYNAMIC_SECTION("Conjugate Transpose with"
-                    << " m = " << m << " n = " << n)
+    INFO("m = " << m << " n = " << n);
     {
         transpose_opts_t<idx_t> opts;
         // Set nx to a small value so that the blocked algorithm gets tested even for small n and m;
@@ -55,7 +54,7 @@ TEMPLATE_LIST_TEST_CASE("Conjugate Transpose gives correct result", "[util]", ty
     }
 }
 
-TEMPLATE_LIST_TEST_CASE("Transpose gives correct result", "[util]", types_to_test)
+TEMPLATE_TEST_CASE("Transpose gives correct result", "[util]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -80,8 +79,7 @@ TEMPLATE_LIST_TEST_CASE("Transpose gives correct result", "[util]", types_to_tes
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 
-    DYNAMIC_SECTION("Transpose with"
-                    << " m = " << m << " n = " << n)
+    INFO("m = " << m << " n = " << n);
     {
         transpose_opts_t<idx_t> opts;
         // Set nx to a small value so that the blocked algorithm gets tested even for small n and m;

--- a/test/src/test_trtri.cpp
+++ b/test/src/test_trtri.cpp
@@ -22,7 +22,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("TRTRI is stable", "[trtri]", types_to_test)
+TEMPLATE_TEST_CASE("TRTRI is stable", "[trtri]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -35,8 +35,12 @@ TEMPLATE_LIST_TEST_CASE("TRTRI is stable", "[trtri]", types_to_test)
     Create<matrix_t> new_matrix;
 
     Uplo uplo = GENERATE(Uplo::Lower, Uplo::Upper);
-    Diag diag = GENERATE(Diag::Unit, Diag::NonUnit);
+    Diag diag = GENERATE(Diag::Unit, Diag::NonUnit); 
     idx_t n = GENERATE(1, 2, 6, 9);
+
+    INFO("uplo = " << uplo);
+    INFO("diag = " << diag);
+    INFO("n = " << n);
 
     const real_t eps = ulp<real_t>();
     const real_t tol = n * eps;
@@ -58,7 +62,6 @@ TEMPLATE_LIST_TEST_CASE("TRTRI is stable", "[trtri]", types_to_test)
 
     lacpy(uplo, A, C);
 
-    DYNAMIC_SECTION("n = " << n << ", " << uplo)
     {
         trtri_recursive(uplo, diag, C);
 

--- a/test/src/test_ul_mult.cpp
+++ b/test/src/test_ul_mult.cpp
@@ -23,7 +23,7 @@
 using namespace tlapack;
 using namespace std;
 
-TEMPLATE_LIST_TEST_CASE("LU factorization of a general m-by-n matrix, blocked", "[ul_mul]", types_to_test)
+TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix, blocked", "[ul_mul]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -22,7 +22,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("lahqr", "[eigenvalues][doubleshift_qr]", types_to_test)
+TEMPLATE_TEST_CASE("Double shift QR", "[eigenvalues][doubleshift_qr]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -97,8 +97,7 @@ TEMPLATE_LIST_TEST_CASE("lahqr", "[eigenvalues][doubleshift_qr]", types_to_test)
     auto s = std::vector<complex_t>(n);
     laset(Uplo::General, zero, one, Q);
 
-    DYNAMIC_SECTION("Double shift QR with"
-                    << " matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi)
+    INFO("matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi);
     {
         int ierr = lahqr(true, true, ilo, ihi, H, s, Q);
 

--- a/test/src/test_unmhr.cpp
+++ b/test/src/test_unmhr.cpp
@@ -23,7 +23,7 @@
 
 using namespace tlapack;
 
-TEMPLATE_LIST_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][hessenberg]", types_to_test)
+TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][hessenberg]", TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -40,10 +40,17 @@ TEMPLATE_LIST_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalu
     Side side = GENERATE(Side::Left, Side::Right);
     Op op = GENERATE(Op::NoTrans, Op::ConjTrans);
 
+    INFO( "matrix_type = " << matrix_type );
+    INFO( "side = " << side );
+    INFO( "Op = " << op );
+
     idx_t m = 12;
     idx_t n = 10;
     idx_t ilo = GENERATE(0, 1);
     idx_t ihi = GENERATE(9, 10);
+
+    INFO("ilo = " << ilo);
+    INFO("ihi = " << ihi);
 
     const T zero(0);
     const T one(1);
@@ -56,8 +63,15 @@ TEMPLATE_LIST_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalu
     std::vector<T> C_copy_; auto C_copy = new_matrix( C_copy_, m, n );
     std::vector<T> tau(n);
 
+    // Workspace computation:
+    workinfo_t workinfo = {};
+    gehd2_worksize(ilo, ihi, H, tau, workinfo);
+    unmhr_worksize(side, op, ilo, ihi, H, tau, C, workinfo);
+    unghr_worksize(ilo, ihi, H, tau, workinfo);
+
+    // Workspace allocation:
     vectorOfBytes workVec;
-    workspace_opts_t<> workOpts( alloc_workspace( workVec, max(m,n)*sizeof(T) ) );
+    workspace_opts_t<> workOpts( alloc_workspace( workVec, workinfo ) );
 
     if (matrix_type == "Random")
     {
@@ -84,8 +98,6 @@ TEMPLATE_LIST_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalu
     // Hessenberg reduction of H
     gehd2(ilo, ihi, H, tau, workOpts);
 
-    DYNAMIC_SECTION("UNMHR with"
-                    << " matrix = " << matrix_type << " ilo = " << ilo << " ihi = " << ihi)
     {
 
         real_t c_norm = lange(frob_norm, C);

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -73,7 +73,7 @@ TEST_CASE( "MatrixAccessPolicy can be cast to Uplo", "[utils]" ) {
     CHECK( dense == (MatrixAccessPolicy) uplo );
 }
 
-TEMPLATE_LIST_TEST_CASE("is_matrix works", "[utils]", types_to_test)
+TEMPLATE_TEST_CASE("is_matrix works", "[utils]", TLAPACK_TYPES_TO_TEST)
 {
     using matrix_t  = TestType;
 


### PR DESCRIPTION
- Use TEMPLATE_TEST_CASE instead of TEMPLATE_LIST_TEST_CASE. The advantage here is that the test messages now will show the type tested instead of an index respective to the type tested.

- Replace DYNAMIC_SECTION by INFO. Advantage: Avoid creating unnecessary sections.

- Use workspace queries on tests.

- Fix bugs on the workspace queries.

- In workspace queries, workinfo is [in,out]. This reduces the lines of code when performing multiple queries. See test_unmhr.hpp and test_gebd2.hpp.