### PR TITLE
Adds an example with Eigen3, testing multishift QR

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,6 +22,7 @@ env:
   blaspp_DIR: "${{github.workspace}}/blaspp"
   lapackpp_DIR: "${{github.workspace}}/lapackpp"
   mdspan_DIR: "${{github.workspace}}/mdspan"
+  eigen_DIR: "${{github.workspace}}/eigen"
   Catch2_DIR: "${{github.workspace}}/Catch2"
   Catch2_CMAKE_DIR: "${{github.workspace}}/Catch2/build/lib/cmake/Catch2"
 
@@ -100,14 +101,19 @@ jobs:
         git checkout tlapack
         cmake -B build -G Ninja -D blaspp_DIR="${{env.blaspp_DIR}}/build"
 
-    - name: Checkout mdspan on Ubuntu
+    - name: Checkout mdspan and Eigen on Ubuntu
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         git clone https://github.com/kokkos/mdspan.git "${{env.mdspan_DIR}}"
+        git clone https://gitlab.com/libeigen/eigen.git "${{env.eigen_DIR}}"
 
-    - name: Install Eigen on Ubuntu
+    - name: Build and install Eigen on Ubuntu
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: sudo apt install libeigen3-dev
+      working-directory: ${{env.eigen_DIR}}
+      run: |
+        git checkout master
+        cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX="${{env.eigen_DIR}}"
+        cmake --build build --target install
 
     - name: Build and install mdspan on Ubuntu
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -96,6 +96,17 @@ if( Eigen3_FOUND )
       "${CMAKE_CURRENT_BINARY_DIR}/eigen/example_eigen${CMAKE_EXECUTABLE_SUFFIX}"
       && echo ""
   )
+  # add the example performance_eigen
+  add_subdirectory( performance_eigen )
+  add_custom_command(
+    OUTPUT run-all-examples-cmd APPEND
+    COMMAND
+      echo "- performance_eigen ----------------" &&
+      "${CMAKE_CURRENT_BINARY_DIR}/performance_eigen/performance_eigen${CMAKE_EXECUTABLE_SUFFIX}"
+      && echo "-x-x-x-x-x-x-x-x-" &&
+      "${CMAKE_CURRENT_BINARY_DIR}/performance_eigen/performance_tlapack${CMAKE_EXECUTABLE_SUFFIX}"
+      && echo ""
+  )
 else()
   mark_as_advanced( FORCE Eigen3_DIR )
 endif()

--- a/examples/performance_eigen/CMakeLists.txt
+++ b/examples/performance_eigen/CMakeLists.txt
@@ -10,6 +10,7 @@ project( performance_eigen CXX )
 
 # Options
 option( USE_MKL "Use MKL for Eigen" OFF )
+option( USE_MDSPAN_DATA "Use USE_MDSPAN_DATA for tests with <T>LAPACK" OFF )
 
 # Load <T>LAPACK
 if( NOT TARGET tlapack )
@@ -27,6 +28,13 @@ target_link_libraries( performance_eigen PRIVATE Eigen3::Eigen )
 add_executable( performance_tlapack performance_tlapack.cpp )
 target_link_libraries( performance_tlapack PRIVATE tlapack Eigen3::Eigen )
 
+if( USE_MDSPAN_DATA )
+  # Load mdspan
+  find_package( mdspan REQUIRED )
+  target_compile_definitions( performance_tlapack PRIVATE "USE_MDSPAN_DATA" )
+  target_link_libraries( performance_tlapack PRIVATE std::mdspan )
+endif()
+
 # Load MKL
 if( USE_MKL )
   set( BLA_VENDOR Intel10_64lp )
@@ -34,5 +42,10 @@ if( USE_MKL )
   if( BLAS_FOUND )
     target_compile_definitions( performance_eigen PRIVATE "EIGEN_USE_MKL_ALL" )
     target_link_libraries( performance_eigen PRIVATE ${BLAS_LIBRARIES} )
+    
+    add_executable( performance_eigen_blasMKL performance_eigen.cpp )
+    target_link_libraries( performance_eigen_blasMKL PRIVATE Eigen3::Eigen )
+    target_compile_definitions( performance_eigen_blasMKL PRIVATE "EIGEN_USE_BLAS" )
+    target_link_libraries( performance_eigen_blasMKL PRIVATE ${BLAS_LIBRARIES} )
   endif()
 endif()

--- a/examples/performance_eigen/CMakeLists.txt
+++ b/examples/performance_eigen/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2021-2022, University of Colorado Denver. All rights reserved.
+#
+# This file is part of <T>LAPACK.
+# <T>LAPACK is free software: you can redistribute it and/or modify it under
+# the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+cmake_minimum_required(VERSION 3.1)
+
+project( performance_eigen CXX )
+
+# Options
+option( USE_MKL "Use MKL for Eigen" OFF )
+
+# Load <T>LAPACK
+if( NOT TARGET tlapack )
+  find_package( tlapack REQUIRED )
+endif()
+
+# Load Eigen
+find_package( Eigen3 REQUIRED )
+
+# add the example performance_eigen
+add_executable( performance_eigen performance_eigen.cpp )
+target_link_libraries( performance_eigen PRIVATE Eigen3::Eigen )
+
+# add the example performance_tlapack
+add_executable( performance_tlapack performance_tlapack.cpp )
+target_link_libraries( performance_tlapack PRIVATE tlapack Eigen3::Eigen )
+
+# Load MKL
+if( USE_MKL )
+  set( BLA_VENDOR Intel10_64lp )
+  find_package( BLAS REQUIRED )
+  if( BLAS_FOUND )
+    target_compile_definitions( performance_eigen PRIVATE "EIGEN_USE_MKL_ALL" )
+    target_link_libraries( performance_eigen PRIVATE ${BLAS_LIBRARIES} )
+  endif()
+endif()

--- a/examples/performance_eigen/Makefile
+++ b/examples/performance_eigen/Makefile
@@ -1,0 +1,24 @@
+-include make.inc
+
+#-------------------------------------------------------------------------------
+# Executables
+
+all: performance_eigen performance_tlapack
+
+performance_eigen: performance_eigen.o
+	$(CXX) $(CXXFLAGS) -o $@ $< $(LDFLAGS)
+performance_tlapack: performance_tlapack.o
+	$(CXX) $(CXXFLAGS) -o $@ $< $(LDFLAGS)
+
+#-------------------------------------------------------------------------------
+# Rules
+
+.PHONY: all
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+clean:
+	rm -f *.o
+	rm -f performance_eigen
+	rm -f performance_tlapack

--- a/examples/performance_eigen/make.inc
+++ b/examples/performance_eigen/make.inc
@@ -1,0 +1,8 @@
+#-------------------------------------------------------------------------------
+# <T>LAPACK library
+tlapack_inc = /home/weslleyp/tlapack-test/include
+tlapack_lib = /home/weslleyp/tlapack-test/lib
+eigen_inc   = /home/weslleyp/storage/eigen
+
+CXXFLAGS = -g -I$(tlapack_inc) -I$(eigen_inc) -Wall -pedantic
+LDFLAGS  = 

--- a/examples/performance_eigen/performance_eigen.cpp
+++ b/examples/performance_eigen/performance_eigen.cpp
@@ -1,0 +1,110 @@
+/// @file example_geqr2.cpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <iostream>
+#include <chrono>   // for high_resolution_clock
+
+// From Eigen
+#include <Eigen/Dense>
+#include <Eigen/Householder>
+
+template <class T>
+bool complex_comparator(const std::complex<T> &a, const std::complex<T> &b) {
+    return std::real(a) == std::real(b) ? std::imag(a) > std::imag(b) : std::real(a) > std::real(b);
+}
+
+//------------------------------------------------------------------------------
+template <typename T>
+void run( Eigen::Index n, bool run_reference )
+{
+    using idx_t = Eigen::Index;
+    using ref_T = long double;
+
+    // Number of eigenvalues to be used to compute error
+    const idx_t N = n;
+    const idx_t Nshow = 2;
+
+    // Matrices
+    Eigen::Matrix<ref_T,-1,-1> A_ref(n,n);
+    Eigen::Matrix<T,-1,-1> A(n,n);
+
+    // Generate a random matrix in A
+    srand(7435);
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = 0; i < n; ++i) {
+            A(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+            A_ref(i,j) = A(i,j);
+        }
+
+    // Reference eigenvalues
+    Eigen::Matrix<std::complex<ref_T>,-1,1> ref_eig(n);
+    if( run_reference )
+    {
+        Eigen::EigenSolver<decltype(A_ref)> solver( A_ref );
+        solver.compute( A_ref, false );
+        ref_eig = solver.eigenvalues();
+
+        // Reorder eigenvalues
+        std::sort(ref_eig.data(), ref_eig.data() + ref_eig.size(), complex_comparator< ref_T >);
+
+        // Output
+        std::cout   << "Reference:" << std::endl
+                    << "First eigenvalues:" << std::endl
+                    << ref_eig.segment(0,Nshow) << std::endl;
+    }
+
+    std::cout << "-x-x-x-x-x-x-x-x-" << std::endl;
+    #ifdef EIGEN_USE_MKL_ALL
+        std::cout << "-x-x-x-MKL-x-x-x-" << std::endl;
+    #endif
+
+    // Compute eigenvalues using Eigen
+    {
+        // Record start time
+        auto start = std::chrono::high_resolution_clock::now();
+        
+            Eigen::Matrix<std::complex<T>,-1,1> eigen_eig(n);
+            Eigen::EigenSolver<decltype(A)> solver;
+            solver.compute( A, false );
+            eigen_eig = solver.eigenvalues();
+        
+        // Record end time
+        auto end = std::chrono::high_resolution_clock::now();
+
+        // Compute elapsed time in nanoseconds
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+
+        // Reorder eigenvalues
+        std::sort(eigen_eig.data(), eigen_eig.data() + eigen_eig.size(), complex_comparator< T >);
+
+        // Compute error
+        Eigen::Matrix<std::complex<ref_T>,-1,1> error(N);
+        for( idx_t i = 0; i < N; ++i )
+            error[i] = (std::complex<ref_T>) eigen_eig[i] - ref_eig[i];
+
+        // Output
+        std::cout   << "Using Eigen:" << std::endl
+                    << "First eigenvalues:" << std::endl
+                    << eigen_eig.segment(0,Nshow) << std::endl
+                    << "Error in the eigenvalues: " << error.norm() / ref_eig.norm() << std::endl
+                    << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
+    }
+}
+
+int main( int argc, char** argv )
+{
+    // Default arguments
+    const Eigen::Index n = ( argc < 2 ) ? 2 : atoi( argv[1] );
+    const bool run_reference = ( argc < 3 ) ? true : (atoi( argv[2] ) != 0);
+
+    run<float>( n, run_reference );
+    run<double>( n, run_reference );
+
+    return 0;
+}

--- a/examples/performance_eigen/performance_eigen.cpp
+++ b/examples/performance_eigen/performance_eigen.cpp
@@ -21,7 +21,7 @@ bool complex_comparator(const std::complex<T> &a, const std::complex<T> &b) {
 
 //------------------------------------------------------------------------------
 template <typename T>
-void run( Eigen::Index n, bool run_reference )
+void run( int n, bool compute_forwardError, bool compute_backwardError, int matrix_type )
 {
     using idx_t = Eigen::Index;
     using ref_T = long double;
@@ -31,80 +31,211 @@ void run( Eigen::Index n, bool run_reference )
     const idx_t Nshow = 2;
 
     // Matrices
-    Eigen::Matrix<ref_T,-1,-1> A_ref(n,n);
     Eigen::Matrix<T,-1,-1> A(n,n);
+    Eigen::Matrix<std::complex<T>,-1,1> exact_eig(n);
 
     // Generate a random matrix in A
-    srand(7435);
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i) {
-            A(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
-            A_ref(i,j) = A(i,j);
-        }
-
-    // Reference eigenvalues
-    Eigen::Matrix<std::complex<ref_T>,-1,1> ref_eig(n);
-    if( run_reference )
+    if( matrix_type == 0 )
     {
-        Eigen::EigenSolver<decltype(A_ref)> solver( A_ref );
-        solver.compute( A_ref, false );
-        ref_eig = solver.eigenvalues();
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i)
+                A(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+    }
+    else
+    {
+        // Generate a random ill-conditioned matrix
+        {
+            // D1 is a diagonal matrix containing the desired eigenvalues
+            Eigen::Matrix<T,-1,1> d1(n);
+            for (int i = 0; i < n; ++i) {
+                d1[i] = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                exact_eig[i] = d1[i];
+            }
 
-        // Reorder eigenvalues
-        std::sort(ref_eig.data(), ref_eig.data() + ref_eig.size(), complex_comparator< ref_T >);
+            // D2 is a diagonal matrix, the condition of this matrix will become the condition of the eigenvector matrix
+            Eigen::Matrix<T,-1,1> d2(n);
+            for (int i = 0; i < n; ++i)
+                d2[i] = std::pow( 2.0, i % matrix_type );
 
-        // Output
-        std::cout   << "Reference:" << std::endl
-                    << "First eigenvalues:" << std::endl
-                    << ref_eig.segment(0,Nshow) << std::endl;
+            // Q1 and Q2 are random unitary matrices
+            Eigen::Matrix<T,-1,-1> Q1(n,n);
+            Eigen::Matrix<T,-1,-1> Q2(n,n);
+            for (int j = 0; j < n; ++j) {
+                for (int i = 0; i < n; ++i) {
+                    Q1(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                    Q2(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                }
+            }
+            Q1 = Eigen::HouseholderQR<decltype(A)>(Q1).householderQ();
+            Q2 = Eigen::HouseholderQR<decltype(A)>(Q2).householderQ();
+
+            // A = Q2^* D2^-1 Q1^* D1 Q1 D2 Q2
+            A = Q2.adjoint()
+                * d2.asDiagonal().inverse()
+                * Q1.adjoint()
+                * d1.asDiagonal()
+                * Q1
+                * d2.asDiagonal()
+                * Q2;
+        }
     }
 
-    std::cout << "-x-x-x-x-x-x-x-x-" << std::endl;
-    #ifdef EIGEN_USE_MKL_ALL
-        std::cout << "-x-x-x-MKL-x-x-x-" << std::endl;
+    // Reference eigenvalues
+    if( compute_forwardError )
+    {
+        if( matrix_type == 0 )
+        {
+            std::cout << "0. Eigen (reference solution using long double)" << std::endl;
+        
+            Eigen::Matrix<ref_T,-1,-1> A_ref(n,n);
+            for (int j = 0; j < n; ++j)
+                for (int i = 0; i < n; ++i)
+                    A_ref(i,j) = A(i,j);
+
+            Eigen::EigenSolver<decltype(A_ref)> solver( A_ref );
+            solver.compute( A_ref, false );
+            Eigen::Matrix<std::complex<ref_T>,-1,1> ref_eig = solver.eigenvalues();
+            for (int i = 0; i < n; ++i)
+                exact_eig[i] = ref_eig[i];
+        }
+
+        // Reorder eigenvalues
+        std::sort(exact_eig.data(), exact_eig.data() + exact_eig.size(), complex_comparator<T>);
+
+        // Output
+        std::cout   << "First eigenvalues:" << std::endl
+                    << exact_eig.segment(0,Nshow) << std::endl;
+    }
+
+    std::cout << "--------------" << std::endl;
+    std::cout << "1. Eigen -----" << std::endl;
+    #if defined(EIGEN_USE_MKL_ALL)
+        std::cout << "Using MKL" << std::endl;
+    #elif defined(EIGEN_USE_BLAS)
+        std::cout << "Using MKL BLAS" << std::endl;
     #endif
 
     // Compute eigenvalues using Eigen
     {
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
+
+            Eigen::Matrix<std::complex<T>,-1,1> lambda(n);
+            Eigen::Matrix<T,-1,-1> matrixT(n,n);
+            Eigen::Matrix<T,-1,-1> U(n,n);
+
+            if( compute_backwardError )
+            {
+                Eigen::RealSchur<decltype(A)> solverSchur( A, true );
+                matrixT = solverSchur.matrixT();
+                U = solverSchur.matrixU();
         
-            Eigen::Matrix<std::complex<T>,-1,1> eigen_eig(n);
-            Eigen::EigenSolver<decltype(A)> solver;
-            solver.compute( A, false );
-            eigen_eig = solver.eigenvalues();
+                idx_t i = 0;
+                while (i < n)
+                {
+                    if (i == n-1 || matrixT(i+1,i) == T(0))
+                    {
+                        lambda[i] = matrixT(i, i);
+                        ++i;
+                    }
+                    else
+                    {
+                        T p = T(0.5) * (matrixT(i, i) - matrixT(i+1, i+1));
+                        T z;
+
+                        // Compute z = sqrt(abs(p * p + matrixT(i+1, i) * matrixT(i, i+1)));
+                        // without overflow
+                        {
+                            T t0 = matrixT(i+1, i);
+                            T t1 = matrixT(i, i+1);
+                            T maxval = std::max( abs(p), std::max(abs(t0),abs(t1)) );
+                            t0 /= maxval;
+                            t1 /= maxval;
+                            T p0 = p/maxval;
+                            z = maxval * sqrt(abs(p0 * p0 + t0 * t1));
+                        }
+                        
+                        lambda[i]   = std::complex<T>(matrixT(i+1, i+1) + p,  z);
+                        lambda[i+1] = std::complex<T>(matrixT(i+1, i+1) + p, -z);
+                        
+                        i += 2;
+                    }
+                }
+            }
+            else
+            {
+                Eigen::EigenSolver<decltype(A)> solver( A, false );
+                lambda = solver.eigenvalues();
+            }
         
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
         auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        
+        // // Compute backward error before reordering eigenvalues
+        // Eigen::Matrix<T,-1,1> bw_error(2);
+        // if( compute_backwardError )
+        // {
+        //     auto V = solverSchur.matrixU() * solver.eigenvectors();
+        //     auto R0 = V * lambda.asDiagonal() - A * V;
+        //     auto R1 = V * lambda.asDiagonal() * V.inverse() - A;
+            
+        //     bw_error[0] = R0.norm() / ( A.norm() * V.norm() );
+        //     bw_error[1] = R1.norm() / A.norm();
+        // }
 
         // Reorder eigenvalues
-        std::sort(eigen_eig.data(), eigen_eig.data() + eigen_eig.size(), complex_comparator< T >);
+        std::sort(lambda.data(), lambda.data() + lambda.size(), complex_comparator< T >);
 
         // Compute error
-        Eigen::Matrix<std::complex<ref_T>,-1,1> error(N);
+        Eigen::Matrix<std::complex<T>,-1,1> error(N);
         for( idx_t i = 0; i < N; ++i )
-            error[i] = (std::complex<ref_T>) eigen_eig[i] - ref_eig[i];
+            error[i] = lambda[i] - exact_eig[i];
 
         // Output
-        std::cout   << "Using Eigen:" << std::endl
-                    << "First eigenvalues:" << std::endl
-                    << eigen_eig.segment(0,Nshow) << std::endl
-                    << "Error in the eigenvalues: " << error.norm() / ref_eig.norm() << std::endl
+        std::cout   << "First eigenvalues:" << std::endl
+                    << lambda.segment(0,Nshow) << std::endl
                     << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
+        if( compute_forwardError )
+            std::cout
+                    << "||fl(lambda)-lambda||/||lambda|| = " << error.norm() / exact_eig.norm() << std::endl;
+        if( compute_backwardError )
+        {        
+            // Check the Schur factorization is correct
+            Eigen::Matrix<T,-1,-1> R0 = U.adjoint() * U - Eigen::Matrix<T,-1,-1>::Identity(n,n);
+            Eigen::Matrix<T,-1,-1> R1 = U * U.adjoint() - Eigen::Matrix<T,-1,-1>::Identity(n,n);
+            Eigen::Matrix<T,-1,-1> R2 = U * matrixT * U.adjoint() - A;
+
+            std::cout
+                    << "||U^H U - I||/||I|| = " << R0.norm() / sqrt(n*T(1)) << std::endl
+                    << "||U U^H - I||/||I|| = " << R1.norm() / sqrt(n*T(1)) << std::endl
+                    << "||U T U^H - A||/||A|| = " << R2.norm() / A.norm() << std::endl;
+                    // << "||V Lambda - A V||/(||A|| ||V||) = " << bw_error[0] << std::endl
+                    // << "||V Lambda V^{-1} - A||/||A|| = " << bw_error[1] << std::endl;
+        }
     }
 }
 
 int main( int argc, char** argv )
 {
     // Default arguments
-    const Eigen::Index n = ( argc < 2 ) ? 2 : atoi( argv[1] );
-    const bool run_reference = ( argc < 3 ) ? true : (atoi( argv[2] ) != 0);
+    const int n = ( argc < 2 ) ? 2 : atoi( argv[1] );
+    const bool compute_forwardError = ( argc < 3 ) ? true : (atoi( argv[2] ) != 0);
+    const bool compute_backwardError = ( argc < 4 ) ? true : (atoi( argv[3] ) != 0);
+    const int matrix_type = ( argc < 5 ) ? 0 : atoi( argv[4] );
+    const int seed = ( argc < 6 ) ? 3 : atoi( argv[5] );
 
-    run<float>( n, run_reference );
-    run<double>( n, run_reference );
+    srand(seed);
+
+    std::cout << "# Single precision:" << std::endl;
+    run<float>( n, compute_forwardError, compute_backwardError, matrix_type );
+    std::cout << std::endl;
+    
+    std::cout << "# Double precision:" << std::endl;
+    run<double>( n, compute_forwardError, compute_backwardError, matrix_type );
+    std::cout << std::endl;
 
     return 0;
 }

--- a/examples/performance_eigen/performance_tlapack.cpp
+++ b/examples/performance_eigen/performance_tlapack.cpp
@@ -1,0 +1,151 @@
+/// @file example_geqr2.cpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <iostream>
+#include <chrono>   // for high_resolution_clock
+
+// From Eigen
+#include <Eigen/Dense>
+#include <Eigen/Householder>
+
+#include <tlapack/plugins/eigen.hpp>
+#include <tlapack/lapack/gehrd.hpp>
+#include <tlapack/lapack/multishift_qr.hpp>
+
+template <class T>
+bool complex_comparator(const std::complex<T> &a, const std::complex<T> &b) {
+    return std::real(a) == std::real(b) ? std::imag(a) > std::imag(b) : std::real(a) > std::real(b);
+}
+
+//------------------------------------------------------------------------------
+template <typename T>
+void run( Eigen::Index n, bool run_reference )
+{
+    using idx_t = Eigen::Index;
+    using namespace tlapack;
+    using ref_T = long double;
+
+    const bool want_t = false;
+    const bool want_z = false;
+
+    // Number of eigenvalues to be used to compute error
+    const idx_t N = n;
+    const idx_t Nshow = 2;
+
+    // Matrices
+    Eigen::Matrix<ref_T,-1,-1> A_ref(n,n);
+    Eigen::Matrix<T,-1,-1> A(n,n);
+
+    // Generate a random matrix in A
+    srand(7435);
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = 0; i < n; ++i) {
+            A(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+            A_ref(i,j) = A(i,j);
+        }
+
+    // Reference eigenvalues
+    Eigen::Matrix<std::complex<ref_T>,-1,1> ref_eig(n);
+    if( run_reference )
+    {
+        Eigen::EigenSolver<decltype(A_ref)> solver( A_ref );
+        solver.compute( A_ref, false );
+        ref_eig = solver.eigenvalues();
+
+        // Reorder eigenvalues
+        std::sort(ref_eig.data(), ref_eig.data() + ref_eig.size(), complex_comparator< ref_T >);
+
+        // Output
+        std::cout   << "Reference:" << std::endl
+                    << "First eigenvalues:" << std::endl
+                    << ref_eig.segment(0,Nshow) << std::endl;
+    }
+
+    std::cout << "-x-x-x-x-x-x-x-x-" << std::endl;
+
+    // Compute eigenvalues using <T>LAPACK
+    {
+        // Record start time
+        auto start = std::chrono::high_resolution_clock::now();
+            
+            // Hessenberg reduction
+            Eigen::Matrix<T,-1,-1> H = A;
+            {
+                Eigen::Matrix<T,-1,1> tau(n);
+                tlapack::gehrd( 0, n, H, tau );
+            }
+
+            // Throw away reflectors to make a true Hessenberg matrix
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = j + 2; i < n; ++i)
+                    H(i, j) = T(0);
+            
+            // Compute eigenvalues
+            Eigen::Matrix<std::complex<T>,-1,1> tlapack_eig(n);
+            Eigen::Matrix<T,-1,-1> Z(n,n); Z.setIdentity();
+            Eigen::Matrix<T,-1,-1> matrixT = H;
+            int n_aed, n_sweep, n_shifts_total;
+            {
+                francis_opts_t<idx_t> opts;
+                
+                tlapack::multishift_qr( want_t, want_z, 0, n, matrixT, tlapack_eig, Z, opts );
+                
+                n_aed = opts.n_aed;
+                n_sweep = opts.n_sweep;
+                n_shifts_total = opts.n_shifts_total;
+            }
+
+        // Record end time
+        auto end = std::chrono::high_resolution_clock::now();
+
+        // Compute elapsed time in nanoseconds
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+
+        // Clean the lower triangular part that was used a workspace
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 2; i < n; ++i)
+                H(i, j) = T(0);
+        
+        // Check the Schur factorization is correct
+        Eigen::Matrix<T,-1,-1> R0 = Z.adjoint() * Z - Eigen::Matrix<T,-1,-1>::Identity(n,n);
+        Eigen::Matrix<T,-1,-1> R1 = Z.adjoint() * H * Z - matrixT;
+
+        // Reorder eigenvalues
+        std::sort(tlapack_eig.data(), tlapack_eig.data() + tlapack_eig.size(), complex_comparator< T >);
+
+        // Compute error
+        Eigen::Matrix<std::complex<ref_T>,-1,1> error(N);
+        for( idx_t i = 0; i < N; ++i )
+            error[i] = (std::complex<ref_T>) tlapack_eig[i] - ref_eig[i];
+
+        // Output
+        std::cout   << "Using <T>LAPACK:" << std::endl
+                    << "First eigenvalues:" << std::endl
+                    << tlapack_eig.segment(0,Nshow) << std::endl
+                    << "Error in the eigenvalues: " << error.norm() / ref_eig.norm() << std::endl
+                    << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl
+                    << "||Z.adjoint() Z - I||/||I|| = " << R0.norm() << std::endl
+                    << "||Z.adjoint() H Z - T||/||T|| = " << R1.norm() << std::endl
+                    << "n_aed = " << n_aed << std::endl
+                    << "n_sweep = " << n_sweep << std::endl
+                    << "n_shifts_total = " << n_shifts_total << std::endl;
+    }
+}
+
+int main( int argc, char** argv )
+{
+    // Default arguments
+    const Eigen::Index n = ( argc < 2 ) ? 2 : atoi( argv[1] );
+    const bool run_reference = ( argc < 3 ) ? true : (atoi( argv[2] ) != 0);
+
+    run<float>( n, run_reference );
+    run<double>( n, run_reference );
+
+    return 0;
+}

--- a/examples/performance_eigen/runWIthMKL.ipynb
+++ b/examples/performance_eigen/runWIthMKL.ipynb
@@ -26,7 +26,7 @@
     "seed = int(seed)\n",
     "\n",
     "seed = 604\n",
-    "matrix_type = 0\n",
+    "matrix_type = 54\n",
     "\n",
     "import random\n",
     "random.seed(seed)\n",
@@ -74,6 +74,16 @@
    "source": [
     "# Eigen version:\n",
     "!cat /usr/lib/cmake/eigen3/Eigen3Config.cmake | grep EIGEN3_VERSION_STRING"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Eigen version:\n",
+    "!cat /usr/local/lib/cmake/mdspan/mdspanConfigVersion.cmake | grep \"set(PACKAGE_VERSION \\\"\""
    ]
   },
   {
@@ -618,6 +628,24 @@
     "\n",
     "    plt.tight_layout()\n",
     "    plt.savefig(\"curves_mdspan_\"+datatypes[datatype]+\".pdf\")\n",
+    "    plt.show()\n",
+    "\n",
+    "    fig1, ax1 = plt.subplots()\n",
+    "\n",
+    "    plt.plot(nSizes,np.divide(data[0,:,datatype],data_mdspan[:,datatype]),markers[1],label=r\"C++ only\")\n",
+    "    plt.plot(nSizes,np.divide(data_mkl[0,:,datatype],data_mkl_mdspan[:,datatype]),markers[1],label=r\"Using MKL BLAS\")\n",
+    "\n",
+    "    ax1.set_xscale(\"log\")\n",
+    "    # ax1.set_yscale(\"log\")\n",
+    "    ax1.set_xticks(nSizes)\n",
+    "    ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "    plt.xlabel(\"n\")\n",
+    "    plt.ylabel(\"Speedup\")\n",
+    "    plt.legend()\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.savefig(\"speedup_mdspan_\"+datatypes[datatype]+\".pdf\")\n",
     "    plt.show()"
    ]
   }
@@ -638,7 +666,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]"
   },
   "vscode": {
    "interpreter": {

--- a/examples/performance_eigen/runWIthMKL.ipynb
+++ b/examples/performance_eigen/runWIthMKL.ipynb
@@ -1,0 +1,803 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 241,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "pwd = os.getcwd()\n",
+    "\n",
+    "blaspp_source = \"/home/weslleyp/storage/blaspp\"\n",
+    "lapackpp_source = \"/home/weslleyp/storage/lapackpp\"\n",
+    "tlapack_source = \"/home/weslleyp/storage/tlapack\"\n",
+    "\n",
+    "tlapack_DIR = pwd+\"/tlapack\"\n",
+    "tlapackMKL_DIR = pwd+\"/tlapack_mkl\"\n",
+    "blaspp_DIR = pwd+\"/blaspp\"\n",
+    "lapackpp_DIR = pwd+\"/lapackpp\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 242,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Linux weslleyp-XPS-15-9510 5.14.0-1054-oem #61-Ubuntu SMP Fri Oct 14 13:05:50 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux\n"
+     ]
+    }
+   ],
+   "source": [
+    "# System:\n",
+    "!uname -a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 243,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Architecture:                    x86_64\n",
+      "CPU op-mode(s):                  32-bit, 64-bit\n",
+      "Byte Order:                      Little Endian\n",
+      "Address sizes:                   39 bits physical, 48 bits virtual\n",
+      "CPU(s):                          16\n",
+      "On-line CPU(s) list:             0-15\n",
+      "Thread(s) per core:              2\n",
+      "Core(s) per socket:              8\n",
+      "Socket(s):                       1\n",
+      "NUMA node(s):                    1\n",
+      "Vendor ID:                       GenuineIntel\n",
+      "CPU family:                      6\n",
+      "Model:                           141\n",
+      "Model name:                      11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz\n",
+      "Stepping:                        1\n",
+      "CPU MHz:                         2300.000\n",
+      "CPU max MHz:                     4600.0000\n",
+      "CPU min MHz:                     800.0000\n",
+      "BogoMIPS:                        4608.00\n",
+      "Virtualization:                  VT-x\n",
+      "L1d cache:                       384 KiB\n",
+      "L1i cache:                       256 KiB\n",
+      "L2 cache:                        10 MiB\n",
+      "L3 cache:                        24 MiB\n",
+      "NUMA node0 CPU(s):               0-15\n",
+      "Vulnerability Itlb multihit:     Not affected\n",
+      "Vulnerability L1tf:              Not affected\n",
+      "Vulnerability Mds:               Not affected\n",
+      "Vulnerability Meltdown:          Not affected\n",
+      "Vulnerability Mmio stale data:   Not affected\n",
+      "Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled v\n",
+      "                                 ia prctl and seccomp\n",
+      "Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user\n",
+      "                                  pointer sanitization\n",
+      "Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RS\n",
+      "                                 B filling\n",
+      "Vulnerability Srbds:             Not affected\n",
+      "Vulnerability Tsx async abort:   Not affected\n",
+      "Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtr\n",
+      "                                 r pge mca cmov pat pse36 clflush dts acpi mmx f\n",
+      "                                 xsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rd\n",
+      "                                 tscp lm constant_tsc art arch_perfmon pebs bts \n",
+      "                                 rep_good nopl xtopology nonstop_tsc cpuid aperf\n",
+      "                                 mperf tsc_known_freq pni pclmulqdq dtes64 monit\n",
+      "                                 or ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr \n",
+      "                                 pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc\n",
+      "                                 _deadline_timer aes xsave avx f16c rdrand lahf_\n",
+      "                                 lm abm 3dnowprefetch cpuid_fault epb cat_l2 inv\n",
+      "                                 pcid_single cdp_l2 ssbd ibrs ibpb stibp ibrs_en\n",
+      "                                 hanced tpr_shadow vnmi flexpriority ept vpid ep\n",
+      "                                 t_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 er\n",
+      "                                 ms invpcid rdt_a avx512f avx512dq rdseed adx sm\n",
+      "                                 ap avx512ifma clflushopt clwb intel_pt avx512cd\n",
+      "                                  sha_ni avx512bw avx512vl xsaveopt xsavec xgetb\n",
+      "                                 v1 xsaves split_lock_detect dtherm ida arat pln\n",
+      "                                  pts hwp hwp_notify hwp_act_window hwp_epp hwp_\n",
+      "                                 pkg_req avx512vbmi umip pku ospke avx512_vbmi2 \n",
+      "                                 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg \n",
+      "                                 avx512_vpopcntdq rdpid movdiri movdir64b fsrm a\n",
+      "                                 vx512_vp2intersect md_clear flush_l1d arch_capa\n",
+      "                                 bilities\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Machine:\n",
+    "!lscpu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 244,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "set (EIGEN3_VERSION_STRING \"3.3.7\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Eigen version:\n",
+    "!cat /usr/lib/cmake/eigen3/Eigen3Config.cmake | grep EIGEN3_VERSION_STRING"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 245,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/opt/intel/oneapi/mkl/2022.2.1/bin/intel64/mkl_link_tool\n"
+     ]
+    }
+   ],
+   "source": [
+    "# MKL version:\n",
+    "!which mkl_link_tool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 246,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-- <T>LAPACK version 0.1.1\n",
+      "-- Submodule update\n",
+      "-- Configuring done\n",
+      "-- Generating done\n",
+      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/tlapack\n",
+      "[0/1] Install the project...\u001b[K\n",
+      "-- Install configuration: \"Release\"\n",
+      "-- Configuring done\n",
+      "-- Generating done\n",
+      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/build\n",
+      "ninja: no work to do.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Build without MKL\n",
+    "\n",
+    "# Install <T>LAPACK\n",
+    "!cmake -B \"$tlapack_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D BUILD_EXAMPLES=OFF -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=\"$tlapack_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" \"$tlapack_source\"\n",
+    "!cmake --build \"$tlapack_DIR\" --target install\n",
+    "\n",
+    "# Build\n",
+    "!cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_PREFIX_PATH=\".\"\n",
+    "!cmake --build build"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 247,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reference:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "-x-x-x-x-x-x-x-x-\n",
+      "Using Eigen:\n",
+      "First eigenvalues:\n",
+      "(499.883,0)\n",
+      "(8.92164,0)\n",
+      "Error in the eigenvalues: 0.00998675\n",
+      "time = 1.5691 s\n",
+      "Reference:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "-x-x-x-x-x-x-x-x-\n",
+      "Using Eigen:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "Error in the eigenvalues: 2.33553e-15\n",
+      "time = 2.78988 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "!./build/performance_eigen 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 248,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reference:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "-x-x-x-x-x-x-x-x-\n",
+      "Using <T>LAPACK:\n",
+      "First eigenvalues:\n",
+      "(499.883,0)\n",
+      "(8.92161,0)\n",
+      "Error in the eigenvalues: 0.00998681\n",
+      "time = 0.976849 s\n",
+      "||Z.adjoint() Z - I||/||I|| = 0\n",
+      "||Z.adjoint() H Z - T||/||T|| = 828.706\n",
+      "n_aed = 41\n",
+      "n_sweep = 7\n",
+      "n_shifts_total = 448\n",
+      "Reference:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "-x-x-x-x-x-x-x-x-\n",
+      "Using <T>LAPACK:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "Error in the eigenvalues: 2.46726e-15\n",
+      "time = 1.57934 s\n",
+      "||Z.adjoint() Z - I||/||I|| = 0\n",
+      "||Z.adjoint() H Z - T||/||T|| = 826.093\n",
+      "n_aed = 41\n",
+      "n_sweep = 13\n",
+      "n_shifts_total = 832\n"
+     ]
+    }
+   ],
+   "source": [
+    "!./build/performance_tlapack 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 249,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-- Using CMAKE_INSTALL_PREFIX = /home/weslleyp/storage/tlapack/examples/performance_eigen/blaspp\n",
+      "-- Not building CUDA support in BLAS++\n",
+      "-- Looking for HIP/ROCm\n",
+      "-- Not building HIP/ROCm support in BLAS++\n",
+      "-- blaspp_id = c498e8d\n",
+      "-- Configuring done\n",
+      "-- Generating done\n",
+      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/blaspp\n",
+      "[0/1] Install the project...\u001b[K\n",
+      "-- Install configuration: \"Release\"\n",
+      "-- Using CMAKE_INSTALL_PREFIX = /home/weslleyp/storage/tlapack/examples/performance_eigen/lapackpp\n",
+      "-- Not building CUDA support in LAPACK++\n",
+      "-- Looking for HIP/ROCm\n",
+      "-- Not building HIP/ROCm support in LAPACK++\n",
+      "-- lapackpp_id = 17edf95\n",
+      "-- Check for BLAS++\n",
+      "\u001b[0m   Found BLAS++: /home/weslleyp/storage/tlapack/examples/performance_eigen/blaspp\u001b[0m\n",
+      "-- Configuring done\n",
+      "-- Generating done\n",
+      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/lapackpp\n",
+      "[0/1] Install the project...\u001b[K\n",
+      "-- Install configuration: \"Release\"\n",
+      "-- <T>LAPACK version 0.1.1\n",
+      "-- Submodule update\n",
+      "-- Configuring done\n",
+      "-- Generating done\n",
+      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/tlapack_mkl\n",
+      "[0/1] Install the project...\u001b[K\n",
+      "-- Install configuration: \"Release\"\n",
+      "-- Configuring done\n",
+      "-- Generating done\n",
+      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/build_mkl\n",
+      "ninja: no work to do.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Build with MKL\n",
+    "\n",
+    "# Install BLAS++\n",
+    "!cmake -B \"$blaspp_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D build_tests=OFF -D CMAKE_INSTALL_PREFIX=\"$blaspp_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" \"$blaspp_source\"\n",
+    "!cmake --build \"$blaspp_DIR\" --target install\n",
+    "\n",
+    "# Install LAPACK++\n",
+    "!cmake -B \"$lapackpp_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D build_tests=OFF -D CMAKE_INSTALL_PREFIX=\"$lapackpp_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" -D blaspp_DIR=\"$blaspp_DIR\" \"$lapackpp_source\"\n",
+    "!cmake --build \"$lapackpp_DIR\" --target install\n",
+    "\n",
+    "# Install <T>LAPACK\n",
+    "!cmake -B \"$tlapackMKL_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D BUILD_EXAMPLES=OFF -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=\"$tlapackMKL_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" -D USE_LAPACKPP_WRAPPERS=ON -D blaspp_DIR=\"$blaspp_DIR\" -D lapackpp_DIR=\"$lapackpp_DIR\" \"$tlapack_source\"\n",
+    "!cmake --build \"$tlapackMKL_DIR\" --target install\n",
+    "\n",
+    "# Build\n",
+    "!cmake -B build_mkl -G Ninja -D CMAKE_BUILD_TYPE=Release -D tlapack_DIR=\"$tlapackMKL_DIR\" -D blaspp_DIR=\"$blaspp_DIR\" -D lapackpp_DIR=\"$lapackpp_DIR\" -D USE_MKL=ON\n",
+    "!cmake --build build_mkl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 250,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-x-x-x-x-x-x-x-x-\n",
+      "-x-x-x-MKL-x-x-x-\n",
+      "Using Eigen:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92162,0)\n",
+      "Error in the eigenvalues: inf\n",
+      "time = 0.400565 s\n",
+      "-x-x-x-x-x-x-x-x-\n",
+      "-x-x-x-MKL-x-x-x-\n",
+      "Using Eigen:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "Error in the eigenvalues: -nan\n",
+      "time = 0.559561 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "!./build_mkl/performance_eigen 1000 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 251,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-x-x-x-x-x-x-x-x-\n",
+      "Using <T>LAPACK:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92166,0)\n",
+      "Error in the eigenvalues: -nan\n",
+      "time = 0.238441 s\n",
+      "||Z.adjoint() Z - I||/||I|| = 0\n",
+      "||Z.adjoint() H Z - T||/||T|| = 830.628\n",
+      "n_aed = 39\n",
+      "n_sweep = 7\n",
+      "n_shifts_total = 448\n",
+      "-x-x-x-x-x-x-x-x-\n",
+      "Using <T>LAPACK:\n",
+      "First eigenvalues:\n",
+      "(499.882,0)\n",
+      "(8.92161,0)\n",
+      "Error in the eigenvalues: -nan\n",
+      "time = 0.354536 s\n",
+      "||Z.adjoint() Z - I||/||I|| = 0\n",
+      "||Z.adjoint() H Z - T||/||T|| = 827.81\n",
+      "n_aed = 41\n",
+      "n_sweep = 13\n",
+      "n_shifts_total = 832\n"
+     ]
+    }
+   ],
+   "source": [
+    "!./build_mkl/performance_tlapack 1000 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 252,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib\n",
+    "\n",
+    "plt.rcParams['font.size'] = 14"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 253,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nSizes = [10, 25, 50, 100, 200, 400, 800, 1600]\n",
+    "N = len(nSizes)\n",
+    "\n",
+    "datatypes = [\"float\",\"double\"]\n",
+    "NT = len(datatypes)\n",
+    "\n",
+    "nRuns = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 254,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.ones([M,N,NT], dtype=np.float64) * 60 * 60 * 24\n",
+    "\n",
+    "executable = [\n",
+    "    \"build/performance_tlapack\",\n",
+    "    \"build/performance_tlapack\"\n",
+    "]\n",
+    "M = len(executable)\n",
+    "\n",
+    "methods = [\n",
+    "    r\"$\\langle$T$\\rangle$LAPACK - C++\",\n",
+    "    r\"Eigen3 - C++\"\n",
+    "]\n",
+    "\n",
+    "for s in range(M):\n",
+    "    for i in range(N):\n",
+    "        n = nSizes[i]\n",
+    "        for j in range(nRuns):\n",
+    "            expr = executable[s]\n",
+    "            output = !$expr {n} 0 | grep time\n",
+    "            for k in range(NT):\n",
+    "                data[s,i,k] = np.minimum( float(output[k].split()[2]), data[s,i,k] )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 255,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[[2.40880e-05, 1.75640e-05],\n",
+       "        [6.18840e-05, 7.54260e-05],\n",
+       "        [2.68579e-04, 3.89268e-04],\n",
+       "        [1.85396e-03, 2.86372e-03],\n",
+       "        [1.19290e-02, 1.75769e-02],\n",
+       "        [7.13812e-02, 1.20622e-01],\n",
+       "        [5.19686e-01, 8.70740e-01],\n",
+       "        [3.29049e+00, 5.65648e+00]],\n",
+       "\n",
+       "       [[2.74140e-05, 1.55220e-05],\n",
+       "        [5.95260e-05, 7.24140e-05],\n",
+       "        [2.50870e-04, 3.64299e-04],\n",
+       "        [1.82118e-03, 2.87912e-03],\n",
+       "        [1.14041e-02, 1.80498e-02],\n",
+       "        [7.19438e-02, 1.20806e-01],\n",
+       "        [5.23304e-01, 8.71808e-01],\n",
+       "        [3.24480e+00, 5.73542e+00]]])"
+      ]
+     },
+     "execution_count": 255,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 259,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "float\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAAA9vElEQVR4nO3dd3wU1frH8c+THkjoARJKgEiVEiAWUECailjABoIl6kURC4rYrvzulavitaCiiIoioeNFRaRKbwJiQi9SYiAQakRCSUjb8/tjF0xCINmQ7Gyyz/v12hfZmdmZ7yYbnpwzZ+aIMQallFLKlbysDqCUUsrzaPFRSinlclp8lFJKuZwWH6WUUi6nxUcppZTLafFRSinlcj5WB3AX1apVM/Xq1bM6hlJKlQlxcXHJxpiQS63X4uNQr149YmNjrY6hlFJlgojsv9x67XZTSinlch5ffETkDhEZm5KSYnUUpZTyGB5ffIwxs40xT1SsWNHqKEop5TE8vvgopZRyPS0+SimlXM7jR7uJyB3AHVddddVltzt16hTHjh0jMzPTNcGUcpKvry/Vq1enQoUKVkdRpdQXK+JpWbsi7atnwXePwr0xrDnmzZaDKQzsFFGsx/L44mOMmQ3MjoqKGnCpbU6dOsXRo0epVasWgYGBiIgLEypVMGMMaWlpJCUlAWgBUkXSsnZFnpm6kbkRM6mZuI4js4fzTHxvRvdrXezHEp3Pxy4qKspc6jqfvXv3EhYWRrly5VycSinnpKamcujQIQpqySuVr7eqQ1b6xct9/GHYMad2JSJxxpioS63Xcz6FkJmZSWBgoNUxlCpQYGCgdg2rIkvqv5KD3rUuPM/08ocW98HgrcV+LC0+haRdbao00M+pKqoVq1dzJuZ+amcnYQxkiR/etgwOp/tBcI1iP57HFx+9yFQp5cnS0rP44au3uXZRb6p7nWQTjTjSuD8+Ty7laKN+7Ni9hzXxycV+XB1wUIgBB0opVRbtTTzAoYlPcHfWGhIqXsvyZv+hccOGhEZUAyC03xgS4pPZcjCF9o5lxcXji49SSnkaYwyLf/6JZmuH0F7+4o/Il2lw52vU97q4M6x9RLViLzyg3W4eY8yYMezbt6/Q28fExLBjx46SC6SUssSp1HPMHf08XdY+go+vH6f6zaFBr9chn8JTkrT4eIDExESef/55KlWqhIhc9hEdHQ1AbGwsY8aMybWf6Ohobr/99gKPt2HDBry9vbnhhhsuWhcdHX3hWL6+vjRo0IChQ4dy9uxZp/YDcPToUQYPHkxERAT+/v7UqlWLHj16MG/evMtmnjNnDuXKlWPYsGEFvpeCFCaDUu5i247txH/Qmdv/jGFvzR6EvLiOKo3aW5JFi48HmDVrFh07dqRSpUocPnz4wuOrr74CyLVs1KhRANx1113MmjWrSMf7+uuvGTRoENu2bWPnzp0Xre/WrRuHDx/mjz/+4K233mLMmDEMHTrUqf3s27ePNm3a8PPPP/POO++wZcsWFi9eTM+ePRk4cOAls02aNIl77rmHd955h7feeqtI7+9KM0RHR/PGG28U+jjObq9UXjabYcF3X1H72+40tv1BQocPafzUNLwCrbuhssef8yns7XWu1IXbVuToO13jOJFX3LetyGvWrFncddddANSsWfPC8kqVKl207LybbrqJ06dPExcXR9u2bQt9rLS0NKZOncqqVatITU1l3LhxfPDBB7m28ff3v3DMfv36sWzZMn788Uc+//zzQu9n0KBBgL2FFhQUdGF506ZNefDBB/PN9vHHH/PKK68wbty4S27jjKJkUMrVjp84yZZxT3Pr2TnsC2hM1UcmUT+ssdWxtOXjqikVzt+24vyQxTXxyTwzdSMta5fscU+ePMnKlSu58847nXqdr68vPXr04Mcff3Tqdd999x3h4eG0aNGChx56iIkTJxZ40WN+F0Zebj8nTpxgwYIFPP3007n+0z/vfFHNadiwYfzzn/9k5syZxVIYipJBKVfb8NsvnPrkRrqencOO+tGEv7SKYDcoPKAtnyIbPns7Ow6dcuo11YP9eXjcempU8OfoqXSuqh7EqMV7GLV4T6Fe3yysAv++42qnjjlnzhyuvvpqwsPDnXod2Lve3n77bd58881Cv2bcuHE89NBDAHTq1Ily5coxa9Ys7r333ny3X79+PVOnTqVr166F3s/evXsxxtC0adNCZVq0aBFz585lzpw53HbbbYV+L5fjbAalXCkzK5tlk9+hY8LHpHqVJ/G2yTS75g6rY+Xi8S0fV6oY6EuNCv4knTxHjQr+VAz0LfFjzps3r8j/4fbo0YPt27eTmJhYqO337t3L6tWr6devH2C/2r5///6MGzcu13YLFiwgKCiIgIAA2rVrR8eOHfn0008LvR9n70fYvHlzIiIiGD58OCdPnixw+ylTphAUFHThsWrVqou2cSbDiBEjcu1vypQpFy3LeQxnt1cqp6Skg2x47zZu3vc++4PbEPjcr9R1s8ID2vIpMmdbIPB3V9tzXa5i8q+JDO7WsETGz+dUr149p4ZY57R//37KlStH9erVC7X9119/TXZ2NnXr1r2w7Px/0gcOHKBOnToAdOzYkbFjx+Lr60tYWBi+vr5O7adhw4aICDt37qR3794F5goNDeWnn36iS5cudOvWjUWLFlG5cuVLbn/nnXdy3XXXXXheq1ati7ZxJsPAgQO5//77Lzx/5ZVXqFWrFs8991y+x3B2e6XO+3XpLOqtfJ42JoVtLV+hee9XXT6EurC0+LjI+cIzul9r2kdU4/qIqrmel5RevXpxyy23kJWVhY+Pcz/uWbNmccsttxAQEFDgtllZWUyYMIF33nnnoqHNDz30EOPHj+df//oXAOXKlbvkXZcLu59bbrmF0aNH89xzz110zuXkyZMXnXOpVasWy5cvp0uXLnTt2pVFixZRtWrVfDMEBwcTHBx82fdbpUqVQmeoUqUKVapUybX/KlWqXPJ74Oz2Sp1LT2fNNy9z05EJHPYJI/neaTRver3VsS7LPUviFRCR20Vkl4jsEZF/WJ3nvC0HU3IVmvYR1RjdrzVbDpbsPeWuueYaypUrx4oVK5x+bc5RcuedOnWKTZs25Xrs27ePuXPnkpyczIABA2jevHmuR9++fRk/fnyhuqoKu5/PPvsMYwxRUVHMmDGDXbt28fvvv/P555/TsmXLfPcdGhrK8uXLycjIoEuXLiQnX9n9qoqSQanitm/vDuLf60SXozFsDelJyIvrCHXzwgNlrOUjIj7Ah0BnIAWIE5GZxpg/rU1GvsOpS+q2FTmJCHfeeSezZs266KT+5Rw8eJDNmzdf1PpYtWoVrVvnnljqnnvuISMjg86dO+fbmrjvvvt49dVXWbRoUYHHHTduXKH2c/PNN7NhwwZGjBjBK6+8QlJSElWrVqVVq1aMHTv2kvuvUaMGy5Yto1u3bnTu3JklS5YUulsxrwYNGhQpg1LFwRjD2p++ovmGf1NNYEe7D2l1y+NWxyq0MjWZnIi0B14yxvR2PP8Y+NUYM62g115uMrmdO3eW6lFNCxYsYODAgU6d+xkzZgwzZsxg2bJlJRdMlYjS/nlVBTt16iTbxj1F+5R57PFtSuWHJ1CtjnsMoT6vVE0mJyIdReQnEUkSESMi0flsM0hEEkTknIjEiUiHHKvDgKQcz5MAjz8z26VLF/766y82bdpU6NfMmjWLXr16lVgmpVTR7Nr0C3991J7rT84ntu5jNHh5pdsVnsJwt263IGAbMNHxyEVE+gCjgEHAase/80WkmTGmcOOBPZCfnx/Ozlf0888/l1AapVRR2LJtrJs+gqjdH5EiFdhz62Si2hV8r0V35VbFxxgzD5gHICIx+WwyBIgxxnzleP6siNwKPAW8Bhwid0unFrC+xAIrpZQL/HksiQPjH6V92q9sLt+Oeo+Np3G1UKtjXRG36na7HBHxA9oCC/OsWgicvy3reqC5iNQSkSCgB3DJP+FF5AkRiRWR2OPHj5dEbKWUuiLbV83CNuYGmqZuYH2TV2k5dB4VS3nhATdr+RSgGuANHM2z/CjQDcAYkyUiLwLLsBfW9y430s0YMxYYC/YBByURWimliiIrI524mKFckzSJA961ONV7Ote2cP8h1IVVmopPoRhjfgJ+Kuz2rrqrtVJKFdaRfTs5PfkRrsvaxboqd9DyH2MoV76C1bGKVanpdgOSgWygRp7lNYAjRd2pq+5qrZRShbF53liCYjpTPfMg66/5iOsHTy5zhQdKUfExxmQAcUD3PKu6A2uKul8RuUNExjo7GkwppYrTuTMn2fhJH1qtf4n9Pg04Fb2Ma3s+ZnWsEuNW3W6OQQLn+7+8gLoiEgmccAyl/hCYJCLrgV+Agdiv7fmiqMc0xswGZkdFRQ24kuxKKVVUB7atweuHx2iZfYSVYY9z/aP/xc/Pz+pYJcqtig8QhX2wwHnDHY8JQLQx5lsRqQoMA0KxXxN0mzFmf1EPqOd8lFJWMbZsNs8YQbMdH3FCKrG562Q6diy91+44w6263Ywxy40xks8jOsc2Y4wx9Ywx/saYtsaYlVd4TI8+51OvXr2LprlWSpW8s38m8fvIW4jc+QGbAq9DnvqFNh5SeMDNio8qXtHR0YjIRY/rr/97uOZvv/3GoEGDXJ5txowZREVFUalSJcqXL09kZCQTJkwotv3Hx8fz+OOPU6dOHfz9/QkPD+fee+9lzZoinx5Uqsi+WBHPmvhkOH0ExvcgcfkE0j9tR/0zm1h61Wu0fWkuNWqU/mt3nOFu3W4uV9a73bp168akSZNyLcvZlxwSEuLqSABUrVqVYcOG0aRJE3x9fZkzZw6PP/44ISEhVzzVdWxsLF27dqVp06Z8/vnnNG3alLNnzzJ37lyeffZZ4uLi8n2diJCQkEC9evUKPMby5cuJjo4u8kR9yrO0rF2RZ6ZuZF7976ixfw11969hl60O29uP4+5b846h8gwe3/Jxebeb4y8fTue9VrZk+Pv7U7NmzVyPnBOV5e122717N506dSIgIIDGjRszb948goKCiImJubBNUlISffv2pXLlylSuXJmePXuyZ8+eC+vfeOMNmjdvzvTp04mIiCA4OJhevXrlmj+nS5cu9OrViyZNmhAREcHgwYNp2bLlFU8PbYwhOjqaBg0a8Msvv3D77bcTERFBy5Ytee2111iyZMkV7V+pomg/rRkbsu+l5t7piGNZY68D3B3b39JcVvL44uNyK96DxHWw4l2rk1zEZrPRu3dvfHx8WLduHTExMQwfPpz09PQL26SmptK5c2cCAgJYsWIFa9euJTQ0lG7dupGamnphu3379vHtt98yc+ZMFi5cyMaNG3n99dfzPa4xhiVLlrBr1y46dux4Re9h06ZNbN++nZdeeglvb++L1ued4VQpVzjYaSQZ+HB+BptML39ocR8M3mptMAtpt1tRu93mvwpHnPjgJP4COedOih1nf4hA3RsKt4+aLaDHf52KuWDBgoumeH766ad5992Li9+iRYvYtWsXCxcupFYt+/1ZP/roI2644e9806dPxxjD+PHjEbH/Dffll19SvXp15syZw/333w/Yp8OOiYnhfIvyiSeeYPz48bmOl5KSQq1atUhPT8fb25vPPvuMHj16OPX+8jrfAtP5bJRbMIYdM4bTePvHnJZyVJBsssUXb1sGh9P9CA3Oe8285/D44uOy63zCroG/EiDtTzA2EC8oVxUq1y/Rw3bs2PGiWTUv9df/77//TlhY2IXCA/ZpuL28/m4gx8XFkZCQQHBwcK7XpqamEh8ff+F5eHg4Obsyw8LCOHbsWK7XBAcHs2nTJs6cOcOSJUsYMmQI9erVu+SMq1dffTX799tH1Xfo0IH58+dftI0zkyPm3F/OZeeLanh4ONu3bwcgMTGRZs2aXdguOzub9PT0XIX9wQcf5IsvinzJmSpjMlNT2Dv2YZqdXM5yvw6YzFSaNGpCaJenOLz0c3bs3kNCfHKJz2bsrjy++BSZky0QAGa/ABtiwCcAsjOg6Z1w+4fFHi2ncuXKUZyDKWw2G5GRkUyfPv2idTnPJfn6+uZaJyLYbLZcy7y8vC5ki4yMZOfOnYwYMeKSxWfevHlkZmYCEBgYmO82jRo1Auyzeead7vty+wNo2LAh8+bNu1B8c76HsLCwXJPx/frrr7zyyissX778wrIKFcreLVBU0ZzYt43USX1pmJXEz7WfZW/EI7QOr0yoo9CE9htDQnwyWw6maPHxVC4d7Xb2GLR9FKIehdjxcMY1gw4Kq0mTJhw6dIhDhw4RFhYG2EeO5Swabdq0Ydq0aVSrVq3Yz5/YbLZc55fyCg8PL3AfkZGRNGvWjPfff58+ffpcdN7n5MmTF3Lnt7/w8PB8R7v5+PjkKuIHDx68aJlSAPErp1Fz6QsY48vaG77mlpvv4ZZ8tmsfUc1jCw/ogAPXjnbrO8Xe0qnZwv5v3yklfsj09HSOHDmS63GpuYu6d+9O48aNeeSRR9i8eTPr1q1jyJAh+Pj4XOiK6t+/PzVq1OCuu+5ixYoVJCQksHLlSl588cVcI94K8vbbb7N48WL++OMPdu7cyciRI5k0aRIPPvjgFb1fEWH8+PHEx8dz4403MmfOHOLj49m6dSvvvfce3bp1u6L9K3UpJjuLbZNeJGLpQPZ71Sa5/0I63HyP1bHclse3fMq6xYsXExqa++K1WrVqcfDgwYu29fLyYubMmfzjH//g2muvpV69eowcOZK7776bgIAAwN6Nt3LlSl599VXuu+8+UlJSCAsLo3PnzlSuXLnQuc6cOcNTTz3FwYMHCQwMpEmTJkycOJEHHnjgyt4wcO211xIXF8eIESMYOHAgx44dIzQ0lGuuuYbRo0df8f6VyutcynH2f/UAzc/8xrLyt9H6ybFUqhBc8As9mDhzgrYsi4qKMrGxsfmu27lzp8eOntq8eTORkZHExsbStm1bq+OoQvDkz6sVju1ej5n+IJWy/2R5xMt0e/BlvL2k4BeWcSISZ4yJutR6bfmoXGbOnEn58uVp2LAh+/btY8iQIbRq1Yo2bdpYHU0pt7Nn4VjqrHmdkyaYjd2mcUuHm62OVGp4fPEp67fXcdbp06d55ZVXOHDgAJUrV+amm27io48+unDORykFJiudHeOf4eqk/7HJuwWVHp7M9eH1rI5Vqmi3m4N2u6myQj+vJSs1+QCHv+5DxLntLKp0H+2eHE1QYIDVsdyOdrsppVQxSdq8lIAfHyPUlsqiq9+h231Paa9AEWnxKSRjjH7IlNvTnowSYgy//zSSiA0jOCwh7L99Ct2vKeRtsVS+tPgUgq+vL2lpaZQrV87qKEpdVlpa2kV3l1BXJjv9LLu+fpxmx+ez3u8aaj0+iTY1PWvunZLg8ReZFkb16tVJSkoiNTVV/7JUbskYQ2pqKklJSVSvXt3qOGXGqUN7OfhBB5ocW8DPIY/R8qX51NLCUyy05VMI5+/ZdejQoVz3AlPKnfj6+lKjRg29x1wxSVw/m4rznqKSsbGi7afcfMeD2vVejDy++BR2qHWFChX0l1opT2AMO/73b5rs+IR4rzqk3zORzi0uf5Na5TyP73Zz+UymSim3lZl6kp2j7qTZzlGsDexIxWeX01wLT4nw+JaPUkoBnNi3lbRJfWmYdYgFdQbTNfrf+PpcPBuuKh5afJRSHu+PlVOpsfQFbMafNTd+w63de1sdqczT4qOU8lgmO4sdU17i6j++YbtXI3z6TqJjoyZWx/IIWnyUUh7pXMoxEsc+wNVnY1ka1JM2T3yp0yC4UJkdcCAiM0XkLxH5zuosSin3cmzXOk6Nak/4mc38HPE6nYZM0cLjYmW2+ACjgIetDqGUci+7f/6SitNuJzvbxsZuU7nlIZ1/xwplttvNGLNcRG6yOodSyj2YrHR2fPM0Vx+awQbvllR+ZDLX1w23OpbHcnnLR0Q6ishPIpIkIkZEovPZZpCIJIjIORGJE5EOrs6plCo7UpMPkPBBZ64+NIOFlfrQaOgi6mvhsZQVLZ8gYBsw0fHIRUT6YO8yGwSsdvw7X0SaGWMSHdtsIv/sNxtjDpVQbqVUKXRo8xICfnyMGrY0FjZ/l+73Pqm3yXEDLi8+xph5wDwAEYnJZ5MhQIwx5ivH82dF5FbgKeA1xz4iSz6pUqpUM4bfZ31AxMZ3OCTV2Xf7NG6+pr3VqZSDW53zERE/oC3wQZ5VC4Fi/9SIyBPAEwB169Yt7t0rpSySnX6W3V89RtPkBazzu446j0+kTc2aVsdSObjbaLdqgDdwNM/yo4BTnxwRWQzMAG4TkYMi0i7vNsaYscaYKGNMVEhISFEzK6XcyKlDu0n64EYaH/+Z+dUfJ/KludTSwuN23K34FBtjTDdjTIgxppwxprYxZm1+24nIHSIyNiUlxdURlVJX4IsV8ayJT4bTR2B8Dzh9lOVzpmDG3kTFjKMsjxrNrU+NJMBPJ9dzR27V7QYkA9lAjTzLawBHXB9HKeWuWtauyDNTNzI3Yiahies49EUvOp7ZyV6pS/q9E+nSItLqiOoy3KrlY4zJAOKA7nlWdQfWlNAxdUoFpUqh9tOasSH7XkJ3TwFjI+zsDrzE0ND7CC208Lg9K67zCRKRSBGJdBy/ruP5+TP+HwLRIvIPEWkqIqOAMOALV2dVSrmxwVtIrdMRm+NpJt7Ymt+HPL/V0liqcKxo+UQBGx2PQGC44+v/ABhjvgWeB4YBm4AbgduMMftLIoye81Gq9DG2bDbPGUNA4krEQCY+eGPjaIYfBOfttVfuSIwxVmdwC1FRUSY2NtbqGEqpApw8eoBDMQ/TLG0DR2yVSa/fhfAeL3B46efs2L2HwIem0T6imtUxPZ6IxBljoi613t0GHLiciNwB3HHVVVdZHUUpVYBtK74nbNnz1DfnGF/1BRrd+jQ3NLJfJhHabwwJ8clsOZiixacU0JaPg7Z8lHJf6elpbBg/hHZHppLgVZes3uNo2OJaq2Opy9CWj1KqVNu3Zxvp06Npl72HX6v2ouVjnxFYPsjqWOoKeXzx0W43pdyTMYbVP35J601vYETY3P5TrrtZp+gqK9zqOh8r6HU+Srmf5BMnWD2yLx02v8Jh//qkP76CVlp4yhSPb/kopdzLb+tWUm3BQG4wh9hc/3Fa9P8vXr5+VsdSxUyLj1LKLZzLyGLJpBF0S/yEM15BHOg5lVbX3GZ1LFVCnCo+IlIfqIf94tDjwFZjzLkSyOUyes5HKevt3refY5OfpGfWWvZUbEedx2KoWknvRF2WFXjOR0Tqici7IpII7AWWAHOAX4GTIrJIRO4TkVJ5/kjP+ShlHWMMc+f8QND4zlyftZ69ka/S8Pl5BGjhKfMuWzBE5BNgM9AAeB1oBlQE/LDPr3Mb9qmu3wS2iMg1JZpWKVVmHEs5yw8fP8+tvz2Gj68fZ/rP46per4FXqfw7VjmpoG63c0CEMSY5n3XHgKWOx3ARuQ0IB34r3ohKqbJmZdwWAmc/xT1sIyG0B/Wiv0QCtPfBk1y2+BhjXi7sjowx8648jlKqLEvLyGbGtK/p+ceblJcMjnYeSf2Oj4OI1dGUixV6wMH5czrGGJvjeU3gdmCnMeaXkolX8nTAgVKusePAMXZMGsrDGbM4Wu4qvB6ZTI2aTa2OpSziTOfqXOBZsM/JA8QC7wPLRaTUXv2lAw6UKlk2m+HbBcvJ/upm7s2YxaFGD1JjyC/4aeHxaM4MtY4CznfD3Q2cAuoD/YGhwMTijaaUKu2OpJzjh5iRPHziE8THl9N3TiAsspfVsZQbcKb4BAEnHV/fDMw0xmSKyFLgs+IOppQq3RZtiiftxxcYxAqOVWlDyCMTkEp1C36h8gjOdLslAjeISHngFmCRY3kVILW4gymlSqez6VmMmvw9DX7oye2s5ETUC1R/ZpEWHpWLMy2fD4FJwBlgP7DSsbwjoJOmK6XYnPgXKya/zcD08WT4Vya7zyyqXNXJ6ljKDRW6+BhjvhSRWKAusOj8qDcgHvi/kginlCodsm2G8YvjqLf6ZZ7ziuOv2p2p3G8clK9qdTTlppy6t5sxJg6Iy7NsbrEmcjEdaq3UlTl0Mo2xEyfx5J/vEOJ1irQub1G5wzN67Y66rIJur/OgSOE+QSISLiIdiieW6+hQa6WKbs7mA/z48bP8358vE1Q+CO8Biwns+KwWHlWgggYcPAbsEpF/ikiLvIVIRKqIyJ0i8j/st9XR/8GV8gBn0rP4z5RFhHx/L4OYQVqTewgevAap1drqaKqUKOj2Ol1EpCfwHPabh54TkWPY7/lWGQjBfo+38cDTxpjjJZxXKWWxDYl/MWPyWF5O/4TyPtlk3f45QW36WR1LlTIFnvNxnNOZKyLVgBux3zw0EEgGNgIbcww+UEqVUVnZNr5YspOgVf/hHe8FnK16NX79JkI1PV+qnOfMaLdk4MeSi1J8RKQO9mHh1YEs4E1jzAxrUylVOnyxIp6WtSvSPqLahWWzNiYxff5Shp17n6u995Me9STlb30TfPwtTKpKs7I6jXYW8LwxZpPjBqhxIjLPGHPW6mBKubuWtSvyzNSNfNmrFtfEvsiYqsOIX/cTX/uOxycgEO6Zjn/jHlbHVKVcmSw+xpjDwGHH10dEJBn7nRi0+ChVgPYR1RjdrzUJk56iLWu5NeExGvgd4Vytdvj3+QYqhFkdUZUBLp8yUEQ6ishPIpIkIkZEovPZZpCIJIjIORGJu5Ih3CLSFvA2xhy4ktxKeYy3qtN+UgT3sxAvDA28jgAQcHSDFh5VbKyYrzYI2AYMBtLyrhSRPsAoYATQGlgDzBeRujm22SQi2/J5hOXZVxXsd9t+ouTejlJlhzGGKdfNYputHsbYl6Xjy7H6d8FgvYuWKj4u73ZzzHg6D0BEYvLZZAgQY4z5yvH8WRG5FXgKeM2xj8iCjiMi/tgHSPzXGLPmioMrVcadOJvB8OnL6bXvLZp778MAePvjl53B8oQ0ah/zpn2w1SlVWeFUy8fRHbZdRFJFpIFj2asicn9xhBERP6AtsDDPqoVAeyf2I0AMsNQYM+ky2z0hIrEiEnv8uF6ipDzX+oQT/Oujz3g9cQA3+uzgbKWmSNTjMGAJEvUYXevAloMpVsdUZYgz02g/j30yuXeB/+ZYlQQ8A/yvGPJUA7yBo3mWHwW6ObGfG4A+wBYR6eVY9pAxJle/gTFmLDAWICoqyhQlsFKlWbbN8MWS35EVI/jEZzYZlSPw7TsX35rN/97o9g+pCgy0LKUqi5zpdhsIDDDGzBWRt3Is3wBcXbyxrowxZjWFbNXpjUWVpzp2+hwjpizg4UNv0sZnLxmtHiSg53vgV97qaMoDOFN8wrEPFMgrE/sdD4pDMpAN1MizvAZwpJiOkYsxZjYwOyoqakBJ7F8pd7Rqz3HmThvDm9mf4+/njbnrG/xa3GN1LOVBnDnn8wfQJp/ltwE7iiOMMSYD+5QN3fOs6o591FuxE5E7RGRsSor2Z6uyLyvbxkdzN5I0cQD/tX2IT82m+D39C6KFR7mYMy2fD4DRIlIOEKCdiDyE/TzQY4XdiYgEAef7uLyAuiISCZwwxiTimDFVRNYDv2Dv7gsDvnAia6Fpy0d5ikMn0xg58QeeSn6LBt6HyWz/AoFdXwdvX6ujKQ/kzL3dxouID/brb8phv3faIeA5Y8y3ThwzCliW4/lwx2MCEG2M+VZEqgLDgFDsXX23GWP2O3GMQtNzPsoTLNp+hNjv3mOEbSImsCJefX7Eq8FNVsdSHkyMcX6Ql+MO117GmGPFH8kaUVFRJjY21uoYShWr9KxsRs3+lcgNw7jZO47U8K6Uu38slK9W8IuVugIiEmeMibrU+iJdZOq4w7VSyo3t//Msn0+YxHMp71LD5xRZ3d6iXLunwcuKG5solZsz1/lUBt4AOmOfqiDXJ9gYU71Yk7mIdrupsmjOxkQSfxzO2/I954Lr4t3vBwjTWUaV+3Cm5TMR+/U8E7Bf9FkmLsrUAQeqLDmXmc3H3y+j847Xud3rd842uZfyvT8Gf70vjnIvzhSfm4BOxpgNJZRFKXUF9hw9zZQJY3j+7CgCfQxZd3xO+dY6vbVyT84Un3isuQt2idJuN1XaGWP4Yf1e0uf+kze8FnK6anP8+0+EqhFWR1PqkpwpJoOBd0SklYh4l1QgVzPGzDbGPFGxYkWroyjltDPpWfx34o80m9ubfl4LOdt2IMGDlmnhUW7PmZbPXuy30dkAYL9x9N+MMWWmIClVGmxPOsn8ie/x/LmvMP7lyb53BuUb32x1LKUKxZniMw2oCDxHGRpwoFRpY4xh+qqtVFz8EkO91nEy7AYq9fsGgmtaHU2pQnOm+EQB1xpj8ru5aKml53xUaZKSlskXk6fR/+Bwanr9xdkOw6jU+UW9dkeVOs4Unx1AhZIKYhUdaq1Kiw37/2T9pH/xYuZUUgNr4tVvAeXrXmt1LKWKxJniMwz4UESGAVuxT6VwgTHmRHEGU0rZ2WyGKYt/pcHqFxnotY2/GtxO5T5jIEAHyajSy5niM8/x70Jyn+8Rx3MdcKBUMfvzTDoTJo7lkaPvEuydQeotH1P5umjIM+BHqdLGmeLTucRSKKUu8uueQ8RPe4khtjmcCG6E78OT8KvexOpYShULZ6ZUWFGSQayiAw6Uu8m2GSbNXUzb34bSz2sff14dTdVe74JvgNXRlCo2ly0+ItIG2GSMsTm+vqTSetsdHXCg3MnRU+f4/pv3eeSvT8HXn7Rek6ja4k6rYylV7Apq+cQCNYFjjq8N9nM8eek5H6Wu0OrtCaR89xyDzEqOV42i2iMTkIq1rY6lVIkoqPjUB47n+FopVcwys21MnjmLm7a8Qjuv4/x5zYuE9HgdvPTvOVV2Xbb45Jm62gAHTD5Tn4pI3eIOppQnOHjiDIu/+Tf9T48n1b8qWX1nUzXiRqtjKVXinBntlgCEYu+Cu0BEqjrW6Z9pSl3GFyviaVm7Iu2rZ8F3j/JLo9ewLRxGtGzmcFg3Qh/6CspVsTqmUi7hTPE5fz1PXkHAueKJo1TZ1bJ2RZ6ZupHZ9X8gbP9aWu+7B28Mm1r+H5G9X9Rrd5RHKbD4iMgnji8N9ikVUnOs9gauBTYVfzTX0KHWylXaT2vGhux0+/3hgXKSAUDkjvfg7qEWJlPK9QpzN8IWjocATXM8bwFchX2KhegSylfidD4f5Spru37Pcf7+nGV6+UOL+2DwVgtTKWWNAls+xpjOACIyHhhsjDlV4qmUKkOysm1MmTmLrluHUkVOYQNs4oe3LYPD6X6EBtewOqJSLlfo+7AbYx7VwqOUc46dPsdXn75J360DCPDxIo5mHG3UH58nl3K0UT927N7Dmvhkq2Mq5XLODDhQSjnht72HSZz6HE/ZFnIs5HrmNX6bRg3qERpRDYDQfmNIiE9my8EU2juWKeUpylzxEZFKwGLs780HGGWM+crSUMqjGGOYsngdzVY9yz1ee/gzchDV73iTaO+Lf93aR1TTwqM8UpkrPsBpoKMxJlVEygPbROQHY8yfVgdTZV9KWiZfTZzII4feINg7k7S7xlM18m6rYynldspc8THGZAPnh4P7Yx+lpxdQqBK3PekkSycM5/n0GM6Ur4t/9LeIToGgVL5cOvG7iHQUkZ9EJElEjIhE57PNIBFJEJFzIhInIh2KcJxKIrIZOAi8b4zRM7qqRH2/dhd/fPkAz2Z8w+nwblR6bpUWHqUuw6XFB/vdELYBg4G0vCtFpA8wChgBtAbWAPNz3jtORDaJyLZ8HmHntzHGnDTGtMJ+M9R+IqJjWVWJOJeZzbtT5tJs/j309FrL2Q6vUzn6WwioYHU0pdyaS7vdjDHzcEzHLSIx+WwyBIjJMUDgWRG5FXgKeM2xj0gnjnfU0QLqAHxX9ORKXWxf8lm+ifmSoaffx9fPB9Pne8o37Gp1LKVKBVe3fC5JRPyAtsDCPKsWAu2d2E8NEQl2fF0R6AjsusS2T4hIrIjEHj9+PL9NlMrXz9sOMffTwbxx5j9IlXoEPr0aby08ShWa2xQfoBr2e8UdzbP8KPYJ7QorHFjlaPGsAj41xuR7/xJjzFhjTJQxJiokJKQomZWHycq2MfKn9Xh/24+nZQZpTe8leNBSqBxudTSlSpWyONptPRBZ2O31xqKqsI6dOse7E37g2eNvUMc7mcxb36f8dQP0btRKFYE7tXySgWwg7+CAGsCRkjqo3lhUFcba+D/5+OP/8mby89QItOH92Hx8r39CC49SReQ2xccYkwHEAd3zrOqOfdRbiRCRO0RkbEpKSkkdQpViNpvhi6U72TH+aUbYPoLQVgQ+8wvUvc7qaEqVaq6+zidIRCJFJNJx7LqO5+eHUn8IRIvIP0SkqYiMAsKAL0oqk7Z81KWkpGYyNGYRkcsf5XGf+WREPUG5AfNA70Kt1BVz9TmfKGBZjufDHY8JQLQx5lvHtNzDsE/ZvQ24zRizv6QC6TkflZ9tSSl8OnEqw8+9RzWfVMxdX+LXqq/VsZQqM8SY/GbG9jxRUVEmNjbW6hjKYsYYpq9PZMecT/iXdwy2oFD8H5wGNVtYHU2pUkVE4owxUZdaX+ZGuylVVGkZ2bzxQxxttr3Nmz7LyajXBf/7x0G5KlZHU6rM8fjio91uCuCP42f496QFDD35Nq18/sDW4SX8Or8GXt5WR1OqTPL44mOMmQ3MjoqKGmB1FmWN+VsP8913U/hEPibY38A90/BqcpvVsZQq0zy++CjPlZlt47/zduKz7lPG+n6LrWpDfB6YCtW0FaxUSfP44qPdbp7pSMo5hk5ezQNH3qWn73qym/XG967R4B9kdTSlPILbXGRqFb3Ox/P8sjeZQaOmM/zYc9zmHQs3v4X3feO18CjlQh7f8lGew2YzjFm+l61LpjDJ9wsCAgOR+3+EBp2sjqaUx9HiozzCydQMhkyPo80fn/Ol7yyyQ1vj3XcyVKxtdTSlPJLHFx8951P2bTl4klcmLee1tJF09NmCafMI3j3eA98Aq6Mp5bE8vvjoUOuyyxjDlF8TmTF7LuP8PqKmz0noOQppG211NKU8nscXH1U2pWZk8c8ftuK1ZToz/L/BJ6gaXn0WQO22VkdTSqGj3VQZ8MWKeNbEJ194Hn/8DLd9uJjW297mQ78v8A2/Dq8nV2rhUcqNeHzLR8/5lH4ta1fkmakb+bJXLRosf5YXj97DB17jifLZDe2fRbq+Ad4e/1FXyq3oXa0d9K7Wpduy349yeOrT9JXFnMMXPx8ffHp/Bs3vtjqaUh5J72qtyjRjDLY3a9DZln6hE7kcGZCdAT8O1OKjlJvScz6q1Np+KIU+Y9cxIO1ZThJ8Yfk5/DhW/y4YvNXCdEqpy9GWjyp1TpzNYOTCXSxbv5HX/f9HT/9VpOGHQRAfP/yzMliekEbtY960Dy54f0op19Pio0qNrGwbU35NZMzCrTyQNZMVAXPw8YK42o9TP2sfgaH1IOpRJHY8XY8eYMbBFNpHVLM6tlIqH1p8VKmwZm8yw3/aTuPkn5kX+C1VSYZmvaHbcNpWDs+98e0fUhUYaElSpVRheHzx0aHW7u3AiVRGzNvJ4e2rGRkwmeZ+uzHVW8GtkyC8vdXxlFJF5PHFR2+v457SMrL5fEU8M1f8xlCvqdzlvxpTrgZ0+wxp1Q+8dKyMUqWZxxcf5V6MMczdepiRczZxx9nvWew3Bz8vA+1fRG58Afx1BIFSZYEWH+U2dh4+xRuztlEjcS7f+n9Ldd/j0LQXdB8OletZHU8pVYy0+CjL/XU2g5GLdrFt/VKG+02mld9uTI2WcOsEqHeD1fGUUiVAi4+yTFa2jWnrE5n481oGZU/hLb9V2MqHQNfRSGQ/8PK2OqJSqoSU2eIjIuWAncAMY8xQq/Oo3NbG/8k7P22gU/J0ZvvNxs/XQPsX8Orwop7XUcoDlNniA7wOrLM6hMrt4F+pvDN3J147fmCs33Rq+iZjmtyJ3PymntdRyoOUyeIjIg2BJsBsoLnFcRT2odNfroxn9fKF/NN7Am38dmOr0QJ6TEDq3Wh1PKWUi7n0YgkR6SgiP4lIkogYEYnOZ5tBIpIgIudEJE5EOhThUB8Ar11xYHXFjDHM23qYviNnUmfFEL7zeZ1W5U/AnZ/i9eQK0MKjlEdydcsnCNgGTHQ8chGRPsAoYBCw2vHvfBFpZoxJdGyzifxz32yMOSQidwG7jTG7RUQvgbfQ70dO8fasDbRKnMy3vj/Zz+u0ex7vDi9CQAWr4ymlLOTS4mOMmQfMAxCRmHw2GQLEGGO+cjx/VkRuBZ7C0ZIxxkQWcJjrgb4ich/2YucrIqeMMf+58negCuNkagYfLtzFX799y7u+0wjzTcbW5A68bn4TqtS3Op5Syg24zTkfEfED2mLvMstpIVDoFowx5jUchcrRrdf8UoVHRJ4AngCoW7eu86FVLtk2w9T1icz/eR5Dsr8hync32dWvhh4xeNUvSu+pUqqscpviA1QDvIGjeZYfBbqVxAGNMWOBsWCfRrskjuEp1v3xJ5/8uJLeJ75hqs9KsspXg26f4N36Qb1eRyl1EXcqPsXOGBNT0DZ6V+srk3QyjffnbKLWzm/42vcn/P2yMdcPxqfjUD2vo5S6JHcqPslANlAjz/IawJGSOqje1bpozmVm8+XyeBJWTWaoTKG2bzLZjW7H+9Y3oUoDq+Mppdyc2xQfY0yGiMQB3YEZOVZ1B74vqeNqy8c5xhgWbDvCjNlzGHjuKwZ77SKjWjPoOR7v+h2tjqeUKiVcWnxEJAg4/7+8F1BXRCKBE46h1B8Ck0RkPfAL9skow4AvSiqTtnzy98WKeFrWrphrGupvf0tk+tLf6Hc6hq99VpEdWAVuHoVf64f0vI5SyimubvlEActyPB/ueEwAoo0x34pIVWAYEIr9mqDbjDH7SyqQtnzy17J2RZ6ZupEve9Wi9a9DGMYzVEmYxRSfWfj7ZsP1z+Db6SUIqGh1VKVUKSTG6CAvsI92i42NtTqG2ziXmU3Mmn1UWPIyfWUxqfgTJOlkXHUbfj3egqoRVkdUSrkxEYkzxkRdar3bnPNR1ktIPsvqHYkc2P4LLx95iYFiu3ADpiDSAfDbtwSqTrMwpVKqLPD44uPJ3W5pGdnE7tjNgc3LkYPraJy+jT6SgJ9kg0C6d3m8s9PwwUYafpyu34Pqd79vdWylVBng8cXHkwYcGJuNxL3b2LdxKSZxLXXPbKGDHAIgE1/+qnI1aQ0G4te4A+uzr2L///7JvSwCnwACstKZnZBG7WPetNfpdpRSV8jji0+Zlp1JWuIGEjctJXPfWsJSNhFOCuHAKYI4UqkVCfX7E9ayM/512lLdN+DCSzesiOe+OiA1HoOoR5HY8XQ9eoAZB1NyjYBTSqmi8PgBBzm63Qbs2bPH6jhX5twpzIH1nPh9Jefif6Faylb8jf1czQFTnYPBrZDwdoRHdiE0ohV4uXRGDaWUBylowIHHF5/zSuVot5QkSFxLRsIazv2xhqCTu/DCRrYRtpt6xAc0h7rXU7tlZ1o1a4qfjxYbpZRr6Gi3ssJmg+M7IXEtJnEdmQlr8DuTBECm8WezrSFbve4mI+w6arfoQPtm9WhZKdDi0EoplT+PLz5uO9otMw2S4iBxHSSuwxz4FUk/BUAylfk1uxGxtq78WaUNdZpdQ6fGoQwIr4yvt7ZulFLuT7vdHCzvdjubbC80BxzF5tAmxJYJwAHvuqzOaMj67Eb87nc1Da5qRqcm1enUKIQaFQIK2LFSSrmedru5I2PgxB+QuNbx+BX+tA92yPbyZb9/E1aanqzMuIo4WyPq1qpFp0Yh9G8cQmSdSvho60YpVcpp8XGF7Ew4vOXvYnPgVzh7HIAs/0oklm/B6vI3Mvuvumyx1SeQ8nRsFMLtjUN4t2EIIcH+Fr8BpZQqXlp8rtTpI/Ddo3BvDAQ7piI6lwIHf7twvoaDsZCVBkB2xXCSqrRjbXBD/nesNhtSQuCUFy1rV+KmyBD+2TiElrUr4e0l1r0npZQqYR5ffK54wMGK92D/WvjhCajW0F5sjm4DDIg3pmYLjjXqy/qsRnyfXJsVh70xR6FqeT86Ng7h4cYhdGgYQpXyfsX5tpRSyq3pgAMHZwccZP0nBB9bxkXLDcLZdkPZYJrwY3IoS+LPkpKWiZdA67qV6dQohJsah9A8rCJe2rpRSpVROuCghGzsvYLj37/ELd6/4Z2dTpaXH/OzohhffgAbltnP0YQEp9G9WQ1uahzCjVdVo1I5bd0opRRo8Smya1o04/CWusjuXziHL37ZmZy0lcOnYigvXWtv3TStWUFbN0oplQ8tPlcg1PsU66r1Yviha3k1ZB19a2bxUL92VsdSSim3pxeMXIE114xi0Mn+dO/clRfOPsRv131idSSllCoVtPgU0Zr4ZJ6ZupHR/Voz5ObGjO7XmmembmRNfLLV0ZRSyu15fPERkTtEZGxKSopTr9tyMIXR/VpfmNumfUQ1RvdrzZaDzu1HKaU8kQ61drD83m5KKVWGFDTU2uNbPkoppVxPi49SSimX0+KjlFLK5bT4KKWUcjktPkoppVxOR7s5iMhxYD9QEbjUeOlLrasGlJYLfC73/i7FmfdXlP0X536KO2tB2xTl8wKl5zPjipzF8Zkpak5njl3YbQva7nJZi+v3pzhc6fc03BgTcsmtjDH6yPEAxjq7Doi1OndxvL/LvKbQ768o+y/O/RR31oK2KcrnxdmcVj5ckbM4PjNFzenMsQu7bSE+M5fMWly/P1b+7Av7HrTb7WKzi7iutCjp91Bc+3fF97owxyhom7L+eXEFK79Pzhy7sNteyfspC5+ZQr0H7XYrBiISay5zMVVpV5reX2nJqjmLV2nJCaUna0nn1JZP8RhrdYASVpreX2nJqjmLV2nJCaUna4nm1JaPUkopl9OWj1JKKZfT4qOUUsrltPgUkoh0FJGfRCRJRIyIROdZLyLyhogcEpE0EVkuIldbFNcpIvKaiPwmIqdE5LiIzBaR5nm2iXG875yPdRZkfSOfHEdyrLfk51Acnw8RqSwik0QkxfGYJCKVijlnYX7WbpE1n9xGREa7W04R8RaRN0UkQUTOOf59S0R8cmzj8qwFfSYd2zQSkR9E5KSIpIrIBhFpmmO9v4h8KiLJInLWsb/aefZR1/E5OuvY7hMR8SsonxafwgsCtgGDgbR81r8MvAg8C1wDHAMWiUiwyxIW3U3AGKA90AXIAhaLSJU82y0GQnM8bnNhxpx25cnRIsc6q34OxfH5mAq0AW51PNoAk4o5500U/LN2l6wAiMj1wBPAljyr3CXnK8DTwHNAE+yfgaeB1yzOetnPpIjUB34BErB/FpoDw4AzOTb7GLgHeADoAFQA5oiIt2Mf3sBcINix/gHgXmBkgemsvpCpND4cP5zoHM8FOAy8nmNZIHAaeNLqvEV4f0FANnBHjmUxwBw3yPYGsO0S69zi51CUzwfQFDDADTm2udGxrLGrftbulhX71fLxQGdgOTDa3XICc4AJeZZNOP/74g5Z834mHcumAlMK+N5nAP1zLKsD2IBbHM97OJ7XybHNg8A5oMLlMmnLp3jUB2oCC88vMMakASux/4VZ2gRjbxX/lWf5jSJyTER2i8hXIlLdgmwADRzdFwkiMl1EGjiWu+vPoTC52mH/D2JNjtf9ApylZLPn/Vm7W9axwHfGmGV5lrtTztVAZxFpAiAizbC3JOa5YVYcGb2AO4AdIrLA0QX7m4j0ybFZW8A3T+4DwM48uXc6lp/3M+DveP0lafEpHjUd/x7Ns/xojnWlyShgE7A2x7IFwMNAV+zdB9cCS0XE38XZfgWisXdLDMD+/V0jIlVx359DYXLVBI4bx5+OAI6vj1Gy2fP+rN0mq4gMAK7C3hWUl9vkBN7F3j22Q0Qyge3YW0Jj3DDredWxt3r/ib24dAemAVNEpGeOTNlcfH+3vLnzvq9kx+sum9vnciuV5xGRD7E39280xmSfX26MmZ5js60iEof9Rqw9gR9clc8YMz/nc7EPevgDeARw+QCI0uxSP2t3ICKNgRHYs2VanacAfbD/YdYPe+GJBEaJSIIxZpyVwS7jfMNjljHmQ8fXm0QkCngG+3kclwRQV+b8aKsaeZbXyLHO7YnIR9hPGHYxxvxxuW2NMYeAg0BDV2S7TI4z2H/hG+K+P4fC5DoChIiInF/p+Lo6JZD9Mj9rd8naDvtdlbeLSJaIZAGdgEGOr/90k5wA7wMfGGOmG2O2GmMmAR/y94ADd/me5pSMfbDJjjzLdwJ1c2Tyxv5zyClv7rzvq5rjdZfNrcWneCRg/0Z3P79ARAKwj/5Yc6kXuRMRGcXf/xn9XojtqwG1sJ9ItYzj+9zEkcNdfw6FybUWezdIuxyvaweUp5izF/CzdpesP2IfxRiZ4xELTHd8vdtNcgKUw97NlFM2f///6i7f0wuMMRnAb0DjPKsaYe/RAIgDMvPkro19cETO3E3zDL/uDqQ7Xn/ZEPoo3GiRIP7+JUgF/uX4uq5j/SvY57C4G/uQxenAISDY6uyFeG+fAaewnyStmeMRlOO9f4D9l6Ee9uG6a7G3fFz6/hw5OmE/iXsd9pFGp7DPHWLZz6E4Ph/AfGCr4/vczvH1bFf+rN0paz7Zl+MY7eZOObGPBD2IvQu6HtAbOA6MtDJrIT6TvbCPZnsC+7m1AdiLTc8c+/jc8d66Aa2BZdjPEXo71ns7ci51rO8GJAGfFpivJD8sZemB/T9ck88jxrFesA8DPox9mOEKoLnVuQv53vJ7XwZ4w7E+EPsIlmOOD+t+xy9cHQuynv+lzXB8yL8HmuVYb8nPoTg+H0BlYDL24nDK8XUlV/6s3SlrPtmXk7v4uEVO7CMGP3b8XqRhPwc5AgiwMmtBn0nHNtHYW5Fp2K+jeiDPPvyBT7F3c6Ziny6hTp5t6mL/IzDVsd0ngH9B+fTGokoppVxOz/kopZRyOS0+SimlXE6Lj1JKKZfT4qOUUsrltPgopZRyOS0+SimlXE6Lj1JKKZfT4qOUUsrltPgopZRyOZ1SQSk3JyLLsd99+CT2+3DZgInAy8YYm3XJlCo6bfkoVTr0x34L/PbY51t5Hvs8MkqVSnpvN6XcnKPl42+MaZdj2SJgvzHmH5YFU+oKaMtHqdJhS57nh7BPNKZUqaTFR6nSIe9U0gb9/VWlmH54lVJKuZwWH6WUUi6nxUcppZTL6Wg3pZRSLqctH6WUUi6nxUcppZTLafFRSinlclp8lFJKuZwWH6WUUi6nxUcppZTLafFRSinlclp8lFJKuZwWH6WUUi73/++6CiJa2VJ1AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2.632408365759907"
+      ]
+     },
+     "execution_count": 259,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fig1, ax1 = plt.subplots()\n",
+    "\n",
+    "datatype = 0; print(datatypes[datatype])\n",
+    "m = 0; plt.plot(nSizes,data[m,:,datatype],'x-',label=methods[m])\n",
+    "m = 1; plt.plot(nSizes,data[m,:,datatype],'*-',label=methods[m])\n",
+    "\n",
+    "ax1.set_xscale(\"log\")\n",
+    "ax1.set_yscale(\"log\")\n",
+    "ax1.set_xticks(nSizes)\n",
+    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "plt.xlabel(\"n\")\n",
+    "plt.ylabel(\"time (s)\")\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"curvesWithNoMKL.pdf\")\n",
+    "plt.show()\n",
+    "\n",
+    "rate = (np.log(data[m,-1,datatype])-np.log(data[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
+    "rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 261,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "double\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAAA5g0lEQVR4nO3dd3xUVfrH8c+TCiEhlFBCAgRC7yV0RUAQwQJ2BdEgyAK64roqFn67uqu4rl0REUWaFBcQQ5depJoAUqWEEkIJRCCUhNTz+2MGTEIgmZDMnSTP+/WaFzP3nrn3O5kJT869Z+4RYwxKKaWUM7lZHUAppVTJo8VHKaWU02nxUUop5XRafJRSSjmdFh+llFJOp8VHKaWU03lYHcBVBAQEmJCQEKtjKKVUsRAVFRVvjKl0o/VafOxCQkKIjIy0OoZSShULInL0Zuv1sJtSSimn0+KjlFLK6bT4KKWUcjotPkoppZxOi49SSimn09FueXThwgVOnz5Namqq1VGUypGnpyeVK1embNmyVkdRRdS4NdE0C/anY+U0mD0QHp7EhtPu7IhNYOgdoQW6Ly0+eXDhwgXi4uIICgqidOnSiIjVkZTKwhhDUlISx48fB9ACpPKlWbA/z0/fxsLQuQTGbOLk/Ld5PvoBxvRrWeD7Ep3PxyYsLMzc6Hs+Bw8epFq1avj4+Dg5lVKOSUxM5MSJE9SpU8fqKKooeqcypCVfv9zDG0addmhTIhJljAm70Xo955MHqamplC5d2uoYSuWqdOnSemhY5dulh2aQ6Fbm2uNUN29o+giM2Fng+9Lik0d6qE0VBfo5VfmSkc7hn97B+4dHkfRUMgykiRfuGSmcTPYCvyoFvks956OUUiVYUtxBTk8ZSK3LO1jl1h63jGTq1WtEYLdhnFz5FXv2H+BwdDwdQwMKdL9afJRSqiQyhqPLx1Fp/VuUN8JPtf9BbPB9tAqpQKC90AT2G8vh6Hh2xCZo8VFKKXVrUs6f4tjkQYSe+4VIt6ZI37H0bdYsx7YdQwMKvPCAnvMpMcaOHcuRI0fy3H7SpEns2bOn8AIppSwRu+EHkj5rQ9DZzURU/Sv1X1lB6xsUnsKkxacEiImJ4cUXX6RcuXKIyE1v4eHhAERGRjJ27Ngs2wkPD+fee+/NdX9bt27F3d2dTp06XbcuPDz82r48PT2pXbs2L7/8MpcvX3ZoOwBxcXGMGDGC0NBQvL29CQoKolevXixatOimmRcsWICPjw+jRo3K9bXkJi8ZlHIF6Ynn2TeuP8FLh3DcBLD17gj6DH0Hv9LeluTRw24lQEREBJ07d6ZcuXKcPHny2vIFCxbw7LPPZll2dUh5nz59eOaZZxgzZozD+/v2228ZPnw4U6ZMYe/evTRs2DDL+u7duzN16lRSU1NZt24dgwcP5vLly3z11Vd53s6RI0fo1KkTfn5+vPfeezRv3pyMjAxWrFjB0KFDiYmJyTHb1KlTGTx4MP/9738ZMWKEw68ts/xmCA8PJyQkhLfeeitP+3G0vVLZnfptKe4RzxGaHs/CCgNoH/4fGvn7WppJi4+TXLtsRaZjpxvsJ/IK+rIV2UVERNCnTx8Aqlatem15uXLlrlt2VZcuXbh48SJRUVG0bt06z/tKSkpi+vTprFu3jsTERCZMmMCHH36YpY23t/e1ffbr149Vq1bx008/ZSk+uW1n+PDhgK2H5uv75y9Rw4YNefLJJ3PM9umnnzJy5EgmTJhwwzaOyE8GpZzJpCaxb9orNDgylSMEsrvzNHp36+USQ/L1sJuTXL1sxYboeMBWeJ6fvo1mwf6Fut/z58+zdu1a7r//foee5+npSa9evfjpp58cet7s2bOpWbMmTZs2ZcCAAUyZMiXXLz3m9MXIm23n7NmzLFmyhOeeey7Lf/pXXS2qmY0aNYo33niDuXPnFkhhyE8GpZzpjwNbOPHfdjQ4MpVlZe7D+7lf6HJnb5coPKA9n3x7e/5u9py44NBzKvt589SELVQp603chWTqVPbls+UH+Gz5gTw9v1G1svzzvsYO7XPBggU0btyYmjVrOvQ8sB16e/fdd/n3v/+d5+dMmDCBAQMGAHDHHXfg4+NDREQEDz/8cI7tt2zZwvTp07nzzjvzvJ2DBw9ijLnucN6NLFu2jIULF7JgwQJ69+6d59dyM45mUMpp0tP4ffbbhO79kjRTluVhY7nznn64ublG0blKez5O5F/akyplvTl+/gpVynrjX9qz0Pe5aNGifP+H26tXL3bv3n3DcxfZHTx4kF9++YV+/foBtm/b9+/fnwkTJmRpt2TJEnx9fSlVqhQdOnSgc+fOfPHFF3nejqPXI2zSpAmhoaG8/fbbnD9/Ptf206ZNw9fX99pt3bp117VxJMPo0aOzbG/atGnXLcu8D0fbK3XVhdi9HP7gdhrs/ZyN3reRNHgd3e/r73KFB7Tnk2+O9kDgz0NtL3Srw/ebYxjRvW6hjJ/PLCQkxKEh1pkdPXoUHx8fKleunKf23377Lenp6dSoUePasqv/SR87dozq1asD0LlzZ8aPH4+npyfVqlXD09PToe3UrVsXEWHv3r088MADueYKDAxk3rx5dOvWje7du7Ns2TLKly9/w/b3338/7dq1u/Y4KCjoujaOZBg6dCiPPvrotccjR44kKCiIF154Icd9ONpeKYxh38JPqRH5HhWMBz83fJc7HxmOh7vr9i+0+DjJ1cIzpl9LOoYG0D60YpbHhaVv37707NmTtLQ0PDwce7sjIiLo2bMnpUqVyrVtWloakydP5r333rtuaPOAAQOYOHEi//jHPwDw8fG54VWX87qdnj17MmbMGF544YXrzrmcP3/+unMuQUFBrF69mm7dunHnnXeybNkyKlasmGMGPz8//Pz8bvp6K1SokOcMFSpUoEKFClm2X6FChRv+DBxtr0q2xPhjHJs8iPoXNxPp0RLfR7+mZ736VsfKleuWxWJmR2xClkLTMTSAMf1asiM2oVD326ZNG3x8fFizZo3Dz808Su6qCxcusH379iy3I0eOsHDhQuLj43n22Wdp0qRJltvjjz/OxIkT83SoKq/b+fLLLzHGEBYWxqxZs9i3bx+///47X331Fc1u8IW5wMBAVq9eTUpKCt26dSM+Pt7hn0lm+cmgVEE6uGoKqWM6UOPCNn6u+TJNXl1OgyJQeEB7Pk6T03DqwrpsRWYiwv33309ERMR1J/VvJjY2lt9+++263se6deto2TLrxFIPPfQQKSkpdO3aNcfexCOPPMJrr73GsmXLct3vhAkT8rSdu+66i61btzJ69GhGjhzJ8ePHqVixIs2bN2f8+PE33H6VKlVYtWoV3bt3p2vXrqxYsSLPhxWzq127dr4yKHWrki/+wcFJQ2n8x1L2uNUl7f6v6NmijdWxHKKTydndbDK5nL4oWZQsWbKEoUOHOnTuZ+zYscyaNYtVq1YVXjBVKIr651Xd3JEt8ymzeATlMs6zuupAOoS/i2/p3A+NO5tOJqfo1q0b586dY/v27Xl+TkREBH379i20TEopx6RducSO8UMIWfQkl0wpfus5ix7DPnLJwpMXetitBPDy8iIhwbFzSz///HMhpVFKOer47vWYH4fQLD2WVeUeokX4J9QqV7hfUC9sWnyUUspFZaSmsHPm/9H44HjipTwbOn1H1x4PWR2rQGjxUUopF3T68A4uTR9E89T9rC9zJ3XDv6Jj5YKfztoqxe6cj4jcKyL7ROSAiAy2Oo9SSjnCZKTz2+z/UHZyNyqknGBtiw/p+MocKhejwgPFrOcjIh7Ax0BXIAGIEpG5xpg/rE2mlFK5O3fiEKemDqZ5UhRRXm2o8uR4OteobXWsQlHcej5tgd3GmOPGmEvAYuAuizMppdTNGcPOxd/gMb4TNRJ3sab+m7QYuZTgYlp4wMWKj4h0FpF5InJcRIyIhOfQZriIHBaRKyISJSK3Z1pdDTie6fFxQC+CpZRyWRfPxfHbJw/QdPPLxLjX5FS/ZdzxxKu4u/B12QqCq706X2AXMAJIyr5SRB4DPgNGAy2BDcBiEamRva1SSrm6vWvnkPxZOxomrGVtjWHUHbmO0PrNrY7lFC5VfIwxi4wxbxhjZgMZOTR5CZhkjPnGGLPXGPNX4CQwzL7+BFl7OkH2ZUopZZlxa6JtE0lePAUTe3El7gBrP36Shiuf4aL4cbDPPDo/8x+8vAp/mhVX4VLF52ZExAtoDSzNtmop0NF+fwvQRESCRMQX6AXc8NuSIjJERCJFJPLMmTOFEdvlhYSEXDfNtVKqYF2dyfjk/H9hjm4k7avbuS1hAT+XfYQqr2ykUavbrI7odEWm+AABgDsQl215HFAVwBiTBvwdWAVsBz662Ug3Y8x4Y0yYMSasUqVKhRLaSuHh4YjIdbf27dtfa/Prr78yfPhwp2ebNWsWYWFhlCtXjjJlytCiRQsmT55cYNuPjo5m0KBBVK9eHW9vb2rWrMnDDz/Mhg0bCmwfSuVVxxmN2Jr+MIH7pyEYfEnCTQw9E+fh43P9NOwlQVEqPnlijJlnjKlnjKljjCnxlxbu3r07J0+ezHJbtGjRtfWVKlXCx8fH6bkqVqzIqFGj2LRpEzt27GDgwIEMGjQoS7b8ioyMpFWrVuzevZuvvvqKPXv2MH/+fFq3bs1f//rXGz5PRPJ88dXVq1cTEhJyy1lVyRD34BwuyJ9zRKWKNzR9BEbstDCVtYpS8YkH0oHs37SqApxyfpx8sh/z5WL2Dlzh8Pb2pmrVqllumScqy37Ybf/+/dxxxx2UKlWK+vXrs2jRInx9fZk0adK1NsePH+fxxx+nfPnylC9fnnvuuYcDBw5cW//WW2/RpEkTZs6cSWhoKH5+fvTt2zfL/DndunWjb9++NGjQgNDQUEaMGEGzZs1ueXpoYwzh4eHUrl2b9evXc++99xIaGkqzZs14/fXXWbFixS1tXylHbVv0DWX+9wjeGYlkGEgTL9xNCieTvcCveH1x1BFFpvgYY1KAKKBHtlU9sI16KxrW/BdiNsGa961Ocp2MjAweeOABPDw82LRpE5MmTeLtt98mOTn5WpvExES6du1KqVKlWLNmDRs3biQwMJDu3buTmJh4rd2RI0f44YcfmDt3LkuXLmXbtm28+eabOe7XGMOKFSvYt28fnTt3vqXXsH37dnbv3s0rr7yCu7v7deuzz3CqVGFJupRA5GeP03LLyxx1q0GkNCGufn88/rKSuHr92LP/gG0QQgnlUlc4sA8SuDpXsBtQQ0RaAGeNMTHYrl4wVUS2AOuBodi+2zPO6WEXvwanHOgyx6yHzHMnRU6w3USgRqe8baNqU+j1H4diLlmy5Lopnp977jnef//64rds2TL27dvH0qVLCQqyDRr85JNP6NTpz3wzZ87EGMPEiRMREQC+/vprKleuzIIFC3j00UcB23TYkyZNwt/fduXdIUOGMHHixCz7S0hIICgoiOTkZNzd3fnyyy/p1auXQ68vu6s9MJ3PRlnp0G+/4BXxLK3ST7I++Bl+C/0LLWoGEGifPDKw31gOR8ezIzah0CeUdFUuVXyAMGyDBa56236bDIQbY34QkYrAKCAQ23eCehtjjjo9qaOqtYFzhyHpDzAZIG7gUxHK1yrU3Xbu3Pm6WTVv9Nf/77//TrVq1a4VHrBNw+3m9mcHOSoqisOHD+Pn55fluYmJiURHR197XLNmzWuFB6BatWqcPn06y3P8/PzYvn07ly5dYsWKFbz00kuEhITccMbVxo0bc/So7a2+/fbbWbx48XVtHJkcMfP2Mi+7WlRr1qzJ7t27AYiJiaFRo0bX2qWnp5OcnJylsD/55JOMG+f8v4OU6zAZ6UTOeIfm+z/jnJRjV49pdLrtHnL689IZMxm7MpcqPsaY1YDk0mYsMNYpgW7GwR4IAPP/BlsngUcpSE+BhvfDvR8XeLTMfHx8qFOnTu4N8ygjI4MWLVowc+bM69ZlPpfk6Zn1+woiQkZG1q9uubm5XcvWokUL9u7dy+jRo29YfBYtWkRqaioApUuXzrFNvXr1ANtsntmn+77Z9gDq1q3LokWLrhXfzK+hWrVqWSbj27x5MyNHjmT16tXXlpUtW/am+1PF27m4Yxyf9DRtkqKIKnMbtQZOoFmlqlbHclkuVXyKvcunofVACBsIkRPhknMGHeRVgwYNOHHiBCdOnKBatWqAbeRY5qLRqlUrZsyYQUBAQIGfP8nIyMhyfim7mjVr5rqNFi1a0KhRIz744AMee+yx6877nD9//lrunLZXs2bNHEexeXh4ZCnisbGx1y1TJdfutXOouvJv1DGJbGz4Ju0ffRlxKzKn1C2hxceZHp/25/1C7vFclZyczKlTWQcDuru7k9P3mnr06EH9+vV5+umn+fDDD0lKSuKll17Cw8Pj2qGo/v378+GHH9KnTx/+9a9/UaNGDY4dO0ZERARDhw6lbt26ecr17rvv0q5dO2rXrk1ycjKLFi1i6tSpfPHFF7f0ekWEiRMn0r17d2677TbefPNNGjZsSGJiIosXL+Z///sfkZGRt7QPpa5KTU5i26SXaHtyOofcanL+wdl0aNLW6lhFghafYm758uUEBgZmWRYUFERsbOx1bd3c3Jg7dy6DBw+mbdu2hISE8NFHH/Hggw9SqpRtnngfHx/Wrl3La6+9xiOPPEJCQgLVqlWja9eulC9fPs+5Ll26xLBhw4iNjaV06dI0aNCAKVOm8MQTT9zaCwbatm1LVFQUo0ePZujQoZw+fZrAwEDatGnDmDFjbnn7SgGcOLiTxJnhtE07yMaKD9D8mS/wKeOX+xMVAOLICdriLCwszNzoL+K9e/eW2NFTv/32Gy1atCAyMpLWrVtbHUflQUn+vDqFMWyd9yUNtv6LFPEkuv1/aH33AKtTuRwRiTLGhN1ovfZ8VBZz586lTJky1K1blyNHjvDSSy/RvHlzWrVqZXU0pSx3KeEs+yc8S6sLy9nt1ZQKAybRuoae98sPLT4qi4sXLzJy5EiOHTtG+fLl6dKlC5988sm1cz5KlVQHt67CZ/5faJZxhvU1h9JuwDt4eJacq1AXNC0+KounnnqKp556yuoYSrmMjLQ0oqb/k5bRYzkjFdnX+390apf9QivKUVp8lFLqBuJPHOb05Kdpk/wbv/p1od4z3xJYofhdAd8KWnzyyBijh56Uy9MBRAVn58oZVF/7CiEmhY1N36b9gy/od3cKkBafPPD09CQpKcmSqQeUckRSUtJ1V5dQjkm+cpkd371Am9OzOeheG/dHJtKhQQurYxU7WnzyoHLlyhw/fpygoCBKly6tPSDlcowxJCUlcfz4capUKbmX6b9Vx/ZtJe1/A2mTfoQNlR6l1TOfUaq0/tFZGLT45MHVa3adOHEiy7XAlHIlnp6eVKlSRa8xlw8mI4OouZ/SeMd7JEkptt42no7dH7M6VrGmxSePypYtq7/UShVDF86d5tCEQYRdWsuOUq2o+tQkWgXlfh1BdWu0+CilSqx9W36m3OLhNM44x/rQEbTv/88cJyFUBU+Lj1KqxElPSyVq6hu0PvINJ92qcPC+H+kU1sXqWCWKFh+lVIly+tgBzk59mrYpu9nsfxcNB31NsH+F3J+oCpQWH6VUibHj58mEbHyd6iadTS3fo12fYTp61SJafJRSxd6VxIvsmjCcsD/msc+9LqWemET7Ok2sjlWiafFRShVrR3dvhjmDCMs4xvqqAwgb+AHe3jlPw66cR4uPUqpYMhkZRM16n6Z7PuKilGF710l0uuMBq2MpOy0+SqliJyH+JEe+G0hY4ka2lW5H8MDvaFEl2OpYKhMtPkqpYuX3DfOpuPSvNDQXWV/vFTo8/gZu7npBUFej74hSqkgatyaaDdHxcPEUTOxF2tkYVnwxnHo/DyBRynDkwXl06j9KC4+L0p6PUqpIahbsz/PTt7EwdC5Vj27k4ue3cScJrPLtRZuhX+Pr5291RHUTWnyUUkVSxxmN2JqeDPttj8uTAEDX5JWghcflaX9UKVUkXQpfwVmPytcep4oXNH0ERuy0MJXKKy0+SqkiZ/8vc7ky4T78U0+TYSBNvHA3qZxM9gI/nc+oKNDio5QqMlKvXGL7uMHUWx7OBVOGSGlMXP3+ePxlJXH1+rFn/wHbIATl8vScj1KqSDixewMZPz5Li/RY1lZ4hB0NRtAqNJDA0AAAAvuN5XB0PDtiE+hoX6ZclxYfpZRLM+mp7PzhLRru+4qz4s/m2yfS+c4H6ZxD246hAVp4iggtPkopl3U+dh9/TA2nWfIeNvh0oXb4ONpVCbQ6lioAWnyUUq7HGPYvHkPwlneoZNxY2Xg0XR4ejpubTn9QXGjxUUq5lCvnT3Fk4iAaJPzCNvdmlHnsG7rVa2B1LFXAtPgopVzGsY1z8Fv6N2plJLKk+gi6PPV/lPLytDqWKgRafJRSlsu4cpH9U16gwYkf2U8ICffM4O62nayOpQqRFh+llKX+2LuOtNlDqJd2ksXlHqftwA+oV66s1bFUIdPio5SyRnoqB2f9H7V+H8cpE8DKDhO5u2dfRHRQQUmgxUcp5XSXT+zh7JRw6lzZxwrvOwl9eizdq1W1OpZyIi0+SinnMYaYJZ9RZfO7lDFeRNT/D70f+wueOudOieNQ8RGRWkAIUBo4A+w0xlwphFxKqWIm7fxxYic9Q8j5TWxya0mph8fRp5EOoS6pci0+IhICDAOeAIKAzAdkU0RkHTAemGOMySiMkEqpou3M5h8oteTvVMlIZnbVF7kr/E3KlvayOpay0E37uiLyOfAbUBt4E2gE+ANeQFWgN/AL8G9gh4i0KdS0SqkixSSd58i3A6i0eAhHTGU29viJh4e9rYVH5drzuQKEGmNyukb5aWCl/fa2iPQGagK/FmxEpVRRdPH31aTMHkJw6hlm+/Wn48D/0LSiDqFWNjctPsaYV/O6IWPMoluPo5Qq8tKSiZ3zJtX2fssfpgprW3/Hg/f21euyqSzyPOBARNwArp7XEZGqwL3AXmPM+sKJp5QqSpKP7+T89+EEJx1kgWdPavf/lAdCqlkdS7kgR0a7LQSWAJ+JiC8QCZQBfEVkkDFmSmEEVEoVARkZnF72CeU2jsbN+PB96H956PHBlPZytzqZclGOFJ8w4OphuAeBC0AtoD/wMqDFR6kSKONcDKemPEO1c7+yRsJw7zuGJ1s0tDqWcnGOFB9f4Lz9/l3AXGNMqoisBL4s6GBKKRdnDAlbpuGx5FX8M9KYVOnv3Pv0qwT4lbI6mSoCHCk+MUAnEZkP9AQesS+vACQWdDCllAtLPMvJ6c8RGLuIraYex+74hKe7dtLrsqk8c6T4fAxMBS4BR4G19uWdgZ0FnEsp5aKSfl9OyuyhBKSeZYrPU3QK/zetqpSzOpYqYvJcfIwxX4tIJFADWJbpagbRwP8VRjillAtJTeLMT29Qafd3xGYEsaH5dzzR5368PPS6bMpxDl3bzRgTBURlW7awQBMppVzDxVMweyA8PIm0hJMkTB9IpcRDzHK/h5r9PuDpekFWJ1RF2E2Lj4g8CUwzxpjcNiQiNYEaxph1BRVOKeV849ZE0yzYn457/wsxm0j+/jHc4naSavz4qsYH9Os3EP/SOrW1ujW59XyeAf4hIpOA+cCuzIVIRCoAtwFPAl3s7ZVSRdiQtR1wS0++9tg7bhsAAW6XGTZoiFWxVDFz04O1xphuwN+AO4DtwCUROSwie0XkFLZpFb4GDgKNjTELCjmvUqqQub2wnfPlmnD1z8wU48Gx4HvweGmXtcFUsZLrOR/7OZ2FIhKArZdTE9t8PvHANmCbTqWgVPFgzh0lfvoQKp3fhQGSjQeekk71qlXBr4rV8VQx4shot3jgp8KLopSyjDFc3PAdHstHUTojgwPutYjKqEtK86fw/m0q3eOOUdHqjKpYKZbTaItIdWzfSaoMpAH/NsbMsjaVUq7JJMRyZtpfqHz6FzZmNGZdo38yY7/w5YBWdAwNYEOzDvSYvo0x0fF0DA2wOq4qJorrAP004EVjTCNslwL6VETKWJxJKddiDBc2TSbps7b4xv3KeN9hVHpuMWUD6/Bl/1bXCk3H0ADG9GvJjtgEiwOr4qRY9nyMMSeBk/b7p0QkHttlgC5bGkwpF2EunOTU9GEEnlpFpKnPgfbvM6hnF9zdhDpV/K9r3zE0QHs9qkA5vecjIp1FZJ6IHBcRIyLhObQZbh9Vd0VEokTk9lvYX2vA3Rhz7FZyK1Us2C8GmvhpG8qf/IXvfJ+l3LBlPNGrK+462ZtyIit6Pr7ALmxTMFw3DYOIPAZ8BgwHfrH/u1hEGhljYuxttpNz9ruMMScybauCfR/PFvBrUKrIMZdOc3LacKqdXMY2U5f97d/n6Z7dtOgoSzhUfERkOPActnl8mhhjDonIa8AhY8z/8rIN+3Tbi+zbm5RDk5eAScaYb+yP/yoidwPDgNft22iRh6ze2Ebn/ccYsyEv2ZQqrhIi/4fbopepmH6ZKb4D6TjgbR6rev3hNaWcJc+H3UTkRWAUMB7I/KfSceD5gggjIl5Aa2BptlVLgY4ObEeAScBKY8zUgsimVFFkLscT+83j+C94liPpFZnXfib9//4JdbTwKIs5cs5nKPCsMeYzbKPJrtoKNC6gPAGAOxCXbXkcUNWB7XQCHgP6ish2+61p9kYiMkREIkUk8syZM/kOrZQrOr/1Ry5+1JrKsUuZVuYpfIav4pFePfQwm3IJjhx2q4ntXE12qdiueOAyjDG/kIfCaowZj60nR1hYWK4XT1WqKDCJZzk2/QVqxM5njwnh93Zf8/jdPbXoKJfiSPE5BLTCNpFcZr2BPQWUJx5IB7Jfx6MKcKqA9qFUsXV++3yYP4LAtPP84NufsAHv8GDVClbHUuo6jhSfD4ExIuKD7ZxPBxEZALxKAV3N2hiTIiJRQA8g8xUJegBzCmIfShVHJuk8R6e/SMixuewz1dnT9gse7tVbezvKZTlybbeJIuIBjAZ8sF2+5gTwgjHmh7xuR0R8gTr2h25ADRFpAZy1D6X+GJgqIluA9djONVUDxuV1H0qVJOd2LMFEPE/1tHjm+D5GywHv8UBVvRKbcm2OzmT6DfCN/QrXbsaY0/nYZxiwKtPjt+23yUC4MeYHEamIbWRdILbzTL2NMdkP9ylVopkrFzg8/SVqx8wi2lRjXZsp9O19n/Z2VJGQry+Z2q9wnS/GmNVkHaqdU5uxwNj87kOp4u7srmVkzH2OkLTTRJR5iOZPfUAf7e2oIiTPxUdEygNvAV2xXS06y2gyY0zlAk2mlLqOSb7IoRmvEHpkBkdMVTa2mci9vftqb0cVOY70fKZg+z7PZGzfu9GhyUo50R+7V5M+dyihaSdZ6NOHxgM+4r7ASlbHUipfHCk+XYA7jDFbCymLUioHJuUyB2eMJPTw98SaSiwK+5Ze9zyMm/Z2VBHmSPGJpvjO/6OUS/pj7zpS5gylblosP/vcS4MnP6F3NT3CrYo+R4rJCOA9EWkuIu6FFUgpBSY1id+nvEi5H+4jI/UKS1p9TY+Xv6emFh5VTDjS8zmI7TI6WwFs1+78kzFGC5JSBSB+30aSZw+hQWoMy0v3ou6AT7m7miOXNlTK9TlSfGYA/sAL6IADpQqcSb3C3h9GUe/gBOJNOZa2Gkv3+/rpuR1VLDlSfMKAtsaYnC4uqpS6BWcObOHK/4bQKPUwq0r3IHTA59xVrZrVsZQqNI4Unz1A2cIKolRJZNJS2P3DP6m//2vO48fylp/T7f6ntLejij1His8o4GMRGQXsxDaVwjXGmLMFGUyp4mbcmmiaBfvTsXIazB5IfOuXSIgYSZP0aNaV7krIgDF0Dwq2OqZSTuFI8Vlk/3cpWc/3iP2xDjhQ6iaaBfvz/PRtLKw1h6pHN1D+yAagLDND3+PRJ4dpb0eVKI4Un66FlkKpEqDjjEZsTU+2jRsF3AUCuMDjMW+B23AroynldI5MqbCmMIMoVdztC/s3tTa9gadJQwRS3bzxbHw/3PWu1dGUcrqbFh8RaQVsN8Zk2O/fkF52R6mcpaamEPXdS7Q/OZXz+FFWLpEunrhnpHAy2YtAv+wT9ypV/OXW84kEqgKn7fcNOU+HoOd8lMrBiZhozk0dQPvU3az2vQdzKY4G9eoT2G0YJ1d+xZ79BzgcHU/H0ACroyrlVLkVn1rAmUz3lVJ5tHnZbOqs/xu1TDLb2vyX3/260yzYn0B7oQnsN5bD0fHsiE3Q4qNKnJsWn2yzhxrgmDHmuisbiEiNgg6mVFGVdCWF9d+9Sre4ScR6VCfliam0rNOCljm07RgaoIVHlUiOjHY7jG1a6yxTZ9unvD6MHnZTioOHDnFhWjjd039jV6Ve1B/0DZ6l/ayOpZTLcaT4XP0+T3a+wJWCiaNU0WSMYfmSH2m+6e8Ey2X2txtNk7uHg+h3d5TKSa7FR0Q+t9812KZUSMy02h1oC2wv+GhKFQ0Jl5NZ+d2b3Bc/gTOegSQ+MYd6oa2tjqWUS8tLz6ep/V8BGgIpmdalYJti4cMCzqVUkbB93yEu/zCYBzKiiK7cg1rPTMCttL/VsZRyebkWH2NMVwARmQiMMMZcKPRUSrm49AzD3Pk/0WHryzSW8xxr/y9Ce76gh9mUyiNHrnAwsDCDKFVUnE5IYsl3b/H4+W+44FmJ5P6LqF6rndWxlCpSHBlwoFSJt3ZnNKlzhvEUmzlepQvVwichPuWtjqVUkaPFR6k8SEnLYMqPEXTfNZLqbmc402EUQXe9rIfZlMonLT5K5eLImUssnPQegy99zRXvcqQ9sYBKtTtZHUupIk2Lj1I3sSByP8z/G8/JL8RXvY2ApyZDGb0igVK3SouPUjlITElj7A8L6HvgdWq5nSKhw6sE9Hgd3NysjqZUsaDFR6lsdp9IYN6Uj3gx6SsyvH3hsbn41+lidSylihUtPkrZGWOY9ss+vJe9xutuq0io2g7/J6eAX1WroylV7GjxUQo4dzmFj2YspH/MP2joFkNiuxfxv+v/wF1/RZQqDPqbpUq8LYfPMm/aGF5L/RIPL2/Mo7PwqXeX1bGUKta0+KgSKz3DMHb5bsque5t33JdyuUprSvWfAv7BVkdTqtjT4qNKpJMJSbz7/RKejfsXzd0PkdJ2OGV6/gvcPa2OplSJoMVHlTjL98SxYNa3vJvxJaW93OCh7/FqeJ/VsZQqUbT4qBIjOS2d9xfuosqv7/Opx0KSKzfF64mpUKGW1dGUKnG0+KgSIfrMJd76fhkjzo0mzGM/6a0H4X33aPAsZXU0pUokLT6q2JsTFcuSiO/53G0Mfl4Z0GcC7k0ftjqWUiWaFh9VbF1KTuMfc38jZNfnfO0RQXrF+ng88T0E1LU6mlIlnhYfVSztjE3gn9NW8PLlD+josYeMFv3x7P0hePlYHU0phRYfVQyMWxNNs2B/OoYGYIxhwi+HWblkDl97jqGC5xW490vcWj5pdUylVCZafFSR1yzYn+enb+OjuytTbflzJF8KYarHAq74heD+5DSo0tjqiEqpbLT4qCKvQ+2KDGhfkzMRf6eL+07qe+7kTM17qdRvHHj7WR1PKZUDLT6qSDt4+hI1xtbib6Rk+TRXOroAPgiFUaetC6eUuiGdGUsVSYkpafxn8e8899kMfiMUgAwEgCS8OF2rD4zYaWVEpdRNaM9HFSnGGJbsOsVH86N4OHEGizwXk+Hpw7bU+rRgP3iUolRaMvMPJxF82p2OetRNKZekxUcVGYfOXOKfEbuocCiCH7xnUtHjLLR8kqk+4dwX81+kym0QNhCJnMidcceYFZtAx9AAq2MrpXIgxhirM7iEsLAwExkZaXUMlYPElDS+XHWQtWtX8ZbHZFrLXkxgS+SeDyE4zOp4SqkciEiUMeaGv6Da81EuyxjDz7vj+HT+Fp64PIUIzxVQqhz0+BxpOQDc9JSlUkWVFh/lkg7HX+btiJ1UOTSbmV4/4O95CQkbBF3fAJ8KVsdTSt0iLT7KpSSlpDN29UE2rl3KP90n0tQzGhPc3naIrWpTq+MppQqIFh/lEowxLN97ms/mrWfApcnM9lhNepkq0PMbpOkjIGJ1RKVUAdLioyx39I/L/HveToIPTmOm5xx8PJOhwwu43/GqXqFAqWJKi4+yzJXUdL5aHU3kmvn8w30S9T1jyKjdFbde/4VK9ayOp5QqRFp8lCVW7I3jy4g1hF/+jr95bCS9bHXo9T1uDe7VQ2xKlQBafJRTHTubyLvzthFyYArTPH/C2zMDbh+Je6cXda4dpUoQLT7KKa6kpvP1mkPsXDObN90mU8vzJBn1euN292ioUMvqeEopJ9Piowrdqn2nGffTSgZdGs8I9yjSytWGe2bjVreH1dGUUhYptsVHRHyAvcAsY8zLVucpiY6dTeT9eVupe3ACUz3m4+7tCV3ewqP9cPDwtjqeUspCxbb4AG8Cm6wOURIlp6XzzZpofl89g9fdphLkcYb0Rg/i3vMd8A+yOp5SygUUy+IjInWBBsB8oInFcUqUNfvPMGHuEgZf+prn3XeSWrEB3DsR91q3Wx1NKeVCnHplRhHpLCLzROS4iBgRCc+hzXAROSwiV0QkSkTy87/Wh8DrtxxY5dnx80mMmLyOvVNe5LukEXQsdQTufh/P4etBC49SKhtn93x8gV3AFPstCxF5DPgMGA78Yv93sYg0MsbE2NtsJ+fcdxljTohIH2C/MWa/iHQsnJehrkpOS+fbtYc4snoSb8o0KnucI715f9x7vA2+layOp5RyUU4tPsaYRcAiABGZlEOTl4BJxphv7I//KiJ3A8Ow92SMMS1y2U174HEReQRbsfMUkQvGmH/d+itQma07cIbJPy7g2cvjeM7td1IqN4f7Z+Ouc+wopXLhMud8RMQLaI3tkFlmS4E892CMMa9jL1T2w3pNblR4RGQIMASgRo0ajocuoU4mJPFRxBaa7v+Crz1WkF7KH3p+jpfOsaOUyiOXKT5AAOAOxGVbHgd0L4wdGmPGA+PBNpNpYeyjqBq3Jppmwf5ZpqFeu/8ME3+JJvjIHN6QGZTzuExG62fwuvNNnWNHKeUQVyo+Bc4YM8nqDEVVs2B/np++ja/7BtEm8u9MDX6LOas28ZbHJFq4HSK5Wlvc7v8YN51jRymVD65UfOKBdKBKtuVVgFPOj1OydQwNYEy/lhyaOozWbKT94acZ4HWS5FKVofc3eOscO0qpW+AyxccYkyIiUUAPYFamVT2AOdakKplS0jJwH12VjhnJ15bVdTsJgHdqAjR71KpoSqliwqnFR0R8gTr2h25ADRFpAZy1D6X+GJgqIluA9cBQoBowzpk5S6qYPxKZvvko+yKX83hqE3q4RyHG1sG5gicXavWm8oMfWB1TKVUMOLvnEwasyvT4bfttMhBujPlBRCoCo4BAbN8J6m2MOerknCVGanoGK/bG8b9NByl/aAHhHj/zmtthkr19OZhWg7pyDDy88U5LZvXhJIJPu9NRJxdVSt0iZ3/PZzVw0xMFxpixwFinBCrBjp9PYuaWGFZu2c7dVxbxocdKKnhdIK1CPejwEVMvtOOBI/9CqvSAsIFI5ETujDvGrNiELCPglFIqP8QYHWEMtqHWkZGRVscoVOkZhtX7TjN901EuHljHU+5L6eW+BTcMpt7duLUfCrXu0IEESqlbJiJRxpgbfuPcZQYcqMITd+EKP/x6jB83H6TN5ZW84rmMBl6HyfD2x63VcGgzGNEJ3ZRSTqTFp5jKyDCsOxjP9M1H2b13L0+4LWW+12r8PC9gKjWAdp/i1uxR8CpjdVSlVAmkxaeYOXMxmVlRx5i5OYaq57cyxHsZX3n9iohB6vWGdn9BQm7XQ2tKKUtp8SkGjDFsPPQH0zbHsGZ3DL35hSmlVxDifQhTqhzS+nkIGwTla1odVSmlAC0+Rdq5yynM2RrL9M0xXIk/yuBSK/ig1Cp80i9AhcbQ7nOk6SPg5WN1VKWUykKLTxFjjCHq6DmmbY5h4c4TtMrYzWi/VbQrtREEpN690O4vULOTHlpTSrksLT5FREJSKnO3xjJ9SwwxcX/wuPdG1vquoOqVaHArD7eNsB1aK1fd6qhKKZUrLT4uzBjDb7EJTNt0lPk7ThCQFsdL5dZyj98yvFMvgH9TuGsMNH0YPEtbHVcppfJMi48LupScRsT240zbFMOekwl09fqdOeVX0+jieuSKQMP7bIfWanTQQ2tKqSJJi48L2XU8gelbYojYdpyMlMsMqxDF9IAllLsUDWkV4ba/Qdgz4B9sdVSllLolWnwslpSSzvwdJ5i2OYbfjp0n1OMMY6usp9PFJXgkXoCqzeDOsdDkIfAsZXVcpZQqEFp8LLI/7iLTN8cwZ2ssF6+k8miFaL4IXkH1+LXIWTdo1Md2aK16Oz20ppQqdrT4ONGV1HQW7zrJ9M0x/HrkHOXcU/hH8HbuvbKA0gkHgQDo/LLt0FrZalbHVUqpQqPFxwmiz1xixuYYZm+N5XxiKp3KJzC/7joan16AW9wFCGwBXcdB4wf00JpSqkTQ4lNIUtIyWLrnFNM2xbDx0B94uhleCDlOf1lM+eOrkePu0Kiv7dBacBs9tKaUKlG0+OTTuDXRNAv2zzKx2oboeNbuO4O4CbMijxF/KYW65WBKk+10/ONHPE4chDKV4Y5XofVAKBto3QtQSikLafHJp2bB/jw/fRtj+rWkbUgFvlwVzZhVB0hNN7gJPFEnlWGlVxB0ZC5y8CIEtYYu46FxX/Dwtjq+UkpZSotPPnUMDWBMv5a8MWU5H/Ap3yf/lbI+Ffm/Bie5O3EepY6sBDdP23mcdn+B4BtO6KeUUiWOFp9b0DE0gP8ELKZ1/O/MKDeWUJ8kZE80+FaBLq/bDq35VbE6plJKuRwtPvn1TmVIS6Y9gECdK7vgCrbezou7wMPL4oBKKeW63KwOUFT92mc1i7iNdHfb+ZsMNy8Wcju/PrhOC49SSuVCi08+RZ31pmXdGrhnpIJHKdxMGq3q1SDqDy08SimVGy0++TT0jlAC3S/YzusMXg6tBxLolsDQO0KtjqaUUi5Pz/ncisen/Xn/3o+ty6GUUkWM9nyUUko5nRYfpZRSTqfFRymllNNp8VFKKeV0WnyUUko5nRYfpZRSTifGGKszuAQROQMcBfyBhBs0u9G6ACC+kKIVtJu9vhtx5PXlZ/sFuZ2Czppbm/x8XqDofGackbMgPjP5zenIvvPaNrd2N8taUL8/BeFWf6Y1jTGVbtjKGKO3TDdgvKPrgEircxfE67vJc/L8+vKz/YLcTkFnza1Nfj4vjua08uaMnAXxmclvTkf2nde2efjM3DBrQf3+WPne5/U16GG3683P57qiorBfQ0Ft3xk/67zsI7c2xf3z4gxW/pwc2Xde297K6ykOn5k8vQY97FYARCTSGFNsJ+wpSq+vqGTVnAWrqOSEopO1sHNqz6dgjLc6QCErSq+vqGTVnAWrqOSEopO1UHNqz0cppZTTac9HKaWU02nxUUop5XRafPJIRDqLyDwROS4iRkTCs60XEXlLRE6ISJKIrBaRxhbFdYiIvC4iv4rIBRE5IyLzRaRJtjaT7K87822TBVnfyiHHqUzrLXkfCuLzISLlRWSqiCTYb1NFpFwB58zLe+0SWXPIbURkjKvlFBF3Efm3iBwWkSv2f98REY9MbZyeNbfPpL1NPRH5UUTOi0iiiGwVkYaZ1nuLyBciEi8il+3bC862jRr2z9Fle7vPRSTXWTW1+OSdL7ALGAEk5bD+VeDvwF+BNsBpYJmI+DktYf51AcYCHYFuQBqwXEQqZGu3HAjMdOvtxIyZ7cuWo2mmdVa9DwXx+ZgOtALutt9aAVMLOGcXcn+vXSUrACLSHhgC7Mi2ylVyjgSeA14AGmD7DDwHvG5x1pt+JkWkFrAeOIzts9AEGAVcytTsU+Ah4AngdqAssEBE3O3bcAcWAn729U8ADwMf5ZrO6i8yFcWb/c0Jz/RYgJPAm5mWlQYuAn+xOm8+Xp8vkA7cl2nZJGCBC2R7C9h1g3Uu8T7k5/MBNAQM0ClTm9vsy+o76712tazYvi0fDXQFVgNjXC0nsACYnG3Z5Ku/L66QNftn0r5sOjAtl599CtA/07LqQAbQ0/64l/1x9UxtngSuAGVvlkl7PgWjFlAVWHp1gTEmCViL7S/MosYPW6/4XLblt4nIaRHZLyLfiEhlC7IB1LYfvjgsIjNFpLZ9uau+D3nJ1QHbfxAbMj1vPXCZws2e/b12tazjgdnGmFXZlrtSzl+AriLSAEBEGmHrSSxywazYM7oB9wF7RGSJ/RDsryLyWKZmrQHPbLmPAXuz5d5rX37Vz4C3/fk3pMWnYFS1/xuXbXlcpnVFyWfAdmBjpmVLgKeAO7EdPmgLrBQRbydn2wyEYzss8Sy2n+8GEamI674PeclVFThj7H86Atjvn6Zws2d/r10mq4g8C9TBdigoO5fJCbyP7fDYHhFJBXZj6wmNdcGsV1XG1ut9A1tx6QHMAKaJyD2ZMqVz/fXdsufO/rri7c+7aW6Pm61UJY+IfIytu3+bMSb96nJjzMxMzXaKSBS2C7HeA/zorHzGmMWZH4tt0MMh4GnA6QMgirIbvdeuQETqA6OxZUu1Ok8uHsP2h1k/bIWnBfCZiBw2xkywMthNXO14RBhjPrbf3y4iYcDz2M7jOCWAujVXR1tVyba8SqZ1Lk9EPsF2wrCbMebQzdoaY04AsUBdZ2S7SY5L2H7h6+K670Necp0CKomIXF1pv1+ZQsh+k/faVbJ2wHZV5d0ikiYiacAdwHD7/T9cJCfAB8CHxpiZxpidxpipwMf8OeDAVX6mmcVjG2yyJ9vyvUCNTJncsb0PmWXPnf11Bdifd9PcWnwKxmFsP+geVxeISClsoz823OhJrkREPuPP/4x+z0P7ACAI24lUy9h/zg3sOVz1fchLro3YDoN0yPS8DkAZCjh7Lu+1q2T9CdsoxhaZbpHATPv9/S6SE8AH22GmzNL58/9XV/mZXmOMSQF+BepnW1UP2xENgCggNVvuYGyDIzLnbpht+HUPINn+/JuG0FveRov48ucvQSLwD/v9Gvb1I7HNYfEgtiGLM4ETgJ/V2fPw2r4ELmA7SVo1080302v/ENsvQwi24bobsfV8nPr67DnuwHYStx22kUYXsM0dYtn7UBCfD2AxsNP+c+5gvz/fme+1K2XNIftq7KPdXCkntpGgsdgOQYcADwBngI+szJqHz2RfbKPZhmA7t/YstmJzT6ZtfGV/bd2BlsAqbOcI3e3r3e05V9rXdweOA1/kmq8wPyzF6YbtP1yTw22Sfb1gGwZ8EtswwzVAE6tz5/G15fS6DPCWfX1pbCNYTts/rEftv3DVLch69Zc2xf4hnwM0yrTekvehID4fQHnge2zF4YL9fjlnvteulDWH7KvJWnxcIie2EYOf2n8vkrCdgxwNlLIya26fSXubcGy9yCRs36N6Its2vIEvsB3mTMQ2XUL1bG1qYPsjMNHe7nPAO7d8emFRpZRSTqfnfJRSSjmdFh+llFJOp8VHKaWU02nxUUop5XRafJRSSjmdFh+llFJOp8VHKaWU02nxUUop5XRafJRSSjmdTqmglIsTkdXYrj58Htt1uDKAKcCrxpgM65IplX/a81GqaOiP7RL4HbHNt/IitnlklCqS9NpuSrk4e8/H2xjTIdOyZcBRY8xgy4IpdQu056NU0bAj2+MT2CYaU6pI0uKjVNGQfSppg/7+qiJMP7xKKaWcTouPUkopp9Pio5RSyul0tJtSSimn056PUkopp9Pio5RSyum0+CillHI6LT5KKaWcTouPUkopp9Pio5RSyum0+CillHI6LT5KKaWcTouPUkopp/t/59PBRMC+sEgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2.7178167899437664"
+      ]
+     },
+     "execution_count": 261,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fig1, ax1 = plt.subplots()\n",
+    "\n",
+    "datatype = 1; print(datatypes[datatype])\n",
+    "m = 0; plt.plot(nSizes,data[m,:,datatype],'x-',label=methods[m])\n",
+    "m = 1; plt.plot(nSizes,data[m,:,datatype],'*-',label=methods[m])\n",
+    "\n",
+    "ax1.set_xscale(\"log\")\n",
+    "ax1.set_yscale(\"log\")\n",
+    "ax1.set_xticks(nSizes)\n",
+    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "plt.xlabel(\"n\")\n",
+    "plt.ylabel(\"time (s)\")\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"curvesWithNoMKL.pdf\")\n",
+    "plt.show()\n",
+    "\n",
+    "rate = (np.log(data[m,-1,datatype])-np.log(data[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
+    "rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 262,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_mkl = np.ones([M,N,NT], dtype=np.float64) * 60 * 60 * 24\n",
+    "\n",
+    "executable = [\n",
+    "    \"build_mkl/performance_tlapack\",\n",
+    "    \"build_mkl/performance_tlapack\"\n",
+    "]\n",
+    "M = len(executable)\n",
+    "\n",
+    "methods = [\n",
+    "    r\"$\\langle$T$\\rangle$LAPACK - C++ using MKL BLAS\",\n",
+    "    r\"Eigen3 - C++ using MKL gees\"\n",
+    "]\n",
+    "\n",
+    "for s in range(M):\n",
+    "    for i in range(N):\n",
+    "        n = nSizes[i]\n",
+    "        for j in range(nRuns):\n",
+    "            expr = executable[s]\n",
+    "            output = !$expr {n} 0 | grep time\n",
+    "            for k in range(NT):\n",
+    "                data_mkl[s,i,k] = np.minimum( float(output[k].split()[2]), data_mkl[s,i,k] )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 263,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "float\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAABQC0lEQVR4nO3dd3gUVdvA4d9Jr4QSQgkQIPQSeldAiohIU1ApSudFXhU79l5ey6eiiIhSpAkKIoKIFGmCgKFK772EACEhPdnz/TGbsOm7IdlNss99XXslO3N25pnsZJ89c86co7TWCCGEEPbk4ugAhBBCOB9JPkIIIexOko8QQgi7k+QjhBDC7iT5CCGEsDtJPkIIIezOzdEBFBWBgYG6evXqjg5DCCFKhB07dkRqrcvntF6Sj1n16tUJDw93dBhCCFEiKKVO57ZeLrsJIYSwO0k+Qggh7E6SjxBCCLuT5COEEMLunD75KKV6K6Wm3bhxw9GhCCGE03D63m5a62XAspYtW47JrVx0dDQREREkJyfbKTIhhLPz9fWlSpUquLjYp54wdcNxwqoE0D40MH3ZluOR7D13g3GdQgt0X06ffKwRHR3N5cuXCQ4OxtvbG6WUo0MSQpRwJpOJ8+fPExkZSVBQkF32GVYlgMfn72Ly4Ga0q1mOv09cTX9e0CT5WCEiIoLg4GB8fHwcHYoQwkm4uLhQoUIFTp8+bbfk0z40kE8fbMLImf9QPdCXiJhEJg9ulqEmVFCcvs3HGsnJyXh7ezs6DCGEk3F3dyclJcVu+9tx+hpvLztAQoqJQ5diGNy6WqEkHpDkYzW51CaEsDd7fe7EJ6Xy7vIDDJj6N9HxydTwimFT0Mf8sW0PW45HFso+JfkIIYQTCz91jXu/2MR3f52ka70gUrXmh1prqRq9m9m11vP4/F2FkoCcvs1HKdUb6F2rVi1HhyKEEHYTn5TKJ6sOM2PzSYJLezN/dBtaz6+PmykJjhllKh2Zx07mkTLPA16/UqD7d/qaj9Z6mdZ6bEBAgKNDEUIIu/jn1DV6TtrI9L9OMrRNCH881ZH2tQJx6zcFXNxvFXTzhsYDcXt6X4HH4PTJx1lMmTKFU6dOWV1+1qxZHDhwoPACEkXW8OHDue+++xwdhigE8UmpvL3sAA9+8zepWjN/TBve6dcIXw9X+OtzWDIWPPwABW5ekJoInqXAv0KBxyLJxwmcOXOGp556itKlS6OUyvUxfPhwAMLDw5kyZUqG7Vj7obRz505cXV3p0KFDlnXDhw9P35e7uzs1a9bkueeeIzY21qbtAFy+fJkJEyYQGhqKp6cnwcHB9OzZkxUrVuQa8/Lly/Hx8eHVV1/N81jyYk0Mxc2kSZOYO3duoe8n7VwYNWpUlnUTJ05EKZXhvbPmvcxP4rQ8J5VSBAYGct9993Ho0KFc952dvM7ZK1euMH78eKpXr46npycVKlSga9eurF692qaY82P7SaO2M2PzSR5pG8LKCR2NnmxJsbBoBKx5Axr0hWptoeVIGL0GWoyAm5cLJR6nb/NxBkuXLqVjx46ULl2aixcvpi9fvnw5Y8aMybAsrUt53759GTlyJJMnT7Z5f9999x3jx49n9uzZHDx4kPr162dY361bN+bMmUNycjKbNm1i9OjRxMbG8vXXX1u9nVOnTtGhQwf8/f354IMPaNKkCSaTibVr1zJu3DjOnDmTbWxz5sxh9OjRfPTRR0yYMMHmY7OU3xiGDx9O9erVefPNN63aj63lb5c9L0FXrVqVH3/8kS+++AJfX18AUlJSmD17NtWqVcv1tQX5XqadkwAXLlzg+eefp3///hw8eNCm7eR17j/wwAPExcUxffp0atWqRUREBBs2bODq1au3FX9u4pJS+PiPw8zacooqZbz5YUxb2oWWM1ZeOwkLh8Ll/dDtTejwFFj2sLvv00KLS5KPHdhzyIrsLF26lL59+wJQsWLF9OWlS5fOsixN586diYmJYceOHbRo0cLqfcXHxzN//nw2bdqU/k/2ySefZCjj6emZvs/Bgwezbt06fvnllwzJJ6/tjB8/HjBqaH5+funL69evz9ChQ7ON7fPPP2fixIlMnz49xzK2yE8M9tC5c2caNWqU4YvD8OHDiYyMZPny5QBs3LiRF154gX379uHq6krdunWZMWMGjRo1ylK2c+fONGjQgNKlSzNt2jRcXFx49NFH+eijj9KHfYmNjeWxxx7j559/xtfXl6eeeorNmzcTGBjIrFmzcow1LCyMCxcu8OOPPzJixAgAfvvtN7y8vOjYsWOOH8oF/V5anpMVK1bk6aefpnfv3sTHx1t9j19e52xUVBSbNm1i9erVdO3aFYCQkBBatWp12/HnZNuJq7yweC+nr8YxrF0IL9xTD19P88f+8T/hpxGAhqGLoFa3QosjO3LZzQ7ShqxI66645Xgkj8/fRViVwv+GGRUVxcaNG+nTp49Nr3N3d6dnz5788ssvNr1u0aJFhISE0LhxYx555BFmz56d53h43t7eWcrktp1r166xcuVK/vvf/2b40E+TllQtvfrqq7z88sssWbKkQD6s8hNDUZGSkkLfvn2544472LNnD9u2beOpp57C1dU1x9fMmzcPNzc3tmzZwuTJk/n8889ZuHBh+vpnn32WDRs2sGTJEv7880/27NnDpk2brIpn1KhRzJgxI/35jBkzGDFiRI73uBT0e5lZTEwMCxcupHHjxjbdXJ7Xue/n54efnx+//vorCQkJBR63pbikFN78dT8PTduK1rBgbFve6tvISDxaw+ZJMPcBKFUZxq63e+IBqfnky1vL9nPgQrRNrwny9+TR6dupUMqTy9GJ1AryY9Kao0xac9Sq1zeoXIo3eje0Odbly5fTsGFDQkJCbH5t3759ee+993jnnXesfs306dN55JFHAOjUqRM+Pj4sXbqUAQMGZFt++/btzJ8/P/2boDXbOXbsGFrrLJc0crJ69Wp+++03li9fzr333mv1seTG1hiKkujoaKKioujduzehoUbNu169erm+pkGDBrz99tsA1KlTh2+//Za1a9cyaNAgbt68yYwZM5g9ezbdu3cHjPevSpUqVsUzePBgnnvuOY4ePYq/vz8rV67kyy+/5PXXX89StjDeS4CVK1emf4mIjY2latWqNrfb5XXuu7m5MWvWLMaMGcO0adNo1qwZHTp0YODAgbRp06bAjmXriau8sGgvZ67FMbx9dV64py4+HuaP+qRY+PUJ2LfYaN/pOwU8s355sgep+dhJgLc7FUp5cj4qgQqlPAnwds/7RQVgxYoV+f4n7dmzJ/v378+x7SKzY8eO8ddffzF48GDAuDt7yJAhTJ8+PUO5tH90Ly8v2rVrR8eOHfnyyy+t3o7W2qbjaNSoEaGhobz11ltERUXlWX7evHnp31L9/Pyy/QZvSwzvv/9+hu3NmzcvyzLLfdha3lZly5Zl+PDh9OjRg169evHpp5/m+R6HhYVleF65cmUiIiIAOH78OMnJybRu3Tp9va+vL40aNbIqnjJlytC/f39mzJjB999/T+fOnXNs77H1vbRWx44d2b17N7t372b79u107dqVu+++m7Nnz1r1emvP/QceeIALFy6wbNkyevbsyZYtW2jbti3vv//+bR9DXFIKbyzdx8PTtqIULBzbljf7NLyVeK6fguk9YN/P0PUNGPi9wxIPSM0nX/JTA0m71PZkl1rM3XaGCd1qF9qYSZaqV69uUxdrS6dPn8bHx8fqQQ2/++47UlNTM3xwpH1Inz17lqpVqwLGP/q0adNwd3encuXKuLu727Sd2rVro5Ti4MGD9O/fP8+4KlWqxK+//kqXLl3o1q0bq1evpkyZMjmW79OnT4ZvosHBwVnK2BLDuHHjePDBB9OfT5w4keDgYJ588sls92Fr+cxcXFyyJMfMlzVnzpzJU089xcqVK/n111955ZVX+OWXX+jRo0e228z8HimlMJlMOcZgq5EjRzJs2DD8/PzSa1jZsfW9tJaPjw+WN5p/9913BAQEMG3aNKtq/tae+wBeXl50796d7t278/rrrzN69GjefPNNnnvuOTw8PPIV/9/HrzJxcQ61HYDj64webdoEQ36C2t3ztZ+C5PQ1H3tMJpeWeCYPbsYzd9dl8uBmhTZkRWb9+vVjxYoV+RqccOnSpfTo0QMvL688y6akpPD999/zwQcfpH+D3L17N3v27CEsLIyZM2eml037Rw8JCcnyoWbNdsqWLUuPHj2YPHkyN2/ezBJLdt+Ig4ODWb9+PbGxsXTt2jXX3kX+/v7UqlUr/ZHddX9bYihbtmyG7fn7+2dZZrkPW8tnVr58+Qw9GAH27NmTpVyTJk2YOHEi69evp3Pnznz//fc5bjM3oaGhuLu7888//6Qvi4uLY98+629M7Nq1Kx4eHkRGRtKvX79cy9ryXuaXUgoXFxfi4uLyLGvLuZ+dBg0akJKSkq92oNjEFF5fuo9B3+ZQ29EatnwJc+8Hv4owZl2RSDwgNR+rJ5O7HXvP3cgwLHn70EAmD27G3nM3Cr3206pVK3x8fNiwYUOWdpW8LF26NMO3bTDaC3bv3p1hWenSpdmzZw+RkZGMGTOGcuXKZVj/8MMPM3XqVF577bU89/nbb79ZtZ2vvvqKDh060LJlS9555x3CwsLQWrNu3To++OCDbC8jVapUifXr19O1a1e6dOnC2rVrCQzM/98/PzHYQ5cuXXjqqaf49ddfqVu3Lt988w1nz56levXqAJw8eZJvvvmGPn36EBwczIkTJ9i7dy+PPfZYvvbn5+fHyJEjmThxIoGBgVSqVIl3330Xk8lk9cCYSin27t2L1hpPT888y+f2XuZ0jqYdf3YSExO5dOkSANevX0//UtG7d+/0Mrd77l+7do2BAwcycuRIwsLC8Pf3Jzw8nI8++oiuXbtSqlSpPI/b0pbjkUxcvJdz1+MZ2aEGz/eoi7eHRaeRpDhY9iT8+xPU7w39vgZPf5v2UZicPvnYQ3bdqduHBtrlsptSij59+rB06VKbks+5c+fYs2dPlhvrNm3aRLNmGSeWeuCBB0hKSuKuu+7K8s8HMHDgQF588UWrbqSbPn26Vdu5++672blzJ++//z4TJ07k/PnzlCtXjiZNmjBt2rQct1+hQgXWrVtHt27duOuuu1i7dm2+50qpWbNmvmIobCNHjmTv3r2MHDkSgP/+97/079+fyEijpu3j48ORI0cYOHAgkZGRVKhQgSFDhjBx4sR87/OTTz4hNjaWPn364Ofnx9NPP83ly5etqjWn8fe37YMxu/cScj5HFy1alOO21qxZQ6VKldLjqFevHj/99BOdO3dOL3O7536nTp1o27YtkyZN4tixYyQmJhIcHMzgwYNtuuE5NjGF//1+iDlbT1O9nA8//qcdraqXzVjo+mlYOAQu7YMur8Gdz2a8f6cIULY23pZULVu21OHh4dmuy+5mseJk5cqVjBs3zqa2nylTpvDTTz+xbt26wgtMlFiJiYmEhITw/PPP8+yzzzo6nGLN8vNny7FIXli8l/NRRm3nubsz1XYATmyAn4aDKRUe+A7q3G3/oAGl1A6tdcuc1kvNxwl06dKF69evs3v3bpo2bWrVa5YuXZrntXch0uzatYuDBw/SunVrYmJi+PDDD4mJieGhhx5ydGglws3EFP73+0Hmbj1DjUDf7Gs7WsPWKbDqVQisAw/Ph3KFfxN7fknycQIeHh7Y2qHijz/+KKRoREn16aefcvjwYdzc3GjatCkbN260+l4fkbPE5FR6fLaRCzfiGX1HDZ7NrraTFAfLJsC/P0K9+6D/1CLVvpMdST5CiNvWrFkzcrpsLfIn1aS5dCOeKzeT8HRzYdG4drQIKZu1YNQZWDAELv0Ld71qtO+4FP2OzJJ8hBCiiLmZkMy56/EkpZrw93JjxYQ78XLPZvijkxuN9p3UZBi8EOpkf59WUSTJRwghiohUk4mLNxK4FpuEp5sroeX9OBPjnjXxaA1bvzbad8rVMtp3AovXbMySfIQQogiISUjmvLm2U97fkwr+Xri4ZNM9Ojkelj0FexcY7Tv9vgYv2+4RKgok+QghhANlV9tJn/Ygs6izxv07F/dA55eh4/PFon0nO5J8hBDCQWLMbTspedV2AE5uMrfvJMGgBVC3p11jLWiSfIQQopBFxCTg4+6Kn5cxlmGqycTZa/FEJyTj6eZKzdxqOwBbp8IfLxv37Tw8HwJr2ynywuP0yUcp1RvobTmirRBCFCQfd1fOXIunWlnQwNlrcaSYNKW93alSxifn2o7JBHFXYeVEqHsv9P+mWLbvZKd4XiwsQFrrZVrrsfact14I4Vz8vNypVtabU1fjOBkZS6pJU7m0N9XK+eaceFKS4OoRYwK4zi/BQ/NKTOIBST5Or3r16hnmmRdF1/Dhw7MM9CqKj9ikVEzmsTTL+3sS6JfL6N2JNyHyMKQkgm956Pxise1YkJOSdTQig+HDh6OUyvJo27Ztepl//vmH8ePH2z22n376iZYtW1K6dGl8fX1p2rRpvueTyc7x48cZNWoUVatWxdPTk5CQEAYMGMCWLVsKbB/2NmnSJObOnVvo+5k1axZKKWrXztqu8Pvvv6OUSp9yGmD9+vUopdJHzQa4cuUKLVq0oHnz5kRERHDq1CmUUk47CkJ0fDKXoxNQShHk78W12GRuJiRnLag13LwCV4+BcoXAuuCe89xNxZkknxKuW7duXLx4McPDcm768uXL4+PjY/e4ypUrx6uvvsrWrVvZu3cvI0aMYNSoURliy6/w8HCaN2/O/v37+frrrzlw4ADLli2jRYsWPPHEEzm+Till9cjf69evz3V+mMIQEBBA6dKl7bIvLy8voqKi2LBhQ4bl06dPz3GK6zSnT5/mjjvuoFSpUqxfvz7fU1aUFInJqZy5FodCUb2cDxUDvKhW1psz1+IzJiCTyRgqJ/qcMS5b+Trgbv2UFMWNJB97irkEM3tCzGW77dLT05OKFStmeJQte2t8qMyX3Y4cOUKnTp3w8vKibt26rFixAj8/P2bNmpVe5vz58zz88MOUKVOGMmXK0KtXL44ePZq+/s0336RRo0YsWLCA0NBQ/P396devX4Zvxl26dKFfv37Uq1eP0NBQJkyYQFhYGJs2bbqt49VaM3z4cGrWrMnmzZu57777CA0NJSwsjJdeeil9zhd7y+mbv1Iqwzwzb7/9NiEhIenv26OPPpq+LvNlt86dOzN+/HhefvllAgMDCQoK4rnnnsswvfXly5fp06cP3t7ehISEMHPmTBo1asSbb76Za7yurq488sgjzJgxI31ZZGQky5cvZ9iwYTm+7sCBA3To0IEGDRrw+++/2zxBmqWCOBeB9C8eXl5e1KhRg1deeYWkpKT09T///DNhYWF4e3tTtmxZOnXqxOXLBfM/mmrSnL5mzIZataw3/ubebmltQHHJqUbBlCS4ehTirxkzjpatCS4luz+YJB972vARnNkKGz50dCTZMplM9O/fHzc3N7Zu3cqsWbN46623SExMTC8TFxfHXXfdhZeXFxs2bODvv/+mUqVKdOvWLcOUw6dOnWLhwoUsWbKEVatWsWvXLl555ZVs96u1Zu3atRw+fJiOHTve1jHs3r2b/fv38/zzz+PqmnUsLHvVHPJj8eLFfPLJJ0yZMoWjR4+yfPlyWrdunetr5s2bh5ubG1u2bGHy5Ml8/vnnLFy4MH39sGHDOH36NH/++SdLly5l7ty5nD592qp4Ro0axeLFi4mJiQFgzpw5tG/fnpo1a2Zbftu2bdx555306NGDRYsW2TSRXGYFdS7+8ccfDBkyhMcff5z9+/czY8YMFi1axMsvvwzApUuXePjhhxk2bBgHDx5k48aNPPLII/mO25LWmvNR8SQkpxJSzofSPh4Z1vt5uRPk72XRvpMAZWpAqUpFbuK3wlCyU2th+f1FYwRZa53ZbFzLTRM+3XgoBdU6WLeNio2h5/9sixNjIjnL6/NgzGz54YdZE+Dq1as5fPgwq1atIjg4GIDPPvuMDh1uxbhgwQK01sycOTN9iuRvvvmGoKAgli9fzoMPPggY89rPmjWLtF6EY8eOzTKX/Y0bNwgODiYxMRFXV1e++uoreva8vRvn0r71FsfJ/06fPk2lSpW4++67cXd3p1q1arRsmeNcXAA0aNCAt99+G4A6derw7bffsnbtWgYNGsThw4f5448/+Pvvv9Pb+WbNmmX15cKGDRvSsGFDFixYwJgxY5g+fTovvvgiKSkp2Za///776du3L9OnT7f+oHNQUOfie++9x/PPP8+IESMACA0N5cMPP2To0KF8/PHHXLhwgeTkZAYMGEBISAgAjRo1uu34Aa7GJhEVl0SFUl7pNZ4MtIa4SLhxHlw9jDHaSmj7TnYk+dhD5VZw/STEXwVtAuUCPuWMbzmFrGPHjlmmdM7p2/+hQ4eoXLly+j87QKtWrXCx6GWzY8cOTp48mWXK47i4OI4fP57+PCQkBMvu65UrVyYiIiLDa/z9/dm9ezc3b95k7dq1PPPMM1SvXj3H6b4bNmyY/q39zjvv5Pfff89SxpaZeS23Z7ks7YMsJCSE/fv3A3DmzBkaNGiQXi41NZXExMQMiX3o0KFMnTrV6v1nNnDgQCZNmkSNGjXo0aMH99xzD3369MHTM+deUWFhYRmeW/6dDx06hIuLS4YEVrVqVSpXrmx1TKNGjWLGjBmEhYVx7tw5HnjggQw1K0v9+vVj2bJlrFmzhm7dulm9j+wU1Lm4Y8cOtm/fnuHLlslkIj4+nkuXLtGkSRO6detGo0aNuPvuu+nWrRsDBgygfPnytxV/bGIKF6MSKOXlTpB/Nu+fyQTRZyHuGniWgjIhJf4yW2bOdbQFJR81EJY9DTtngZuXMTxG/T5w36cFHlpmPj4+FOQNtCaTiaZNm7JgwYIs6yzbktzdM37TU0plaIsAcHFxSY+tadOmHDx4kPfffz/H5LNixQqSk40GWm/v7L8h1qlTBzCmHm7WrFmux2K5PYDatWuzYsWK9A88y2OoXLkyu3fvTn++bds2Jk6cyPr169OX5da+kfahaZkcLfcNRmI4fPgwa9euZc2aNTz77LO89dZbbNu2DV9f32y3a83f+XY8/PDDPP3007z44osMGjQox787wOTJkylfvjy9e/dm6dKl3H134U7fbM25aDKZeOONNxg4cGCWMuXLl8fV1ZVVq1axdetWVq1axfTp03nppZfYsGEDTZo0yVdcyakmTl+Lw8NNUaWsd/qXGcCY+uDaCaPWkxIPfhXA3zkus2UmycdeYiOgxQhoOQLCZ8JN+3U6sFa9evW4cOECFy5cSP92HB4enuHDrHnz5vzwww8EBgYWePuJyWTKcE0/s7TLIrlp2rQpDRo04OOPP+ahhx7K0u4TFRWVHnd22wsJCcn2spSbm1uGJH7u3Lksy3KT9k364sWL6cssk1kaLy8vevXqRa9evXjxxRepWLEimzdvztcHeb169TCZTOzYsYM2bdqkx33hwgWrt1GqVCkGDBjA7Nmz+fjjj3Mtq5Ri8uTJuLu706dPH5YsWZLvy6gFdS42b96cQ4cO5fo+KaVo164d7dq14/XXX6dhw4YsXLgwX8nHpDVnrsZhMmlqBvnhlvnenBtnITkOUMaVD+/s43YGknzs5eF5t363Q40nTWJiIpcuXcqwzNXVNdvLCt27d6du3boMGzaMTz75hPj4eJ555hnc3NzSv70NGTKETz75hL59+/L2229TrVo1zp49y9KlSxk3bly294Zk57333qNNmzbUrFmTxMREVqxYwZw5c/jyyy9v63iVUsycOZNu3bpxxx138Morr1C/fn3i4uL4/fff+fHHHx1yr4m3tzdt27blww8/JDQ0lBs3bvDSSy9lKDNr1ixSUlJo06YNfn5+LFy4EHd3d6v/ppnVrVuXHj16MG7cOL7++mu8vLx4/vnn8fHxyfhtPA/ffPMNn376KeXKlbOq/GeffYabmxv9+/dn0aJFGXroHTlyBDe3jB879erVy9I5oaDOxddff5377ruPkJAQHnzwQdzc3Ni3bx/bt2/no48+YuvWraxZs4YePXpQoUIFdu3axdmzZzNcYrXFpRsJxCalUK2sT8Y5eC7sxhhYJ402LsVfV1C5ab72VdxJb7cSbs2aNVSqVCnDI6fLUS4uLixZsoTExERat27NsGHDeOWVV1BKpX84+Pj4sHHjRmrWrMnAgQOpV68ew4YN4/r165QpU8bquG7evMljjz1Gw4YN6dChA4sXL2b27NmMGzfuto+5devW7Nixg3r16jFu3Djq16/Pfffdx/bt25k8efJtbz+/0rott2rViv/85z+8++67GdaXLl2a6dOnc+edd9KoUSMWL17Mzz//TI0a+W8bnDVrFlWqVKFz58706dOHIUOGEBQUZFNPNC8vL6sTT5qPP/6YZ555hgceeIClS5emLx8yZAjNmjXL8Dh27FiW1xfUudijRw9+++031q1bR+vWrWndujX/+9//0u9VCggISO+SX7t2bZ599llee+01hg4datPxAlyPSyLyZiKBfp5ZerZRrhZgmfBdwLsMVGho835KCmVLA21J1rJlS53TN+KDBw8Wy95TBWHPnj00bdqU8PBwWrRo4ehwxG2KjIykcuXK/PDDDzzwwAOODscmRflcjE9K5fiVm3h7uFIj0BeXDO08KRB5xGjrRWMkIQ0+gVC6ap7bLq6fP0qpHVrrHLtrymU3kcGSJUvw9fWldu3anDp1imeeeYYmTZrQvHlzR4cm8uHPP/8kJiaGxo0bExERwSuvvEJgYCD33HOPo0PLU3E5F1NSTZy+Fouri6JaWZ+MicdkgusnjMTj4Wt0OPItB7FXwZTN8DpORJKPyCAmJoaJEydy9uxZypQpQ+fOnfnss89saiMQRUdycjKvvvoqJ06cwMfHh7Zt27Jx48Yce88VJcXhXNRac/Z6PMmpmpqBvri7uliuNIbLSYqFMtWNy2xpStt/SKuiRi67mcllNyGErS5HJ3A5OoHg0t6UyzxKdfQFo1erfyXwr5jvfRTXz5+8LruVyA4HSqklSqnrSqlFeZcWQgjbpY1UXcbHg7K+mToYxF41Eo9POeNeHpFFiUw+wCTg0TxL2UBqiEKINIkpqZy9Hoe3uyvBpTPdSJoQbdzP4+kPAVVu6wbSkvy5UyKTj9Z6PRBTUNtzd3cnPj6+oDYnhCjGTCbN6avGwKUh5TJNgZ0cD9dPgZuncROpur2P2OTk5Cz3RZUUdk0+SqmOSqlflVLnlVJaKTU8mzLjlVInlVIJSqkdSqk77RljdoKCgjh//jxxcXEl+puIECJ3WmvOmUeqrlbWBw83ixtJ04bOUS5QNhRcso6qbguTycTly5czjJFYktg7pfoB+4DZ5kcGSqmHMC6ZjQf+Mv/8XSnVQGt9xlxmN9nHfbfW2vpxQ2yQNmZX2gi4QgjndDMxhai4ZEp5u3EuxmJcPW2CmxFgSgG/ILh+POeN2MDX15fAwMAC2VZRY9fko7VeAawAUErNyqbIM8AsrfW35udPKKXuAR4DXjJvo2nhR5pVqVKlbmtiLCFE8fbPqWsMmrOVznXLM+2RZrcut5lSYcEQOPoHPPwD1M3fgKTOpsi0+SilPIAWwKpMq1YB7Qtpn2OVUuFKqfArV64Uxi6EECVARHQC4+ftpEoZb/7vwaYZ23n+eBmO/A49P4K6Rf/m3aKiyCQfIBBwBTIP93wZsKmTvFJqDfATcK9S6pxSql125bTW07TWLbXWLW93/g4hRMmUnGriv/N3cjMhhW8eaUmAt8Xltq1fw7ap0Pa/0HqM44IshkpkNwqt9e3NZCWEEGbv/XaQf05d54tBzahb0WLiukO/wcqXoN59cPc7jguwmCpKNZ9IIBXIfEdWBeBS1uJCCFG4luw6x6wtpxjZoQZ9mljMAHt+JyweDZWbwf3f3nbPNmdUZJKP1joJ2AF0z7SqO7ClsParlOqtlJp248aNwtqFEKIYOnAhmpd+/pfWNcry0r31bq2IOgPzHwLfQBi8EDxknLb8sPd9Pn5KqaZKqabmfVczP69mLvIpMFwpNVopVV8pNQmoDEwtrJi01su01mNLal96IYTtbsQlM27uDgK83flqcPNbA4bGR8G8gZCSCIN/MrpVi3yxd5tPS2CdxfO3zI/vgeFa64VKqXLAq0AljHuC7tVan7ZznEIIJ2UyaZ5auIuLN+JZMLYd5f3NA4amJMGPj8LVYzD0Zwiql/uGRK7sfZ/PejJO55ddmSnAFLsEJIQQmXzx51HWHb7CO30b0iLEPA2C1rD8aTi5Afp9DTU7OTbIEqDItPk4irT5CCHSrDsUwaS1R7m/eTBD24bcWrHpE9g9FzpNhKaDHRdgCeL0yUfafIQQAKevxjJhwS7qVyzF+/0b3xqpeu9P8Oe7EPYQdH7JsUGWIE6ffIQQIj4plXFzd6KU4ptHWuDlbu46fXoLLB0PIR2gz5e3NT2CyKhE3mQqhBDW0lrz8pJ/OXQpmpnDW1G1rLnrdOQxWDAYSofAQ3ONaRJEgXH6mo+0+Qjh3Gb/fZolu87zdLc6dK5r7jodGwnzBoByhSE/gU9ZxwZZAjl98pE2HyGc1z+nrvHO8gN0qx/E43fVMhYmx8MPgyDmIgxaAGVrODbIEkouuwkhnFK2I1WbTLBkHJzbDgO/h6qtHB1miSXJRwjhdCxHqp47qs2tkarXvgUHfoHu70DDfo4MscST5COEcDrZjlQdPhM2fw4tR0L7JxwanzNw+jYf6XAghHNZuvt81pGqj66B356FWt2h58fSpdoOnD75SIcDIZzHwYvRTFy8N+NI1Zf2wU/DIagBDJwJrnJByB6cPvkIIZzDjfhbI1VPHtzMGKk6+gLMfxA8/Y3pETz9896QKBCS4oUQJZ7JpHlm4W4uRMWzYGxbgvy9IDHGSDwJN2DkSggIdnSYTkWSjxCixPvyz2OsPRRhHqm6LKSmwKKRcPmAUeOp2NjRITodST5CiBJt3eEIPl975NZI1VrDyolwdBX0+hRqZ548WdiD07f5SG83IUqu01djmfBDppGq//4K/vkO2j8JrUY5OkSn5fTJR3q7CVEyZTtS9YGlsOpVaNAXur3l6BCdmk2X3ZRSNYDqgDdwBfhXa51QCHEJIUS+ZTtS9blw+HksVGkJ/b8BF6f/7u1QeSYfpVR14DFgEBBMxmmwk5RSm4BpwGKttakwghRCCFukjVT9THfzSNXXT8H8h8CvAjz8A7h7OzpEp5dr6ldKfQHsAWoCrwANgADAA6gI3Av8BbwD7FVKySh8QgiHCs88UnX8dZg3EEwpMGQR+JV3dIiCvGs+CUCo1joym3URwJ/mx1tKqXuBEOCfgg1RCCGsExGTaaRqUzIsfASunYRHf4HydRwdojDLNflorV+wdkNa6xW3H44QQuRPcqqJx+ftIiYhhdmjWhPg5WZMj3BqE/SfBtXvcHSIwoLVLW5KKRellIvF84pKqdFKqQ6FE5oQQuRs6objbDl+66LM+ysOsv3UNbo3CKJexVKw4UPYuwA6vwxNHnJgpCI7tnT3+A14AkAp5QeEAx8D65VSjxZCbHYh9/kIUTyFVQng8fm72HI8kqW7zzNz8ym83Fx4uHU12P0DrP8AmgyGTlZfwBF2pLTW1hVU6grQRWv9rznZvAg0AYYAz2itwwovzMLXsmVLHR4e7ugwhBA22HI8knFzdhCXlArAzBGtuNPtEMzpD9XawtCfwc3DwVE6J6XUDq11y5zW21Lz8QOizL/fDSzRWidjdDgIzXeEQgiRT0kpJuKSUkkxaYa1D+HO0tdg4RAoWxMemiuJpwizJfmcAToopXyBHsBq8/KyQFxBByaEELn5Zdd5Rs76Bw2MuqMGG3YeIGHW/eDqAUN+Au/Sjg5R5MKWEQ4+BeYAN4HTwEbz8o7AvwUclxBC5Gj6Xyd5Z/kB3FwUMwZUpeOup3k6IBp9PYK9PRcQVibE0SGKPFidfLTW3yilwoFqwGqL0QyOA68VRnBCCGFJa81Hfxzm6/XHqVPBj5fvrU/HIx/A2a34AYc6TWFLQnWKdQO0k7C6w0FJJx0OhCjaUlJNvLzkX34MP8eg1tV4/0BXVEpi1oJunvBqhP0DFBncVocDpdRQpZTKrYxF2RCl1J22BiiEEHlJSDZGqP4x/BxPdqnF+/0bocZsAJ9ytwq5eUPjgTBBWgGKg7w6HIwEDiulXlZKNc6ciJRSZZVSfZRSP2IMqyPzEgghCtSN+GQenb6dtYcu81afhjxzd13UtRNGr7a464ACNy9ITQTPUuBfwdEhCyvkNbxOF6VUL+BJjMFDE5RSERhjvpUBymOM8TYT+K/W+kohx1vglFK9gd61atVydChCiEwiohN4dMZ2jl+5yRcPN6N3k8pwdjv88LAxI2lIWyhfH1qOgPCZcPOyo0MWVrLlJtNA4A6MwUO9gUhgF7CrJEylIG0+QhQtJyNjeWT6Nq7FJvHNIy24s3Z5YzK4n8eCfyUYuhjKyS2GRVVebT629HaLBH4piKCEECI3/567wfCZ29HAgrFtCQsOgC2TjVlIq7SCQT+Ab6CjwxS3waaZTIUQorBtPhbJ2NnhlPbxYM6o1tQs5w2/vwDbp0H9PnD/NJkMrgSQ5COEKDJ+23uRpxfupkagL7NHtaaCVyosHAqHV0C7x6H7OzL9dQkh76IQ9hZzCWb2hBhpHLc05+9TPP7DTppUDeDH/7SjgroBs3rBkZVw7yfQ4z1JPCWIvJNC2NuGj+DMVmO+GYHWms9WH+G1pfvpWi+IOaPaEBB7AqZ3gyuH4eH50HqMo8MUBUwuuwlhL+8GgeUd+eHTjYcT35GfatK8vnQf87adYUCLKvzv/sa4nd0CCwaDqycM/w2Cmzs6TFEIbKr5KKXGK6X2K6XilFI1zcteVEo9WDjhCVGCTNgL9Xrdeu7iDo0GOO0d+YkpqTzxw07mbTvDfzrV5OMBYbjtXwSz+4FfRRi9RhJPCWbLNNpPAa8C0wDLkQ7OA48XbFhClED+FeH6aeN35QKmZDj+J0SdcWxcDhCTkMyImf+w4t9LvNqrPi/dUw+16RP4eQxUbQOj/gAZmbpEs6XmMw4Yo7WeBKRYLN8JNCzQqIQoieKvQ8RBY6KzsRsgtCskx8H07rBsAsRdc3SEdnElJpFB325l+8lrfPpgE0a3rwrLnoQ/34XGD8IjP4N3GUeHKQqZLW0+IcC+bJYnY4x4IITIzT/TQafCwO+hUpjxIZsYA+v/B1u/hoPL4e53oMkgsG4832Ln7LU4Hpm+jUvRCXw7rCV3hXjB/Ifg+Fro+Dzc9UqJPXaRkS01nxNAdhdg7wUOFEw4QpRQyfGwbSrU6mYknjSe/kYX4v9sNGpEvzxmdC+OOOS4WAvJgQvR3P/1Fq7HJTNvdFvuqphsdDk/sR76fAldXpXE40RsST6fAJOVUkMw2nzaKaXeAN4DPi6M4IQoMXbPh9gr0OGp7NdXbAQj/4DeX0DEAZjaAda8CUklY4b6bSeu8tA3f+Pmolg0rh0tPM/Dd92MNrAhP0HzRx0dorAzmyaTU0qNweh0UNW86ALwhtZ6eiHEZhcWo1qPOXr0qKPDESVRagpMbmHMPTN6bd7f7mMjYfUbsHsuBFSDez+Cuj3tE2sh+GP/JZ74YRdVy3gzZ1QbKkdugR+HGbW+IT9CxcaODlEUgtuaTC4zrfW3WusQIAioqLWuUpwTD4DWepnWemxAgExFJArJwaVw/RTc8bR1l5V8A6HfVzBiJXj4GtMH/DAYos4WeqgFbcH2Mzw2dwcNKpVi0bj2VD6xCOYNNHqyjV4jiceJ5WuEA611pNbaOe+KE8IWWsNfn0O52lC3V57FMwhpB+M2Qfe34cQ6+Kq1sa3U5MKItEBprflq3TFe/Plf7qxdnvmjW1Nm64fw6+NQsxOM+B0Cgh0dpnAgW+7zKaOUmqSU2quUuqSUirB8FGaQQhRbJ9bBpb3Q4cn8jUvm6g4dJsB/t0NoF1jzBky9E05vKfhYC4jJpHlr2QE+/uMw/ZpW5rshjfFZPh42fQLNHoHBP4JXKUeHKRzMlq7WszHu5/keuAxY31gkhLP663Nj4rOwh25vO6WrwsPz4PDvsOIFo5dY0yFGragIzWuTlGLiuZ/28OueC4y6owav3FUJlx8GwqlNRm+2O5+THm0CsC35dAY6aa13FlIsQpQs53fCyQ3GNABungWzzbo9oUZH2PgxbPkSDv0G3d+CZo86fMTn2MQUxs3dwaajkUy8px7jmriiZvaAayfg/m8hTEbhErfYcrYet7G8EM5t8+fgGQAthhfsdj18odubMG4zVGhkjI4wowdcctwYcddikxj83TY2H4vkowfCeKz2DdR33eHmJXhkiSQekYUtyWQC8IFSqolSyrWwAhKiRLh6HA78Cq1GFV77RlA9GL4c+k01ahffdIKVLxujJtjR+ah4BkzdwqGL0Uwd2oIHS+0zbpR184KRq6DGnXaNRxQPtiSfYxjD6OwEkpRSqZaPwglPiGJqyxfg6gFtHyvc/SgFTQfB4/8YN2punQKTW8P+X4yedoXsyOUYHpiyhSsxicwZ1Ya7Y5cZ0yEE1jG6UgfVK/QYRPFkS5vPD0AA8CTS4UCInMVcMkY0aDYU/ILss0+fstD7c6MTwm9Pw0/DjKF87v3YGLanEOw4fY2Rs8LxdHPhx7FtqP/vx/D3ZKjTEwZMNy4PCpEDW5JPS6C11jq7wUWFEGm2fg2mFGj/hP33XbUVjFkP26fBuvdgSjujh1mHJwuu0wPw56HLjJ+3k0oB3sx5tDFV1j8JB5ZCqzHQ80NwkSvzIne2XHY7AEjnfCFyk3ADwmdAg76FVuPIk6sbtBtvXIqrcw+sexe+7gAnNhTI5hfvOMeY2TuoHeTPokdrU+XXh43Ec/e7Rk1LEo+wgi3J51XgU6VUN6VUBaVUWctHYQUoRLESPgMSo3MeQNSeSlWGB7+HIYuNmtjsPrB4NMRczvcmp208zrM/7aFtzbIsGFCecgvug4t7jGki2j8h9/AIq9ly2W2F+ecqMrb3KPNz+bojnFtygnHJreZdULmpo6O5pXY3GP83/PWZ8TiyCrq+Bi1HWl1L0Vrzv98P8c3GE/QKq8Rn7RLwmH2PsXLYMqjWphAPQJREtiSfuwotCiFKgr0L4OZluH+aoyPJyt0b7nrZmCl0xbOw4jnYPQ96fQrB2U3TdUtKqomJi/9l8c5zPNouhDdCj+I69z/G2GxDFkG5UDsdhChJbJpSoSRr2bKlDg8Pd3QYorgypcLkVsY0AWPXF+3LT1rDvsXwx8twMwJajTZqQl7GyO5TNxwnrEoA7UMDiU9K5fH5O1l7KII7Qssxp8F21OrXoEprGLQAfMs5+GBEUZXXlAq51nyUUs2B3Vprk/n3HMmwO8KpHVwG144bbR9FOfGAEV/jAVC7O/z5LvzzHRz8FXq8D40eIKxKAI/P38WH94fxzcbjhJ++jr8HfOw7B7V6rtGZov83Rm1KiHzKteajlDJhzNsTYf5dY7TxZKa11kWizUcpVRWYgzHnUArwjtb6p7xeJzUfkW9aw7d3QUK00cOsuPX2urALlj9t/KzRCXr9H1P+VXy/aitfuH/JG2o886v8QtnzfxqdCrq97fBx5ETRd1s1H6AGcMXi9+IgBXhKa71bKVUR2KGUWqG1jnV0YKKEOrnR+OC+7/Pil3gAKjczZlgNn4Fp7duYvmpHcvJ9vOAZTSt9mMXur+N7IRru/QRaj3F0tKKEyDX5aK1PWz4FzupsqkpKqWoFHVh+aa0vAhfNv19SSkUCZQFJPqJwbP4cfIOgySBHR5JvWrnwq8e9TE4OYKVpLBPclhgrFPimRBm/r3pFko8oMLbUnU8C5TMvVEqVM6/Lk1Kqo1LqV6XUeaWUVkoNz6bMeKXUSaVUglJqh1Iq36MSKqVaAK5a6+I3/7AoHi7shuN/Gjd1uns5Opp8uRAVz6jvw5mwYDc+5YJZ3u1PttEIbb7CbnLx4Dfu5J9+BXOTqhBgW/JJu58nMz8gwcpt+AH7MEbIjs+yA6UeAiYB7wPNgC3A75Y1K6XUbqXUvmwelTNtqyzGBHhjrYxNCNttngSepYx7ZooZk0kzZ+tp7v5sI38fv8pr9zXg58fac9EUQLXaYSilwM0TF51C8zrV2HHVw9EhixIkz/t8lFJfmH/VGFMqxFmsdgVaA7ut2ZnWegXmm1WVUrOyKfIMMEtr/a35+RNKqXuAx4CXzNtoakXMnsAvwP+01kV3vmFRvF07AQd+MRrhzd2Ui4vjV27y0uJ/2X7qGnfUCuSD+xtTtawPAOM6hcKCaGgxAlqOgPCZVLp52VguRAGx5ibTxuafCqgPJFmsS8KYYuGT2w1EKeUBtMhmW6uA9jZsRwGzgD+11nPyKDsWc82oWrUi02wliostk8HFDdqOd3QkVktONTFt4wkmrT2Kl5sLHw0IY2CLKkYtx9LD8279ft+n9g1SOIU8k4/W+i4ApdRMYILWOrqQYgnEqEllHnjqMtDNhu10AB4C9iql+pmXPaK1zjLNo9Z6GjANjK7WtgYsnNjNCNg11+hk4F/R0dFYZd/5G7ywaC8HLkZzb+OKvNmnIUH+xbOdShR/Vg+vo7UeUZiBFBSt9V/IdN+isG2bCqlJ0P5JR0eSp4TkVD5bc4TvNp2krK8HU4e24J5GxSNhipLLlrHdClskkApUyLS8AnCpsHaqlOoN9K5Vq1Zh7UKUNAnRxqgA9XtDYNE+b7aeuMpLP//LychYHmpZlZfvrU+Aj7ujwxKi6NQQtNZJwA6ge6ZV3TF6vRXWfpdprccGBBSvBmPhQDtmGfP23PGUoyPJUXRCMi/9/C8PT9tKqkkzb3QbPhwQJolHFBl2rfkopfyAtK+KLkA1pVRT4JrW+gzwKTBHKbUd2AyMAyoDU+0ZpxA5SkmErVOgRkcIbuHoaLK1+sBlXv3lX67EJDLmzho8070u3h7FcOQFUaLZ+7JbS2CdxfO3zI/vgeFa64Xmm1ZfBSph3BN0b6aRFoRwnL0/QsxF6PuVoyPJIvJmIm/+up/ley9Sr6I/0x5pSZOqpR0dlhDZsmvy0VqvJ/uBSS3LTAGm2CUgpM1H2MBkMm4qrRgGoV0cHU06rTVLdp3n7eUHiEtM5dnudfhPp1A83IrMVXUhsihKHQ4cQmu9DFjWsmVLGbRK5O7wb3D1KAyYUWSmTTh3PY6Xl+xj45ErtAgpw4cPNKZWkL+jwxIiT06ffISwitbw1+dQpjrU7+voaEg1aeb8fYqP/jgMwFt9GvJI2xBcXIpGUhQiL5J8hLDG6c1wPhx6/R+4Ovbf5ujlGCYu3svOM1F0qlOe9/o3okoZH4fGJIStnD75SJuPsMpfn4NveWg6xGEhJKWYmLrhOJP/PIaPpyufPdSEfk2Dsw6NI0Qx4PTJR9p8RJ4u/QvHVkOX1xw2dfSes1FMXLyXQ5di6N2kMm/0bkCgn6dDYhGiIDh98hEiT5sngYcftBpl913HJ6Xy6erDTP/rJEH+Xnz3aEu6Ncg8CIgQxY8kHyFyc/007PsZ2j4G3mXsuuvNxyJ56ed/OXMtjsFtqvFiz3qU8pIRCkTJIMlHiNz8PRmUC7T7r912eSMumfdWHODH8HPUCPRlwdi2tK1Zzm77F8IeJPkIkZPYSNg5B5o8BKUq512+AKzcd5HXlu7nWmwS4zqF8lS32ni5y9A4ouRx+uQjvd1EjrZ9AykJ0H5Coe8qIiaBN5bu5/d9l2hQqRQzh7eiUbAMditKLqdPPtLbTWQr8SZsnwb1ekH5OoW2G601P+04x7vLD5CQYuKFe+oy5s6auLvK0DiiZHP65CNEtnZ+DwlR0OGpAtvk1A3HCasSQPvQQADOXI1j/Lwd7LsQTevqZfnggcaElvcrsP0JUZRJ8hEis5Qk+PsrCLkDqrYqsM2GVQng8fm7+OLhZhy6FM1HKw+TlGpiZIfqvNqrgQyNI5yKJB8hMtu3CKLPQ+9JBbrZ9qGBfDQgjOEzt5Ni0ri7KiYPbsZ9YfbpzCBEUSIXloWwlDZtQoVGUKtbgW46LimFbzYcJ9WkARjXKVQSj3BaTp98lFK9lVLTbty44ehQRFFwZCVcOWS09RTgmGkJyan8Z84Owk9dx9fTjSe71GLetjNsOR5ZYPsQojhx+uSjtV6mtR4bECDdWgWw+XMoXQ0a9i+wTSanmnjih11sOhqJj4cr0x5twTN312Xy4GY8Pn+XJCDhlJw++QiR7vTfcHYbtHuiwKZNSDVpnv1xD6sPXKZ7gwp8O6xlem+39qGBTB7cjL3npNYtnI90OBAizebPwaccNBtaIJvTWvPKkn/5dc8FXuxZj3GdQrOUaR8amJ6MhHAmUvMRAuDyAaO9p8048Lj9idm01ry9/AAL/jnLE11qZZt4hHBmknyEAKOHm7svtBpdIJv7dPURZm4+xcgONXime+GNkCBEcSXJR4ioM8a9PS2GgU/Z297c1+uP8+Wfx3i4VVVeu6++zDQqRDacPvlIV2vB318ZPwtg2oTZf5/iw5WH6NOkMu/1byyJR4gcOH3yka7WTi7uGuycDY0fhIAqt7WpRTvO8frS/XRvUIH/e7AJrjJcjhA5cvrkI5zc9mmQHAcdbm/ahN/2XuSFRXu4s3YgXw5qJqNSC5EH+Q8Rzisp1pizp+69EFQv35v589BlJizYRYuQMnzzSAuZ/E0IK0jyEc5r5xyIv3Zb0yZsORbJuLk7qV+pFNOHt8LHQ26dE8IaknyEc0pNhr8nQ7V2UK1Nvjax4/R1Rs8Op0Y5X2aPbE0pL/cCDlKIkkuSj3BO+36GG2fzXevZd/4Gw2duJ8jfkzmjW1PG16Ng4xOihJPkI5yP1sZQOkENoPbdNr/8WEQMj87YTikvd+aNaUuQv1fBxyhECSfJRzifo6sg4oDRw83Ftn+BM1fjGPLdNlxdFHNHtyG4tHchBSlEySbJRzifvz6HgKrQ6AGbXnbxRjyDv9tKYoqJuaPaUCPQt3DiE8IJOH3ykREOnMzZ7XBmizGagav1HQQibyYy5Ltt3IhLZs7INtSt6F+IQQpR8jl98pERDpzMX5+Ddxlo/qjVL4mKS2Lod9u4EBXPjBGtaFxFzhUhbpfTJx/hRCIOweHfoPV/wMO6S2Y3E1MYNvMfTlyJ5dtHW9Kq+u0PPCqEkMnkhDPZ8gW4eUPrsVYVj09KZdSsf9h3/gZTh7bgztrlCzlAIZyH1HyEc7hxDvb+aEyb4Fsuz+KJKamMm7uD7aeu8emDTejeoIIdghTCeUjyEc7h7ymgTVZNm5CSamLCD7vZcOQK/7u/MX2bBtshQCGciyQfUfLFXYMds6DxAChdLdeiJpPmhUV7Wbn/Eq/f14CHWuVeXgiRP5J8RMn3z3RIjs1z2gStNa8t3cfPu87z3N11GHlHDTsFKITzkeQjSrakONg2FWr3gAoNcyymteaD3w8xb9sZHuscyn/vqmXHIIVwPpJ8RMm2ex7ERcIdT+Va7Iu1x5i28QTD2oXwQo+6Mv21EIVMko8ouVJTjO7VVVobUyfk4LtNJ/hszREGtKjCG70bSuIRwg4k+YiS68AvEHXGqPXkkFDmbzvDu78dpFfjSnz4QBguLpJ4hLAHST6iZNLaGEonsC7U6ZltkSW7zvHKL//SpV4Qnz3UFFdJPELYjdMnHxlYtIQ6thYu/5vjtAkr913iuZ/20rZGOaYMaY6Hm9P/KwhhV07/HycDi5ZQmz+HUsHQeGCWVesPR/DEDztpUiWA74a1xMvd1f7xCeHknD75iBLo3A44tckYzcAt4/TW205c5T9zdlA7yJ+ZI1rj6ynDGwrhCJJ8RMmz+TPwKg3Nh2VYvPtsFKO+D6dqWR/mjGpNgLf18/kIIQqWJB9RskQehYPLofUY8PRLX3zwYjTDZmynrK8Hc0e1oZyfpwODFEJI8hEly+ZJ4OZpzNljdvzKTR6Zvg1vd1fmjW5DxQAvBwYohACZz0eUFDGXYMEQuLAbWo4AP2PunbPX4hj63TYA5o1pQ9WyPg4MUgiRRpKPKBk2fATnw43f2z8OwOXoBIZ8t424pFQWjG1LaHm/XDYghLAnST6ieHsnCFITMy6b1ATt6slQ35+4ejOReWPaUr9SKcfEJ4TIliQfUTykJBqdCa4cgogDEHHQeGROPG6eJNXpzcgLfTkTGcf3I1vTtGpph4QshMiZJJ98mrrhOGFVAmgflAKLRsCAWWyJcGXvuRuM6xTq6PCKr9QUuHbCSDCWiebqcdCpRhnlCoG1oVIT/gnoQa3EfZS5uBncPNCpyaw8epMtN12ZMbwFbWvmPWW2EML+JPnkU1iVAB6fv4vfQpdQ6cxWLi57i8eP92fy4GaODq14MJkg6rS5BpOWaA5C5BFITTIXUlC2BgQ1gPp9IKi+8ShXy+jRBiQfj2TnnEE0qDOYsh3/w+o5/8Mj7goTutamc90gxx2fECJXSmvt6BiKhJYtW+rw8HDrX/BukHEpKBOtXInv+Cre/mVQXgHgVcq44dGzFKQ9d/PKcZTlEkdriD4PERa1mCsH4cphSI67VS6g6q3kUt78M7AOeOTeO01rzR/7L/H8or2U9fXg9NU4xncO5YV76hXygQkhcqOU2qG1bpnTeqn55NeEvfDHq6TsW4IbKZg0JOOGq07FZ8Nbub5Uu3qAVwDKMiF5BVgkqIBsnluU8SyV7WCZhSLmUvplRfwr5HJQGmKvmBOMZaI5BInRt8r5VYSgetBiOJSvZ9Rqytc1ji8XSSkmTl+N5fiVWE5E3uTElVhOXLnJichYouKSjVATUuhct7wkHiGKAUk++eVfkYuJ7lQglRTlgQvJnK56Pydav83lq9e4fu0KN65HcvPGNRJvXoeEaEqpWPyJp1RKLAFJcZR3TyTQLYHSrlfw5xQ+pjg8U2JwTY3PY+cKPP1zT1BZnpfO+NzdyhstN3wEZ7bChg/hvk+NZXHXLNpjDt26dBZ/7dbrvMsaiSXswYy1GZ+yOe5Ka03kzSROXLlpJBlzcjlx5SZnr8eTarpVSw/y96RmeV96Na6Ei1Is2XWegS2qsHTPBbYcj6R9aKB1xyeEcAhJPvm05Xgk8UePQZ3BVOryGBf//JqzR45SqrM79zRumKV8fFIqF27Ec/56POej4rkQFU+4+ffzUfFcupFAivnD1Y0U/ImjincSNfxMhPglU8UrmYqeiZT3SKSsazylVDzeqTGohGijZhF9DiKiIeGG8Vybcj8AV8/cE9bWr8GUcqt8+HTjkZmHv5FU6vfOeNnMLyjHS4sJyamcvhpnTjJGLea4OcnEJNzap6ebCzUCfWlYOYDeTSoTWt6PmuV9qRHoi7+Xe/r78Pj8XUx7tAXtQwPp3rACj8/fxeTBzSQBCVGESZuPma1tPum93Sw+4LYcj8x3b7dUkyYiJiE9OZ2PMhLVBYvfY5NSM7zGw82F4NLeBJf2pnJpL4JL+5h/elHF10RFj0Q8Um7eSkgJN249MjyPzrQsGlKyqX15lYaad0Fw81uJplRwtklGa01ETOKt5GL+eSLyJueux2N52lUK8KJmeV9qBhrJpWZ5P0LL+1I5wDvPmUUL+n0QQhSMvNp8SlzyUUqVBtZg1OrcgEla62/zep3NHQ7sTGtNdHyKRWKK48KNjMnqSkzGDhBKGZenKpsTVHBpb4LLpCUr4/dSXtmP7Dxt3SH6nv2QCieWgKs7mFK4WHsQS4OfzfChHp+UysnIjO0wx6/EcjIylpuJt2ox3u6u1Aj0JTTIj5qBvtQs70toeT9qBPrKtAZClEDOmHxcAU+tdZxSyhfYB7TUWl/N7XVFPflYIyE5lUs3EjLUnNIu8Z2PiudiVAJJqRkvx/l7umVJSJVLe3MtNomqq8bQoHZtKnYZx6lVUzh+8jh/Nf8cIL0mcz4qYw0puLS3uRaTlmiM2kzFUl551mKEECWH0yUfS0qpssBOjOQTmVvZkpB88mIyaSJvJnIuLSFZXtaLSuD89TiiLdpc0ri5qPT2KABfD1dqmttfbl0qM9pifDykFiOEKGJdrZVSHYHngBZAZWCE1npWpjLjgeeBSsB+4Cmt9SYb91Ma2ADUBp7PK/E4CxcXRVApL4JKedG8Wplsy8QkJHMhKoHzUXGcj0rgl53n2XHmOp3rlmfsnTWpWd6PCqU8Uc5yn5IQolDYez4fP4zLYBOALC3aSqmHgEnA+0AzYAvwu1KqmkWZ3Uqpfdk8KqeV0VpHaa2bADWAwUqpXG5QEZb8vdypW9GfLvUqEFrel5NXY3mySy32nrsBCioGeEniEULcNrvWfLTWK4AVAEqpWdkUeQaYZdFB4Aml1D3AY8BL5m00tWF/l5VSe4A7gUX5j9z5pHVhTuuy3Da0nHRhFkIUmCIzk6lSygPjctyqTKtWAe1t2E4FpZS/+fcAoCNwOIeyY5VS4Uqp8CtXruQv8BJq77kbGRJN+9BAJg9uZtSAhBDiNhWl1uFAwBW4nGn5ZaCbDdsJAaYp49qQAr7UWv+bXUGt9TRgGhgdDmyOuATL7h6Z9qGBUusRQhSIopR8CoTWejvQ1NFxCCGEyFmRuewGRAKpQObOARWAS4W1U6VUb6XUtBs35HKSEELYS5FJPlrrJGAH0D3Tqu4Yvd4Ka7/LtNZjAwICCmsXQgghMrH3fT5+QC3zUxegmlKqKXBNa30G+BSYo5TaDmwGxmHcDzTVnnEKIYQoXPZu82kJrLN4/pb58T0wXGu9UClVDngV4ybTfcC9WuvTdo5TCCFEISrRw+vYQil1BTgNBAA5NQDltC4Qo82qOMjt+HJiy/HlZ/sFtR1b3wdr9pFXmfycL1B8zhl7xFkQ50x+47Rl39aWzatcbrEW1P9PQbjdv2mI1rp8jqW01vKweADTbF0HhDs67oI4vlxeY/Xx5Wf7jojT2n3kVSY/50t+YnXUwx5xFsQ5k984bdm3tWWtOGdyjLWg/n8c+d5bewxFpsNBEbIsn+uKi8I+hoLavj3+1tbsI68yJf18sQdH/p1s2be1ZW/neErCOWPVMchltwKglArXuYzeWtwVl+MrLnFC8YlV4ix4xSXWwo5Taj4FY5qjAyhkxeX4ikucUHxilTgLXnGJtVDjlJqPEEIIu5OajxBCCLuT5COEEMLuJPlYSSnVUSn1q1LqvFJKK6WGZ1qvlFJvKqUuKKXilVLrlVINHRSuTZRSLyml/lFKRSulriillimlGmUqM8t83JaPrQ6I9c1s4rhksd4h70NBnB9KqTJKqTlKqRvmxxzzrLwFGac173WRiDWbuLVSanJRi1Mp5aqUekcpdVIplWD++a5Sys2ijN1jzeucNJepo5T6WSkVpZSKU0rtVErVt1jvqZT6UikVqZSKNW+vSqZtVDOfR7Hmcl8oY4qcXEnysV6us7ACLwDPAk8ArYAIYLUyzy1UxHUGpmDMm9QFSAHWKKXKZiq3BmPkibTHvXaM0dLhTHE0tljnqPehIM6P+UBz4B7zozkwp4Dj7Eze73VRiRUApVRbYCywN9OqohLnROC/wJNAPYxz4L+YJ8B0YKx5zRxdA2MYs5MY50IjjNFlbloU+xx4ABiEMSlnKWC5UsrVvA1X4DfA37x+EDAA+L88o3P0jUzF8WF+c4ZbPFfAReAVi2XeQAzwH0fHm4/j88MYYby3xbJZwPIiENubwL4c1hWJ9yE/5wdQH9BAB4syd5iX1bXXe13UYsW4W/44cBewHphc1OIElgPfZ1r2fdr/S1GINfM5aV42H5iXx98+CRhisawqYAJ6mJ/3ND+valFmKJAAlMotJqn5FIwaQEUsZmHVWscDG7FhFtYixB+jVnw90/I7lFIRSqkjSqlvlVJBDogNoKb58sVJpdQCpVRN8/Ki+j5YE1c7jA8IyxHcNwOxFG7smd/rohbrNGCR1npdpuVFKc6/gLuUUvUAlFINMGoSK4pgrJhjdAF6AweUUivNl2D/UUo9ZFGsBeCeKe6zwMFMcR80L0/zB+Bpfn2OJPkUjIrmn9nNwlqR4mcSsBv422LZSuBRoCvG5YPWwJ9KKU87x7YNGI5xWWIMxt93izIGpC2q74M1cVUErmjzV0cA8+8RFG7smd/rIhOrUmoMxij4r2azusjECXyIcXnsgFIqGdiPUROaUgRjTROEUet9GSO5dAd+AOYppXpZxJRK1vHdMsed+bjS5mbLNe4SN5OpuD1KqU8xqvt3aK1T05ZrrRdYFPtXKbUDYyDWXsDP9opPa/275XNldHo4AQwD7N4BojjL6b0uCpRSdYH3MWJLdnQ8eXgI44vZYIzE0xSYpJQ6qbWe7sjAcpFW8Viqtf7U/PtupVRL4HGMdhy7BCBuT1pvK7vOwlrQlFKfYTQYdtFan8itrNb6AnAOqG2P2HKJ4ybGP3xtiu77YE1cl4DySimVttL8exCFEHsu73VRibUdxqjK+5VSKUqpFKATMN78+9UiEifAx8AnWusFWut/tdZzMOYmS+twUFT+ppYiMTqbHMi0/CBQzSImV4z3wVLmuDMfV6D5dbnGLcmnYJzE+EOnz8KqlPLC6P1RaLOwFiSl1CRufRgdsqJ8IBCM0ZDqMOa/cz1zHEX1fbAmrr8xLoO0s3hdO8CXAo49j/e6qMT6C0YvxqYWj3Bggfn3I0UkTgAfjMtMllK59flaVP6m6bQxc/Q/QN1Mq+pgXNEAY2bp5ExxV8HoHGEZd/1M3a+7A4nm1+cahDys6y3ix61/gjjgdfPv1czrJ2LMYXE/RpfFBcAFwN/RsVtxbF8B0RiNpBUtHn4Wx/4Jxj9DdYzuun9j1HzsenzmODphNOK2wehpFI0xd4jD3oeCOD+A34F/zX/ndubfl9nzvS5KsWYT+3rMvd2KUpwYPUHPYVyCrg70B64A/+fIWK04J/th9GYbi9G2NgYj2fSy2MbX5mPrBjTDmAx0N+BqXu9qjvNP8/puwHngyzzjK8yTpSQ9MD5wdTaPWeb1CqMb8EWMboYbgEaOjtvKY8vuuDTwpnm9N0YPlgjzyXra/A9X1QGxpv3TJplP8sVAA4v1DnkfCuL8AMoAczGSQ7T599L2fK+LUqzZxL6ejMmnSMSJ0WPwc/P/RTxGG+T7gJcjY83rnDSXGY5Ri4zHuI9qUKZteAJfYlzmjMOYLqFqpjLVML4ExpnLfQF45hWfDCwqhBDC7qTNRwghhN1J8hFCCGF3knyEEELYnSQfIYQQdifJRwghhN1J8hFCCGF3knyEEELYnSQfIYQQdifJRwghhN3JlApCFHFKqfUYow9HYYzDZQJmAy9orU2Oi0yI/JOajxDFwxCMIfDbY8y38hTGPDJCFEsytpsQRZy55uOptW5nsWw1cFprPdphgQlxG6TmI0TxsDfT8wsYE40JUSxJ8hGieMg8lbRG/n9FMSYnrxBCCLuT5COEEMLuJPkIIYSwO+ntJoQQwu6k5iOEEMLuJPkIIYSwO0k+Qggh7E6SjxBCCLuT5COEEMLuJPkIIYSwO0k+Qggh7E6SjxBCCLuT5COEEMLu/h8RySdJ3l4jKwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1.4752284113717873"
+      ]
+     },
+     "execution_count": 263,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fig1, ax1 = plt.subplots()\n",
+    "\n",
+    "datatype = 0; print(datatypes[datatype])\n",
+    "m = 0; plt.plot(nSizes,data_mkl[m,:,datatype],'x-',label=methods[m])\n",
+    "m = 1; plt.plot(nSizes,data_mkl[m,:,datatype],'*-',label=methods[m])\n",
+    "\n",
+    "ax1.set_xscale(\"log\")\n",
+    "ax1.set_yscale(\"log\")\n",
+    "ax1.set_xticks(nSizes)\n",
+    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "plt.xlabel(\"n\")\n",
+    "plt.ylabel(\"time (s)\")\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"curvesWithMKL.pdf\")\n",
+    "plt.show()\n",
+    "\n",
+    "rate = (np.log(data_mkl[m,-1,datatype])-np.log(data_mkl[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
+    "rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 264,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "double\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAABKf0lEQVR4nO3dd3gUVdvA4d/Z9BBIgBBKgAChEyIlUhWQKlIVsIAIyosfoq9ixYK9Ky+KIiIKRBAUBZEivSMgGJDekZpAQighIT17vj92E5OQshs2u5vkua9rr+zOnJ15Zmeyz86ZM+corTVCCCGEPRkcHYAQQoiyR5KPEEIIu5PkI4QQwu4k+QghhLA7ST5CCCHsTpKPEEIIu5PkI4QQwu4k+QghhLC7Upd8lFJ9lVJHlVLHlVL/cXQ8QgghbqZKUw8HSilX4BBwFxAH7AI6aK0vOzQwIYQQObg6OgAbawMc1FpHAiilVgA9gR8Le6O/v7+uU6dO8UYnhBBlxK5du2K11lXym+9UyUcp1Ql4AWgN1AAe1VqH5yozFngRqA4cBMZprbeYZ9cAIrMVjwQCLVl3nTp1iIiIuKX4hRBCmCilzhQ039mu+fgAB4BngKTcM5VSDwCTgQ+AlsA2YIVSqrY9gxRCCHFrnCr5aK2Xa61f1VovAIx5FHkOCNdaf6u1Pqy1/i9wAXjCPD+KnGc6geZpQgghnIhTJZ+CKKXcMVXHrc41azXQwfx8JxCilApUSvkAvYFVBSzzcaVUhFIq4tKlS8URthBCiDyUmOQD+AMuQHSu6dFANQCtdTrwPLAB2AP8r6CWblrr6VrrMK11WJUq+V4XE0IIYWNO1eDAFrTWS4AllpZXSvUD+tWvX7/4ghJCCJFDSUo+sUAGUDXX9KrAxaIuVGu9FFgaFhY2uqBy169fJyYmhrS0tKKuSgghrOLm5kZAQAAVKlSwy/qmbTpJaE1fOgSkw4JHYXA422Jc2Hc+jjGdg226rhKTfLTWqUqpXUAP4Jdss3oAC4u6XEvOfK5fv050dDSBgYF4eXmhlCrq6oQQwiJaa5KSkoiMNN09Yo8EFFrTl6fm/c3vwYuodvZPLi59m6dO3suUoS1tvi6n6uHA3EggMwtsAz7CVIV2RWt91tzUeg4wFtgKjAFGAc201gW2KS9MWFiYzu8+nxMnTlCjRg28vb1vZRVCCGG1xMREoqKisMulgfcCID3l5umuHjAhxqpFKaV2aa3D8pvvbA0OwoC/zQ8v4G3z83cAtNbzgXHABEwNCu4A7rnVxFOYtLQ0vLy8inMVQgiRJy8vL7tU9x+OimO235MkaI+saWkGD2g+BJ7Zb/P1OVW1m9Z6I1BgnZbWeiow1VbrtLTBgVS1CSEcobi/e45ejGfxst/oevYLHjEc44aLD0ZjKkblhosxlQsp7lQvn/tS+61ztjMfu9NaL9VaP+7r6+voUIQQwm6OR8fzZvhSTnw1iJfOP0Vjj8scav0uO4xNiG44FNf/W090w6EcOnacbSdjbb5+pzrzEUIIUbxOxCTw3epd1D/yNRNcVqPd3Ehq9yI+ncex+c9oQocPpXqwPwDVh07l1MlY9p2Po4N5mq2U+eQj9/kIIcqCfy4lMHXtISoeDOcVl98o75pEauhQPLtPgArVARjT2eem93UI9rd54gGpdisz1W5Tp07l9OnTFpcPDw/n0KFDxReQcFojR46kb9++jg5D2Mjp2Bs8N/9vPv/8Q8YdGcprrnPxqtcOwxNb8bzvq6zEY29lPvmUBWfPnmXcuHH4+fmhlCrwMXLkSAAiIiKYOjVnuw5Lv5R2796Ni4sLHTt2vGneyJEjs9bl5uZGvXr1eOGFF7hx44ZVywGIjo7mmWeeITg4GA8PDwIDA+nduzfLly8vMOZly5bh7e3NhAkTCt2WwlgSQ0kzefJkfvjhh2JfT+axMGrUqJvmjR8/HqVUjn1nyb4sSuLMfkwqpfD396dv374cOXKkwHXnpbBj9tKlS4wdO5Y6derg4eFB1apV6datG2vWrLEqZkucvZzIi7/s5eXPpjHy0Ci+cJtCtYAAGL4I9xG/QtWmNl+nNST5lAGLFy+mU6dO+Pn5ceHChazHt99+C5Bj2uTJkwEYMGAAixcvLtL6vvvuO8aOHcuBAwc4fPjwTfO7d+/OhQsX+Oeff3jvvfeYOnUqL7zwglXLOX36NK1atWLVqlV8+OGH7Nu3j7Vr19KnTx/GjBmTb2xz5sxh0KBBfPjhh7z33ntF2r5bjWHkyJG89dZbFq/H2vK3ytfXFz8/P7usq1atWvz88885fnykp6cze/ZsatcueKQUW+7LzGPywoULrF69mqSkJO69916rl1PYsT9o0CB27tzJjBkzOHbsGMuWLaN3795cvmy7wZbPXUnk5YX7eOx/P9Jz//P85PYOzconwsCvcX1iCwR3tdm6boVc87HTNZ+sbiuy1Z1uM1/Is3W3FbktXryYAQMGAFCtWrWs6ZlfMNmnZerSpQvx8fHs2rWL1q1bW7yupKQk5s2bx5YtW0hMTGTGjBlMnDgxRxkPD4+sdQ4dOpQNGzbw22+/8fXXX1u8nLFjxwKmMzQfn3/rqZs0acLDDz+cZ2yff/4548ePZ8aMGfmWsUZRYrCHLl26EBISwpQpU7KmjRw5ktjYWJYtWwbA5s2beemllzhw4AAuLi40atSImTNnEhISclPZLl260LRpU/z8/Jg+fToGg4FHHnmETz75BIPB9Pv1xo0bPPHEE/z666+UK1eOcePGsXXrVvz9/QkPD8831tDQUKKiovj555959NFHAfj999/x9PSkU6dO+X4p23pfZj8mq1WrxrPPPku/fv1ISkqy+B6/wo7Za9eusWXLFtasWUO3bt0ACAoK4vbbb7/l+AEiryUxZf0J1kUc5GnXhbzvvg7l5gl3vo5Lu7Hg7lw3yZf5Mx97XfPJ7LYis8nitpOxPDXvb0JrFu96r127xubNm+nfv79V73Nzc6N379789ttvVr1vwYIFBAUF0bx5c4YPH87s2bMLvUEur5voClrOlStXWLlyJU8++WSOL/1Mef1qnzBhAq+++iqLFi2yyZdVUWJwFunp6QwYMIA77riDvXv3smPHDsaNG4eLi0u+75k7dy6urq5s27aNKVOm8PnnnzN//vys+c8//zybNm1i0aJFrF+/nr1797Jly5Z8l5fdqFGjmDlzZtbrmTNn8uijj+Z7f4ut92Vu8fHxzJ8/n+bNm1t1c3lhx76Pjw8+Pj4sWbKE5ORkm8V7IS6JCb/tp9enq/D/ewqbPZ9lmMs6XMJGYnhmD3R6wekSD8iZT5G9vfQgh6KuW/WegPIePDJjJ1UreBB9PYX6AT5MXnucyWuPW/T+pjUq8Ga/Zlatc9myZTRr1oygoCCr3gemqrf333+fd9991+L3zJgxg+HDhwPQuXNnvL29Wbx4MYMHD86z/M6dO5k3b17WL0FLlnPixAm01jRp0sSimNasWcPvv//OsmXLuOeeeyzeloJYG4MzuX79OteuXaNfv34EB5vOuhs3blzge5o2bco777wDQMOGDfn2229Zt24dDz30EAkJCcycOZPZs2fTo0cPwLT/atasaVE8Q4cO5YUXXuD48eOUL1+elStX8uWXX/LGG2/cVLY49iXAypUrs35E3Lhxg1q1all93a6wY9/V1ZXw8HBGjx7N9OnTadmyJR07dmTIkCG0bdvW6pgvxiUzdeMJ5u88Q3+1hT+8F+KXFgMN7oHub0OVhlYv057K/JmPPfl6uVG1ggeR15KpWsEDXy+3Yl/n8uXLi/xP2rt3bw4ePMjZs2ctKn/ixAn++OMPhg4dCpjuzB42bBgzZszIUS7zH93T05P27dvTqVMnvvzyS4uXY21/hCEhIQQHB/P2229z7dq1QsvPnTs361eqj49Pnr/grYnhgw8+yLG8uXPn3jQt+zqsLW+tSpUqMXLkSHr16kWfPn2YNGlSofs4NDQ0x+saNWoQE2Pq6+vkyZOkpaXRpk2brPnlypUjJCTEongqVqzIvffey8yZM/n+++/p0qVLvtd7rN2XlurUqRN79uxhz5497Ny5k27dutGzZ0/OnTtn0fstPfYHDRpEVFQUS5cupXfv3mzbto127drxwQcfWBxrzPVk3lpykE6fbuDUzuWsL/8Wn7p+jV+VQBj5Ozz0o9MnHpAznyKz9gwE/q1qe7prfX7YcZZnujcolvbz2dWpU8eqJtbZnTlzBm9vbwICAiwq/91335GRkZHjiyPzS/rcuXPUqlULMP2jT58+HTc3N2rUqIGbm5tVy2nQoAFKKQ4fPmzRReHq1auzZMkSunbtSvfu3VmzZg0VK1bMt3z//v1z/BINDAy8qYw1MYwZM4b7778/6/X48eMJDAzk6aefznMd1pbPzWAw3JQcc1drzpo1i3HjxrFy5UqWLFnCa6+9xm+//UavXr3yXGbufaSUwmjMa6T7onnssccYMWIEPj4+WWdYebF2X1rK29s7R8ed3333Hb6+vkyfPt2iM39Lj30AT09PevToQY8ePXjjjTf4z3/+w1tvvcULL7yAu7t7vuuIiU9m2sZ/mLvjDHX1WRZX/JUmCX+CR2245zsIGQSGknM+UXIiLSZKqX5KqelxcXHFup7MxDNlaEue69mIKUNb5rgGVFwGDhzI8uXLSU9Pt/q9ixcvplevXnh6ehZaNj09ne+//54PP/ww6xfknj172Lt3L6GhocyaNSurbOY/elBQ0E1fapYsp1KlSvTq1YspU6aQkJBwUyx5/SIODAxk48aN3Lhxg27duhXYuqh8+fLUr18/65FXvb81MVSqVCnH8sqXL3/TtOzrsLZ8blWqVOHChQs5pu3du/emcrfddhvjx49n48aNdOnShe+//z7fZRYkODgYNzc3/vrrr6xpiYmJHDhwwOJldOvWDXd3d2JjYxk4cGCBZa3Zl0WllMJgMJCYmFhoWWuO/bw0bdqU9PT0fK8DpWUYiUtKo9MnG/h9+x7Cq8xlhfvLNEk7DD3egaf+gtAhJSrxgJz5WDyY3K3adz6OKUNbZp3pdAj2Z8rQlsXSbUV2t99+O97e3mzatOmm6yqFWbx4cY5f22C6XrBnz54c0/z8/Ni7dy+xsbGMHj2aypUr55j/4IMPMm3aNF5//fVC1/n7779btJyvvvqKjh07EhYWxrvvvktoaChaazZs2MCHH36YZzVS9erV2bhxI926daNr166sW7cOf/+if/ZFicEeunbtyrhx41iyZAmNGjXim2++4dy5c9SpUweAU6dO8c0339C/f38CAwP5559/2LdvH0888USR1ufj48Njjz3G+PHj8ff3p3r16rz33nsYjUaLO8VUSrFv3z601nh4eBRavqB9md8xmrn9eUlJSeHiRdOYlFevXs36UdGvX7+sMrd67F+5coUhQ4bw2GOPERoaSvny5YmIiOCTTz6hW7duN43Xk55h5FJCCpcTUrmRnMbn1VbR89p8DHGp0Ob/oPNL4F2p0M/KWZX55GMveTWnLq5uK7JTStG/f38WL15sVfI5f/48e/fuvenGui1bttCyZc6BpQYNGkRqaip33XXXTf98AEOGDOHll1+26Ea6GTNmWLScnj17snv3bj744APGjx9PZGQklStX5rbbbmP69On5Lr9q1aps2LCB7t27c9ddd7Fu3TqLqxVzq1evXpFiKG6PPfYY+/bt47HHHgPgySef5N577yU21nSW7e3tzbFjxxgyZAixsbFUrVqVYcOGMX78+CKvc+LEidy4cYP+/fvj4+PDs88+S3R0tEVnzZnKly9v1Trz2peQ/zG6YMGCfJe1du1aqlevnhVH48aN+eWXX+jSpUtWmVs99jt37ky7du2YPHkyJ06cICUlhcDAQIYOHZrjhufsSUdrTQ33RAyGqzS9NAuaDoBub0Ll4r09wx6cajA5RypoMLnDhw+XyFZNmVauXMmYMWOsuvYzdepUfvnlFzZs2FB8gYlSKyUlhaCgIF588UWef/55R4dTIqRnGIlNSCU2IQWj1lTzSMXfeBlDRjKHz8fRpJoX1La+VZyjFDaYnJz5lAFdu3bl6tWr7NmzhxYtWlj0nsWLFxda9y5Epr///pvDhw/Tpk0b4uPj+fjjj4mPj+eBBx5wdGhOLzPpXE5IIUNrqngaCdCXcUlLABd3qFgH4i5C7ZL7AzgvZT75lIVerd3d3bG2QcWqVauKKRpRWk2aNImjR4/i6upKixYt2Lx5s8X3+pR2MfHJeLu54OP5bwOb60lpxCakkJSWQYZRU8lTUU1dwzXlKigXqBAI5fxBGYCLjgu+mJT55GOvBgdClGYtW7Ykv2prAd5uLpy9kkTtSuDl7kLUtWSuJqYC4OfpQnXX67glxgIaygVA+apgKN1fz6V764QQwgn4eLpRqxKcvmxqum3UmnLuLtTyTMI9MRpS08Gzoml4A9fCW/uVBpJ8hBCimKWmG4m5noJBp1NbxZDq4UclfRUSUsDdByrUAPdyjg7TriT5CCFEMYpLSuP81US0hlrqMuVUMj5pF8kweOBSsS54+oKF90OVJpJ8hBCiGBiNmgtxyVy+kUKI4TQGlfO2FhdjCvrqaVSNFo4J0MEk+QghhI0lp2Vw9koiyWkZVC3nQnqKJ+7GpGwlDKS5VyDOrQrFe5u585LkI4QQNqK15mpiKlHXkjEoRf0KRrwTz4E2mq7tpCYACjDi5uqKv+/NY0GVFZJ8hBDCBjKMRiKvJnEtKY3yHi7UdovDJeESuHqZbhSNjwJvfyhXGW5cBmPBgyyWdmU++ZSFm0yFEMUrMSWds1cTSUvXBJZ3oVJqFCox0ZRsKgSaepyuVO/fN/g538ii9lay+uAuBvYaRttZ1alTJ8c488J5jRw58qaOXoVjaa2JiU/m5KUboKFhhTQqJ55CpadAxbrgV6vEDXVgL/KplGIjR45EKXXTo127dlll/vrrL8aOHWv32H755RfCwsLw8/OjXLlytGjRosjjyeTl5MmTjBo1ilq1auHh4UFQUBCDBw9m27ZtNluHvU2ePJkffvih2NcTHh6OUooGDRrcNG/FihUopbKGnAbYuHEjSqmsXrMBLl26ROvWrWnVqhUxMTGcPn0apVSp6gUhLcPIqdgbXIxLxtfLhYaeV/FIOAeunlClEXj5OTpEpybJp5Tr3r07Fy5cyPHIPjZ9lSpV8Pa2fxVA5cqVmTBhAn/++Sf79u3j0UcfZdSoUTliK6qIiAhatWrFwYMH+frrrzl06BBLly6ldevW/Pe//833fUopi3v+3rhxY4HjwxQHX19f/Pz87LIuT09Prl27xqZNm3JMnzFjRr5DXGc6c+YMd9xxBxUqVGDjxo1FHrLCmcUnp3E8OoHE1AyCKhiolXEOQ9IV8KkK/g3KTC8Ft0KSj73FX4RZvSE+2i6r8/DwoFq1ajkelSr9OwBV7mq3Y8eO0blzZzw9PWnUqBHLly/Hx8eH8PDwrDKRkZE8+OCDVKxYkYoVK9KnTx+OHz+eNf+tt94iJCSEn376ieDgYMqXL8/AgQNz/DLu2rUrAwcOpHHjxgQHB/PMM88QGhrKli1bbml7tdaMHDmSevXqsXXrVvr27UtwcDChoaG88sorWWO+2Ft+v/yVUjnGmXnnnXcICgrK2m+PPPJI1rzc1W5dunRh7NixvPrqq/j7+xMQEMALL7yQY3jr6Oho+vfvj5eXF0FBQcyaNYuQkBDeeuutAuN1cXFh+PDhzJw5M2tabGwsy5YtY8SIEfm+79ChQ3Ts2JGmTZuyYsWKmwZIs4YtjkUg64eHp6cndevW5bXXXiM1NTVr/q+//kpoaCheXl5UqlSJzp07Ex2d9/+nUWsuxCVxKvYGrgZFo/Ip+Cb8gzKmQ+X6pp4KyuANo0UhycfeNn0CZ/+ETR87OpKbGI1G7r33XlxdXfnzzz8JDw/n7bffJiUlJatMYmIid911F56enmzatInt27dTvXp1unfvnmPI4dOnTzN//nwWLVrE6tWr+fvvv3nttdfyXK/WmnXr1nH06FE6dep0S9uwZ88eDh48yIsvvoiLi8tN8+115lAUCxcuZOLEiUydOpXjx4+zbNky2rRpU+B75s6di6urK9u2bWPKlCl8/vnnzJ8/P2v+iBEjOHPmDOvXr2fx4sX88MMPnDlzxqJ4Ro0axcKFC4mPjwdgzpw5dOjQgXr16uVZfseOHdx555306tWLBQsWWDWQXG62OhZXrVrFsGHDeOqppzh48CAzZ85kwYIFvPrqqwBcvHiRBx98kBEjRnD48GE2b97M8OHD84wpJT2Dfy4lcCk+BX9vVxq4X8ItIRI8fKBKY/CwbjC8sq7Mt3YrshUvw8X9lpc/uxWyD9wXMcP0UApqd7RsGdWaQ++PrApz5cqVOernwTSy5ccf35z81qxZw9GjR1m9ejWBgYEAfPbZZ3Ts+G98P/30E1prZs2alTVE8jfffENAQADLli3j/vvvB0zj2oeHh5PZkOPxxx+/aSz7uLg4AgMDSUlJwcXFha+++orevXtbtX25Zf7qLYmD/505c4bq1avTs2dP3NzcqF27NmFh+Y7FBUDTpk155513AGjYsCHffvst69at46GHHuLo0aOsWrWK7du3Z13nCw8Pt7i6sFmzZjRr1oyffvqJ0aNHM2PGDF5++WXS09PzLH/fffcxYMAAZsyYYflG58NWx+L777/Piy++yKOPPgpAcHAwH3/8MQ8//DCffvopUVFRpKWlMXjwYIKCggAICQm5KZ5rialEXk0CBfV8FT6JZyAjzXSmUy5AznaKQJKPvdS4Ha6egqTLphvOlAG8K5taxBSjTp063TSkc36//o8cOUKNGjWy/tkBbr/9dgzZWuvs2rWLU6dO3TTkcWJiIidPnsx6HRQURPYWhDVq1CAmJibHe8qXL8+ePXtISEhg3bp1PPfcc9SpUyff4b6bNWuW9av9zjvvZMWKFTeVsWZk3uzLyz4t84ssKCiIgwcPAnD27FmaNm2aVS4jI4OUlJQcif3hhx9m2rRpFq8/tyFDhjB58mTq1q1Lr169uPvuu+nfvz8eHvlfPwgNDc3xOvvnfOTIEQwGQ44EVqtWLWrUqGFxTKNGjWLmzJmEhoZy/vx5Bg0alOPMKruBAweydOlS1q5dS/fu3S1eR15sdSzu2rWLnTt35vixZTQaSUpK4uLFi9x22210796dkJAQevbsSffu3Rk8eDBVqlQBIMOoibqWxNXEVMq5uxDkkYBr/EXTIG/+DcpcZ6C2VGqTj1JqEdAFWKe1HmzzFVh5BgLA0mdhd7ipNUxGKjTpD30n2Ty07Ly9vbHlPUxGo5EWLVrw008/3TQv+7UkNze3HPOUUjmuRQAYDIas2Fq0aMHhw4f54IMP8k0+y5cvJy3NdGOel5dXnmUaNmwImIY+b9myZYHbkn15AA0aNGD58uVZX3jZt6FGjRrs2bMn6/WOHTsYP348GzduzJpW0PWNzC/N7Mkx+7rBlBiOHj3KunXrWLt2Lc8//zxvv/02O3bsoFy5vL/kLPmcb8WDDz7Is88+y8svv8xDDz2U7+cOMGXKFKpUqUK/fv1YvHgxPXv2tFkcebHkWDQajbz55psMGTLkpjJVqlTBxcWF1atX8+eff7J69WpmzJjBK6+8wqZNm2jYpBlnrySRkp5BNR9XqqRfRN2IB08/cxPqUvv1aRel+dObDMwE8r86am83YqD1oxD2KETMggT7NDqwVOPGjYmKiiIqKirr13FERESOL7NWrVrx448/4u/vb/PrJ0ajMUedfm6Z1SIFadGiBU2bNuXTTz/lgQceuOm6z7Vr17Lizmt5QUFBeVZLubq65kji58+fv2laQTJ/SV+4cCFrWvZklsnT05M+ffrQp08fXn75ZapVq8bWrVuL9EXeuHFjjEYju3btom3btllxR0VFWbyMChUqMHjwYGbPns2nn35aYFmlFFOmTMHNzY3+/fuzaNGiIlej2upYbNWqFUeOHClwPymlaN++Pe3bt+eNN96gWbNmzJozl1HPvoarQdHAV+N14xQYjeBby1RjIdVst6zUJh+t9UalVBdHx5HDg3P/fV7MZzyZUlJSuHgx5xC8Li4uWV+G2fXo0YNGjRoxYsQIJk6cSFJSEs899xyurq5ZVVHDhg1j4sSJDBgwgHfeeYfatWtz7tw5Fi9ezJgxY/K8NyQv77//Pm3btqVevXqkpKSwfPly5syZw5dffnlL26uUYtasWXTv3p077riD1157jSZNmpCYmMiKFSv4+eefHXKviZeXF+3atePjjz8mODiYuLg4XnnllRxlwsPDSU9Pp23btvj4+DB//nzc3Nws/kxza9SoEb169WLMmDF8/fXXeHp68uKLL+Lt7Z21Py3xzTffMGnSJCpXrmxR+c8++wxXV1fuvfdeFixYkKOF3rFjx3B1zfm107hx45saJ9jqWHzjjTfo27cvQUFB3H///bi6unLgwAF27tzJJ598wp9//snatWvp1asXVatWJWLXLs6ePUdA7eCsLnIM8TGm2orKdcAt/zM/YR27t3ZTSnVSSi1RSkUqpbRSamQeZcYqpU4ppZKVUruUUnfaO87SYu3atVSvXj3HI7/qKIPBwKJFi0hJSaFNmzaMGDGC1157DaVU1peDt7c3mzdvpl69egwZMoTGjRszYsQIrl69SsWKFS2OKyEhgSeeeIJmzZrRsWNHFi5cyOzZsxkzZswtb3ObNm3YtWsXjRs3ZsyYMTRp0oS+ffuyc+dOpkyZcsvLL6rMZsu33347//d//8d7772XY76fnx8zZszgzjvvJCQkhIULF/Lrr79St27RrwuGh4dTs2ZNunTpQv/+/Rk2bBgBAQFWtUTz9PS0OPFk+vTTT3nuuecYNGgQixcvzpo+bNgwWrZsmeNx4sSJm95vq2OxV69e/P7772zYsIE2bdrQpk0bPvroo6x7lXx9fbOa5Ddo0IBxzz3P6GdeZMzIoQTpSAw3YkxnOv6NJPHYmtbarg/gHuADYDCQCIzMNf8BIA0YDTQBvgQSgNrZyuwBDuTxqJFrWV2ABZbE1bp1a52fQ4cO5TuvtNuzZ48GdEREhKNDETZw6dIl7ebmphcsWODoUKxWXMei0WjUF+KS9L5zV/WRC9d18vVYraP2mh6JV2y6rqIqid9BQIQu4DvX7tVuWuvlwHIApVR4HkWeA8K11t+aX/9XKXU38ATwinkZLYo/0rJp0aJFlCtXjgYNGnD69Gmee+45brvtNlq1auXo0EQRrF+/nvj4eJo3b05MTAyvvfYa/v7+3H333Y4OrVD2OBZT042cu5LIjdR0Knm7UcNwGUP8ZXDzNvVELT0VFBunuuajlHIHWgO5e7pcDXQohvU9DjwOFNplSFkRHx/P+PHjOXfuHBUrVqRLly589tlnVl0jEM4jLS2NCRMm8M8//+Dt7U27du3YvHlzvq3nnElxH4vZh7eu4+tChaSzkJ4MPgFQvrrpdghRbJS24r4Im69cqQTgKa11uPl1DSAS6Ky13pyt3BvAMK11IyuWvRa4DSgHXAGGaK2351c+LCxM53ch+vDhwyXypkUhxM2yD2/t5eZCHe9k3OKjTL1P+wWBZ9G7BCouJfE7SCm1S2ud713STnXmY0taa4vucpPxfIQoO7IPbx1Qzo2qOgYVfw3cy0PFIHBxK3QZwjac7bwyFsgAquaaXhW4eHPxW6fL+Hg+QpQFWmuu3EjhREwC6RmaYD9FtdTTqORrpiq2ysGSeOzMqZKP1joV2AX0yDWrB1AsA7EopfoppabHxcUVWM6Wd40LIewnw2hqVHD+ahLe7i408kmk3PVTppn+DaF8Nae+abS0fvc44j4fH6VUC6VUC/P6a5tfZ17xnwSMVEr9RynVRCk1GagBFL3TrAJYcuZTrlw5IiMjSU1NtarvMCGEYyWmpHM8JoG4pHRqlHejruEiLgkXTNd1qjRy6r7ZtNakpqYSGRlZIhqIWMsR13zCgA3ZXr9tfnyP6Z6f+UqpysAEoDqm+3fu0Vpb1g98MahZsyaxsbGcOXMm3x59hRDOQ2tISEnjelI6LgZFZU8jlyKvckkbwbMieKRA9PHCF+Rgrq6u+Pr64u/v7+hQbM6hrd2cQbYGB6NzD0IlhCh5YuKTef7nvWw5Hku/kCp8WmU5nts/N1WxDZkFVZs5OsQyobDWbk51zccRpMGBECXTtE0n2XYy9qZpXT7dyF+nrzC5d2W+SJmA5/bPoNVweHyDJB4nUuaTjxCiZAqt6ctT8/5m28lYUtONPDVvNx+tOELlcu6sv+c6A7bfj4o+BINmQP8vnfr6TllUau/zsZTc5yNEydQh2J8pQ1vyxA+78XQ1EB2fwt0NfZnivxDXVTOhRisYPAMq5T3st3CsMn/mI9VuQpRMRqPm8IV4vJJj+CLlNf4bHMO05Jdw3T0TOvwXHlsliceJlfkzHyFEyXP2ciIvLNjLzlNXeN9tEW0MR2kd+RxpHn64DVsADXLfKiicjSQfIUSJobXmhx1n+XD5YXarh/H0/Hcoclc0pFzB+NMwDK/HODBKYYkyX+1maQ8HQgjHiryWxPAZO3n9twO0r+XF/ur3ocnWM4GrFzF1BzCn7VLHBSksVuaTj1zzEcK5aa35+a9z3P3ZZnafvcL3HWL4LuFJbr84H1WpHqBMw1xnpBBQ2Z8RPds6OmRhAal2E0I4rejryby8cB8bjl6if61kPi43F6/d6yCgKYxcDn9OhXpdIOxRiJgFCdGODllYSJKPEMLpaK1ZvCeKN5cchPQkFjXdSosz4ag4N+j1AbR53NQLdZ2O/76p7yTHBSysJslHCOFULsWnMOG3/aw6GM3oqkd5Sc/C7Z+zEDIYer4HFao7OkRhA2U++chNpkI4j9/3XeD1xQfwS4liY82F1IndBP6NYMRSqNvJ0eEJGyrzHYtmKmgYbSFE8bp6I5XXFx9gzb4zvFFpLQ+l/ILB4ApdxkPbJ8DV3dEhCiuV2WG0hRAlw5pD0bzy635Ck3eyw28efonnoNm90PN98A10dHiimEjyEUI4RFxSGm8vPcifu/fyefmfuMN1G5SrD0MWQXBXR4cnipkkHyGE3W08GsOEBbvpn7SITd6/4aoVdHsD2j8Frh6ODk/YQZlPPtLgQAj7SUhJ5/3fD3E2YjnzPGdT2zUSGvaFuz8Cv1qODk/YkTQ4MJMGB0IUr20nYvnkl/X8J3EGfV3+xFixLoZ7PpVOQEspaXAghHCoxNR0Pv19P24R3/Cj2yI83DV0eg1Dh6fBzdPR4QkHkeQjhCg2f52+wtyffuDJxGk0cIsko0FvDPd8BBXrODo04WCSfIQQNpeclsG0pX9Q9++P+NxlG8kVakG/+bg0utvRoQknIclHCGFTf5+OYfuPHzIq+Uc8XTNI7fAinl2eBzcvR4cmnIgkHyGETaSkZ7Dw159pdeB9xhrOcSWwM+UHfQaVgx0dmnBCViUfpVRdoA7gBVwC9mutk4shLiFECXL4+Akif36BoWkbuOpRlcR+s6nUvD8oVfibRZlUaPJRStUBngAeAgIh+9CBpCqltgDTgYVaa2NxBCmEcE5paan88ePHhJ38ivoqjdNNx1Bn4Jvg7u3o0ISTK3AkU6XUF8BeoB7wGtAU8AXcgWrAPcAfwLvAPqXU7cUabTGQYbSFKJozezZw9qO23PXPRCLLNSPpP39Q5/6PJfEIixR4k6lS6hPgE611bKELUuoewFtrvcCG8dmN3GQqhGXSr0dzfN4LNLm4hItU5kK7N2jZa4RUsYkcbukmU631S5auSGu93JrAhBAljDGDmI3T8N7yAfWNSayq9CBhwz+gZaXKjo5MlEAWNzhQShkAMq/rKKWqAX2Bw1rrrcUTnhDCYeIvwoJHYXA4GdfOceXnpwiIP8wOQrjR/SN63nEHSs52RBFZ09rtd2AlMFkp5QNEAOUAH6XUKK317OIIUAhhX9M2nSS0pi8dDn8CZ7aTOrMPrldPkKH9+CZgAvcOf4qACnLPjrg11iSfMCCzGu4+4DpQFxgGvABI8hGiFHh8c3sMGSlZr92vHgfA33CDx8e+IGc7wiYKbO2Wiw9wzfy8J7BIa50GrAfkLjIhSgnDkztJ8P53eINk7cb5Wn1xfe6AJB5hM9Ykn7NAR6VUOaAXsMY8vRKQaOvAhBD2p2OPcy38fnwSz6G1KfG4q3RqVq0K5as6OjxRilhT7TYJmAMkAGeAzebpnYD9No7rliilamGKNQBIB97VWv/i2KiEcG7XI37G7fdn0EYDB10bsz8jiNTbhuOxdw7do88hbdqELVmcfLTW3yilIoDawJpsvRmcBF4vjuBuQTowTmu9x9wqb5dSarnW+oajAxPC6aSncObHcQSdnMdu3YB1TT/kx6MwZXhLOgT7sy20PT3m/c2Uk7F0CPZ3dLSilLCqbzet9S5gV65pv9s0IhvQWl8ALpifX1RKxWKqHpTkI0Q21y8cJ+77YQQlH+VXz3tp/sgkyh+/ypQw36xE0yHYnylDW7LvfJwkH2EzhXWv87Cy8AqjUipIKXWnBeU6KaWWKKUilVJaKTUyjzJjlVKnlFLJSqldliy3gPW1Bly01ueKugwhSqND6+eivulEhaTzLG48kX4vzqRBjUqM6Rx8U5LpEOzPmM7SrkjYTmENDh4DjiqlXlVKNc+diJRSlZRS/ZVSPwN/Yer3rTA+wAHgGSAp90yl1APAZOADoCWwDVihlKqdrcwepdSBPB41cseHqQn44xbEJUSZkJiUyLavRtN081giDYFEPbiSAQ+Oxs3FmvZHQtyaAvt2A1BK9QGeBroDyUCM+W9FoIr59SzgM631JatWrlQC8JTWOjzbtB3APq316GzTjgMLtNavWLFsD0wt8r7VWs8prLz07SbKgv0H9+GycBRNjcfYGTCE0Ee/wNNLOgIVtndLfbtB1jWd35VS/sAdQBCm8Xxigb+Bv201lIJSyh1oDUzMNWs10MGK5SggHFhfUOJRSj2O+ayodu3a+RUTosRLSc9gyc+z6HH0DVyV5ljnKbS5a7ijwxJlmDWt3WKB34ovFAD8ARcgOtf0aExnXpbqCDyAaZiHgeZpw7XWOZqEa62nYxqLiLCwsIJPAYUooQ6dv8zBOS8wJOVXorwa4DtiHg2rN3R0WKKMK5XDaGut/8DCG2iVUv2AfvXr1y/eoISws/QMIz+s2U7ItmcZYjjK+foPUfOBz8HN09GhCWFVDwf2EAtkALlvpa4KXCyOFWqtl2qtH/f1taSthBAlwz+XEvjgiy/pt/0BQlzOktD3G2o+PE0Sj3AaTnXmo7VOVUrtAnoA2Xsk6AEsdExUQpQcRqNmztYTJK55nzcMi7ju2xDPR+aBfwNHhyZEDnZPPubhGDLruAxAbaVUC+CK1vos5m58lFI7ga3AGKAGMK2Y4pFqN1EqRF5L4v2f1vNI1Lu0MxwmKWQoFfr/T4a1Fk6p0KbWNl+hUl2ADXnM+l5rPdJcZiym4RuqY7on6Fmt9eY83mMz0tRalFRaaxbujmTlkp/4iC/wc03Fpd8kVIuhjg5NlGG33NQ618LGAk9iGscnRGv9j1LqZeAfrfXPlixDa70RKLDXBK31VGCqNbEVlZz5iJIsNiGFVxfuocmxb5ju9isZFevj+tAPENDY0aEJUSCLGxwopcYBEzA1Tc6ePCKBp2wblv1IgwNRUq08cIEHJy1hxMnnedZtISr0ftye2CSJR5QI1pz5jAFGa61/V0q9l236bqCZbcMSQuQnLimNt5YcJHLPWuZ7fkVFtxvQ50tUy+Egg72JEsKa5BOE6fpLbmmYejwokaTaTZQkm49dYvwve7gv6Rf+5/ELqmI91P1LoVqIo0MTwirWJJ9/gFaYBpLL7h7gkM0isjOt9VJgaVhY2OhCCwvhIImp6Xy4/AjL/tzPNJ9vaeu6C0IGQb/J4FHe0eEJYTVrks9EYIpSyhvTNZ/2SqnhmFqlPVYcwQkhYNeZKzz/814qX93DpvJTKW+8Bn3+B2GjpJpNlFjW9O02SynlimmoA29Mw1RHAU9rrecXU3xClFkp6Rl8tuY40zef4Plyq3nCYy4Gn5ow5Beo0cLR4QlxS6wdyfRb4FtzD9cGrXVM8YRlP3LNRzijg1FxPP/zXqIuXmBZwGyaXv8DmvSDAV+Bp7TMFCVfkfp201rHlobEA9LUWjiX9AwjU9YfZ+BXW6kWf5Adld6macIOuPtjuH+OJB5Ralh85qOUqgi8BdwFBJArcWmtA2wamRBlzD+XEnju573sOXeVT2ttZ/Dlb1Bu1WHoKqjZ2tHhCWFT1lS7zcZ0P8/3mMbXkfFvhLABo1Eze/tpPlp5BH/XZLbVm0eNqNXQsDcMnArelRwdohA2Z03y6QJ01lrvLqZYhChzIq8l8eIve9l28jIj61zj9aSPcblwHnq+B+2fktZsotSyJvmcxPnG/7ll0uBA2Mu0TScJrelLh2B/tNYs2HWeNxYfIN1oZEHrQ7Q+8gmqXBV4dAXUbuvocIUoVtYkk2eAD5VStymlXIorIHuTBgfCXkJr+vLUvL9Zsf8Co2fv4sUF+3DPSGRDnTmEHXwPVbcz/N8WSTyiTLDmzOcEpm50dgOoXNUBWutSk5CEKA4dgv15s29T3pq3ji/cviTdfQhf+/6AV9QZ6PYGdHwWDKWuckGIPFmTfH4EfIGnkQYHQlgt5noyk9Ye42nXRdyujnC7eh+DDoARy6BOR0eHJ4RdWZN8woA2Wuu8OhcVQhTg6o1UfCfVZBNpkFVHYISEi/DDvTChVNw2J4TFrDnHPwRUKK5AhCit4pPTGDlrJ91SJxFJlazpGS6e/M6d/DVwkwOjE8IxrEk+E4BJSqnuSqmqSqlK2R/FFWBxU0r1U0pNj4uLc3QoohRKSs1g1PcRHIm6ypf+iwjkEqDA1RMXYyqtGtZm12V3R4cphN0prS27dKOUMmZ7mf1NCtAlvcFBWFiYjoiIcHQYohRJTTfy+JwI/jh2kU315hEYuQKqNIGgDhD2KETMgoRoeHCuo0MVwuaUUru01mH5zbfmms9dNohHiDIhw6h5dv4e/jh6gfV1fiAwcjX0eBc6Pv1vob6THBegEA5mzZAKUjEthAWMRs3LC/exav85VteeTe2La6Hn+9DhKUeHJoTTKDD5KKVaAXu01kbz83xJtztCgNaad5YdYtGu06wIDKdezHro9QG0f9LRoQnhVAo784kAqgEx5uca0zWe3DTZGpAKUVZ9tuYYc7edYFm1GTS4vAnu/gjaPeHosIRwOoUln7rApWzPhRD5mL75JF+vP8KiKt/S+NoW0xg87cY4OiwhnFKByUdrfSb7S+CczqN5nFKqtq0DE6IkmbfjLJ8uP8CCyt8QEr8Ven8KbR93dFhCOC1r7vM5BdnukDNTSlU2zyuR5D4fcasW74nk7d9283PFr7ntxla4Z6IkHiEKYU3yUeTdn5sPkGybcOxPerUWt2LNoWhe/jmCeRWm0jJpO/T5H7QZ7eiwhHB6hTa1Vkp9YX6qMQ2pkJhttgvQBthj+9CEcG5bT8Qybt4OZvt8SeuUv6DPJLh9lKPDEqJEsOQ+n+bmvwpoAqRmm5eKaYiFiTaOSwintuvMVZ6cvY2ZnpO5PTUC+n5u6rVACGGRQpOP1vouAKXULOAZrfX1Yo9KCCd2KOo6/zfrD6a5fUbb9N3QbzK0HunosIQoUazp4UB+1oky7+SlBP4zYwtT1ETaZuyF/l9Cq0ccHZYQJY41fbsJUaadv5rIqG838z/jx7TV+1D9v4RWwx0dlhAlkiQfISwQE5/MY99u5oPUD2nHftSAKdDyYUeHJUSJVeoGjFdK+SmlIpRSe5RSB5RS0u5V3JJrian859vNvHXjPdqzHzVwqiQeIW5RaTzziQc6aa0TlVLlgANKqV+11pcdHZgoeRJS0hk9YzOvXHuLdoZDqIFfQ4uHHB2WECVeqUs+WusMIPNeJA9MTcTz6gxViAIlp2UwduYWnrv0Ou0Mh1H3ToPbHnR0WEKUCnatdlNKdVJKLVFKRSqltFJqZB5lxiqlTimlkpVSu5RSdxZhPX5Kqb3AeeBTrXWsDcIXZUhqupFnZv/BExdepZ3hCOrebyTxCGFD9r7m4wMcAJ4BknLPVEo9AEwGPgBaAtuAFdk7Ls12LSf3o0ZmGa31Na31bZh64h6qlKpavJslSpMMo2b8T9t59Mx42hqOoO6bDrc94OiwhChV7FrtprVeDiwHUEqF51HkOSBca/2t+fV/lVJ3A08Ar5iX0cKK9UWbz4DuBBYUPXJRVhiNmjd/+ZMHjz3H7YZjGAZ9C80HOzosIUodp2ntppRyB1oDq3PNWg10sGI5VZVS5c3PfYFOwNF8yj5ubhkXcenSpbyKiDJEa83HS3bR7+A4bjccxzD4O0k8QhQTp0k+gD+mjkqjc02PxjSaqqWCgC3mM54twJda6/15FdRaT9dah2mtw6pUuWm0CFHGfLVyD912j+V2w3HU4O8gZJCjQxKi1CqNrd12Ai0sLa+U6gf0q1+/frHFJJxf+Pr9tN3+OK0MJ2HwDFTIvY4OSYhSzZnOfGKBDCB344CqwMXiWqmM5yN+2XqIkI2PmRLPkJkYJPEIUeycJvlorVOBXUCPXLN6YGr1JoTNLY84SvCq4bQwnMQ4eBYuzQY6OiQhygS7VrsppXyAzPotA1BbKdUCuKK1PgtMAuYopXYCW4ExQA1gWjHGJNVuZdSGPSeosWQoIYZTGAfNwj1kgKNDEqLMUFrnNTJ2Ma1MqS7Ahjxmfa+1HmkuMxZ4CaiO6Z6gZ7XWm4s7trCwMB0REVHcqxFOYsehf/CcP5hm6jRp983CK1QSjxC2pJTapbUOy2++ve/z2UghXd1oracCU+0SEHLmUxbtPX4ar/mDaaLOkDxwFj6SeISwO6e55uMo0uCgbDl6+iwuc++jiTrDjQEz8WkhiUcIRyjzyUeUHafPnScjfAANOcO1fjPxaymJRwhHKfPJRynVTyk1PS4uztGhiGIUdTGK5Jn9qM9ZLveZQZXWkniEcKQyn3yk2q30uxRzgYTpfainz3Lh7u+ofvtAR4ckRJlX5pOPKN3iLl8k7pt7CMo4x5ke3xHUTm4gFcIZSPIRpVbC1WguT+1NrfRzHO86nQYdJfEI4SzKfPKRaz6lU3JcDJe/6kWN9HMc6DSNkM73OTokIUQ2ZT75yDWf0iftegyXpvSkatp5dnX4mtbdZFgEIZxNqevVWpQ90zadJLSmLx0C0tHzH+Zy9EWqpF7k6xrv82yvIY4OTwiRhzJ/5iNKvtCavjw172+iF70C5//CPzWSJ4zjadtdxuMRwlnZtW83ZyZ9u5Vg7wVAesrN0109YEKM/eMRQhTat1uZP/ORBgclXHw0cUE90UDm76g0gwc0HwLP5DmArRDCCZT55CMNDkqo9BRSN/2PlM9a4HViOUcIQqNIV+64GFO5kOIO5XOPSyiEcBZlPvmIEkZrOLyMxM9a477hHTanNeH1Gt8RRVWiGw3F9f/WE91wKIeOHWfbyVhHRyuEyIe0dhMlR/RBUpa9hMe5PzhnrMlMn7cZNOQR6p69ilf3H6ke7A9A9aFTOXUyln3n4+hgniaEcC6SfITzu3EZ44b3IWIWSdqbj/WjVOkyhnc7NcTd1UCbupVuekuHYH9JPEI4MUk+wnllpMFfM0hf/z4qNYHZ6T2IqPM4L9/XgVqVvB0dnRDiFpT55CMjmTqp42vJWPkKLpePsd3YnK/cH+ORQb2ZElINpQocDFcIUQKU+eSjtV4KLA0LCxvt6FgEEHsCvepV1PFVRFKNd9Kep2ab+/i2VyPKe7o5OjohhI2U+eQjnETSNdj8KXrHNJK0O5+lDSWi6v28fV9LQmv6OTo6IYSNSfIRjmXMgN2z0evfg8TL/GK8i6/Ug4y8pw0L2tfBxSBVbEKURpJ8hOOc/gNWvAzR+9nv0pRXUp4jKKQd8/s2o5qvp6OjE0IUI0k+wv6unoE1r8OhxVx1q8qE1KfZW6EL745ozl2NAxwdnRDCDiT5CPtJSYA/PkNv+5IMDExXD/DVjXt4pFNjJnZtgJe7i6MjFELYiSQfUfyMRtj/M6x9C+Iv8IfnXbx47T5qBtXn13ub06haeUdHKISwszKffOQ+n2J2PgJWjIfICC6Ua8rT6WM4ntqUVwY1ZkjrWhikQYEQZZKM52Mm4/nY2PUoWPs27PuJFK8AJmY8xHfXb+e+VrV59Z7GVPbxcHSEQohiVNh4PmX+zEfYWFoSbJ8CWyahjRmsqjSM56K6Ua1KZeaNbk774MqOjlAI4QQk+Qjb0BoOLYbVr0PcWc4EdGNM9EBOxlThvz3q83jneni4SoMCIYSJJB9x6y7sg5Uvw5mtJFVqwvsVPuCHs3W4s4E/Xw8IoY5/OUdHKIRwMpJ8RNElXIIN78Gu79Felfi99kuMOx6KXzkvvnioKf1Cq0snoEKIPEnyEdZLT4Wd38CmT9BpiZxp8Aj/Od2dk8ddGNa2Ni/2aoyvl3QCKoTInyQfUbD4i7DgURgcDj4BcGwVrHoVrpwkqU433ksdxtz9njSpXoFfh4fQsnZFR0cshCgBSm3yUUp5A4eBX7TWLzg6nhJr0ydw9k9Y9Yqp5+mT69CVG7Ai9Aue/7sqSsGEPg0Z2aEOri4GR0crhCghSm3yAV4D/nR0ECXWewGQnvLv6wMLAdDKlT5pn3BoZxI9m/rzZv9mBPp5OShIIURJVSp/qiqlGgCNgRWOjqXEyUiH01s5ENCPdDefrMlauRDhfSdtkr7gWorm20fCmP5ImCQeIUSR2PXMRynVCXgBaA3UAB7VWofnKjMWeBGoDhwExmmtt1i5qonmZXS41ZjLhKSrcGIdHFsJx9dA8jWaGtyIMZanKgqjwQ1lTOPwdQ/ahjbh40GhlPMozSfNQojiZu9vEB/gADDb/MhBKfUAMBkYC/xh/rtCKdVUa33WXGYPecfdU2sdpZQaABzTWh9TSknyyYvWEHvMlGyOrTJd09EZaG9/rtfuwaHyHdiYHsKdB19ndbIPP2Z0Y5jreroEGhk+tJWjoxdClAJ2TT5a6+XAcgClVHgeRZ4DwrXW35pf/1cpdTfwBPCKeRktCllNO+BBpdQQTMnOTSl1XWv9zq1vQQmWngpntpqSzbEVcPU0ANcqNGJvwMOsSL2NJbHVSNxnKu7tfoXdNd4kNd3I4fNxRN/xPrV6NXJc/EKIUsVp6k6UUu6YquMm5pq1Giuqz7TWr2BOVEqpkUBIfolHKfU48DhA7dq1rQ/a2SVcguOrMR5diT65Hpe0BNKUO3vdbmOZsSurU1sQlexPOXcXmtXw5cE2vjSvWYHmgb7U9fdhx6nLPDXvb57uWp8fdpylff3KdAj2d/RWCSFKAadJPoA/4AJE55oeDXQvjhVqracD08HUq3VxrMOutCYtah9X/16K4cRqKl3bhwHNJV2RdRltWGdsyT6326hbOYDmgb68FOhLSKAv9fzL3TS0wbaTsTw172+mDG1Jh2B/2gVXzvFaCCFuhTMlH5vL3ZghLyV5PJ+0DCPHIy8Ru28NHqfWEHz1D/yNsQQAe4z1+EkN4VyVTpQPakXzWn68GuhL3co3J5q87DsflyPRdAj2Z8rQluw7HyfJRwhxyxw2no9SKgF4KjNBmKvdEoGHtNa/ZCv3Faaqs87FGY+zj+eTmm7kWHQ8ByLjOHP6BD5n19H4+nY6qP14qVQStQcHvFoTU60Lro170TC4PnUsTDRCCGFrJWY8H611qlJqF9AD+CXbrB7AQsdE5RiZiWZ/ZBz7I+M4eP4qrtH76EQE3Qx/86DhNADXPKtzoeYQvEP6EBDSjTbuno4NXAghLGTv+3x8gMz6LQNQWynVArhibko9CZijlNoJbAXGYLofaFoxxuTQareU9AyOXUzISjQHIuM4ejEet4wb3GE4QC/3Pbxk2IOf61U0BlKqh6GbjkQ1uhu/Ko3xk16jhRAlkF2r3ZRSXYANecz6Xms90lxmLPASpptMDwDPaq03F3ds9qh2S0nP4OjF+Kwks9+caNIyTPugqecVHvA7xJ16F0Hxu3ExpqE9KqDqd4dGvaF+d/CuVKwxCiGELRRW7eawaz7OItuZz+jjx49b/L5pm04SWtM3x8X3bSdj2Xc+jjGdg0lOy+DIRdM1msxEcyz630Tj5+3GbTV86FHhLO3TI6gduxm3K0dNC6rcABr2goZ3Q+124CLDEwghShZJPhay9swne1PkVrUr8nPEOT5acYQ2dSoSHZ/K8eh40o2mz7aitxshgb40D/SlZRVFy7RdVI7cgDqxxtS1jcEVgjqYkk3Du6FycHFtphBC2EWJaXBQ0mQ2PR49exeJKelkpvB9kdcJCfSla+MqNA/0JaRGBQIzIlHHV5l6F9ixDXQGeFc2J5teENwVPH0duj1CCGFPknxuQYdgf4Y3c+euA2+wKPh9/jugIzV8PVEZaXB2Oxz7HtavhCv/mN4Q0Aw6PmO6fhPYGgwujt0AIYRwkDKffG6ltdu2k7HUOzSV2w1HuXjqSxJ3/oO6thVOroeU6+DiAXU7QbuxpjMcv1LYhY8QQhSBXPMxs/aaj/HdAAwZKTdN14Bq9Qg07A31OoN7ORtGKYQQJUNh13xK5WBy9vBD2yVcqtPfdHYDYHDlSo1OzG6/Evp/CY3vkcQjhBD5KPPJRynVTyk1PS4uzqr3PdKzHVUq+4MxDVw9QRupVKMBI3q1L6ZIhRCi9CjzyUdrvVRr/bivbxFam92IgdaPwn/Wmv4m5O6QWwghRF7KfIODW/Lg3H+f953kuDiEEKKEKfNnPkIIIexPko8QQgi7K/PJp6gNDoQQQhRdmU8+t9TgQAghRJGU+eQjhBDC/iT5CCGEsDvpXsdMKXUJOAP4AvldAMpvnj8QW0yh2VpB25cfa7avKMu35XJsHWthZYpyvEDJOWbsEactjpmixmnNui0tW1i5gmK11f+PLdzqZxqkta6SbymttTyyPYDp1s4DIhwdty22r4D3WLx9RVm+LZdj61gLK1OU48XaOB35sEectjhmihqnNeu2tKwFx0y+sdrq/8eR+97SbZBqt5stLeK8kqK4t8FWy7fHZ23JOgorU9qPF3tw5OdkzbotLXsr21MajhmLtkGq3WxAKRWhC+i9taQrSdtXUmKVOG2rpMQJJSfW4o5TznxsY7qjAyhmJWn7SkqsEqdtlZQ4oeTEWqxxypmPEEIIu5MzHyGEEHYnyUcIIYTdSfKxkFKqk1JqiVIqUimllVIjc81XSqm3lFJRSqkkpdRGpVQzB4VrFaXUK0qpv5RS15VSl5RSS5VSIbnKhJu3O/vjTwfE+lYecVzMNt8h+8EWx4dSqqJSao5SKs78mKOU8rNxnJbsa6eINY+4tVJqirPFqZRyUUq9q5Q6pZRKNv99Tynlmq2M3WMt7Jg0l2molPpVKXVNKZWolNqtlGqSbb6HUupLpVSsUuqGeXk1cy2jtvk4umEu94VSyr2w+CT5WM4HOAA8AyTlMf8l4Hngv8DtQAywRilV3m4RFl0XYCrQAegKpANrlVKVcpVbC1TP9rjHjjFmdzRXHM2zzXPUfrDF8TEPaAXcbX60AubYOM4uFL6vnSVWAJRS7YDHgX25ZjlLnOOBJ4GngcaYjoEngVccHGuBx6RSqi6wFTiF6VgIASYACdmKfQ4MAh4C7gQqAMuUUi7mZbgAvwPlzfMfAgYD/ys0OkffyFQSH+adMzLbawVcAF7LNs0LiAf+z9HxFmH7fIAMoF+2aeHAMieI7S3gQD7znGI/FOX4AJoAGuiYrcwd5mmN7LWvnS1WTHfLnwTuAjYCU5wtTmAZ8H2uad9n/r84Q6y5j0nztHnA3EI++1RgWLZptQAj0Mv8urf5da1sZR4GkoEKBcUkZz62UReoBqzOnKC1TgI2Y/qFWdKUx3RWfDXX9DuUUjFKqWNKqW+VUgEOiA2gnrn64pRS6ielVD3zdGfdD5bE1R7TF8S2bO/bCtygeGPPva+dLdbpwAKt9YZc050pzj+Au5RSjQGUUk0xnUksd8JYMcdoAPoBh5RSK81VsH8ppR7IVqw14JYr7nPA4VxxHzZPz7QK8DC/P1+SfGyjmvlvdK7p0dnmlSSTgT3A9mzTVgKPAN0wVR+0AdYrpTzsHNsOYCSmaonRmD7fbUqpyjjvfrAkrmrAJW3+6Qhgfh5D8caee187TaxKqdFAfUxVQbk5TZzAx5iqxw4ppdKAg5jOhKY6YayZAjCd9b6KKbn0AH4E5iql+mSLKYOb+3fLHXfu7Yo1v6/AuF0LminKHqXUJEyn+3dorTMyp2utf8pWbL9Sahemjlj7AL/aKz6t9Yrsr5Wp0cM/wAjA7g0gSrL89rUzUEo1Aj7AFFuao+MpxAOYfpgNxZR4WgCTlVKntNYzHBlYATJPPBZrrSeZn+9RSoUBT2G6jmOXAMStyWxtVTXX9KrZ5jk9pdRnmC4YdtVa/1NQWa11FHAeaGCP2AqIIwHTP3wDnHc/WBLXRaCKUkplzjQ/D6AYYi9gXztLrO0x9ap8UCmVrpRKBzoDY83PLztJnACfAhO11j9prfdrrecAk/i3wYGzfKbZxWJqbHIo1/TDQO1sMblg2g/Z5Y4793b5m99XYNySfGzjFKYPukfmBKWUJ6bWH9vye5MzUUpN5t8voyMWlPcHAjFdSHUY8+fc2ByHs+4HS+LajqkapH2297UHymHj2AvZ184S62+YWjG2yPaIAH4yPz/mJHECeGOqZsoug3+/X53lM82itU4F/gIa5ZrVEFONBsAuIC1X3DUxNY7IHneTXM2vewAp5vcXGIQ8LGst4sO//wSJwBvm57XN88djGsPiPkxNFn8CooDyjo7dgm37CriO6SJptWwPn2zbPhHTP0MdTM11t2M687Hr9pnj6IzpIm5bTC2NrmMaO8Rh+8EWxwewAthv/pzbm58vtee+dqZY84h9I+bWbs4UJ6aWoOcxVUHXAe4FLgH/c2SsFhyTAzG1Znsc07W10ZiSTZ9sy/javG3dgZbABkzXCF3M813Mca43z+8ORAJfFhpfcR4spemB6QtX5/EIN89XmJoBX8DUzHATEOLouC3ctry2SwNvmed7YWrBEmM+WM+Y/+FqOSDWzH/aVPNBvhBomm2+Q/aDLY4PoCLwA6bkcN383M+e+9qZYs0j9o3kTD5OESemFoOfm/8vkjBdg/wA8HRkrIUdk+YyIzGdRSZhuo/qoVzL8AC+xFTNmYhpuIRaucrUxvQjMNFc7gvAo7D4pGNRIYQQdifXfIQQQtidJB8hhBB2J8lHCCGE3UnyEUIIYXeSfIQQQtidJB8hhBB2J8lHCCGE3UnyEUIIYXeSfIQQQtidDKkghJNTSm3E1PvwNUz9cBmB2cBLWmuj4yIToujkzEeIkmEYpi7wO2Aab2UcpnFkhCiRpG83IZyc+czHQ2vdPtu0NcAZrfV/HBaYELdAznyEKBn25XodhWmgMSFKJEk+QpQMuYeS1sj/ryjB5OAVQghhd5J8hBBC2J0kHyGEEHYnrd2EEELYnZz5CCGEsDtJPkIIIexOko8QQgi7k+QjhBDC7iT5CCGEsDtJPkIIIexOko8QQgi7k+QjhBDC7iT5CCGEsLv/B6UQC7Jfu8ryAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1.650615023237321"
+      ]
+     },
+     "execution_count": 264,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fig1, ax1 = plt.subplots()\n",
+    "\n",
+    "datatype = 1; print(datatypes[datatype])\n",
+    "m = 0; plt.plot(nSizes,data_mkl[m,:,datatype],'x-',label=methods[m])\n",
+    "m = 1; plt.plot(nSizes,data_mkl[m,:,datatype],'*-',label=methods[m])\n",
+    "\n",
+    "ax1.set_xscale(\"log\")\n",
+    "ax1.set_yscale(\"log\")\n",
+    "ax1.set_xticks(nSizes)\n",
+    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "plt.xlabel(\"n\")\n",
+    "plt.ylabel(\"time (s)\")\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"curvesWithMKL.pdf\")\n",
+    "plt.show()\n",
+    "\n",
+    "rate = (np.log(data_mkl[m,-1,datatype])-np.log(data_mkl[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
+    "rate"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.10 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/performance_eigen/runWIthMKL.ipynb
+++ b/examples/performance_eigen/runWIthMKL.ipynb
@@ -1,13 +1,8 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,22 +16,41 @@
     "tlapack_DIR = pwd+\"/tlapack\"\n",
     "tlapackMKL_DIR = pwd+\"/tlapack_mkl\"\n",
     "blaspp_DIR = pwd+\"/blaspp\"\n",
-    "lapackpp_DIR = pwd+\"/lapackpp\""
+    "lapackpp_DIR = pwd+\"/lapackpp\"\n",
+    "\n",
+    "from datetime import datetime\n",
+    "from decimal import Decimal\n",
+    "seed = datetime.now().timestamp()\n",
+    "seed = seed - int(seed)\n",
+    "seed = 1000*seed\n",
+    "seed = int(seed)\n",
+    "\n",
+    "seed = 604\n",
+    "matrix_type = 0\n",
+    "\n",
+    "import random\n",
+    "random.seed(seed)\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib\n",
+    "from IPython.display import display, Math"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Linux weslleyp-XPS-15-9510 5.14.0-1054-oem #61-Ubuntu SMP Fri Oct 14 13:05:50 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "seed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# System:\n",
     "!uname -a"
@@ -44,77 +58,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 243,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Architecture:                    x86_64\n",
-      "CPU op-mode(s):                  32-bit, 64-bit\n",
-      "Byte Order:                      Little Endian\n",
-      "Address sizes:                   39 bits physical, 48 bits virtual\n",
-      "CPU(s):                          16\n",
-      "On-line CPU(s) list:             0-15\n",
-      "Thread(s) per core:              2\n",
-      "Core(s) per socket:              8\n",
-      "Socket(s):                       1\n",
-      "NUMA node(s):                    1\n",
-      "Vendor ID:                       GenuineIntel\n",
-      "CPU family:                      6\n",
-      "Model:                           141\n",
-      "Model name:                      11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz\n",
-      "Stepping:                        1\n",
-      "CPU MHz:                         2300.000\n",
-      "CPU max MHz:                     4600.0000\n",
-      "CPU min MHz:                     800.0000\n",
-      "BogoMIPS:                        4608.00\n",
-      "Virtualization:                  VT-x\n",
-      "L1d cache:                       384 KiB\n",
-      "L1i cache:                       256 KiB\n",
-      "L2 cache:                        10 MiB\n",
-      "L3 cache:                        24 MiB\n",
-      "NUMA node0 CPU(s):               0-15\n",
-      "Vulnerability Itlb multihit:     Not affected\n",
-      "Vulnerability L1tf:              Not affected\n",
-      "Vulnerability Mds:               Not affected\n",
-      "Vulnerability Meltdown:          Not affected\n",
-      "Vulnerability Mmio stale data:   Not affected\n",
-      "Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled v\n",
-      "                                 ia prctl and seccomp\n",
-      "Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user\n",
-      "                                  pointer sanitization\n",
-      "Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RS\n",
-      "                                 B filling\n",
-      "Vulnerability Srbds:             Not affected\n",
-      "Vulnerability Tsx async abort:   Not affected\n",
-      "Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtr\n",
-      "                                 r pge mca cmov pat pse36 clflush dts acpi mmx f\n",
-      "                                 xsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rd\n",
-      "                                 tscp lm constant_tsc art arch_perfmon pebs bts \n",
-      "                                 rep_good nopl xtopology nonstop_tsc cpuid aperf\n",
-      "                                 mperf tsc_known_freq pni pclmulqdq dtes64 monit\n",
-      "                                 or ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr \n",
-      "                                 pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc\n",
-      "                                 _deadline_timer aes xsave avx f16c rdrand lahf_\n",
-      "                                 lm abm 3dnowprefetch cpuid_fault epb cat_l2 inv\n",
-      "                                 pcid_single cdp_l2 ssbd ibrs ibpb stibp ibrs_en\n",
-      "                                 hanced tpr_shadow vnmi flexpriority ept vpid ep\n",
-      "                                 t_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 er\n",
-      "                                 ms invpcid rdt_a avx512f avx512dq rdseed adx sm\n",
-      "                                 ap avx512ifma clflushopt clwb intel_pt avx512cd\n",
-      "                                  sha_ni avx512bw avx512vl xsaveopt xsavec xgetb\n",
-      "                                 v1 xsaves split_lock_detect dtherm ida arat pln\n",
-      "                                  pts hwp hwp_notify hwp_act_window hwp_epp hwp_\n",
-      "                                 pkg_req avx512vbmi umip pku ospke avx512_vbmi2 \n",
-      "                                 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg \n",
-      "                                 avx512_vpopcntdq rdpid movdiri movdir64b fsrm a\n",
-      "                                 vx512_vp2intersect md_clear flush_l1d arch_capa\n",
-      "                                 bilities\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Machine:\n",
     "!lscpu"
@@ -122,17 +68,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "set (EIGEN3_VERSION_STRING \"3.3.7\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Eigen version:\n",
     "!cat /usr/lib/cmake/eigen3/Eigen3Config.cmake | grep EIGEN3_VERSION_STRING"
@@ -140,17 +78,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/opt/intel/oneapi/mkl/2022.2.1/bin/intel64/mkl_link_tool\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# MKL version:\n",
     "!which mkl_link_tool"
@@ -158,32 +88,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 246,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-- <T>LAPACK version 0.1.1\n",
-      "-- Submodule update\n",
-      "-- Configuring done\n",
-      "-- Generating done\n",
-      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/tlapack\n",
-      "[0/1] Install the project...\u001b[K\n",
-      "-- Install configuration: \"Release\"\n",
-      "-- Configuring done\n",
-      "-- Generating done\n",
-      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/build\n",
-      "ninja: no work to do.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Build without MKL\n",
     "\n",
     "# Install <T>LAPACK\n",
-    "!cmake -B \"$tlapack_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D BUILD_EXAMPLES=OFF -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=\"$tlapack_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" \"$tlapack_source\"\n",
+    "!cmake -B \"$tlapack_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D BUILD_EXAMPLES=OFF -D BUILD_TESTING=OFF -D TLAPACK_NDEBUG=ON -D CMAKE_INSTALL_PREFIX=\"$tlapack_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" \"$tlapack_source\"\n",
     "!cmake --build \"$tlapack_DIR\" --target install\n",
     "\n",
     "# Build\n",
@@ -193,135 +105,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reference:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "-x-x-x-x-x-x-x-x-\n",
-      "Using Eigen:\n",
-      "First eigenvalues:\n",
-      "(499.883,0)\n",
-      "(8.92164,0)\n",
-      "Error in the eigenvalues: 0.00998675\n",
-      "time = 1.5691 s\n",
-      "Reference:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "-x-x-x-x-x-x-x-x-\n",
-      "Using Eigen:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "Error in the eigenvalues: 2.33553e-15\n",
-      "time = 2.78988 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!./build/performance_eigen 1000"
+    "!./build/performance_eigen 100 1 1 {matrix_type} {seed}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reference:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "-x-x-x-x-x-x-x-x-\n",
-      "Using <T>LAPACK:\n",
-      "First eigenvalues:\n",
-      "(499.883,0)\n",
-      "(8.92161,0)\n",
-      "Error in the eigenvalues: 0.00998681\n",
-      "time = 0.976849 s\n",
-      "||Z.adjoint() Z - I||/||I|| = 0\n",
-      "||Z.adjoint() H Z - T||/||T|| = 828.706\n",
-      "n_aed = 41\n",
-      "n_sweep = 7\n",
-      "n_shifts_total = 448\n",
-      "Reference:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "-x-x-x-x-x-x-x-x-\n",
-      "Using <T>LAPACK:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "Error in the eigenvalues: 2.46726e-15\n",
-      "time = 1.57934 s\n",
-      "||Z.adjoint() Z - I||/||I|| = 0\n",
-      "||Z.adjoint() H Z - T||/||T|| = 826.093\n",
-      "n_aed = 41\n",
-      "n_sweep = 13\n",
-      "n_shifts_total = 832\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!./build/performance_tlapack 1000"
+    "!./build/performance_tlapack 100 1 1 {matrix_type} {seed}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-- Using CMAKE_INSTALL_PREFIX = /home/weslleyp/storage/tlapack/examples/performance_eigen/blaspp\n",
-      "-- Not building CUDA support in BLAS++\n",
-      "-- Looking for HIP/ROCm\n",
-      "-- Not building HIP/ROCm support in BLAS++\n",
-      "-- blaspp_id = c498e8d\n",
-      "-- Configuring done\n",
-      "-- Generating done\n",
-      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/blaspp\n",
-      "[0/1] Install the project...\u001b[K\n",
-      "-- Install configuration: \"Release\"\n",
-      "-- Using CMAKE_INSTALL_PREFIX = /home/weslleyp/storage/tlapack/examples/performance_eigen/lapackpp\n",
-      "-- Not building CUDA support in LAPACK++\n",
-      "-- Looking for HIP/ROCm\n",
-      "-- Not building HIP/ROCm support in LAPACK++\n",
-      "-- lapackpp_id = 17edf95\n",
-      "-- Check for BLAS++\n",
-      "\u001b[0m   Found BLAS++: /home/weslleyp/storage/tlapack/examples/performance_eigen/blaspp\u001b[0m\n",
-      "-- Configuring done\n",
-      "-- Generating done\n",
-      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/lapackpp\n",
-      "[0/1] Install the project...\u001b[K\n",
-      "-- Install configuration: \"Release\"\n",
-      "-- <T>LAPACK version 0.1.1\n",
-      "-- Submodule update\n",
-      "-- Configuring done\n",
-      "-- Generating done\n",
-      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/tlapack_mkl\n",
-      "[0/1] Install the project...\u001b[K\n",
-      "-- Install configuration: \"Release\"\n",
-      "-- Configuring done\n",
-      "-- Generating done\n",
-      "-- Build files have been written to: /home/weslleyp/storage/tlapack/examples/performance_eigen/build_mkl\n",
-      "ninja: no work to do.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Build with MKL\n",
     "\n",
@@ -334,7 +138,7 @@
     "!cmake --build \"$lapackpp_DIR\" --target install\n",
     "\n",
     "# Install <T>LAPACK\n",
-    "!cmake -B \"$tlapackMKL_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D BUILD_EXAMPLES=OFF -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=\"$tlapackMKL_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" -D USE_LAPACKPP_WRAPPERS=ON -D blaspp_DIR=\"$blaspp_DIR\" -D lapackpp_DIR=\"$lapackpp_DIR\" \"$tlapack_source\"\n",
+    "!cmake -B \"$tlapackMKL_DIR\" -G Ninja -D CMAKE_BUILD_TYPE=Release -D BUILD_EXAMPLES=OFF -D BUILD_TESTING=OFF -D TLAPACK_NDEBUG=ON -D CMAKE_INSTALL_PREFIX=\"$tlapackMKL_DIR\" -D CMAKE_INSTALL_MESSAGE=\"LAZY\" -D USE_LAPACKPP_WRAPPERS=ON -D blaspp_DIR=\"$blaspp_DIR\" -D lapackpp_DIR=\"$lapackpp_DIR\" \"$tlapack_source\"\n",
     "!cmake --build \"$tlapackMKL_DIR\" --target install\n",
     "\n",
     "# Build\n",
@@ -344,92 +148,381 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 250,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-x-x-x-x-x-x-x-x-\n",
-      "-x-x-x-MKL-x-x-x-\n",
-      "Using Eigen:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92162,0)\n",
-      "Error in the eigenvalues: inf\n",
-      "time = 0.400565 s\n",
-      "-x-x-x-x-x-x-x-x-\n",
-      "-x-x-x-MKL-x-x-x-\n",
-      "Using Eigen:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "Error in the eigenvalues: -nan\n",
-      "time = 0.559561 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "!./build_mkl/performance_eigen 1000 0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 251,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-x-x-x-x-x-x-x-x-\n",
-      "Using <T>LAPACK:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92166,0)\n",
-      "Error in the eigenvalues: -nan\n",
-      "time = 0.238441 s\n",
-      "||Z.adjoint() Z - I||/||I|| = 0\n",
-      "||Z.adjoint() H Z - T||/||T|| = 830.628\n",
-      "n_aed = 39\n",
-      "n_sweep = 7\n",
-      "n_shifts_total = 448\n",
-      "-x-x-x-x-x-x-x-x-\n",
-      "Using <T>LAPACK:\n",
-      "First eigenvalues:\n",
-      "(499.882,0)\n",
-      "(8.92161,0)\n",
-      "Error in the eigenvalues: -nan\n",
-      "time = 0.354536 s\n",
-      "||Z.adjoint() Z - I||/||I|| = 0\n",
-      "||Z.adjoint() H Z - T||/||T|| = 827.81\n",
-      "n_aed = 41\n",
-      "n_sweep = 13\n",
-      "n_shifts_total = 832\n"
-     ]
-    }
-   ],
-   "source": [
-    "!./build_mkl/performance_tlapack 1000 0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 252,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "import matplotlib\n",
-    "\n",
-    "plt.rcParams['font.size'] = 14"
+    "!./build_mkl/performance_eigen 500 1 1 {matrix_type} {seed}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 253,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./build_mkl/performance_eigen_blasMKL 500 1 1 {matrix_type} {seed}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./build_mkl/performance_tlapack 500 1 1 {matrix_type} {seed}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nSizes = [10, 25, 50, 100, 200, 400, 800, 1600]\n",
+    "N = len(nSizes)\n",
+    "\n",
+    "datatypes = [\"float\",\"double\"]\n",
+    "NT = len(datatypes)\n",
+    "\n",
+    "nRuns = 3\n",
+    "\n",
+    "executable = [\n",
+    "    \"build/performance_tlapack\",\n",
+    "    \"build/performance_eigen\"\n",
+    "]\n",
+    "methods = [\n",
+    "    r\"<T>LAPACK - C++\",\n",
+    "    r\"Eigen3 - C++\"\n",
+    "]\n",
+    "M = len(executable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.ones([M,N,NT], dtype=np.float64) * 60 * 60 * 24\n",
+    "\n",
+    "for s in range(M):\n",
+    "    for i in range(N):\n",
+    "        n = nSizes[i]\n",
+    "        for j in range(nRuns):\n",
+    "            expr = executable[s]\n",
+    "            output = !$expr {n} 0 0 {matrix_type} {seed} | grep time\n",
+    "            for k in range(NT):\n",
+    "                data[s,i,k] = np.minimum( float(output[k].split()[2]), data[s,i,k] )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers = ['x-','*-','+-']\n",
+    "plt.rcParams['font.size'] = 12\n",
+    "\n",
+    "for datatype in range(NT):\n",
+    "    print(datatypes[datatype])\n",
+    "\n",
+    "    fig1, ax1 = plt.subplots()\n",
+    "\n",
+    "    for m in range(M):\n",
+    "        plt.plot(nSizes,data[m,:,datatype],markers[m%3],label=methods[m])\n",
+    "\n",
+    "    ax1.set_xscale(\"log\")\n",
+    "    ax1.set_yscale(\"log\")\n",
+    "    ax1.set_xticks(nSizes)\n",
+    "    ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "    plt.xlabel(\"n\")\n",
+    "    plt.ylabel(\"time (s)\")\n",
+    "    plt.legend()\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.savefig(\"curvesWithNoMKL_\"+datatypes[datatype]+\".pdf\")\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nSizes = [10, 25, 50, 100, 200, 400, 800, 1600]\n",
+    "N = len(nSizes)\n",
+    "\n",
+    "datatypes = [\"float\",\"double\"]\n",
+    "NT = len(datatypes)\n",
+    "\n",
+    "nRuns = 3\n",
+    "\n",
+    "executable = [\n",
+    "    \"build_mkl/performance_tlapack\",\n",
+    "    \"build_mkl/performance_eigen\",\n",
+    "    \"build_mkl/performance_eigen_blasMKL\"\n",
+    "]\n",
+    "methods = [\n",
+    "    r\"<T>LAPACK using MKL BLAS\",\n",
+    "    r\"MKL gees (Eigen3 wrapper)\",\n",
+    "    r\"Eigen3 using MKL BLAS\"\n",
+    "]\n",
+    "M = len(executable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_mkl = np.ones([M,N,NT], dtype=np.float64) * 60 * 60 * 24\n",
+    "\n",
+    "for s in range(M):\n",
+    "    for i in range(N):\n",
+    "        n = nSizes[i]\n",
+    "        for j in range(nRuns):\n",
+    "            expr = executable[s]\n",
+    "            output = !$expr {n} 0 0 {matrix_type} {seed} | grep time\n",
+    "            for k in range(NT):\n",
+    "                data_mkl[s,i,k] = np.minimum( float(output[k].split()[2]), data_mkl[s,i,k] )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers = ['x-','*-','+-']\n",
+    "plt.rcParams['font.size'] = 12\n",
+    "\n",
+    "for datatype in range(NT):\n",
+    "    print(datatypes[datatype])\n",
+    "\n",
+    "    fig1, ax1 = plt.subplots()\n",
+    "\n",
+    "    for m in range(M):\n",
+    "        plt.plot(nSizes,data_mkl[m,:,datatype],markers[m%3],label=methods[m])\n",
+    "\n",
+    "    ax1.set_xscale(\"log\")\n",
+    "    ax1.set_yscale(\"log\")\n",
+    "    ax1.set_xticks(nSizes)\n",
+    "    ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "    plt.xlabel(\"n\")\n",
+    "    plt.ylabel(\"time (s)\")\n",
+    "    plt.legend()\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.savefig(\"curvesWithMKL_\"+datatypes[datatype]+\".pdf\")\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers = ['x-','*-','+-']\n",
+    "plt.rcParams['font.size'] = 12\n",
+    "\n",
+    "methods = [\n",
+    "    r\"Eigen3 - C++\",\n",
+    "    r\"<T>LAPACK - C++\",\n",
+    "    r\"Eigen3 using MKL BLAS\",\n",
+    "    r\"<T>LAPACK using MKL BLAS\",\n",
+    "    r\"MKL gees (Eigen3 wrapper)\"\n",
+    "]\n",
+    "\n",
+    "for datatype in range(NT):\n",
+    "    print(datatypes[datatype])\n",
+    "\n",
+    "    fig1, ax1 = plt.subplots()\n",
+    "    \n",
+    "    plt.plot(\n",
+    "        nSizes,\n",
+    "        np.divide( data[1,:,datatype], data[1,:,datatype] ),\n",
+    "        '--',\n",
+    "        label = methods[0])\n",
+    "    plt.plot(\n",
+    "        nSizes,\n",
+    "        np.divide( data[1,:,datatype], data[0,:,datatype] ),\n",
+    "        markers[1],\n",
+    "        label = methods[1])\n",
+    "    plt.plot(\n",
+    "        nSizes,\n",
+    "        np.divide( data[1,:,datatype], data_mkl[2,:,datatype] ),\n",
+    "        markers[0],\n",
+    "        label = methods[2])\n",
+    "    plt.plot(\n",
+    "        nSizes,\n",
+    "        np.divide( data[1,:,datatype], data_mkl[0,:,datatype] ),\n",
+    "        markers[1],\n",
+    "        label = methods[3])\n",
+    "    plt.plot(\n",
+    "        nSizes,\n",
+    "        np.divide( data[1,:,datatype], data_mkl[1,:,datatype] ),\n",
+    "        markers[0],\n",
+    "        label = methods[4])\n",
+    "\n",
+    "    ax1.set_xscale(\"log\")\n",
+    "    # ax1.set_yscale(\"log\")\n",
+    "    ax1.set_xticks(nSizes)\n",
+    "    ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "    plt.xlabel(\"n\")\n",
+    "    plt.ylabel(\"Speedup\")\n",
+    "    plt.legend()\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.savefig(\"speedup_\"+datatypes[datatype]+\".pdf\")\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Backward stability analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nSizes = [10, 25, 50, 100, 200, 400, 800, 1600]\n",
+    "N = len(nSizes)\n",
+    "\n",
+    "datatypes = [\"float\",\"double\"]\n",
+    "NT = len(datatypes)\n",
+    "\n",
+    "executable = [\n",
+    "    \"build/performance_tlapack\",\n",
+    "    \"build/performance_eigen\"\n",
+    "]\n",
+    "M = len(executable)\n",
+    "\n",
+    "methods = [\n",
+    "    r\"<T>LAPACK - C++\",\n",
+    "    r\"Eigen3 - C++\"\n",
+    "]\n",
+    "\n",
+    "errors = [\n",
+    "    [\n",
+    "        r\"$\\|Z^H Z - I\\|/\\|I\\|$\",\n",
+    "        r\"$\\|Z Z^H - I\\|/\\|I\\|$\", \n",
+    "        r\"$\\|Z T Z^H - A\\|/\\|A\\|$\" #,\n",
+    "        # r\"$\\|Q^H Q - I\\|/\\|I\\|$\",\n",
+    "        # r\"$\\|Q Q^H - I\\|/\\|I\\|$\"\n",
+    "    ],\n",
+    "    [\n",
+    "        r\"$\\|Z^H Z - I\\|/\\|I\\|$\",\n",
+    "        r\"$\\|Z Z^H - I\\|/\\|I\\|$\",\n",
+    "        r\"$\\|Z T Z^H - A\\|/\\|A\\|$\"\n",
+    "        # r\"$\\|V \\Lambda - A V\\|/(\\|A\\| \\|V\\|)$\",\n",
+    "        # r\"$\\|V \\Lambda V^{-1} - A\\|/\\|A\\|$\"\n",
+    "    ]\n",
+    "]\n",
+    "NE = 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_bwError = np.ones([M,N,NT,NE], dtype=np.float64)\n",
+    "\n",
+    "for s in range(M):\n",
+    "    for i in range(N):\n",
+    "        n = nSizes[i]\n",
+    "        expr = executable[s]\n",
+    "        output = !$expr {n} 0 1 {matrix_type} {seed} | grep \"||\"\n",
+    "        # print(output)\n",
+    "        for k in range(NT):\n",
+    "            for j in range( len(errors[s]) ):\n",
+    "                try:\n",
+    "                    data_bwError[s,i,k,j] = float(output[k*len(errors[s])+j].split()[-1])\n",
+    "                except Exception:\n",
+    "                    data_bwError[s,i,k,j] = float(\"nan\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers = ['x-','*-','+-']\n",
+    "plt.rcParams['font.size'] = 12\n",
+    "\n",
+    "for datatype in range(NT):\n",
+    "    for m in range(M):\n",
+    "        fig1, ax1 = plt.subplots()\n",
+    "        \n",
+    "        print(datatypes[datatype])\n",
+    "        print(methods[m])\n",
+    "\n",
+    "        for i in range( len(errors[m]) ):\n",
+    "            plt.plot(nSizes,data_bwError[m,:,datatype,i],markers[i % 3],label=errors[m][i])\n",
+    "\n",
+    "        ax1.set_xscale(\"log\")\n",
+    "        # ax1.set_yscale(\"log\")\n",
+    "        ax1.set_xticks(nSizes)\n",
+    "        ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "        plt.xlabel(\"n\")\n",
+    "        plt.ylabel(\"Relative error\")\n",
+    "        plt.legend()\n",
+    "\n",
+    "        plt.tight_layout()\n",
+    "        plt.savefig(\"error_\"+datatypes[datatype]+\"_\"+methods[m]+\".pdf\")\n",
+    "        plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing with mdspan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build without MKL\n",
+    "!cmake -B build_mdspan -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_PREFIX_PATH=\".\" -D USE_MDSPAN_DATA=ON\n",
+    "!cmake --build build_mdspan --target performance_tlapack\n",
+    "\n",
+    "# Build with MKL\n",
+    "!cmake -B build_mkl_mdspan -G Ninja -D CMAKE_BUILD_TYPE=Release -D tlapack_DIR=\"$tlapackMKL_DIR\" -D blaspp_DIR=\"$blaspp_DIR\" -D lapackpp_DIR=\"$lapackpp_DIR\" -D USE_MKL=ON -D USE_MDSPAN_DATA=ON\n",
+    "!cmake --build build_mkl_mdspan --target performance_tlapack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,338 +537,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = np.ones([M,N,NT], dtype=np.float64) * 60 * 60 * 24\n",
+    "data_mdspan = np.ones([N,NT], dtype=np.float64) * 60 * 60 * 24\n",
     "\n",
-    "executable = [\n",
-    "    \"build/performance_tlapack\",\n",
-    "    \"build/performance_tlapack\"\n",
-    "]\n",
-    "M = len(executable)\n",
-    "\n",
-    "methods = [\n",
-    "    r\"$\\langle$T$\\rangle$LAPACK - C++\",\n",
-    "    r\"Eigen3 - C++\"\n",
-    "]\n",
-    "\n",
-    "for s in range(M):\n",
-    "    for i in range(N):\n",
-    "        n = nSizes[i]\n",
-    "        for j in range(nRuns):\n",
-    "            expr = executable[s]\n",
-    "            output = !$expr {n} 0 | grep time\n",
-    "            for k in range(NT):\n",
-    "                data[s,i,k] = np.minimum( float(output[k].split()[2]), data[s,i,k] )"
+    "executable = \"build_mdspan/performance_tlapack\"\n",
+    "for i in range(N):\n",
+    "    n = nSizes[i]\n",
+    "    for j in range(nRuns):\n",
+    "        output = !$executable {n} 0 0 {matrix_type} {seed} | grep time\n",
+    "        for k in range(NT):\n",
+    "            data_mdspan[i,k] = np.minimum( float(output[k].split()[2]), data_mdspan[i,k] )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[[2.40880e-05, 1.75640e-05],\n",
-       "        [6.18840e-05, 7.54260e-05],\n",
-       "        [2.68579e-04, 3.89268e-04],\n",
-       "        [1.85396e-03, 2.86372e-03],\n",
-       "        [1.19290e-02, 1.75769e-02],\n",
-       "        [7.13812e-02, 1.20622e-01],\n",
-       "        [5.19686e-01, 8.70740e-01],\n",
-       "        [3.29049e+00, 5.65648e+00]],\n",
-       "\n",
-       "       [[2.74140e-05, 1.55220e-05],\n",
-       "        [5.95260e-05, 7.24140e-05],\n",
-       "        [2.50870e-04, 3.64299e-04],\n",
-       "        [1.82118e-03, 2.87912e-03],\n",
-       "        [1.14041e-02, 1.80498e-02],\n",
-       "        [7.19438e-02, 1.20806e-01],\n",
-       "        [5.23304e-01, 8.71808e-01],\n",
-       "        [3.24480e+00, 5.73542e+00]]])"
-      ]
-     },
-     "execution_count": 255,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 259,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "float\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAAA9vElEQVR4nO3dd3wU1frH8c+THkjoARJKgEiVEiAWUECailjABoIl6kURC4rYrvzulavitaCiiIoioeNFRaRKbwJiQi9SYiAQakRCSUjb8/tjF0xCINmQ7Gyyz/v12hfZmdmZ7yYbnpwzZ+aIMQallFLKlbysDqCUUsrzaPFRSinlclp8lFJKuZwWH6WUUi6nxUcppZTLafFRSinlcj5WB3AX1apVM/Xq1bM6hlJKlQlxcXHJxpiQS63X4uNQr149YmNjrY6hlFJlgojsv9x67XZTSinlch5ffETkDhEZm5KSYnUUpZTyGB5ffIwxs40xT1SsWNHqKEop5TE8vvgopZRyPS0+SimlXM7jR7uJyB3AHVddddVltzt16hTHjh0jMzPTNcGUcpKvry/Vq1enQoUKVkdRpdQXK+JpWbsi7atnwXePwr0xrDnmzZaDKQzsFFGsx/L44mOMmQ3MjoqKGnCpbU6dOsXRo0epVasWgYGBiIgLEypVMGMMaWlpJCUlAWgBUkXSsnZFnpm6kbkRM6mZuI4js4fzTHxvRvdrXezHEp3Pxy4qKspc6jqfvXv3EhYWRrly5VycSinnpKamcujQIQpqySuVr7eqQ1b6xct9/GHYMad2JSJxxpioS63Xcz6FkJmZSWBgoNUxlCpQYGCgdg2rIkvqv5KD3rUuPM/08ocW98HgrcV+LC0+haRdbao00M+pKqoVq1dzJuZ+amcnYQxkiR/etgwOp/tBcI1iP57HFx+9yFQp5cnS0rP44au3uXZRb6p7nWQTjTjSuD8+Ty7laKN+7Ni9hzXxycV+XB1wUIgBB0opVRbtTTzAoYlPcHfWGhIqXsvyZv+hccOGhEZUAyC03xgS4pPZcjCF9o5lxcXji49SSnkaYwyLf/6JZmuH0F7+4o/Il2lw52vU97q4M6x9RLViLzyg3W4eY8yYMezbt6/Q28fExLBjx46SC6SUssSp1HPMHf08XdY+go+vH6f6zaFBr9chn8JTkrT4eIDExESef/55KlWqhIhc9hEdHQ1AbGwsY8aMybWf6Ohobr/99gKPt2HDBry9vbnhhhsuWhcdHX3hWL6+vjRo0IChQ4dy9uxZp/YDcPToUQYPHkxERAT+/v7UqlWLHj16MG/evMtmnjNnDuXKlWPYsGEFvpeCFCaDUu5i247txH/Qmdv/jGFvzR6EvLiOKo3aW5JFi48HmDVrFh07dqRSpUocPnz4wuOrr74CyLVs1KhRANx1113MmjWrSMf7+uuvGTRoENu2bWPnzp0Xre/WrRuHDx/mjz/+4K233mLMmDEMHTrUqf3s27ePNm3a8PPPP/POO++wZcsWFi9eTM+ePRk4cOAls02aNIl77rmHd955h7feeqtI7+9KM0RHR/PGG28U+jjObq9UXjabYcF3X1H72+40tv1BQocPafzUNLwCrbuhssef8yns7XWu1IXbVuToO13jOJFX3LetyGvWrFncddddANSsWfPC8kqVKl207LybbrqJ06dPExcXR9u2bQt9rLS0NKZOncqqVatITU1l3LhxfPDBB7m28ff3v3DMfv36sWzZMn788Uc+//zzQu9n0KBBgL2FFhQUdGF506ZNefDBB/PN9vHHH/PKK68wbty4S27jjKJkUMrVjp84yZZxT3Pr2TnsC2hM1UcmUT+ssdWxtOXjqikVzt+24vyQxTXxyTwzdSMta5fscU+ePMnKlSu58847nXqdr68vPXr04Mcff3Tqdd999x3h4eG0aNGChx56iIkTJxZ40WN+F0Zebj8nTpxgwYIFPP3007n+0z/vfFHNadiwYfzzn/9k5syZxVIYipJBKVfb8NsvnPrkRrqencOO+tGEv7SKYDcoPKAtnyIbPns7Ow6dcuo11YP9eXjcempU8OfoqXSuqh7EqMV7GLV4T6Fe3yysAv++42qnjjlnzhyuvvpqwsPDnXod2Lve3n77bd58881Cv2bcuHE89NBDAHTq1Ily5coxa9Ys7r333ny3X79+PVOnTqVr166F3s/evXsxxtC0adNCZVq0aBFz585lzpw53HbbbYV+L5fjbAalXCkzK5tlk9+hY8LHpHqVJ/G2yTS75g6rY+Xi8S0fV6oY6EuNCv4knTxHjQr+VAz0LfFjzps3r8j/4fbo0YPt27eTmJhYqO337t3L6tWr6devH2C/2r5///6MGzcu13YLFiwgKCiIgIAA2rVrR8eOHfn0008LvR9n70fYvHlzIiIiGD58OCdPnixw+ylTphAUFHThsWrVqou2cSbDiBEjcu1vypQpFy3LeQxnt1cqp6Skg2x47zZu3vc++4PbEPjcr9R1s8ID2vIpMmdbIPB3V9tzXa5i8q+JDO7WsETGz+dUr149p4ZY57R//37KlStH9erVC7X9119/TXZ2NnXr1r2w7Px/0gcOHKBOnToAdOzYkbFjx+Lr60tYWBi+vr5O7adhw4aICDt37qR3794F5goNDeWnn36iS5cudOvWjUWLFlG5cuVLbn/nnXdy3XXXXXheq1ati7ZxJsPAgQO5//77Lzx/5ZVXqFWrFs8991y+x3B2e6XO+3XpLOqtfJ42JoVtLV+hee9XXT6EurC0+LjI+cIzul9r2kdU4/qIqrmel5RevXpxyy23kJWVhY+Pcz/uWbNmccsttxAQEFDgtllZWUyYMIF33nnnoqHNDz30EOPHj+df//oXAOXKlbvkXZcLu59bbrmF0aNH89xzz110zuXkyZMXnXOpVasWy5cvp0uXLnTt2pVFixZRtWrVfDMEBwcTHBx82fdbpUqVQmeoUqUKVapUybX/KlWqXPJ74Oz2Sp1LT2fNNy9z05EJHPYJI/neaTRver3VsS7LPUviFRCR20Vkl4jsEZF/WJ3nvC0HU3IVmvYR1RjdrzVbDpbsPeWuueYaypUrx4oVK5x+bc5RcuedOnWKTZs25Xrs27ePuXPnkpyczIABA2jevHmuR9++fRk/fnyhuqoKu5/PPvsMYwxRUVHMmDGDXbt28fvvv/P555/TsmXLfPcdGhrK8uXLycjIoEuXLiQnX9n9qoqSQanitm/vDuLf60SXozFsDelJyIvrCHXzwgNlrOUjIj7Ah0BnIAWIE5GZxpg/rU1GvsOpS+q2FTmJCHfeeSezZs266KT+5Rw8eJDNmzdf1PpYtWoVrVvnnljqnnvuISMjg86dO+fbmrjvvvt49dVXWbRoUYHHHTduXKH2c/PNN7NhwwZGjBjBK6+8QlJSElWrVqVVq1aMHTv2kvuvUaMGy5Yto1u3bnTu3JklS5YUulsxrwYNGhQpg1LFwRjD2p++ovmGf1NNYEe7D2l1y+NWxyq0MjWZnIi0B14yxvR2PP8Y+NUYM62g115uMrmdO3eW6lFNCxYsYODAgU6d+xkzZgwzZsxg2bJlJRdMlYjS/nlVBTt16iTbxj1F+5R57PFtSuWHJ1CtjnsMoT6vVE0mJyIdReQnEUkSESMi0flsM0hEEkTknIjEiUiHHKvDgKQcz5MAjz8z26VLF/766y82bdpU6NfMmjWLXr16lVgmpVTR7Nr0C3991J7rT84ntu5jNHh5pdsVnsJwt263IGAbMNHxyEVE+gCjgEHAase/80WkmTGmcOOBPZCfnx/Ozlf0888/l1AapVRR2LJtrJs+gqjdH5EiFdhz62Si2hV8r0V35VbFxxgzD5gHICIx+WwyBIgxxnzleP6siNwKPAW8Bhwid0unFrC+xAIrpZQL/HksiQPjH6V92q9sLt+Oeo+Np3G1UKtjXRG36na7HBHxA9oCC/OsWgicvy3reqC5iNQSkSCgB3DJP+FF5AkRiRWR2OPHj5dEbKWUuiLbV83CNuYGmqZuYH2TV2k5dB4VS3nhATdr+RSgGuANHM2z/CjQDcAYkyUiLwLLsBfW9y430s0YMxYYC/YBByURWimliiIrI524mKFckzSJA961ONV7Ote2cP8h1IVVmopPoRhjfgJ+Kuz2rrqrtVJKFdaRfTs5PfkRrsvaxboqd9DyH2MoV76C1bGKVanpdgOSgWygRp7lNYAjRd2pq+5qrZRShbF53liCYjpTPfMg66/5iOsHTy5zhQdKUfExxmQAcUD3PKu6A2uKul8RuUNExjo7GkwppYrTuTMn2fhJH1qtf4n9Pg04Fb2Ma3s+ZnWsEuNW3W6OQQLn+7+8gLoiEgmccAyl/hCYJCLrgV+Agdiv7fmiqMc0xswGZkdFRQ24kuxKKVVUB7atweuHx2iZfYSVYY9z/aP/xc/Pz+pYJcqtig8QhX2wwHnDHY8JQLQx5lsRqQoMA0KxXxN0mzFmf1EPqOd8lFJWMbZsNs8YQbMdH3FCKrG562Q6diy91+44w6263Ywxy40xks8jOsc2Y4wx9Ywx/saYtsaYlVd4TI8+51OvXr2LprlWSpW8s38m8fvIW4jc+QGbAq9DnvqFNh5SeMDNio8qXtHR0YjIRY/rr/97uOZvv/3GoEGDXJ5txowZREVFUalSJcqXL09kZCQTJkwotv3Hx8fz+OOPU6dOHfz9/QkPD+fee+9lzZoinx5Uqsi+WBHPmvhkOH0ExvcgcfkE0j9tR/0zm1h61Wu0fWkuNWqU/mt3nOFu3W4uV9a73bp168akSZNyLcvZlxwSEuLqSABUrVqVYcOG0aRJE3x9fZkzZw6PP/44ISEhVzzVdWxsLF27dqVp06Z8/vnnNG3alLNnzzJ37lyeffZZ4uLi8n2diJCQkEC9evUKPMby5cuJjo4u8kR9yrO0rF2RZ6ZuZF7976ixfw11969hl60O29uP4+5b846h8gwe3/Jxebeb4y8fTue9VrZk+Pv7U7NmzVyPnBOV5e122717N506dSIgIIDGjRszb948goKCiImJubBNUlISffv2pXLlylSuXJmePXuyZ8+eC+vfeOMNmjdvzvTp04mIiCA4OJhevXrlmj+nS5cu9OrViyZNmhAREcHgwYNp2bLlFU8PbYwhOjqaBg0a8Msvv3D77bcTERFBy5Ytee2111iyZMkV7V+pomg/rRkbsu+l5t7piGNZY68D3B3b39JcVvL44uNyK96DxHWw4l2rk1zEZrPRu3dvfHx8WLduHTExMQwfPpz09PQL26SmptK5c2cCAgJYsWIFa9euJTQ0lG7dupGamnphu3379vHtt98yc+ZMFi5cyMaNG3n99dfzPa4xhiVLlrBr1y46dux4Re9h06ZNbN++nZdeeglvb++L1ued4VQpVzjYaSQZ+HB+BptML39ocR8M3mptMAtpt1tRu93mvwpHnPjgJP4COedOih1nf4hA3RsKt4+aLaDHf52KuWDBgoumeH766ad5992Li9+iRYvYtWsXCxcupFYt+/1ZP/roI2644e9806dPxxjD+PHjEbH/Dffll19SvXp15syZw/333w/Yp8OOiYnhfIvyiSeeYPz48bmOl5KSQq1atUhPT8fb25vPPvuMHj16OPX+8jrfAtP5bJRbMIYdM4bTePvHnJZyVJBsssUXb1sGh9P9CA3Oe8285/D44uOy63zCroG/EiDtTzA2EC8oVxUq1y/Rw3bs2PGiWTUv9df/77//TlhY2IXCA/ZpuL28/m4gx8XFkZCQQHBwcK7XpqamEh8ff+F5eHg4Obsyw8LCOHbsWK7XBAcHs2nTJs6cOcOSJUsYMmQI9erVu+SMq1dffTX799tH1Xfo0IH58+dftI0zkyPm3F/OZeeLanh4ONu3bwcgMTGRZs2aXdguOzub9PT0XIX9wQcf5IsvinzJmSpjMlNT2Dv2YZqdXM5yvw6YzFSaNGpCaJenOLz0c3bs3kNCfHKJz2bsrjy++BSZky0QAGa/ABtiwCcAsjOg6Z1w+4fFHi2ncuXKUZyDKWw2G5GRkUyfPv2idTnPJfn6+uZaJyLYbLZcy7y8vC5ki4yMZOfOnYwYMeKSxWfevHlkZmYCEBgYmO82jRo1Auyzeead7vty+wNo2LAh8+bNu1B8c76HsLCwXJPx/frrr7zyyissX778wrIKFcreLVBU0ZzYt43USX1pmJXEz7WfZW/EI7QOr0yoo9CE9htDQnwyWw6maPHxVC4d7Xb2GLR9FKIehdjxcMY1gw4Kq0mTJhw6dIhDhw4RFhYG2EeO5Swabdq0Ydq0aVSrVq3Yz5/YbLZc55fyCg8PL3AfkZGRNGvWjPfff58+ffpcdN7n5MmTF3Lnt7/w8PB8R7v5+PjkKuIHDx68aJlSAPErp1Fz6QsY48vaG77mlpvv4ZZ8tmsfUc1jCw/ogAPXjnbrO8Xe0qnZwv5v3yklfsj09HSOHDmS63GpuYu6d+9O48aNeeSRR9i8eTPr1q1jyJAh+Pj4XOiK6t+/PzVq1OCuu+5ixYoVJCQksHLlSl588cVcI94K8vbbb7N48WL++OMPdu7cyciRI5k0aRIPPvjgFb1fEWH8+PHEx8dz4403MmfOHOLj49m6dSvvvfce3bp1u6L9K3UpJjuLbZNeJGLpQPZ71Sa5/0I63HyP1bHclse3fMq6xYsXExqa++K1WrVqcfDgwYu29fLyYubMmfzjH//g2muvpV69eowcOZK7776bgIAAwN6Nt3LlSl599VXuu+8+UlJSCAsLo3PnzlSuXLnQuc6cOcNTTz3FwYMHCQwMpEmTJkycOJEHHnjgyt4wcO211xIXF8eIESMYOHAgx44dIzQ0lGuuuYbRo0df8f6VyutcynH2f/UAzc/8xrLyt9H6ybFUqhBc8As9mDhzgrYsi4qKMrGxsfmu27lzp8eOntq8eTORkZHExsbStm1bq+OoQvDkz6sVju1ej5n+IJWy/2R5xMt0e/BlvL2k4BeWcSISZ4yJutR6bfmoXGbOnEn58uVp2LAh+/btY8iQIbRq1Yo2bdpYHU0pt7Nn4VjqrHmdkyaYjd2mcUuHm62OVGp4fPEp67fXcdbp06d55ZVXOHDgAJUrV+amm27io48+unDORykFJiudHeOf4eqk/7HJuwWVHp7M9eH1rI5Vqmi3m4N2u6myQj+vJSs1+QCHv+5DxLntLKp0H+2eHE1QYIDVsdyOdrsppVQxSdq8lIAfHyPUlsqiq9+h231Paa9AEWnxKSRjjH7IlNvTnowSYgy//zSSiA0jOCwh7L99Ct2vKeRtsVS+tPgUgq+vL2lpaZQrV87qKEpdVlpa2kV3l1BXJjv9LLu+fpxmx+ez3u8aaj0+iTY1PWvunZLg8ReZFkb16tVJSkoiNTVV/7JUbskYQ2pqKklJSVSvXt3qOGXGqUN7OfhBB5ocW8DPIY/R8qX51NLCUyy05VMI5+/ZdejQoVz3AlPKnfj6+lKjRg29x1wxSVw/m4rznqKSsbGi7afcfMeD2vVejDy++BR2qHWFChX0l1opT2AMO/73b5rs+IR4rzqk3zORzi0uf5Na5TyP73Zz+UymSim3lZl6kp2j7qTZzlGsDexIxWeX01wLT4nw+JaPUkoBnNi3lbRJfWmYdYgFdQbTNfrf+PpcPBuuKh5afJRSHu+PlVOpsfQFbMafNTd+w63de1sdqczT4qOU8lgmO4sdU17i6j++YbtXI3z6TqJjoyZWx/IIWnyUUh7pXMoxEsc+wNVnY1ka1JM2T3yp0yC4UJkdcCAiM0XkLxH5zuosSin3cmzXOk6Nak/4mc38HPE6nYZM0cLjYmW2+ACjgIetDqGUci+7f/6SitNuJzvbxsZuU7nlIZ1/xwplttvNGLNcRG6yOodSyj2YrHR2fPM0Vx+awQbvllR+ZDLX1w23OpbHcnnLR0Q6ishPIpIkIkZEovPZZpCIJIjIORGJE5EOrs6plCo7UpMPkPBBZ64+NIOFlfrQaOgi6mvhsZQVLZ8gYBsw0fHIRUT6YO8yGwSsdvw7X0SaGWMSHdtsIv/sNxtjDpVQbqVUKXRo8xICfnyMGrY0FjZ/l+73Pqm3yXEDLi8+xph5wDwAEYnJZ5MhQIwx5ivH82dF5FbgKeA1xz4iSz6pUqpUM4bfZ31AxMZ3OCTV2Xf7NG6+pr3VqZSDW53zERE/oC3wQZ5VC4Fi/9SIyBPAEwB169Yt7t0rpSySnX6W3V89RtPkBazzu446j0+kTc2aVsdSObjbaLdqgDdwNM/yo4BTnxwRWQzMAG4TkYMi0i7vNsaYscaYKGNMVEhISFEzK6XcyKlDu0n64EYaH/+Z+dUfJ/KludTSwuN23K34FBtjTDdjTIgxppwxprYxZm1+24nIHSIyNiUlxdURlVJX4IsV8ayJT4bTR2B8Dzh9lOVzpmDG3kTFjKMsjxrNrU+NJMBPJ9dzR27V7QYkA9lAjTzLawBHXB9HKeWuWtauyDNTNzI3Yiahies49EUvOp7ZyV6pS/q9E+nSItLqiOoy3KrlY4zJAOKA7nlWdQfWlNAxdUoFpUqh9tOasSH7XkJ3TwFjI+zsDrzE0ND7CC208Lg9K67zCRKRSBGJdBy/ruP5+TP+HwLRIvIPEWkqIqOAMOALV2dVSrmxwVtIrdMRm+NpJt7Ymt+HPL/V0liqcKxo+UQBGx2PQGC44+v/ABhjvgWeB4YBm4AbgduMMftLIoye81Gq9DG2bDbPGUNA4krEQCY+eGPjaIYfBOfttVfuSIwxVmdwC1FRUSY2NtbqGEqpApw8eoBDMQ/TLG0DR2yVSa/fhfAeL3B46efs2L2HwIem0T6imtUxPZ6IxBljoi613t0GHLiciNwB3HHVVVdZHUUpVYBtK74nbNnz1DfnGF/1BRrd+jQ3NLJfJhHabwwJ8clsOZiixacU0JaPg7Z8lHJf6elpbBg/hHZHppLgVZes3uNo2OJaq2Opy9CWj1KqVNu3Zxvp06Npl72HX6v2ouVjnxFYPsjqWOoKeXzx0W43pdyTMYbVP35J601vYETY3P5TrrtZp+gqK9zqOh8r6HU+Srmf5BMnWD2yLx02v8Jh//qkP76CVlp4yhSPb/kopdzLb+tWUm3BQG4wh9hc/3Fa9P8vXr5+VsdSxUyLj1LKLZzLyGLJpBF0S/yEM15BHOg5lVbX3GZ1LFVCnCo+IlIfqIf94tDjwFZjzLkSyOUyes5HKevt3refY5OfpGfWWvZUbEedx2KoWknvRF2WFXjOR0Tqici7IpII7AWWAHOAX4GTIrJIRO4TkVJ5/kjP+ShlHWMMc+f8QND4zlyftZ69ka/S8Pl5BGjhKfMuWzBE5BNgM9AAeB1oBlQE/LDPr3Mb9qmu3wS2iMg1JZpWKVVmHEs5yw8fP8+tvz2Gj68fZ/rP46per4FXqfw7VjmpoG63c0CEMSY5n3XHgKWOx3ARuQ0IB34r3ohKqbJmZdwWAmc/xT1sIyG0B/Wiv0QCtPfBk1y2+BhjXi7sjowx8648jlKqLEvLyGbGtK/p+ceblJcMjnYeSf2Oj4OI1dGUixV6wMH5czrGGJvjeU3gdmCnMeaXkolX8nTAgVKusePAMXZMGsrDGbM4Wu4qvB6ZTI2aTa2OpSziTOfqXOBZsM/JA8QC7wPLRaTUXv2lAw6UKlk2m+HbBcvJ/upm7s2YxaFGD1JjyC/4aeHxaM4MtY4CznfD3Q2cAuoD/YGhwMTijaaUKu2OpJzjh5iRPHziE8THl9N3TiAsspfVsZQbcKb4BAEnHV/fDMw0xmSKyFLgs+IOppQq3RZtiiftxxcYxAqOVWlDyCMTkEp1C36h8gjOdLslAjeISHngFmCRY3kVILW4gymlSqez6VmMmvw9DX7oye2s5ETUC1R/ZpEWHpWLMy2fD4FJwBlgP7DSsbwjoJOmK6XYnPgXKya/zcD08WT4Vya7zyyqXNXJ6ljKDRW6+BhjvhSRWKAusOj8qDcgHvi/kginlCodsm2G8YvjqLf6ZZ7ziuOv2p2p3G8clK9qdTTlppy6t5sxJg6Iy7NsbrEmcjEdaq3UlTl0Mo2xEyfx5J/vEOJ1irQub1G5wzN67Y66rIJur/OgSOE+QSISLiIdiieW6+hQa6WKbs7mA/z48bP8358vE1Q+CO8Biwns+KwWHlWgggYcPAbsEpF/ikiLvIVIRKqIyJ0i8j/st9XR/8GV8gBn0rP4z5RFhHx/L4OYQVqTewgevAap1drqaKqUKOj2Ol1EpCfwHPabh54TkWPY7/lWGQjBfo+38cDTxpjjJZxXKWWxDYl/MWPyWF5O/4TyPtlk3f45QW36WR1LlTIFnvNxnNOZKyLVgBux3zw0EEgGNgIbcww+UEqVUVnZNr5YspOgVf/hHe8FnK16NX79JkI1PV+qnOfMaLdk4MeSi1J8RKQO9mHh1YEs4E1jzAxrUylVOnyxIp6WtSvSPqLahWWzNiYxff5Shp17n6u995Me9STlb30TfPwtTKpKs7I6jXYW8LwxZpPjBqhxIjLPGHPW6mBKubuWtSvyzNSNfNmrFtfEvsiYqsOIX/cTX/uOxycgEO6Zjn/jHlbHVKVcmSw+xpjDwGHH10dEJBn7nRi0+ChVgPYR1RjdrzUJk56iLWu5NeExGvgd4Vytdvj3+QYqhFkdUZUBLp8yUEQ6ishPIpIkIkZEovPZZpCIJIjIORGJu5Ih3CLSFvA2xhy4ktxKeYy3qtN+UgT3sxAvDA28jgAQcHSDFh5VbKyYrzYI2AYMBtLyrhSRPsAoYATQGlgDzBeRujm22SQi2/J5hOXZVxXsd9t+ouTejlJlhzGGKdfNYputHsbYl6Xjy7H6d8FgvYuWKj4u73ZzzHg6D0BEYvLZZAgQY4z5yvH8WRG5FXgKeM2xj8iCjiMi/tgHSPzXGLPmioMrVcadOJvB8OnL6bXvLZp778MAePvjl53B8oQ0ah/zpn2w1SlVWeFUy8fRHbZdRFJFpIFj2asicn9xhBERP6AtsDDPqoVAeyf2I0AMsNQYM+ky2z0hIrEiEnv8uF6ipDzX+oQT/Oujz3g9cQA3+uzgbKWmSNTjMGAJEvUYXevAloMpVsdUZYgz02g/j30yuXeB/+ZYlQQ8A/yvGPJUA7yBo3mWHwW6ObGfG4A+wBYR6eVY9pAxJle/gTFmLDAWICoqyhQlsFKlWbbN8MWS35EVI/jEZzYZlSPw7TsX35rN/97o9g+pCgy0LKUqi5zpdhsIDDDGzBWRt3Is3wBcXbyxrowxZjWFbNXpjUWVpzp2+hwjpizg4UNv0sZnLxmtHiSg53vgV97qaMoDOFN8wrEPFMgrE/sdD4pDMpAN1MizvAZwpJiOkYsxZjYwOyoqakBJ7F8pd7Rqz3HmThvDm9mf4+/njbnrG/xa3GN1LOVBnDnn8wfQJp/ltwE7iiOMMSYD+5QN3fOs6o591FuxE5E7RGRsSor2Z6uyLyvbxkdzN5I0cQD/tX2IT82m+D39C6KFR7mYMy2fD4DRIlIOEKCdiDyE/TzQY4XdiYgEAef7uLyAuiISCZwwxiTimDFVRNYDv2Dv7gsDvnAia6Fpy0d5ikMn0xg58QeeSn6LBt6HyWz/AoFdXwdvX6ujKQ/kzL3dxouID/brb8phv3faIeA5Y8y3ThwzCliW4/lwx2MCEG2M+VZEqgLDgFDsXX23GWP2O3GMQtNzPsoTLNp+hNjv3mOEbSImsCJefX7Eq8FNVsdSHkyMcX6Ql+MO117GmGPFH8kaUVFRJjY21uoYShWr9KxsRs3+lcgNw7jZO47U8K6Uu38slK9W8IuVugIiEmeMibrU+iJdZOq4w7VSyo3t//Msn0+YxHMp71LD5xRZ3d6iXLunwcuKG5solZsz1/lUBt4AOmOfqiDXJ9gYU71Yk7mIdrupsmjOxkQSfxzO2/I954Lr4t3vBwjTWUaV+3Cm5TMR+/U8E7Bf9FkmLsrUAQeqLDmXmc3H3y+j847Xud3rd842uZfyvT8Gf70vjnIvzhSfm4BOxpgNJZRFKXUF9hw9zZQJY3j+7CgCfQxZd3xO+dY6vbVyT84Un3isuQt2idJuN1XaGWP4Yf1e0uf+kze8FnK6anP8+0+EqhFWR1PqkpwpJoOBd0SklYh4l1QgVzPGzDbGPFGxYkWroyjltDPpWfx34o80m9ubfl4LOdt2IMGDlmnhUW7PmZbPXuy30dkAYL9x9N+MMWWmIClVGmxPOsn8ie/x/LmvMP7lyb53BuUb32x1LKUKxZniMw2oCDxHGRpwoFRpY4xh+qqtVFz8EkO91nEy7AYq9fsGgmtaHU2pQnOm+EQB1xpj8ru5aKml53xUaZKSlskXk6fR/+Bwanr9xdkOw6jU+UW9dkeVOs4Unx1AhZIKYhUdaq1Kiw37/2T9pH/xYuZUUgNr4tVvAeXrXmt1LKWKxJniMwz4UESGAVuxT6VwgTHmRHEGU0rZ2WyGKYt/pcHqFxnotY2/GtxO5T5jIEAHyajSy5niM8/x70Jyn+8Rx3MdcKBUMfvzTDoTJo7lkaPvEuydQeotH1P5umjIM+BHqdLGmeLTucRSKKUu8uueQ8RPe4khtjmcCG6E78OT8KvexOpYShULZ6ZUWFGSQayiAw6Uu8m2GSbNXUzb34bSz2sff14dTdVe74JvgNXRlCo2ly0+ItIG2GSMsTm+vqTSetsdHXCg3MnRU+f4/pv3eeSvT8HXn7Rek6ja4k6rYylV7Apq+cQCNYFjjq8N9nM8eek5H6Wu0OrtCaR89xyDzEqOV42i2iMTkIq1rY6lVIkoqPjUB47n+FopVcwys21MnjmLm7a8Qjuv4/x5zYuE9HgdvPTvOVV2Xbb45Jm62gAHTD5Tn4pI3eIOppQnOHjiDIu/+Tf9T48n1b8qWX1nUzXiRqtjKVXinBntlgCEYu+Cu0BEqjrW6Z9pSl3GFyviaVm7Iu2rZ8F3j/JLo9ewLRxGtGzmcFg3Qh/6CspVsTqmUi7hTPE5fz1PXkHAueKJo1TZ1bJ2RZ6ZupHZ9X8gbP9aWu+7B28Mm1r+H5G9X9Rrd5RHKbD4iMgnji8N9ikVUnOs9gauBTYVfzTX0KHWylXaT2vGhux0+/3hgXKSAUDkjvfg7qEWJlPK9QpzN8IWjocATXM8bwFchX2KhegSylfidD4f5Spru37Pcf7+nGV6+UOL+2DwVgtTKWWNAls+xpjOACIyHhhsjDlV4qmUKkOysm1MmTmLrluHUkVOYQNs4oe3LYPD6X6EBtewOqJSLlfo+7AbYx7VwqOUc46dPsdXn75J360DCPDxIo5mHG3UH58nl3K0UT927N7Dmvhkq2Mq5XLODDhQSjnht72HSZz6HE/ZFnIs5HrmNX6bRg3qERpRDYDQfmNIiE9my8EU2juWKeUpylzxEZFKwGLs780HGGWM+crSUMqjGGOYsngdzVY9yz1ee/gzchDV73iTaO+Lf93aR1TTwqM8UpkrPsBpoKMxJlVEygPbROQHY8yfVgdTZV9KWiZfTZzII4feINg7k7S7xlM18m6rYynldspc8THGZAPnh4P7Yx+lpxdQqBK3PekkSycM5/n0GM6Ur4t/9LeIToGgVL5cOvG7iHQUkZ9EJElEjIhE57PNIBFJEJFzIhInIh2KcJxKIrIZOAi8b4zRM7qqRH2/dhd/fPkAz2Z8w+nwblR6bpUWHqUuw6XFB/vdELYBg4G0vCtFpA8wChgBtAbWAPNz3jtORDaJyLZ8HmHntzHGnDTGtMJ+M9R+IqJjWVWJOJeZzbtT5tJs/j309FrL2Q6vUzn6WwioYHU0pdyaS7vdjDHzcEzHLSIx+WwyBIjJMUDgWRG5FXgKeM2xj0gnjnfU0QLqAHxX9ORKXWxf8lm+ifmSoaffx9fPB9Pne8o37Gp1LKVKBVe3fC5JRPyAtsDCPKsWAu2d2E8NEQl2fF0R6AjsusS2T4hIrIjEHj9+PL9NlMrXz9sOMffTwbxx5j9IlXoEPr0aby08ShWa2xQfoBr2e8UdzbP8KPYJ7QorHFjlaPGsAj41xuR7/xJjzFhjTJQxJiokJKQomZWHycq2MfKn9Xh/24+nZQZpTe8leNBSqBxudTSlSpWyONptPRBZ2O31xqKqsI6dOse7E37g2eNvUMc7mcxb36f8dQP0btRKFYE7tXySgWwg7+CAGsCRkjqo3lhUFcba+D/5+OP/8mby89QItOH92Hx8r39CC49SReQ2xccYkwHEAd3zrOqOfdRbiRCRO0RkbEpKSkkdQpViNpvhi6U72TH+aUbYPoLQVgQ+8wvUvc7qaEqVaq6+zidIRCJFJNJx7LqO5+eHUn8IRIvIP0SkqYiMAsKAL0oqk7Z81KWkpGYyNGYRkcsf5XGf+WREPUG5AfNA70Kt1BVz9TmfKGBZjufDHY8JQLQx5lvHtNzDsE/ZvQ24zRizv6QC6TkflZ9tSSl8OnEqw8+9RzWfVMxdX+LXqq/VsZQqM8SY/GbG9jxRUVEmNjbW6hjKYsYYpq9PZMecT/iXdwy2oFD8H5wGNVtYHU2pUkVE4owxUZdaX+ZGuylVVGkZ2bzxQxxttr3Nmz7LyajXBf/7x0G5KlZHU6rM8fjio91uCuCP42f496QFDD35Nq18/sDW4SX8Or8GXt5WR1OqTPL44mOMmQ3MjoqKGmB1FmWN+VsP8913U/hEPibY38A90/BqcpvVsZQq0zy++CjPlZlt47/zduKz7lPG+n6LrWpDfB6YCtW0FaxUSfP44qPdbp7pSMo5hk5ezQNH3qWn73qym/XG967R4B9kdTSlPILbXGRqFb3Ox/P8sjeZQaOmM/zYc9zmHQs3v4X3feO18CjlQh7f8lGew2YzjFm+l61LpjDJ9wsCAgOR+3+EBp2sjqaUx9HiozzCydQMhkyPo80fn/Ol7yyyQ1vj3XcyVKxtdTSlPJLHFx8951P2bTl4klcmLee1tJF09NmCafMI3j3eA98Aq6Mp5bE8vvjoUOuyyxjDlF8TmTF7LuP8PqKmz0noOQppG211NKU8nscXH1U2pWZk8c8ftuK1ZToz/L/BJ6gaXn0WQO22VkdTSqGj3VQZ8MWKeNbEJ194Hn/8DLd9uJjW297mQ78v8A2/Dq8nV2rhUcqNeHzLR8/5lH4ta1fkmakb+bJXLRosf5YXj97DB17jifLZDe2fRbq+Ad4e/1FXyq3oXa0d9K7Wpduy349yeOrT9JXFnMMXPx8ffHp/Bs3vtjqaUh5J72qtyjRjDLY3a9DZln6hE7kcGZCdAT8O1OKjlJvScz6q1Np+KIU+Y9cxIO1ZThJ8Yfk5/DhW/y4YvNXCdEqpy9GWjyp1TpzNYOTCXSxbv5HX/f9HT/9VpOGHQRAfP/yzMliekEbtY960Dy54f0op19Pio0qNrGwbU35NZMzCrTyQNZMVAXPw8YK42o9TP2sfgaH1IOpRJHY8XY8eYMbBFNpHVLM6tlIqH1p8VKmwZm8yw3/aTuPkn5kX+C1VSYZmvaHbcNpWDs+98e0fUhUYaElSpVRheHzx0aHW7u3AiVRGzNvJ4e2rGRkwmeZ+uzHVW8GtkyC8vdXxlFJF5PHFR2+v457SMrL5fEU8M1f8xlCvqdzlvxpTrgZ0+wxp1Q+8dKyMUqWZxxcf5V6MMczdepiRczZxx9nvWew3Bz8vA+1fRG58Afx1BIFSZYEWH+U2dh4+xRuztlEjcS7f+n9Ldd/j0LQXdB8OletZHU8pVYy0+CjL/XU2g5GLdrFt/VKG+02mld9uTI2WcOsEqHeD1fGUUiVAi4+yTFa2jWnrE5n481oGZU/hLb9V2MqHQNfRSGQ/8PK2OqJSqoSU2eIjIuWAncAMY8xQq/Oo3NbG/8k7P22gU/J0ZvvNxs/XQPsX8Orwop7XUcoDlNniA7wOrLM6hMrt4F+pvDN3J147fmCs33Rq+iZjmtyJ3PymntdRyoOUyeIjIg2BJsBsoLnFcRT2odNfroxn9fKF/NN7Am38dmOr0QJ6TEDq3Wh1PKWUi7n0YgkR6SgiP4lIkogYEYnOZ5tBIpIgIudEJE5EOhThUB8Ar11xYHXFjDHM23qYviNnUmfFEL7zeZ1W5U/AnZ/i9eQK0MKjlEdydcsnCNgGTHQ8chGRPsAoYBCw2vHvfBFpZoxJdGyzifxz32yMOSQidwG7jTG7RUQvgbfQ70dO8fasDbRKnMy3vj/Zz+u0ex7vDi9CQAWr4ymlLOTS4mOMmQfMAxCRmHw2GQLEGGO+cjx/VkRuBZ7C0ZIxxkQWcJjrgb4ich/2YucrIqeMMf+58negCuNkagYfLtzFX799y7u+0wjzTcbW5A68bn4TqtS3Op5Syg24zTkfEfED2mLvMstpIVDoFowx5jUchcrRrdf8UoVHRJ4AngCoW7eu86FVLtk2w9T1icz/eR5Dsr8hync32dWvhh4xeNUvSu+pUqqscpviA1QDvIGjeZYfBbqVxAGNMWOBsWCfRrskjuEp1v3xJ5/8uJLeJ75hqs9KsspXg26f4N36Qb1eRyl1EXcqPsXOGBNT0DZ6V+srk3QyjffnbKLWzm/42vcn/P2yMdcPxqfjUD2vo5S6JHcqPslANlAjz/IawJGSOqje1bpozmVm8+XyeBJWTWaoTKG2bzLZjW7H+9Y3oUoDq+Mppdyc2xQfY0yGiMQB3YEZOVZ1B74vqeNqy8c5xhgWbDvCjNlzGHjuKwZ77SKjWjPoOR7v+h2tjqeUKiVcWnxEJAg4/7+8F1BXRCKBE46h1B8Ck0RkPfAL9skow4AvSiqTtnzy98WKeFrWrphrGupvf0tk+tLf6Hc6hq99VpEdWAVuHoVf64f0vI5SyimubvlEActyPB/ueEwAoo0x34pIVWAYEIr9mqDbjDH7SyqQtnzy17J2RZ6ZupEve9Wi9a9DGMYzVEmYxRSfWfj7ZsP1z+Db6SUIqGh1VKVUKSTG6CAvsI92i42NtTqG2ziXmU3Mmn1UWPIyfWUxqfgTJOlkXHUbfj3egqoRVkdUSrkxEYkzxkRdar3bnPNR1ktIPsvqHYkc2P4LLx95iYFiu3ADpiDSAfDbtwSqTrMwpVKqLPD44uPJ3W5pGdnE7tjNgc3LkYPraJy+jT6SgJ9kg0C6d3m8s9PwwUYafpyu34Pqd79vdWylVBng8cXHkwYcGJuNxL3b2LdxKSZxLXXPbKGDHAIgE1/+qnI1aQ0G4te4A+uzr2L///7JvSwCnwACstKZnZBG7WPetNfpdpRSV8jji0+Zlp1JWuIGEjctJXPfWsJSNhFOCuHAKYI4UqkVCfX7E9ayM/512lLdN+DCSzesiOe+OiA1HoOoR5HY8XQ9eoAZB1NyjYBTSqmi8PgBBzm63Qbs2bPH6jhX5twpzIH1nPh9Jefif6Faylb8jf1czQFTnYPBrZDwdoRHdiE0ohV4uXRGDaWUBylowIHHF5/zSuVot5QkSFxLRsIazv2xhqCTu/DCRrYRtpt6xAc0h7rXU7tlZ1o1a4qfjxYbpZRr6Gi3ssJmg+M7IXEtJnEdmQlr8DuTBECm8WezrSFbve4mI+w6arfoQPtm9WhZKdDi0EoplT+PLz5uO9otMw2S4iBxHSSuwxz4FUk/BUAylfk1uxGxtq78WaUNdZpdQ6fGoQwIr4yvt7ZulFLuT7vdHCzvdjubbC80BxzF5tAmxJYJwAHvuqzOaMj67Eb87nc1Da5qRqcm1enUKIQaFQIK2LFSSrmedru5I2PgxB+QuNbx+BX+tA92yPbyZb9/E1aanqzMuIo4WyPq1qpFp0Yh9G8cQmSdSvho60YpVcpp8XGF7Ew4vOXvYnPgVzh7HIAs/0oklm/B6vI3Mvuvumyx1SeQ8nRsFMLtjUN4t2EIIcH+Fr8BpZQqXlp8rtTpI/Ddo3BvDAQ7piI6lwIHf7twvoaDsZCVBkB2xXCSqrRjbXBD/nesNhtSQuCUFy1rV+KmyBD+2TiElrUr4e0l1r0npZQqYR5ffK54wMGK92D/WvjhCajW0F5sjm4DDIg3pmYLjjXqy/qsRnyfXJsVh70xR6FqeT86Ng7h4cYhdGgYQpXyfsX5tpRSyq3pgAMHZwccZP0nBB9bxkXLDcLZdkPZYJrwY3IoS+LPkpKWiZdA67qV6dQohJsah9A8rCJe2rpRSpVROuCghGzsvYLj37/ELd6/4Z2dTpaXH/OzohhffgAbltnP0YQEp9G9WQ1uahzCjVdVo1I5bd0opRRo8Smya1o04/CWusjuXziHL37ZmZy0lcOnYigvXWtv3TStWUFbN0oplQ8tPlcg1PsU66r1Yviha3k1ZB19a2bxUL92VsdSSim3pxeMXIE114xi0Mn+dO/clRfOPsRv131idSSllCoVtPgU0Zr4ZJ6ZupHR/Voz5ObGjO7XmmembmRNfLLV0ZRSyu15fPERkTtEZGxKSopTr9tyMIXR/VpfmNumfUQ1RvdrzZaDzu1HKaU8kQ61drD83m5KKVWGFDTU2uNbPkoppVxPi49SSimX0+KjlFLK5bT4KKWUcjktPkoppVxOR7s5iMhxYD9QEbjUeOlLrasGlJYLfC73/i7FmfdXlP0X536KO2tB2xTl8wKl5zPjipzF8Zkpak5njl3YbQva7nJZi+v3pzhc6fc03BgTcsmtjDH6yPEAxjq7Doi1OndxvL/LvKbQ768o+y/O/RR31oK2KcrnxdmcVj5ckbM4PjNFzenMsQu7bSE+M5fMWly/P1b+7Av7HrTb7WKzi7iutCjp91Bc+3fF97owxyhom7L+eXEFK79Pzhy7sNteyfspC5+ZQr0H7XYrBiISay5zMVVpV5reX2nJqjmLV2nJCaUna0nn1JZP8RhrdYASVpreX2nJqjmLV2nJCaUna4nm1JaPUkopl9OWj1JKKZfT4qOUUsrltPgUkoh0FJGfRCRJRIyIROdZLyLyhogcEpE0EVkuIldbFNcpIvKaiPwmIqdE5LiIzBaR5nm2iXG875yPdRZkfSOfHEdyrLfk51Acnw8RqSwik0QkxfGYJCKVijlnYX7WbpE1n9xGREa7W04R8RaRN0UkQUTOOf59S0R8cmzj8qwFfSYd2zQSkR9E5KSIpIrIBhFpmmO9v4h8KiLJInLWsb/aefZR1/E5OuvY7hMR8SsonxafwgsCtgGDgbR81r8MvAg8C1wDHAMWiUiwyxIW3U3AGKA90AXIAhaLSJU82y0GQnM8bnNhxpx25cnRIsc6q34OxfH5mAq0AW51PNoAk4o5500U/LN2l6wAiMj1wBPAljyr3CXnK8DTwHNAE+yfgaeB1yzOetnPpIjUB34BErB/FpoDw4AzOTb7GLgHeADoAFQA5oiIt2Mf3sBcINix/gHgXmBkgemsvpCpND4cP5zoHM8FOAy8nmNZIHAaeNLqvEV4f0FANnBHjmUxwBw3yPYGsO0S69zi51CUzwfQFDDADTm2udGxrLGrftbulhX71fLxQGdgOTDa3XICc4AJeZZNOP/74g5Z834mHcumAlMK+N5nAP1zLKsD2IBbHM97OJ7XybHNg8A5oMLlMmnLp3jUB2oCC88vMMakASux/4VZ2gRjbxX/lWf5jSJyTER2i8hXIlLdgmwADRzdFwkiMl1EGjiWu+vPoTC52mH/D2JNjtf9ApylZLPn/Vm7W9axwHfGmGV5lrtTztVAZxFpAiAizbC3JOa5YVYcGb2AO4AdIrLA0QX7m4j0ybFZW8A3T+4DwM48uXc6lp/3M+DveP0lafEpHjUd/x7Ns/xojnWlyShgE7A2x7IFwMNAV+zdB9cCS0XE38XZfgWisXdLDMD+/V0jIlVx359DYXLVBI4bx5+OAI6vj1Gy2fP+rN0mq4gMAK7C3hWUl9vkBN7F3j22Q0Qyge3YW0Jj3DDredWxt3r/ib24dAemAVNEpGeOTNlcfH+3vLnzvq9kx+sum9vnciuV5xGRD7E39280xmSfX26MmZ5js60iEof9Rqw9gR9clc8YMz/nc7EPevgDeARw+QCI0uxSP2t3ICKNgRHYs2VanacAfbD/YdYPe+GJBEaJSIIxZpyVwS7jfMNjljHmQ8fXm0QkCngG+3kclwRQV+b8aKsaeZbXyLHO7YnIR9hPGHYxxvxxuW2NMYeAg0BDV2S7TI4z2H/hG+K+P4fC5DoChIiInF/p+Lo6JZD9Mj9rd8naDvtdlbeLSJaIZAGdgEGOr/90k5wA7wMfGGOmG2O2GmMmAR/y94ADd/me5pSMfbDJjjzLdwJ1c2Tyxv5zyClv7rzvq5rjdZfNrcWneCRg/0Z3P79ARAKwj/5Yc6kXuRMRGcXf/xn9XojtqwG1sJ9ItYzj+9zEkcNdfw6FybUWezdIuxyvaweUp5izF/CzdpesP2IfxRiZ4xELTHd8vdtNcgKUw97NlFM2f///6i7f0wuMMRnAb0DjPKsaYe/RAIgDMvPkro19cETO3E3zDL/uDqQ7Xn/ZEPoo3GiRIP7+JUgF/uX4uq5j/SvY57C4G/uQxenAISDY6uyFeG+fAaewnyStmeMRlOO9f4D9l6Ee9uG6a7G3fFz6/hw5OmE/iXsd9pFGp7DPHWLZz6E4Ph/AfGCr4/vczvH1bFf+rN0paz7Zl+MY7eZOObGPBD2IvQu6HtAbOA6MtDJrIT6TvbCPZnsC+7m1AdiLTc8c+/jc8d66Aa2BZdjPEXo71ns7ci51rO8GJAGfFpivJD8sZemB/T9ck88jxrFesA8DPox9mOEKoLnVuQv53vJ7XwZ4w7E+EPsIlmOOD+t+xy9cHQuynv+lzXB8yL8HmuVYb8nPoTg+H0BlYDL24nDK8XUlV/6s3SlrPtmXk7v4uEVO7CMGP3b8XqRhPwc5AgiwMmtBn0nHNtHYW5Fp2K+jeiDPPvyBT7F3c6Ziny6hTp5t6mL/IzDVsd0ngH9B+fTGokoppVxOz/kopZRyOS0+SimlXE6Lj1JKKZfT4qOUUsrltPgopZRyOS0+SimlXE6Lj1JKKZfT4qOUUsrltPgopZRyOZ1SQSk3JyLLsd99+CT2+3DZgInAy8YYm3XJlCo6bfkoVTr0x34L/PbY51t5Hvs8MkqVSnpvN6XcnKPl42+MaZdj2SJgvzHmH5YFU+oKaMtHqdJhS57nh7BPNKZUqaTFR6nSIe9U0gb9/VWlmH54lVJKuZwWH6WUUi6nxUcppZTL6Wg3pZRSLqctH6WUUi6nxUcppZTLafFRSinlclp8lFJKuZwWH6WUUi6nxUcppZTLafFRSinlclp8lFJKuZwWH6WUUi73/++6CiJa2VJ1AAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2.632408365759907"
-      ]
-     },
-     "execution_count": 259,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fig1, ax1 = plt.subplots()\n",
-    "\n",
-    "datatype = 0; print(datatypes[datatype])\n",
-    "m = 0; plt.plot(nSizes,data[m,:,datatype],'x-',label=methods[m])\n",
-    "m = 1; plt.plot(nSizes,data[m,:,datatype],'*-',label=methods[m])\n",
-    "\n",
-    "ax1.set_xscale(\"log\")\n",
-    "ax1.set_yscale(\"log\")\n",
-    "ax1.set_xticks(nSizes)\n",
-    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
-    "\n",
-    "plt.xlabel(\"n\")\n",
-    "plt.ylabel(\"time (s)\")\n",
-    "plt.legend()\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.savefig(\"curvesWithNoMKL.pdf\")\n",
-    "plt.show()\n",
-    "\n",
-    "rate = (np.log(data[m,-1,datatype])-np.log(data[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
-    "rate"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 261,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "double\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAAA5g0lEQVR4nO3dd3xUVfrH8c+TCiEhlFBCAgRC7yV0RUAQwQJ2BdEgyAK64roqFn67uqu4rl0REUWaFBcQQ5depJoAUqWEEkIJRCCUhNTz+2MGTEIgmZDMnSTP+/WaFzP3nrn3O5kJT869Z+4RYwxKKaWUM7lZHUAppVTJo8VHKaWU02nxUUop5XRafJRSSjmdFh+llFJOp8VHKaWU03lYHcBVBAQEmJCQEKtjKKVUsRAVFRVvjKl0o/VafOxCQkKIjIy0OoZSShULInL0Zuv1sJtSSimn0+KjlFLK6bT4KKWUcjotPkoppZxOi49SSimn09FueXThwgVOnz5Namqq1VGUypGnpyeVK1embNmyVkdRRdS4NdE0C/anY+U0mD0QHp7EhtPu7IhNYOgdoQW6Ly0+eXDhwgXi4uIICgqidOnSiIjVkZTKwhhDUlISx48fB9ACpPKlWbA/z0/fxsLQuQTGbOLk/Ld5PvoBxvRrWeD7Ep3PxyYsLMzc6Hs+Bw8epFq1avj4+Dg5lVKOSUxM5MSJE9SpU8fqKKooeqcypCVfv9zDG0addmhTIhJljAm70Xo955MHqamplC5d2uoYSuWqdOnSemhY5dulh2aQ6Fbm2uNUN29o+giM2Fng+9Lik0d6qE0VBfo5VfmSkc7hn97B+4dHkfRUMgykiRfuGSmcTPYCvyoFvks956OUUiVYUtxBTk8ZSK3LO1jl1h63jGTq1WtEYLdhnFz5FXv2H+BwdDwdQwMKdL9afJRSqiQyhqPLx1Fp/VuUN8JPtf9BbPB9tAqpQKC90AT2G8vh6Hh2xCZo8VFKKXVrUs6f4tjkQYSe+4VIt6ZI37H0bdYsx7YdQwMKvPCAnvMpMcaOHcuRI0fy3H7SpEns2bOn8AIppSwRu+EHkj5rQ9DZzURU/Sv1X1lB6xsUnsKkxacEiImJ4cUXX6RcuXKIyE1v4eHhAERGRjJ27Ngs2wkPD+fee+/NdX9bt27F3d2dTp06XbcuPDz82r48PT2pXbs2L7/8MpcvX3ZoOwBxcXGMGDGC0NBQvL29CQoKolevXixatOimmRcsWICPjw+jRo3K9bXkJi8ZlHIF6Ynn2TeuP8FLh3DcBLD17gj6DH0Hv9LeluTRw24lQEREBJ07d6ZcuXKcPHny2vIFCxbw7LPPZll2dUh5nz59eOaZZxgzZozD+/v2228ZPnw4U6ZMYe/evTRs2DDL+u7duzN16lRSU1NZt24dgwcP5vLly3z11Vd53s6RI0fo1KkTfn5+vPfeezRv3pyMjAxWrFjB0KFDiYmJyTHb1KlTGTx4MP/9738ZMWKEw68ts/xmCA8PJyQkhLfeeitP+3G0vVLZnfptKe4RzxGaHs/CCgNoH/4fGvn7WppJi4+TXLtsRaZjpxvsJ/IK+rIV2UVERNCnTx8Aqlatem15uXLlrlt2VZcuXbh48SJRUVG0bt06z/tKSkpi+vTprFu3jsTERCZMmMCHH36YpY23t/e1ffbr149Vq1bx008/ZSk+uW1n+PDhgK2H5uv75y9Rw4YNefLJJ3PM9umnnzJy5EgmTJhwwzaOyE8GpZzJpCaxb9orNDgylSMEsrvzNHp36+USQ/L1sJuTXL1sxYboeMBWeJ6fvo1mwf6Fut/z58+zdu1a7r//foee5+npSa9evfjpp58cet7s2bOpWbMmTZs2ZcCAAUyZMiXXLz3m9MXIm23n7NmzLFmyhOeeey7Lf/pXXS2qmY0aNYo33niDuXPnFkhhyE8GpZzpjwNbOPHfdjQ4MpVlZe7D+7lf6HJnb5coPKA9n3x7e/5u9py44NBzKvt589SELVQp603chWTqVPbls+UH+Gz5gTw9v1G1svzzvsYO7XPBggU0btyYmjVrOvQ8sB16e/fdd/n3v/+d5+dMmDCBAQMGAHDHHXfg4+NDREQEDz/8cI7tt2zZwvTp07nzzjvzvJ2DBw9ijLnucN6NLFu2jIULF7JgwQJ69+6d59dyM45mUMpp0tP4ffbbhO79kjRTluVhY7nznn64ublG0blKez5O5F/akyplvTl+/gpVynrjX9qz0Pe5aNGifP+H26tXL3bv3n3DcxfZHTx4kF9++YV+/foBtm/b9+/fnwkTJmRpt2TJEnx9fSlVqhQdOnSgc+fOfPHFF3nejqPXI2zSpAmhoaG8/fbbnD9/Ptf206ZNw9fX99pt3bp117VxJMPo0aOzbG/atGnXLcu8D0fbK3XVhdi9HP7gdhrs/ZyN3reRNHgd3e/r73KFB7Tnk2+O9kDgz0NtL3Srw/ebYxjRvW6hjJ/PLCQkxKEh1pkdPXoUHx8fKleunKf23377Lenp6dSoUePasqv/SR87dozq1asD0LlzZ8aPH4+npyfVqlXD09PToe3UrVsXEWHv3r088MADueYKDAxk3rx5dOvWje7du7Ns2TLKly9/w/b3338/7dq1u/Y4KCjoujaOZBg6dCiPPvrotccjR44kKCiIF154Icd9ONpeKYxh38JPqRH5HhWMBz83fJc7HxmOh7vr9i+0+DjJ1cIzpl9LOoYG0D60YpbHhaVv37707NmTtLQ0PDwce7sjIiLo2bMnpUqVyrVtWloakydP5r333rtuaPOAAQOYOHEi//jHPwDw8fG54VWX87qdnj17MmbMGF544YXrzrmcP3/+unMuQUFBrF69mm7dunHnnXeybNkyKlasmGMGPz8//Pz8bvp6K1SokOcMFSpUoEKFClm2X6FChRv+DBxtr0q2xPhjHJs8iPoXNxPp0RLfR7+mZ736VsfKleuWxWJmR2xClkLTMTSAMf1asiM2oVD326ZNG3x8fFizZo3Dz808Su6qCxcusH379iy3I0eOsHDhQuLj43n22Wdp0qRJltvjjz/OxIkT83SoKq/b+fLLLzHGEBYWxqxZs9i3bx+///47X331Fc1u8IW5wMBAVq9eTUpKCt26dSM+Pt7hn0lm+cmgVEE6uGoKqWM6UOPCNn6u+TJNXl1OgyJQeEB7Pk6T03DqwrpsRWYiwv33309ERMR1J/VvJjY2lt9+++263se6deto2TLrxFIPPfQQKSkpdO3aNcfexCOPPMJrr73GsmXLct3vhAkT8rSdu+66i61btzJ69GhGjhzJ8ePHqVixIs2bN2f8+PE33H6VKlVYtWoV3bt3p2vXrqxYsSLPhxWzq127dr4yKHWrki/+wcFJQ2n8x1L2uNUl7f6v6NmijdWxHKKTydndbDK5nL4oWZQsWbKEoUOHOnTuZ+zYscyaNYtVq1YVXjBVKIr651Xd3JEt8ymzeATlMs6zuupAOoS/i2/p3A+NO5tOJqfo1q0b586dY/v27Xl+TkREBH379i20TEopx6RducSO8UMIWfQkl0wpfus5ix7DPnLJwpMXetitBPDy8iIhwbFzSz///HMhpVFKOer47vWYH4fQLD2WVeUeokX4J9QqV7hfUC9sWnyUUspFZaSmsHPm/9H44HjipTwbOn1H1x4PWR2rQGjxUUopF3T68A4uTR9E89T9rC9zJ3XDv6Jj5YKfztoqxe6cj4jcKyL7ROSAiAy2Oo9SSjnCZKTz2+z/UHZyNyqknGBtiw/p+MocKhejwgPFrOcjIh7Ax0BXIAGIEpG5xpg/rE2mlFK5O3fiEKemDqZ5UhRRXm2o8uR4OteobXWsQlHcej5tgd3GmOPGmEvAYuAuizMppdTNGcPOxd/gMb4TNRJ3sab+m7QYuZTgYlp4wMWKj4h0FpF5InJcRIyIhOfQZriIHBaRKyISJSK3Z1pdDTie6fFxQC+CpZRyWRfPxfHbJw/QdPPLxLjX5FS/ZdzxxKu4u/B12QqCq706X2AXMAJIyr5SRB4DPgNGAy2BDcBiEamRva1SSrm6vWvnkPxZOxomrGVtjWHUHbmO0PrNrY7lFC5VfIwxi4wxbxhjZgMZOTR5CZhkjPnGGLPXGPNX4CQwzL7+BFl7OkH2ZUopZZlxa6JtE0lePAUTe3El7gBrP36Shiuf4aL4cbDPPDo/8x+8vAp/mhVX4VLF52ZExAtoDSzNtmop0NF+fwvQRESCRMQX6AXc8NuSIjJERCJFJPLMmTOFEdvlhYSEXDfNtVKqYF2dyfjk/H9hjm4k7avbuS1hAT+XfYQqr2ykUavbrI7odEWm+AABgDsQl215HFAVwBiTBvwdWAVsBz662Ug3Y8x4Y0yYMSasUqVKhRLaSuHh4YjIdbf27dtfa/Prr78yfPhwp2ebNWsWYWFhlCtXjjJlytCiRQsmT55cYNuPjo5m0KBBVK9eHW9vb2rWrMnDDz/Mhg0bCmwfSuVVxxmN2Jr+MIH7pyEYfEnCTQw9E+fh43P9NOwlQVEqPnlijJlnjKlnjKljjCnxlxbu3r07J0+ezHJbtGjRtfWVKlXCx8fH6bkqVqzIqFGj2LRpEzt27GDgwIEMGjQoS7b8ioyMpFWrVuzevZuvvvqKPXv2MH/+fFq3bs1f//rXGz5PRPJ88dXVq1cTEhJyy1lVyRD34BwuyJ9zRKWKNzR9BEbstDCVtYpS8YkH0oHs37SqApxyfpx8sh/z5WL2Dlzh8Pb2pmrVqllumScqy37Ybf/+/dxxxx2UKlWK+vXrs2jRInx9fZk0adK1NsePH+fxxx+nfPnylC9fnnvuuYcDBw5cW//WW2/RpEkTZs6cSWhoKH5+fvTt2zfL/DndunWjb9++NGjQgNDQUEaMGEGzZs1ueXpoYwzh4eHUrl2b9evXc++99xIaGkqzZs14/fXXWbFixS1tXylHbVv0DWX+9wjeGYlkGEgTL9xNCieTvcCveH1x1BFFpvgYY1KAKKBHtlU9sI16KxrW/BdiNsGa961Ocp2MjAweeOABPDw82LRpE5MmTeLtt98mOTn5WpvExES6du1KqVKlWLNmDRs3biQwMJDu3buTmJh4rd2RI0f44YcfmDt3LkuXLmXbtm28+eabOe7XGMOKFSvYt28fnTt3vqXXsH37dnbv3s0rr7yCu7v7deuzz3CqVGFJupRA5GeP03LLyxx1q0GkNCGufn88/rKSuHr92LP/gG0QQgnlUlc4sA8SuDpXsBtQQ0RaAGeNMTHYrl4wVUS2AOuBodi+2zPO6WEXvwanHOgyx6yHzHMnRU6w3USgRqe8baNqU+j1H4diLlmy5Lopnp977jnef//64rds2TL27dvH0qVLCQqyDRr85JNP6NTpz3wzZ87EGMPEiRMREQC+/vprKleuzIIFC3j00UcB23TYkyZNwt/fduXdIUOGMHHixCz7S0hIICgoiOTkZNzd3fnyyy/p1auXQ68vu6s9MJ3PRlnp0G+/4BXxLK3ST7I++Bl+C/0LLWoGEGifPDKw31gOR8ezIzah0CeUdFUuVXyAMGyDBa56236bDIQbY34QkYrAKCAQ23eCehtjjjo9qaOqtYFzhyHpDzAZIG7gUxHK1yrU3Xbu3Pm6WTVv9Nf/77//TrVq1a4VHrBNw+3m9mcHOSoqisOHD+Pn55fluYmJiURHR197XLNmzWuFB6BatWqcPn06y3P8/PzYvn07ly5dYsWKFbz00kuEhITccMbVxo0bc/So7a2+/fbbWbx48XVtHJkcMfP2Mi+7WlRr1qzJ7t27AYiJiaFRo0bX2qWnp5OcnJylsD/55JOMG+f8v4OU6zAZ6UTOeIfm+z/jnJRjV49pdLrtHnL689IZMxm7MpcqPsaY1YDk0mYsMNYpgW7GwR4IAPP/BlsngUcpSE+BhvfDvR8XeLTMfHx8qFOnTu4N8ygjI4MWLVowc+bM69ZlPpfk6Zn1+woiQkZG1q9uubm5XcvWokUL9u7dy+jRo29YfBYtWkRqaioApUuXzrFNvXr1ANtsntmn+77Z9gDq1q3LokWLrhXfzK+hWrVqWSbj27x5MyNHjmT16tXXlpUtW/am+1PF27m4Yxyf9DRtkqKIKnMbtQZOoFmlqlbHclkuVXyKvcunofVACBsIkRPhknMGHeRVgwYNOHHiBCdOnKBatWqAbeRY5qLRqlUrZsyYQUBAQIGfP8nIyMhyfim7mjVr5rqNFi1a0KhRIz744AMee+yx6877nD9//lrunLZXs2bNHEexeXh4ZCnisbGx1y1TJdfutXOouvJv1DGJbGz4Ju0ffRlxKzKn1C2hxceZHp/25/1C7vFclZyczKlTWQcDuru7k9P3mnr06EH9+vV5+umn+fDDD0lKSuKll17Cw8Pj2qGo/v378+GHH9KnTx/+9a9/UaNGDY4dO0ZERARDhw6lbt26ecr17rvv0q5dO2rXrk1ycjKLFi1i6tSpfPHFF7f0ekWEiRMn0r17d2677TbefPNNGjZsSGJiIosXL+Z///sfkZGRt7QPpa5KTU5i26SXaHtyOofcanL+wdl0aNLW6lhFghafYm758uUEBgZmWRYUFERsbOx1bd3c3Jg7dy6DBw+mbdu2hISE8NFHH/Hggw9SqpRtnngfHx/Wrl3La6+9xiOPPEJCQgLVqlWja9eulC9fPs+5Ll26xLBhw4iNjaV06dI0aNCAKVOm8MQTT9zaCwbatm1LVFQUo0ePZujQoZw+fZrAwEDatGnDmDFjbnn7SgGcOLiTxJnhtE07yMaKD9D8mS/wKeOX+xMVAOLICdriLCwszNzoL+K9e/eW2NFTv/32Gy1atCAyMpLWrVtbHUflQUn+vDqFMWyd9yUNtv6LFPEkuv1/aH33AKtTuRwRiTLGhN1ovfZ8VBZz586lTJky1K1blyNHjvDSSy/RvHlzWrVqZXU0pSx3KeEs+yc8S6sLy9nt1ZQKAybRuoae98sPLT4qi4sXLzJy5EiOHTtG+fLl6dKlC5988sm1cz5KlVQHt67CZ/5faJZxhvU1h9JuwDt4eJacq1AXNC0+KounnnqKp556yuoYSrmMjLQ0oqb/k5bRYzkjFdnX+390apf9QivKUVp8lFLqBuJPHOb05Kdpk/wbv/p1od4z3xJYofhdAd8KWnzyyBijh56Uy9MBRAVn58oZVF/7CiEmhY1N36b9gy/od3cKkBafPPD09CQpKcmSqQeUckRSUtJ1V5dQjkm+cpkd371Am9OzOeheG/dHJtKhQQurYxU7WnzyoHLlyhw/fpygoCBKly6tPSDlcowxJCUlcfz4capUKbmX6b9Vx/ZtJe1/A2mTfoQNlR6l1TOfUaq0/tFZGLT45MHVa3adOHEiy7XAlHIlnp6eVKlSRa8xlw8mI4OouZ/SeMd7JEkptt42no7dH7M6VrGmxSePypYtq7/UShVDF86d5tCEQYRdWsuOUq2o+tQkWgXlfh1BdWu0+CilSqx9W36m3OLhNM44x/rQEbTv/88cJyFUBU+Lj1KqxElPSyVq6hu0PvINJ92qcPC+H+kU1sXqWCWKFh+lVIly+tgBzk59mrYpu9nsfxcNB31NsH+F3J+oCpQWH6VUibHj58mEbHyd6iadTS3fo12fYTp61SJafJRSxd6VxIvsmjCcsD/msc+9LqWemET7Ok2sjlWiafFRShVrR3dvhjmDCMs4xvqqAwgb+AHe3jlPw66cR4uPUqpYMhkZRM16n6Z7PuKilGF710l0uuMBq2MpOy0+SqliJyH+JEe+G0hY4ka2lW5H8MDvaFEl2OpYKhMtPkqpYuX3DfOpuPSvNDQXWV/vFTo8/gZu7npBUFej74hSqkgatyaaDdHxcPEUTOxF2tkYVnwxnHo/DyBRynDkwXl06j9KC4+L0p6PUqpIahbsz/PTt7EwdC5Vj27k4ue3cScJrPLtRZuhX+Pr5291RHUTWnyUUkVSxxmN2JqeDPttj8uTAEDX5JWghcflaX9UKVUkXQpfwVmPytcep4oXNH0ERuy0MJXKKy0+SqkiZ/8vc7ky4T78U0+TYSBNvHA3qZxM9gI/nc+oKNDio5QqMlKvXGL7uMHUWx7OBVOGSGlMXP3+ePxlJXH1+rFn/wHbIATl8vScj1KqSDixewMZPz5Li/RY1lZ4hB0NRtAqNJDA0AAAAvuN5XB0PDtiE+hoX6ZclxYfpZRLM+mp7PzhLRru+4qz4s/m2yfS+c4H6ZxD246hAVp4iggtPkopl3U+dh9/TA2nWfIeNvh0oXb4ONpVCbQ6lioAWnyUUq7HGPYvHkPwlneoZNxY2Xg0XR4ejpubTn9QXGjxUUq5lCvnT3Fk4iAaJPzCNvdmlHnsG7rVa2B1LFXAtPgopVzGsY1z8Fv6N2plJLKk+gi6PPV/lPLytDqWKgRafJRSlsu4cpH9U16gwYkf2U8ICffM4O62nayOpQqRFh+llKX+2LuOtNlDqJd2ksXlHqftwA+oV66s1bFUIdPio5SyRnoqB2f9H7V+H8cpE8DKDhO5u2dfRHRQQUmgxUcp5XSXT+zh7JRw6lzZxwrvOwl9eizdq1W1OpZyIi0+SinnMYaYJZ9RZfO7lDFeRNT/D70f+wueOudOieNQ8RGRWkAIUBo4A+w0xlwphFxKqWIm7fxxYic9Q8j5TWxya0mph8fRp5EOoS6pci0+IhICDAOeAIKAzAdkU0RkHTAemGOMySiMkEqpou3M5h8oteTvVMlIZnbVF7kr/E3KlvayOpay0E37uiLyOfAbUBt4E2gE+ANeQFWgN/AL8G9gh4i0KdS0SqkixSSd58i3A6i0eAhHTGU29viJh4e9rYVH5drzuQKEGmNyukb5aWCl/fa2iPQGagK/FmxEpVRRdPH31aTMHkJw6hlm+/Wn48D/0LSiDqFWNjctPsaYV/O6IWPMoluPo5Qq8tKSiZ3zJtX2fssfpgprW3/Hg/f21euyqSzyPOBARNwArp7XEZGqwL3AXmPM+sKJp5QqSpKP7+T89+EEJx1kgWdPavf/lAdCqlkdS7kgR0a7LQSWAJ+JiC8QCZQBfEVkkDFmSmEEVEoVARkZnF72CeU2jsbN+PB96H956PHBlPZytzqZclGOFJ8w4OphuAeBC0AtoD/wMqDFR6kSKONcDKemPEO1c7+yRsJw7zuGJ1s0tDqWcnGOFB9f4Lz9/l3AXGNMqoisBL4s6GBKKRdnDAlbpuGx5FX8M9KYVOnv3Pv0qwT4lbI6mSoCHCk+MUAnEZkP9AQesS+vACQWdDCllAtLPMvJ6c8RGLuIraYex+74hKe7dtLrsqk8c6T4fAxMBS4BR4G19uWdgZ0FnEsp5aKSfl9OyuyhBKSeZYrPU3QK/zetqpSzOpYqYvJcfIwxX4tIJFADWJbpagbRwP8VRjillAtJTeLMT29Qafd3xGYEsaH5dzzR5368PPS6bMpxDl3bzRgTBURlW7awQBMppVzDxVMweyA8PIm0hJMkTB9IpcRDzHK/h5r9PuDpekFWJ1RF2E2Lj4g8CUwzxpjcNiQiNYEaxph1BRVOKeV849ZE0yzYn457/wsxm0j+/jHc4naSavz4qsYH9Os3EP/SOrW1ujW59XyeAf4hIpOA+cCuzIVIRCoAtwFPAl3s7ZVSRdiQtR1wS0++9tg7bhsAAW6XGTZoiFWxVDFz04O1xphuwN+AO4DtwCUROSwie0XkFLZpFb4GDgKNjTELCjmvUqqQub2wnfPlmnD1z8wU48Gx4HvweGmXtcFUsZLrOR/7OZ2FIhKArZdTE9t8PvHANmCbTqWgVPFgzh0lfvoQKp3fhQGSjQeekk71qlXBr4rV8VQx4shot3jgp8KLopSyjDFc3PAdHstHUTojgwPutYjKqEtK86fw/m0q3eOOUdHqjKpYKZbTaItIdWzfSaoMpAH/NsbMsjaVUq7JJMRyZtpfqHz6FzZmNGZdo38yY7/w5YBWdAwNYEOzDvSYvo0x0fF0DA2wOq4qJorrAP004EVjTCNslwL6VETKWJxJKddiDBc2TSbps7b4xv3KeN9hVHpuMWUD6/Bl/1bXCk3H0ADG9GvJjtgEiwOr4qRY9nyMMSeBk/b7p0QkHttlgC5bGkwpF2EunOTU9GEEnlpFpKnPgfbvM6hnF9zdhDpV/K9r3zE0QHs9qkA5vecjIp1FZJ6IHBcRIyLhObQZbh9Vd0VEokTk9lvYX2vA3Rhz7FZyK1Us2C8GmvhpG8qf/IXvfJ+l3LBlPNGrK+462ZtyIit6Pr7ALmxTMFw3DYOIPAZ8BgwHfrH/u1hEGhljYuxttpNz9ruMMScybauCfR/PFvBrUKrIMZdOc3LacKqdXMY2U5f97d/n6Z7dtOgoSzhUfERkOPActnl8mhhjDonIa8AhY8z/8rIN+3Tbi+zbm5RDk5eAScaYb+yP/yoidwPDgNft22iRh6ze2Ebn/ccYsyEv2ZQqrhIi/4fbopepmH6ZKb4D6TjgbR6rev3hNaWcJc+H3UTkRWAUMB7I/KfSceD5gggjIl5Aa2BptlVLgY4ObEeAScBKY8zUgsimVFFkLscT+83j+C94liPpFZnXfib9//4JdbTwKIs5cs5nKPCsMeYzbKPJrtoKNC6gPAGAOxCXbXkcUNWB7XQCHgP6ish2+61p9kYiMkREIkUk8syZM/kOrZQrOr/1Ry5+1JrKsUuZVuYpfIav4pFePfQwm3IJjhx2q4ntXE12qdiueOAyjDG/kIfCaowZj60nR1hYWK4XT1WqKDCJZzk2/QVqxM5njwnh93Zf8/jdPbXoKJfiSPE5BLTCNpFcZr2BPQWUJx5IB7Jfx6MKcKqA9qFUsXV++3yYP4LAtPP84NufsAHv8GDVClbHUuo6jhSfD4ExIuKD7ZxPBxEZALxKAV3N2hiTIiJRQA8g8xUJegBzCmIfShVHJuk8R6e/SMixuewz1dnT9gse7tVbezvKZTlybbeJIuIBjAZ8sF2+5gTwgjHmh7xuR0R8gTr2h25ADRFpAZy1D6X+GJgqIluA9djONVUDxuV1H0qVJOd2LMFEPE/1tHjm+D5GywHv8UBVvRKbcm2OzmT6DfCN/QrXbsaY0/nYZxiwKtPjt+23yUC4MeYHEamIbWRdILbzTL2NMdkP9ylVopkrFzg8/SVqx8wi2lRjXZsp9O19n/Z2VJGQry+Z2q9wnS/GmNVkHaqdU5uxwNj87kOp4u7srmVkzH2OkLTTRJR5iOZPfUAf7e2oIiTPxUdEygNvAV2xXS06y2gyY0zlAk2mlLqOSb7IoRmvEHpkBkdMVTa2mci9vftqb0cVOY70fKZg+z7PZGzfu9GhyUo50R+7V5M+dyihaSdZ6NOHxgM+4r7ASlbHUipfHCk+XYA7jDFbCymLUioHJuUyB2eMJPTw98SaSiwK+5Ze9zyMm/Z2VBHmSPGJpvjO/6OUS/pj7zpS5gylblosP/vcS4MnP6F3NT3CrYo+R4rJCOA9EWkuIu6FFUgpBSY1id+nvEi5H+4jI/UKS1p9TY+Xv6emFh5VTDjS8zmI7TI6WwFs1+78kzFGC5JSBSB+30aSZw+hQWoMy0v3ou6AT7m7miOXNlTK9TlSfGYA/sAL6IADpQqcSb3C3h9GUe/gBOJNOZa2Gkv3+/rpuR1VLDlSfMKAtsaYnC4uqpS6BWcObOHK/4bQKPUwq0r3IHTA59xVrZrVsZQqNI4Unz1A2cIKolRJZNJS2P3DP6m//2vO48fylp/T7f6ntLejij1His8o4GMRGQXsxDaVwjXGmLMFGUyp4mbcmmiaBfvTsXIazB5IfOuXSIgYSZP0aNaV7krIgDF0Dwq2OqZSTuFI8Vlk/3cpWc/3iP2xDjhQ6iaaBfvz/PRtLKw1h6pHN1D+yAagLDND3+PRJ4dpb0eVKI4Un66FlkKpEqDjjEZsTU+2jRsF3AUCuMDjMW+B23AroynldI5MqbCmMIMoVdztC/s3tTa9gadJQwRS3bzxbHw/3PWu1dGUcrqbFh8RaQVsN8Zk2O/fkF52R6mcpaamEPXdS7Q/OZXz+FFWLpEunrhnpHAy2YtAv+wT9ypV/OXW84kEqgKn7fcNOU+HoOd8lMrBiZhozk0dQPvU3az2vQdzKY4G9eoT2G0YJ1d+xZ79BzgcHU/H0ACroyrlVLkVn1rAmUz3lVJ5tHnZbOqs/xu1TDLb2vyX3/260yzYn0B7oQnsN5bD0fHsiE3Q4qNKnJsWn2yzhxrgmDHmuisbiEiNgg6mVFGVdCWF9d+9Sre4ScR6VCfliam0rNOCljm07RgaoIVHlUiOjHY7jG1a6yxTZ9unvD6MHnZTioOHDnFhWjjd039jV6Ve1B/0DZ6l/ayOpZTLcaT4XP0+T3a+wJWCiaNU0WSMYfmSH2m+6e8Ey2X2txtNk7uHg+h3d5TKSa7FR0Q+t9812KZUSMy02h1oC2wv+GhKFQ0Jl5NZ+d2b3Bc/gTOegSQ+MYd6oa2tjqWUS8tLz6ep/V8BGgIpmdalYJti4cMCzqVUkbB93yEu/zCYBzKiiK7cg1rPTMCttL/VsZRyebkWH2NMVwARmQiMMMZcKPRUSrm49AzD3Pk/0WHryzSW8xxr/y9Ce76gh9mUyiNHrnAwsDCDKFVUnE5IYsl3b/H4+W+44FmJ5P6LqF6rndWxlCpSHBlwoFSJt3ZnNKlzhvEUmzlepQvVwichPuWtjqVUkaPFR6k8SEnLYMqPEXTfNZLqbmc402EUQXe9rIfZlMonLT5K5eLImUssnPQegy99zRXvcqQ9sYBKtTtZHUupIk2Lj1I3sSByP8z/G8/JL8RXvY2ApyZDGb0igVK3SouPUjlITElj7A8L6HvgdWq5nSKhw6sE9Hgd3NysjqZUsaDFR6lsdp9IYN6Uj3gx6SsyvH3hsbn41+lidSylihUtPkrZGWOY9ss+vJe9xutuq0io2g7/J6eAX1WroylV7GjxUQo4dzmFj2YspH/MP2joFkNiuxfxv+v/wF1/RZQqDPqbpUq8LYfPMm/aGF5L/RIPL2/Mo7PwqXeX1bGUKta0+KgSKz3DMHb5bsque5t33JdyuUprSvWfAv7BVkdTqtjT4qNKpJMJSbz7/RKejfsXzd0PkdJ2OGV6/gvcPa2OplSJoMVHlTjL98SxYNa3vJvxJaW93OCh7/FqeJ/VsZQqUbT4qBIjOS2d9xfuosqv7/Opx0KSKzfF64mpUKGW1dGUKnG0+KgSIfrMJd76fhkjzo0mzGM/6a0H4X33aPAsZXU0pUokLT6q2JsTFcuSiO/53G0Mfl4Z0GcC7k0ftjqWUiWaFh9VbF1KTuMfc38jZNfnfO0RQXrF+ng88T0E1LU6mlIlnhYfVSztjE3gn9NW8PLlD+josYeMFv3x7P0hePlYHU0phRYfVQyMWxNNs2B/OoYGYIxhwi+HWblkDl97jqGC5xW490vcWj5pdUylVCZafFSR1yzYn+enb+OjuytTbflzJF8KYarHAq74heD+5DSo0tjqiEqpbLT4qCKvQ+2KDGhfkzMRf6eL+07qe+7kTM17qdRvHHj7WR1PKZUDLT6qSDt4+hI1xtbib6Rk+TRXOroAPgiFUaetC6eUuiGdGUsVSYkpafxn8e8899kMfiMUgAwEgCS8OF2rD4zYaWVEpdRNaM9HFSnGGJbsOsVH86N4OHEGizwXk+Hpw7bU+rRgP3iUolRaMvMPJxF82p2OetRNKZekxUcVGYfOXOKfEbuocCiCH7xnUtHjLLR8kqk+4dwX81+kym0QNhCJnMidcceYFZtAx9AAq2MrpXIgxhirM7iEsLAwExkZaXUMlYPElDS+XHWQtWtX8ZbHZFrLXkxgS+SeDyE4zOp4SqkciEiUMeaGv6Da81EuyxjDz7vj+HT+Fp64PIUIzxVQqhz0+BxpOQDc9JSlUkWVFh/lkg7HX+btiJ1UOTSbmV4/4O95CQkbBF3fAJ8KVsdTSt0iLT7KpSSlpDN29UE2rl3KP90n0tQzGhPc3naIrWpTq+MppQqIFh/lEowxLN97ms/mrWfApcnM9lhNepkq0PMbpOkjIGJ1RKVUAdLioyx39I/L/HveToIPTmOm5xx8PJOhwwu43/GqXqFAqWJKi4+yzJXUdL5aHU3kmvn8w30S9T1jyKjdFbde/4VK9ayOp5QqRFp8lCVW7I3jy4g1hF/+jr95bCS9bHXo9T1uDe7VQ2xKlQBafJRTHTubyLvzthFyYArTPH/C2zMDbh+Je6cXda4dpUoQLT7KKa6kpvP1mkPsXDObN90mU8vzJBn1euN292ioUMvqeEopJ9Piowrdqn2nGffTSgZdGs8I9yjSytWGe2bjVreH1dGUUhYptsVHRHyAvcAsY8zLVucpiY6dTeT9eVupe3ACUz3m4+7tCV3ewqP9cPDwtjqeUspCxbb4AG8Cm6wOURIlp6XzzZpofl89g9fdphLkcYb0Rg/i3vMd8A+yOp5SygUUy+IjInWBBsB8oInFcUqUNfvPMGHuEgZf+prn3XeSWrEB3DsR91q3Wx1NKeVCnHplRhHpLCLzROS4iBgRCc+hzXAROSwiV0QkSkTy87/Wh8DrtxxY5dnx80mMmLyOvVNe5LukEXQsdQTufh/P4etBC49SKhtn93x8gV3AFPstCxF5DPgMGA78Yv93sYg0MsbE2NtsJ+fcdxljTohIH2C/MWa/iHQsnJehrkpOS+fbtYc4snoSb8o0KnucI715f9x7vA2+layOp5RyUU4tPsaYRcAiABGZlEOTl4BJxphv7I//KiJ3A8Ow92SMMS1y2U174HEReQRbsfMUkQvGmH/d+itQma07cIbJPy7g2cvjeM7td1IqN4f7Z+Ouc+wopXLhMud8RMQLaI3tkFlmS4E892CMMa9jL1T2w3pNblR4RGQIMASgRo0ajocuoU4mJPFRxBaa7v+Crz1WkF7KH3p+jpfOsaOUyiOXKT5AAOAOxGVbHgd0L4wdGmPGA+PBNpNpYeyjqBq3Jppmwf5ZpqFeu/8ME3+JJvjIHN6QGZTzuExG62fwuvNNnWNHKeUQVyo+Bc4YM8nqDEVVs2B/np++ja/7BtEm8u9MDX6LOas28ZbHJFq4HSK5Wlvc7v8YN51jRymVD65UfOKBdKBKtuVVgFPOj1OydQwNYEy/lhyaOozWbKT94acZ4HWS5FKVofc3eOscO0qpW+AyxccYkyIiUUAPYFamVT2AOdakKplS0jJwH12VjhnJ15bVdTsJgHdqAjR71KpoSqliwqnFR0R8gTr2h25ADRFpAZy1D6X+GJgqIluA9cBQoBowzpk5S6qYPxKZvvko+yKX83hqE3q4RyHG1sG5gicXavWm8oMfWB1TKVUMOLvnEwasyvT4bfttMhBujPlBRCoCo4BAbN8J6m2MOerknCVGanoGK/bG8b9NByl/aAHhHj/zmtthkr19OZhWg7pyDDy88U5LZvXhJIJPu9NRJxdVSt0iZ3/PZzVw0xMFxpixwFinBCrBjp9PYuaWGFZu2c7dVxbxocdKKnhdIK1CPejwEVMvtOOBI/9CqvSAsIFI5ETujDvGrNiELCPglFIqP8QYHWEMtqHWkZGRVscoVOkZhtX7TjN901EuHljHU+5L6eW+BTcMpt7duLUfCrXu0IEESqlbJiJRxpgbfuPcZQYcqMITd+EKP/x6jB83H6TN5ZW84rmMBl6HyfD2x63VcGgzGNEJ3ZRSTqTFp5jKyDCsOxjP9M1H2b13L0+4LWW+12r8PC9gKjWAdp/i1uxR8CpjdVSlVAmkxaeYOXMxmVlRx5i5OYaq57cyxHsZX3n9iohB6vWGdn9BQm7XQ2tKKUtp8SkGjDFsPPQH0zbHsGZ3DL35hSmlVxDifQhTqhzS+nkIGwTla1odVSmlAC0+Rdq5yynM2RrL9M0xXIk/yuBSK/ig1Cp80i9AhcbQ7nOk6SPg5WN1VKWUykKLTxFjjCHq6DmmbY5h4c4TtMrYzWi/VbQrtREEpN690O4vULOTHlpTSrksLT5FREJSKnO3xjJ9SwwxcX/wuPdG1vquoOqVaHArD7eNsB1aK1fd6qhKKZUrLT4uzBjDb7EJTNt0lPk7ThCQFsdL5dZyj98yvFMvgH9TuGsMNH0YPEtbHVcppfJMi48LupScRsT240zbFMOekwl09fqdOeVX0+jieuSKQMP7bIfWanTQQ2tKqSJJi48L2XU8gelbYojYdpyMlMsMqxDF9IAllLsUDWkV4ba/Qdgz4B9sdVSllLolWnwslpSSzvwdJ5i2OYbfjp0n1OMMY6usp9PFJXgkXoCqzeDOsdDkIfAsZXVcpZQqEFp8LLI/7iLTN8cwZ2ssF6+k8miFaL4IXkH1+LXIWTdo1Md2aK16Oz20ppQqdrT4ONGV1HQW7zrJ9M0x/HrkHOXcU/hH8HbuvbKA0gkHgQDo/LLt0FrZalbHVUqpQqPFxwmiz1xixuYYZm+N5XxiKp3KJzC/7joan16AW9wFCGwBXcdB4wf00JpSqkTQ4lNIUtIyWLrnFNM2xbDx0B94uhleCDlOf1lM+eOrkePu0Kiv7dBacBs9tKaUKlG0+OTTuDXRNAv2zzKx2oboeNbuO4O4CbMijxF/KYW65WBKk+10/ONHPE4chDKV4Y5XofVAKBto3QtQSikLafHJp2bB/jw/fRtj+rWkbUgFvlwVzZhVB0hNN7gJPFEnlWGlVxB0ZC5y8CIEtYYu46FxX/Dwtjq+UkpZSotPPnUMDWBMv5a8MWU5H/Ap3yf/lbI+Ffm/Bie5O3EepY6sBDdP23mcdn+B4BtO6KeUUiWOFp9b0DE0gP8ELKZ1/O/MKDeWUJ8kZE80+FaBLq/bDq35VbE6plJKuRwtPvn1TmVIS6Y9gECdK7vgCrbezou7wMPL4oBKKeW63KwOUFT92mc1i7iNdHfb+ZsMNy8Wcju/PrhOC49SSuVCi08+RZ31pmXdGrhnpIJHKdxMGq3q1SDqDy08SimVGy0++TT0jlAC3S/YzusMXg6tBxLolsDQO0KtjqaUUi5Pz/ncisen/Xn/3o+ty6GUUkWM9nyUUko5nRYfpZRSTqfFRymllNNp8VFKKeV0WnyUUko5nRYfpZRSTifGGKszuAQROQMcBfyBhBs0u9G6ACC+kKIVtJu9vhtx5PXlZ/sFuZ2Czppbm/x8XqDofGackbMgPjP5zenIvvPaNrd2N8taUL8/BeFWf6Y1jTGVbtjKGKO3TDdgvKPrgEircxfE67vJc/L8+vKz/YLcTkFnza1Nfj4vjua08uaMnAXxmclvTkf2nde2efjM3DBrQf3+WPne5/U16GG3683P57qiorBfQ0Ft3xk/67zsI7c2xf3z4gxW/pwc2Xde297K6ykOn5k8vQY97FYARCTSGFNsJ+wpSq+vqGTVnAWrqOSEopO1sHNqz6dgjLc6QCErSq+vqGTVnAWrqOSEopO1UHNqz0cppZTTac9HKaWU02nxUUop5XRafPJIRDqLyDwROS4iRkTCs60XEXlLRE6ISJKIrBaRxhbFdYiIvC4iv4rIBRE5IyLzRaRJtjaT7K87822TBVnfyiHHqUzrLXkfCuLzISLlRWSqiCTYb1NFpFwB58zLe+0SWXPIbURkjKvlFBF3Efm3iBwWkSv2f98REY9MbZyeNbfPpL1NPRH5UUTOi0iiiGwVkYaZ1nuLyBciEi8il+3bC862jRr2z9Fle7vPRSTXWTW1+OSdL7ALGAEk5bD+VeDvwF+BNsBpYJmI+DktYf51AcYCHYFuQBqwXEQqZGu3HAjMdOvtxIyZ7cuWo2mmdVa9DwXx+ZgOtALutt9aAVMLOGcXcn+vXSUrACLSHhgC7Mi2ylVyjgSeA14AGmD7DDwHvG5x1pt+JkWkFrAeOIzts9AEGAVcytTsU+Ah4AngdqAssEBE3O3bcAcWAn729U8ADwMf5ZrO6i8yFcWb/c0Jz/RYgJPAm5mWlQYuAn+xOm8+Xp8vkA7cl2nZJGCBC2R7C9h1g3Uu8T7k5/MBNAQM0ClTm9vsy+o76712tazYvi0fDXQFVgNjXC0nsACYnG3Z5Ku/L66QNftn0r5sOjAtl599CtA/07LqQAbQ0/64l/1x9UxtngSuAGVvlkl7PgWjFlAVWHp1gTEmCViL7S/MosYPW6/4XLblt4nIaRHZLyLfiEhlC7IB1LYfvjgsIjNFpLZ9uau+D3nJ1QHbfxAbMj1vPXCZws2e/b12tazjgdnGmFXZlrtSzl+AriLSAEBEGmHrSSxywazYM7oB9wF7RGSJ/RDsryLyWKZmrQHPbLmPAXuz5d5rX37Vz4C3/fk3pMWnYFS1/xuXbXlcpnVFyWfAdmBjpmVLgKeAO7EdPmgLrBQRbydn2wyEYzss8Sy2n+8GEamI674PeclVFThj7H86Atjvn6Zws2d/r10mq4g8C9TBdigoO5fJCbyP7fDYHhFJBXZj6wmNdcGsV1XG1ut9A1tx6QHMAKaJyD2ZMqVz/fXdsufO/rri7c+7aW6Pm61UJY+IfIytu3+bMSb96nJjzMxMzXaKSBS2C7HeA/zorHzGmMWZH4tt0MMh4GnA6QMgirIbvdeuQETqA6OxZUu1Ok8uHsP2h1k/bIWnBfCZiBw2xkywMthNXO14RBhjPrbf3y4iYcDz2M7jOCWAujVXR1tVyba8SqZ1Lk9EPsF2wrCbMebQzdoaY04AsUBdZ2S7SY5L2H7h6+K670Necp0CKomIXF1pv1+ZQsh+k/faVbJ2wHZV5d0ikiYiacAdwHD7/T9cJCfAB8CHxpiZxpidxpipwMf8OeDAVX6mmcVjG2yyJ9vyvUCNTJncsb0PmWXPnf11Bdifd9PcWnwKxmFsP+geVxeISClsoz823OhJrkREPuPP/4x+z0P7ACAI24lUy9h/zg3sOVz1fchLro3YDoN0yPS8DkAZCjh7Lu+1q2T9CdsoxhaZbpHATPv9/S6SE8AH22GmzNL58/9XV/mZXmOMSQF+BepnW1UP2xENgCggNVvuYGyDIzLnbpht+HUPINn+/JuG0FveRov48ucvQSLwD/v9Gvb1I7HNYfEgtiGLM4ETgJ/V2fPw2r4ELmA7SVo1080302v/ENsvQwi24bobsfV8nPr67DnuwHYStx22kUYXsM0dYtn7UBCfD2AxsNP+c+5gvz/fme+1K2XNIftq7KPdXCkntpGgsdgOQYcADwBngI+szJqHz2RfbKPZhmA7t/YstmJzT6ZtfGV/bd2BlsAqbOcI3e3r3e05V9rXdweOA1/kmq8wPyzF6YbtP1yTw22Sfb1gGwZ8EtswwzVAE6tz5/G15fS6DPCWfX1pbCNYTts/rEftv3DVLch69Zc2xf4hnwM0yrTekvehID4fQHnge2zF4YL9fjlnvteulDWH7KvJWnxcIie2EYOf2n8vkrCdgxwNlLIya26fSXubcGy9yCRs36N6Its2vIEvsB3mTMQ2XUL1bG1qYPsjMNHe7nPAO7d8emFRpZRSTqfnfJRSSjmdFh+llFJOp8VHKaWU02nxUUop5XRafJRSSjmdFh+llFJOp8VHKaWU02nxUUop5XRafJRSSjmdTqmglIsTkdXYrj58Htt1uDKAKcCrxpgM65IplX/a81GqaOiP7RL4HbHNt/IitnlklCqS9NpuSrk4e8/H2xjTIdOyZcBRY8xgy4IpdQu056NU0bAj2+MT2CYaU6pI0uKjVNGQfSppg/7+qiJMP7xKKaWcTouPUkopp9Pio5RSyul0tJtSSimn056PUkopp9Pio5RSyum0+CillHI6LT5KKaWcTouPUkopp9Pio5RSyum0+CillHI6LT5KKaWcTouPUkopp/t/59PBRMC+sEgAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2.7178167899437664"
-      ]
-     },
-     "execution_count": 261,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fig1, ax1 = plt.subplots()\n",
-    "\n",
-    "datatype = 1; print(datatypes[datatype])\n",
-    "m = 0; plt.plot(nSizes,data[m,:,datatype],'x-',label=methods[m])\n",
-    "m = 1; plt.plot(nSizes,data[m,:,datatype],'*-',label=methods[m])\n",
-    "\n",
-    "ax1.set_xscale(\"log\")\n",
-    "ax1.set_yscale(\"log\")\n",
-    "ax1.set_xticks(nSizes)\n",
-    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
-    "\n",
-    "plt.xlabel(\"n\")\n",
-    "plt.ylabel(\"time (s)\")\n",
-    "plt.legend()\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.savefig(\"curvesWithNoMKL.pdf\")\n",
-    "plt.show()\n",
-    "\n",
-    "rate = (np.log(data[m,-1,datatype])-np.log(data[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
-    "rate"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 262,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_mkl = np.ones([M,N,NT], dtype=np.float64) * 60 * 60 * 24\n",
+    "data_mkl_mdspan = np.ones([N,NT], dtype=np.float64) * 60 * 60 * 24\n",
     "\n",
-    "executable = [\n",
-    "    \"build_mkl/performance_tlapack\",\n",
-    "    \"build_mkl/performance_tlapack\"\n",
-    "]\n",
-    "M = len(executable)\n",
-    "\n",
-    "methods = [\n",
-    "    r\"$\\langle$T$\\rangle$LAPACK - C++ using MKL BLAS\",\n",
-    "    r\"Eigen3 - C++ using MKL gees\"\n",
-    "]\n",
-    "\n",
-    "for s in range(M):\n",
-    "    for i in range(N):\n",
-    "        n = nSizes[i]\n",
-    "        for j in range(nRuns):\n",
-    "            expr = executable[s]\n",
-    "            output = !$expr {n} 0 | grep time\n",
-    "            for k in range(NT):\n",
-    "                data_mkl[s,i,k] = np.minimum( float(output[k].split()[2]), data_mkl[s,i,k] )"
+    "executable = \"build_mkl_mdspan/performance_tlapack\"\n",
+    "for i in range(N):\n",
+    "    n = nSizes[i]\n",
+    "    for j in range(nRuns):\n",
+    "        output = !$executable {n} 0 0 {matrix_type} {seed} | grep time\n",
+    "        for k in range(NT):\n",
+    "            data_mkl_mdspan[i,k] = np.minimum( float(output[k].split()[2]), data_mkl_mdspan[i,k] )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 263,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "float\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAABQC0lEQVR4nO3dd3gUVdvA4d9Jr4QSQgkQIPQSeldAiohIU1ApSudFXhU79l5ey6eiiIhSpAkKIoKIFGmCgKFK772EACEhPdnz/TGbsOm7IdlNss99XXslO3N25pnsZJ89c86co7TWCCGEEPbk4ugAhBBCOB9JPkIIIexOko8QQgi7k+QjhBDC7iT5CCGEsDtJPkIIIezOzdEBFBWBgYG6evXqjg5DCCFKhB07dkRqrcvntF6Sj1n16tUJDw93dBhCCFEiKKVO57ZeLrsJIYSwO0k+Qggh7E6SjxBCCLuT5COEEMLunD75KKV6K6Wm3bhxw9GhCCGE03D63m5a62XAspYtW47JrVx0dDQREREkJyfbKTIhhLPz9fWlSpUquLjYp54wdcNxwqoE0D40MH3ZluOR7D13g3GdQgt0X06ffKwRHR3N5cuXCQ4OxtvbG6WUo0MSQpRwJpOJ8+fPExkZSVBQkF32GVYlgMfn72Ly4Ga0q1mOv09cTX9e0CT5WCEiIoLg4GB8fHwcHYoQwkm4uLhQoUIFTp8+bbfk0z40kE8fbMLImf9QPdCXiJhEJg9ulqEmVFCcvs3HGsnJyXh7ezs6DCGEk3F3dyclJcVu+9tx+hpvLztAQoqJQ5diGNy6WqEkHpDkYzW51CaEsDd7fe7EJ6Xy7vIDDJj6N9HxydTwimFT0Mf8sW0PW45HFso+JfkIIYQTCz91jXu/2MR3f52ka70gUrXmh1prqRq9m9m11vP4/F2FkoCcvs1HKdUb6F2rVi1HhyKEEHYTn5TKJ6sOM2PzSYJLezN/dBtaz6+PmykJjhllKh2Zx07mkTLPA16/UqD7d/qaj9Z6mdZ6bEBAgKNDEUIIu/jn1DV6TtrI9L9OMrRNCH881ZH2tQJx6zcFXNxvFXTzhsYDcXt6X4HH4PTJx1lMmTKFU6dOWV1+1qxZHDhwoPACEkXW8OHDue+++xwdhigE8UmpvL3sAA9+8zepWjN/TBve6dcIXw9X+OtzWDIWPPwABW5ekJoInqXAv0KBxyLJxwmcOXOGp556itKlS6OUyvUxfPhwAMLDw5kyZUqG7Vj7obRz505cXV3p0KFDlnXDhw9P35e7uzs1a9bkueeeIzY21qbtAFy+fJkJEyYQGhqKp6cnwcHB9OzZkxUrVuQa8/Lly/Hx8eHVV1/N81jyYk0Mxc2kSZOYO3duoe8n7VwYNWpUlnUTJ05EKZXhvbPmvcxP4rQ8J5VSBAYGct9993Ho0KFc952dvM7ZK1euMH78eKpXr46npycVKlSga9eurF692qaY82P7SaO2M2PzSR5pG8LKCR2NnmxJsbBoBKx5Axr0hWptoeVIGL0GWoyAm5cLJR6nb/NxBkuXLqVjx46ULl2aixcvpi9fvnw5Y8aMybAsrUt53759GTlyJJMnT7Z5f9999x3jx49n9uzZHDx4kPr162dY361bN+bMmUNycjKbNm1i9OjRxMbG8vXXX1u9nVOnTtGhQwf8/f354IMPaNKkCSaTibVr1zJu3DjOnDmTbWxz5sxh9OjRfPTRR0yYMMHmY7OU3xiGDx9O9erVefPNN63aj63lb5c9L0FXrVqVH3/8kS+++AJfX18AUlJSmD17NtWqVcv1tQX5XqadkwAXLlzg+eefp3///hw8eNCm7eR17j/wwAPExcUxffp0atWqRUREBBs2bODq1au3FX9u4pJS+PiPw8zacooqZbz5YUxb2oWWM1ZeOwkLh8Ll/dDtTejwFFj2sLvv00KLS5KPHdhzyIrsLF26lL59+wJQsWLF9OWlS5fOsixN586diYmJYceOHbRo0cLqfcXHxzN//nw2bdqU/k/2ySefZCjj6emZvs/Bgwezbt06fvnllwzJJ6/tjB8/HjBqaH5+funL69evz9ChQ7ON7fPPP2fixIlMnz49xzK2yE8M9tC5c2caNWqU4YvD8OHDiYyMZPny5QBs3LiRF154gX379uHq6krdunWZMWMGjRo1ylK2c+fONGjQgNKlSzNt2jRcXFx49NFH+eijj9KHfYmNjeWxxx7j559/xtfXl6eeeorNmzcTGBjIrFmzcow1LCyMCxcu8OOPPzJixAgAfvvtN7y8vOjYsWOOH8oF/V5anpMVK1bk6aefpnfv3sTHx1t9j19e52xUVBSbNm1i9erVdO3aFYCQkBBatWp12/HnZNuJq7yweC+nr8YxrF0IL9xTD19P88f+8T/hpxGAhqGLoFa3QosjO3LZzQ7ShqxI66645Xgkj8/fRViVwv+GGRUVxcaNG+nTp49Nr3N3d6dnz5788ssvNr1u0aJFhISE0LhxYx555BFmz56d53h43t7eWcrktp1r166xcuVK/vvf/2b40E+TllQtvfrqq7z88sssWbKkQD6s8hNDUZGSkkLfvn2544472LNnD9u2beOpp57C1dU1x9fMmzcPNzc3tmzZwuTJk/n8889ZuHBh+vpnn32WDRs2sGTJEv7880/27NnDpk2brIpn1KhRzJgxI/35jBkzGDFiRI73uBT0e5lZTEwMCxcupHHjxjbdXJ7Xue/n54efnx+//vorCQkJBR63pbikFN78dT8PTduK1rBgbFve6tvISDxaw+ZJMPcBKFUZxq63e+IBqfnky1vL9nPgQrRNrwny9+TR6dupUMqTy9GJ1AryY9Kao0xac9Sq1zeoXIo3eje0Odbly5fTsGFDQkJCbH5t3759ee+993jnnXesfs306dN55JFHAOjUqRM+Pj4sXbqUAQMGZFt++/btzJ8/P/2boDXbOXbsGFrrLJc0crJ69Wp+++03li9fzr333mv1seTG1hiKkujoaKKioujduzehoUbNu169erm+pkGDBrz99tsA1KlTh2+//Za1a9cyaNAgbt68yYwZM5g9ezbdu3cHjPevSpUqVsUzePBgnnvuOY4ePYq/vz8rV67kyy+/5PXXX89StjDeS4CVK1emf4mIjY2latWqNrfb5XXuu7m5MWvWLMaMGcO0adNo1qwZHTp0YODAgbRp06bAjmXriau8sGgvZ67FMbx9dV64py4+HuaP+qRY+PUJ2LfYaN/pOwU8s355sgep+dhJgLc7FUp5cj4qgQqlPAnwds/7RQVgxYoV+f4n7dmzJ/v378+x7SKzY8eO8ddffzF48GDAuDt7yJAhTJ8+PUO5tH90Ly8v2rVrR8eOHfnyyy+t3o7W2qbjaNSoEaGhobz11ltERUXlWX7evHnp31L9/Pyy/QZvSwzvv/9+hu3NmzcvyzLLfdha3lZly5Zl+PDh9OjRg169evHpp5/m+R6HhYVleF65cmUiIiIAOH78OMnJybRu3Tp9va+vL40aNbIqnjJlytC/f39mzJjB999/T+fOnXNs77H1vbRWx44d2b17N7t372b79u107dqVu+++m7Nnz1r1emvP/QceeIALFy6wbNkyevbsyZYtW2jbti3vv//+bR9DXFIKbyzdx8PTtqIULBzbljf7NLyVeK6fguk9YN/P0PUNGPi9wxIPSM0nX/JTA0m71PZkl1rM3XaGCd1qF9qYSZaqV69uUxdrS6dPn8bHx8fqQQ2/++47UlNTM3xwpH1Inz17lqpVqwLGP/q0adNwd3encuXKuLu727Sd2rVro5Ti4MGD9O/fP8+4KlWqxK+//kqXLl3o1q0bq1evpkyZMjmW79OnT4ZvosHBwVnK2BLDuHHjePDBB9OfT5w4keDgYJ588sls92Fr+cxcXFyyJMfMlzVnzpzJU089xcqVK/n111955ZVX+OWXX+jRo0e228z8HimlMJlMOcZgq5EjRzJs2DD8/PzSa1jZsfW9tJaPjw+WN5p/9913BAQEMG3aNKtq/tae+wBeXl50796d7t278/rrrzN69GjefPNNnnvuOTw8PPIV/9/HrzJxcQ61HYDj64webdoEQ36C2t3ztZ+C5PQ1H3tMJpeWeCYPbsYzd9dl8uBmhTZkRWb9+vVjxYoV+RqccOnSpfTo0QMvL688y6akpPD999/zwQcfpH+D3L17N3v27CEsLIyZM2eml037Rw8JCcnyoWbNdsqWLUuPHj2YPHkyN2/ezBJLdt+Ig4ODWb9+PbGxsXTt2jXX3kX+/v7UqlUr/ZHddX9bYihbtmyG7fn7+2dZZrkPW8tnVr58+Qw9GAH27NmTpVyTJk2YOHEi69evp3Pnznz//fc5bjM3oaGhuLu7888//6Qvi4uLY98+629M7Nq1Kx4eHkRGRtKvX79cy9ryXuaXUgoXFxfi4uLyLGvLuZ+dBg0akJKSkq92oNjEFF5fuo9B3+ZQ29EatnwJc+8Hv4owZl2RSDwgNR+rJ5O7HXvP3cgwLHn70EAmD27G3nM3Cr3206pVK3x8fNiwYUOWdpW8LF26NMO3bTDaC3bv3p1hWenSpdmzZw+RkZGMGTOGcuXKZVj/8MMPM3XqVF577bU89/nbb79ZtZ2vvvqKDh060LJlS9555x3CwsLQWrNu3To++OCDbC8jVapUifXr19O1a1e6dOnC2rVrCQzM/98/PzHYQ5cuXXjqqaf49ddfqVu3Lt988w1nz56levXqAJw8eZJvvvmGPn36EBwczIkTJ9i7dy+PPfZYvvbn5+fHyJEjmThxIoGBgVSqVIl3330Xk8lk9cCYSin27t2L1hpPT888y+f2XuZ0jqYdf3YSExO5dOkSANevX0//UtG7d+/0Mrd77l+7do2BAwcycuRIwsLC8Pf3Jzw8nI8++oiuXbtSqlSpPI/b0pbjkUxcvJdz1+MZ2aEGz/eoi7eHRaeRpDhY9iT8+xPU7w39vgZPf5v2UZicPvnYQ3bdqduHBtrlsptSij59+rB06VKbks+5c+fYs2dPlhvrNm3aRLNmGSeWeuCBB0hKSuKuu+7K8s8HMHDgQF588UWrbqSbPn26Vdu5++672blzJ++//z4TJ07k/PnzlCtXjiZNmjBt2rQct1+hQgXWrVtHt27duOuuu1i7dm2+50qpWbNmvmIobCNHjmTv3r2MHDkSgP/+97/079+fyEijpu3j48ORI0cYOHAgkZGRVKhQgSFDhjBx4sR87/OTTz4hNjaWPn364Ofnx9NPP83ly5etqjWn8fe37YMxu/cScj5HFy1alOO21qxZQ6VKldLjqFevHj/99BOdO3dOL3O7536nTp1o27YtkyZN4tixYyQmJhIcHMzgwYNtuuE5NjGF//1+iDlbT1O9nA8//qcdraqXzVjo+mlYOAQu7YMur8Gdz2a8f6cIULY23pZULVu21OHh4dmuy+5mseJk5cqVjBs3zqa2nylTpvDTTz+xbt26wgtMlFiJiYmEhITw/PPP8+yzzzo6nGLN8vNny7FIXli8l/NRRm3nubsz1XYATmyAn4aDKRUe+A7q3G3/oAGl1A6tdcuc1kvNxwl06dKF69evs3v3bpo2bWrVa5YuXZrntXch0uzatYuDBw/SunVrYmJi+PDDD4mJieGhhx5ydGglws3EFP73+0Hmbj1DjUDf7Gs7WsPWKbDqVQisAw/Ph3KFfxN7fknycQIeHh7Y2qHijz/+KKRoREn16aefcvjwYdzc3GjatCkbN260+l4fkbPE5FR6fLaRCzfiGX1HDZ7NrraTFAfLJsC/P0K9+6D/1CLVvpMdST5CiNvWrFkzcrpsLfIn1aS5dCOeKzeT8HRzYdG4drQIKZu1YNQZWDAELv0Ld71qtO+4FP2OzJJ8hBCiiLmZkMy56/EkpZrw93JjxYQ78XLPZvijkxuN9p3UZBi8EOpkf59WUSTJRwghiohUk4mLNxK4FpuEp5sroeX9OBPjnjXxaA1bvzbad8rVMtp3AovXbMySfIQQogiISUjmvLm2U97fkwr+Xri4ZNM9Ojkelj0FexcY7Tv9vgYv2+4RKgok+QghhANlV9tJn/Ygs6izxv07F/dA55eh4/PFon0nO5J8hBDCQWLMbTspedV2AE5uMrfvJMGgBVC3p11jLWiSfIQQopBFxCTg4+6Kn5cxlmGqycTZa/FEJyTj6eZKzdxqOwBbp8IfLxv37Tw8HwJr2ynywuP0yUcp1RvobTmirRBCFCQfd1fOXIunWlnQwNlrcaSYNKW93alSxifn2o7JBHFXYeVEqHsv9P+mWLbvZKd4XiwsQFrrZVrrsfact14I4Vz8vNypVtabU1fjOBkZS6pJU7m0N9XK+eaceFKS4OoRYwK4zi/BQ/NKTOIBST5Or3r16hnmmRdF1/Dhw7MM9CqKj9ikVEzmsTTL+3sS6JfL6N2JNyHyMKQkgm956Pxise1YkJOSdTQig+HDh6OUyvJo27Ztepl//vmH8ePH2z22n376iZYtW1K6dGl8fX1p2rRpvueTyc7x48cZNWoUVatWxdPTk5CQEAYMGMCWLVsKbB/2NmnSJObOnVvo+5k1axZKKWrXztqu8Pvvv6OUSp9yGmD9+vUopdJHzQa4cuUKLVq0oHnz5kRERHDq1CmUUk47CkJ0fDKXoxNQShHk78W12GRuJiRnLag13LwCV4+BcoXAuuCe89xNxZkknxKuW7duXLx4McPDcm768uXL4+PjY/e4ypUrx6uvvsrWrVvZu3cvI0aMYNSoURliy6/w8HCaN2/O/v37+frrrzlw4ADLli2jRYsWPPHEEzm+Till9cjf69evz3V+mMIQEBBA6dKl7bIvLy8voqKi2LBhQ4bl06dPz3GK6zSnT5/mjjvuoFSpUqxfvz7fU1aUFInJqZy5FodCUb2cDxUDvKhW1psz1+IzJiCTyRgqJ/qcMS5b+Trgbv2UFMWNJB97irkEM3tCzGW77dLT05OKFStmeJQte2t8qMyX3Y4cOUKnTp3w8vKibt26rFixAj8/P2bNmpVe5vz58zz88MOUKVOGMmXK0KtXL44ePZq+/s0336RRo0YsWLCA0NBQ/P396devX4Zvxl26dKFfv37Uq1eP0NBQJkyYQFhYGJs2bbqt49VaM3z4cGrWrMnmzZu57777CA0NJSwsjJdeeil9zhd7y+mbv1Iqwzwzb7/9NiEhIenv26OPPpq+LvNlt86dOzN+/HhefvllAgMDCQoK4rnnnsswvfXly5fp06cP3t7ehISEMHPmTBo1asSbb76Za7yurq488sgjzJgxI31ZZGQky5cvZ9iwYTm+7sCBA3To0IEGDRrw+++/2zxBmqWCOBeB9C8eXl5e1KhRg1deeYWkpKT09T///DNhYWF4e3tTtmxZOnXqxOXLBfM/mmrSnL5mzIZataw3/ubebmltQHHJqUbBlCS4ehTirxkzjpatCS4luz+YJB972vARnNkKGz50dCTZMplM9O/fHzc3N7Zu3cqsWbN46623SExMTC8TFxfHXXfdhZeXFxs2bODvv/+mUqVKdOvWLcOUw6dOnWLhwoUsWbKEVatWsWvXLl555ZVs96u1Zu3atRw+fJiOHTve1jHs3r2b/fv38/zzz+PqmnUsLHvVHPJj8eLFfPLJJ0yZMoWjR4+yfPlyWrdunetr5s2bh5ubG1u2bGHy5Ml8/vnnLFy4MH39sGHDOH36NH/++SdLly5l7ty5nD592qp4Ro0axeLFi4mJiQFgzpw5tG/fnpo1a2Zbftu2bdx555306NGDRYsW2TSRXGYFdS7+8ccfDBkyhMcff5z9+/czY8YMFi1axMsvvwzApUuXePjhhxk2bBgHDx5k48aNPPLII/mO25LWmvNR8SQkpxJSzofSPh4Z1vt5uRPk72XRvpMAZWpAqUpFbuK3wlCyU2th+f1FYwRZa53ZbFzLTRM+3XgoBdU6WLeNio2h5/9sixNjIjnL6/NgzGz54YdZE+Dq1as5fPgwq1atIjg4GIDPPvuMDh1uxbhgwQK01sycOTN9iuRvvvmGoKAgli9fzoMPPggY89rPmjWLtF6EY8eOzTKX/Y0bNwgODiYxMRFXV1e++uoreva8vRvn0r71FsfJ/06fPk2lSpW4++67cXd3p1q1arRsmeNcXAA0aNCAt99+G4A6derw7bffsnbtWgYNGsThw4f5448/+Pvvv9Pb+WbNmmX15cKGDRvSsGFDFixYwJgxY5g+fTovvvgiKSkp2Za///776du3L9OnT7f+oHNQUOfie++9x/PPP8+IESMACA0N5cMPP2To0KF8/PHHXLhwgeTkZAYMGEBISAgAjRo1uu34Aa7GJhEVl0SFUl7pNZ4MtIa4SLhxHlw9jDHaSmj7TnYk+dhD5VZw/STEXwVtAuUCPuWMbzmFrGPHjlmmdM7p2/+hQ4eoXLly+j87QKtWrXCx6GWzY8cOTp48mWXK47i4OI4fP57+PCQkBMvu65UrVyYiIiLDa/z9/dm9ezc3b95k7dq1PPPMM1SvXj3H6b4bNmyY/q39zjvv5Pfff89SxpaZeS23Z7ks7YMsJCSE/fv3A3DmzBkaNGiQXi41NZXExMQMiX3o0KFMnTrV6v1nNnDgQCZNmkSNGjXo0aMH99xzD3369MHTM+deUWFhYRmeW/6dDx06hIuLS4YEVrVqVSpXrmx1TKNGjWLGjBmEhYVx7tw5HnjggQw1K0v9+vVj2bJlrFmzhm7dulm9j+wU1Lm4Y8cOtm/fnuHLlslkIj4+nkuXLtGkSRO6detGo0aNuPvuu+nWrRsDBgygfPnytxV/bGIKF6MSKOXlTpB/Nu+fyQTRZyHuGniWgjIhJf4yW2bOdbQFJR81EJY9DTtngZuXMTxG/T5w36cFHlpmPj4+FOQNtCaTiaZNm7JgwYIs6yzbktzdM37TU0plaIsAcHFxSY+tadOmHDx4kPfffz/H5LNixQqSk40GWm/v7L8h1qlTBzCmHm7WrFmux2K5PYDatWuzYsWK9A88y2OoXLkyu3fvTn++bds2Jk6cyPr169OX5da+kfahaZkcLfcNRmI4fPgwa9euZc2aNTz77LO89dZbbNu2DV9f32y3a83f+XY8/PDDPP3007z44osMGjQox787wOTJkylfvjy9e/dm6dKl3H134U7fbM25aDKZeOONNxg4cGCWMuXLl8fV1ZVVq1axdetWVq1axfTp03nppZfYsGEDTZo0yVdcyakmTl+Lw8NNUaWsd/qXGcCY+uDaCaPWkxIPfhXA3zkus2UmycdeYiOgxQhoOQLCZ8JN+3U6sFa9evW4cOECFy5cSP92HB4enuHDrHnz5vzwww8EBgYWePuJyWTKcE0/s7TLIrlp2rQpDRo04OOPP+ahhx7K0u4TFRWVHnd22wsJCcn2spSbm1uGJH7u3Lksy3KT9k364sWL6cssk1kaLy8vevXqRa9evXjxxRepWLEimzdvztcHeb169TCZTOzYsYM2bdqkx33hwgWrt1GqVCkGDBjA7Nmz+fjjj3Mtq5Ri8uTJuLu706dPH5YsWZLvy6gFdS42b96cQ4cO5fo+KaVo164d7dq14/XXX6dhw4YsXLgwX8nHpDVnrsZhMmlqBvnhlvnenBtnITkOUMaVD+/s43YGknzs5eF5t363Q40nTWJiIpcuXcqwzNXVNdvLCt27d6du3boMGzaMTz75hPj4eJ555hnc3NzSv70NGTKETz75hL59+/L2229TrVo1zp49y9KlSxk3bly294Zk57333qNNmzbUrFmTxMREVqxYwZw5c/jyyy9v63iVUsycOZNu3bpxxx138Morr1C/fn3i4uL4/fff+fHHHx1yr4m3tzdt27blww8/JDQ0lBs3bvDSSy9lKDNr1ixSUlJo06YNfn5+LFy4EHd3d6v/ppnVrVuXHj16MG7cOL7++mu8vLx4/vnn8fHxyfhtPA/ffPMNn376KeXKlbOq/GeffYabmxv9+/dn0aJFGXroHTlyBDe3jB879erVy9I5oaDOxddff5377ruPkJAQHnzwQdzc3Ni3bx/bt2/no48+YuvWraxZs4YePXpQoUIFdu3axdmzZzNcYrXFpRsJxCalUK2sT8Y5eC7sxhhYJ402LsVfV1C5ab72VdxJb7cSbs2aNVSqVCnDI6fLUS4uLixZsoTExERat27NsGHDeOWVV1BKpX84+Pj4sHHjRmrWrMnAgQOpV68ew4YN4/r165QpU8bquG7evMljjz1Gw4YN6dChA4sXL2b27NmMGzfuto+5devW7Nixg3r16jFu3Djq16/Pfffdx/bt25k8efJtbz+/0rott2rViv/85z+8++67GdaXLl2a6dOnc+edd9KoUSMWL17Mzz//TI0a+W8bnDVrFlWqVKFz58706dOHIUOGEBQUZFNPNC8vL6sTT5qPP/6YZ555hgceeIClS5emLx8yZAjNmjXL8Dh27FiW1xfUudijRw9+++031q1bR+vWrWndujX/+9//0u9VCggISO+SX7t2bZ599llee+01hg4datPxAlyPSyLyZiKBfp5ZerZRrhZgmfBdwLsMVGho835KCmVLA21J1rJlS53TN+KDBw8Wy95TBWHPnj00bdqU8PBwWrRo4ehwxG2KjIykcuXK/PDDDzzwwAOODscmRflcjE9K5fiVm3h7uFIj0BeXDO08KRB5xGjrRWMkIQ0+gVC6ap7bLq6fP0qpHVrrHLtrymU3kcGSJUvw9fWldu3anDp1imeeeYYmTZrQvHlzR4cm8uHPP/8kJiaGxo0bExERwSuvvEJgYCD33HOPo0PLU3E5F1NSTZy+Fouri6JaWZ+MicdkgusnjMTj4Wt0OPItB7FXwZTN8DpORJKPyCAmJoaJEydy9uxZypQpQ+fOnfnss89saiMQRUdycjKvvvoqJ06cwMfHh7Zt27Jx48Yce88VJcXhXNRac/Z6PMmpmpqBvri7uliuNIbLSYqFMtWNy2xpStt/SKuiRi67mcllNyGErS5HJ3A5OoHg0t6UyzxKdfQFo1erfyXwr5jvfRTXz5+8LruVyA4HSqklSqnrSqlFeZcWQgjbpY1UXcbHg7K+mToYxF41Eo9POeNeHpFFiUw+wCTg0TxL2UBqiEKINIkpqZy9Hoe3uyvBpTPdSJoQbdzP4+kPAVVu6wbSkvy5UyKTj9Z6PRBTUNtzd3cnPj6+oDYnhCjGTCbN6avGwKUh5TJNgZ0cD9dPgZuncROpur2P2OTk5Cz3RZUUdk0+SqmOSqlflVLnlVJaKTU8mzLjlVInlVIJSqkdSqk77RljdoKCgjh//jxxcXEl+puIECJ3WmvOmUeqrlbWBw83ixtJ04bOUS5QNhRcso6qbguTycTly5czjJFYktg7pfoB+4DZ5kcGSqmHMC6ZjQf+Mv/8XSnVQGt9xlxmN9nHfbfW2vpxQ2yQNmZX2gi4QgjndDMxhai4ZEp5u3EuxmJcPW2CmxFgSgG/ILh+POeN2MDX15fAwMAC2VZRY9fko7VeAawAUErNyqbIM8AsrfW35udPKKXuAR4DXjJvo2nhR5pVqVKlbmtiLCFE8fbPqWsMmrOVznXLM+2RZrcut5lSYcEQOPoHPPwD1M3fgKTOpsi0+SilPIAWwKpMq1YB7Qtpn2OVUuFKqfArV64Uxi6EECVARHQC4+ftpEoZb/7vwaYZ23n+eBmO/A49P4K6Rf/m3aKiyCQfIBBwBTIP93wZsKmTvFJqDfATcK9S6pxSql125bTW07TWLbXWLW93/g4hRMmUnGriv/N3cjMhhW8eaUmAt8Xltq1fw7ap0Pa/0HqM44IshkpkNwqt9e3NZCWEEGbv/XaQf05d54tBzahb0WLiukO/wcqXoN59cPc7jguwmCpKNZ9IIBXIfEdWBeBS1uJCCFG4luw6x6wtpxjZoQZ9mljMAHt+JyweDZWbwf3f3nbPNmdUZJKP1joJ2AF0z7SqO7ClsParlOqtlJp248aNwtqFEKIYOnAhmpd+/pfWNcry0r31bq2IOgPzHwLfQBi8EDxknLb8sPd9Pn5KqaZKqabmfVczP69mLvIpMFwpNVopVV8pNQmoDEwtrJi01su01mNLal96IYTtbsQlM27uDgK83flqcPNbA4bGR8G8gZCSCIN/MrpVi3yxd5tPS2CdxfO3zI/vgeFa64VKqXLAq0AljHuC7tVan7ZznEIIJ2UyaZ5auIuLN+JZMLYd5f3NA4amJMGPj8LVYzD0Zwiql/uGRK7sfZ/PejJO55ddmSnAFLsEJIQQmXzx51HWHb7CO30b0iLEPA2C1rD8aTi5Afp9DTU7OTbIEqDItPk4irT5CCHSrDsUwaS1R7m/eTBD24bcWrHpE9g9FzpNhKaDHRdgCeL0yUfafIQQAKevxjJhwS7qVyzF+/0b3xqpeu9P8Oe7EPYQdH7JsUGWIE6ffIQQIj4plXFzd6KU4ptHWuDlbu46fXoLLB0PIR2gz5e3NT2CyKhE3mQqhBDW0lrz8pJ/OXQpmpnDW1G1rLnrdOQxWDAYSofAQ3ONaRJEgXH6mo+0+Qjh3Gb/fZolu87zdLc6dK5r7jodGwnzBoByhSE/gU9ZxwZZAjl98pE2HyGc1z+nrvHO8gN0qx/E43fVMhYmx8MPgyDmIgxaAGVrODbIEkouuwkhnFK2I1WbTLBkHJzbDgO/h6qtHB1miSXJRwjhdCxHqp47qs2tkarXvgUHfoHu70DDfo4MscST5COEcDrZjlQdPhM2fw4tR0L7JxwanzNw+jYf6XAghHNZuvt81pGqj66B356FWt2h58fSpdoOnD75SIcDIZzHwYvRTFy8N+NI1Zf2wU/DIagBDJwJrnJByB6cPvkIIZzDjfhbI1VPHtzMGKk6+gLMfxA8/Y3pETz9896QKBCS4oUQJZ7JpHlm4W4uRMWzYGxbgvy9IDHGSDwJN2DkSggIdnSYTkWSjxCixPvyz2OsPRRhHqm6LKSmwKKRcPmAUeOp2NjRITodST5CiBJt3eEIPl975NZI1VrDyolwdBX0+hRqZ548WdiD07f5SG83IUqu01djmfBDppGq//4K/vkO2j8JrUY5OkSn5fTJR3q7CVEyZTtS9YGlsOpVaNAXur3l6BCdmk2X3ZRSNYDqgDdwBfhXa51QCHEJIUS+ZTtS9blw+HksVGkJ/b8BF6f/7u1QeSYfpVR14DFgEBBMxmmwk5RSm4BpwGKttakwghRCCFukjVT9THfzSNXXT8H8h8CvAjz8A7h7OzpEp5dr6ldKfQHsAWoCrwANgADAA6gI3Av8BbwD7FVKySh8QgiHCs88UnX8dZg3EEwpMGQR+JV3dIiCvGs+CUCo1joym3URwJ/mx1tKqXuBEOCfgg1RCCGsExGTaaRqUzIsfASunYRHf4HydRwdojDLNflorV+wdkNa6xW3H44QQuRPcqqJx+ftIiYhhdmjWhPg5WZMj3BqE/SfBtXvcHSIwoLVLW5KKRellIvF84pKqdFKqQ6FE5oQQuRs6objbDl+66LM+ysOsv3UNbo3CKJexVKw4UPYuwA6vwxNHnJgpCI7tnT3+A14AkAp5QeEAx8D65VSjxZCbHYh9/kIUTyFVQng8fm72HI8kqW7zzNz8ym83Fx4uHU12P0DrP8AmgyGTlZfwBF2pLTW1hVU6grQRWv9rznZvAg0AYYAz2itwwovzMLXsmVLHR4e7ugwhBA22HI8knFzdhCXlArAzBGtuNPtEMzpD9XawtCfwc3DwVE6J6XUDq11y5zW21Lz8QOizL/fDSzRWidjdDgIzXeEQgiRT0kpJuKSUkkxaYa1D+HO0tdg4RAoWxMemiuJpwizJfmcAToopXyBHsBq8/KyQFxBByaEELn5Zdd5Rs76Bw2MuqMGG3YeIGHW/eDqAUN+Au/Sjg5R5MKWEQ4+BeYAN4HTwEbz8o7AvwUclxBC5Gj6Xyd5Z/kB3FwUMwZUpeOup3k6IBp9PYK9PRcQVibE0SGKPFidfLTW3yilwoFqwGqL0QyOA68VRnBCCGFJa81Hfxzm6/XHqVPBj5fvrU/HIx/A2a34AYc6TWFLQnWKdQO0k7C6w0FJJx0OhCjaUlJNvLzkX34MP8eg1tV4/0BXVEpi1oJunvBqhP0DFBncVocDpdRQpZTKrYxF2RCl1J22BiiEEHlJSDZGqP4x/BxPdqnF+/0bocZsAJ9ytwq5eUPjgTBBWgGKg7w6HIwEDiulXlZKNc6ciJRSZZVSfZRSP2IMqyPzEgghCtSN+GQenb6dtYcu81afhjxzd13UtRNGr7a464ACNy9ITQTPUuBfwdEhCyvkNbxOF6VUL+BJjMFDE5RSERhjvpUBymOM8TYT+K/W+kohx1vglFK9gd61atVydChCiEwiohN4dMZ2jl+5yRcPN6N3k8pwdjv88LAxI2lIWyhfH1qOgPCZcPOyo0MWVrLlJtNA4A6MwUO9gUhgF7CrJEylIG0+QhQtJyNjeWT6Nq7FJvHNIy24s3Z5YzK4n8eCfyUYuhjKyS2GRVVebT629HaLBH4piKCEECI3/567wfCZ29HAgrFtCQsOgC2TjVlIq7SCQT+Ab6CjwxS3waaZTIUQorBtPhbJ2NnhlPbxYM6o1tQs5w2/vwDbp0H9PnD/NJkMrgSQ5COEKDJ+23uRpxfupkagL7NHtaaCVyosHAqHV0C7x6H7OzL9dQkh76IQ9hZzCWb2hBhpHLc05+9TPP7DTppUDeDH/7SjgroBs3rBkZVw7yfQ4z1JPCWIvJNC2NuGj+DMVmO+GYHWms9WH+G1pfvpWi+IOaPaEBB7AqZ3gyuH4eH50HqMo8MUBUwuuwlhL+8GgeUd+eHTjYcT35GfatK8vnQf87adYUCLKvzv/sa4nd0CCwaDqycM/w2Cmzs6TFEIbKr5KKXGK6X2K6XilFI1zcteVEo9WDjhCVGCTNgL9Xrdeu7iDo0GOO0d+YkpqTzxw07mbTvDfzrV5OMBYbjtXwSz+4FfRRi9RhJPCWbLNNpPAa8C0wDLkQ7OA48XbFhClED+FeH6aeN35QKmZDj+J0SdcWxcDhCTkMyImf+w4t9LvNqrPi/dUw+16RP4eQxUbQOj/gAZmbpEs6XmMw4Yo7WeBKRYLN8JNCzQqIQoieKvQ8RBY6KzsRsgtCskx8H07rBsAsRdc3SEdnElJpFB325l+8lrfPpgE0a3rwrLnoQ/34XGD8IjP4N3GUeHKQqZLW0+IcC+bJYnY4x4IITIzT/TQafCwO+hUpjxIZsYA+v/B1u/hoPL4e53oMkgsG4832Ln7LU4Hpm+jUvRCXw7rCV3hXjB/Ifg+Fro+Dzc9UqJPXaRkS01nxNAdhdg7wUOFEw4QpRQyfGwbSrU6mYknjSe/kYX4v9sNGpEvzxmdC+OOOS4WAvJgQvR3P/1Fq7HJTNvdFvuqphsdDk/sR76fAldXpXE40RsST6fAJOVUkMw2nzaKaXeAN4DPi6M4IQoMXbPh9gr0OGp7NdXbAQj/4DeX0DEAZjaAda8CUklY4b6bSeu8tA3f+Pmolg0rh0tPM/Dd92MNrAhP0HzRx0dorAzmyaTU0qNweh0UNW86ALwhtZ6eiHEZhcWo1qPOXr0qKPDESVRagpMbmHMPTN6bd7f7mMjYfUbsHsuBFSDez+Cuj3tE2sh+GP/JZ74YRdVy3gzZ1QbKkdugR+HGbW+IT9CxcaODlEUgtuaTC4zrfW3WusQIAioqLWuUpwTD4DWepnWemxAgExFJArJwaVw/RTc8bR1l5V8A6HfVzBiJXj4GtMH/DAYos4WeqgFbcH2Mzw2dwcNKpVi0bj2VD6xCOYNNHqyjV4jiceJ5WuEA611pNbaOe+KE8IWWsNfn0O52lC3V57FMwhpB+M2Qfe34cQ6+Kq1sa3U5MKItEBprflq3TFe/Plf7qxdnvmjW1Nm64fw6+NQsxOM+B0Cgh0dpnAgW+7zKaOUmqSU2quUuqSUirB8FGaQQhRbJ9bBpb3Q4cn8jUvm6g4dJsB/t0NoF1jzBky9E05vKfhYC4jJpHlr2QE+/uMw/ZpW5rshjfFZPh42fQLNHoHBP4JXKUeHKRzMlq7WszHu5/keuAxY31gkhLP663Nj4rOwh25vO6WrwsPz4PDvsOIFo5dY0yFGragIzWuTlGLiuZ/28OueC4y6owav3FUJlx8GwqlNRm+2O5+THm0CsC35dAY6aa13FlIsQpQs53fCyQ3GNABungWzzbo9oUZH2PgxbPkSDv0G3d+CZo86fMTn2MQUxs3dwaajkUy8px7jmriiZvaAayfg/m8hTEbhErfYcrYet7G8EM5t8+fgGQAthhfsdj18odubMG4zVGhkjI4wowdcctwYcddikxj83TY2H4vkowfCeKz2DdR33eHmJXhkiSQekYUtyWQC8IFSqolSyrWwAhKiRLh6HA78Cq1GFV77RlA9GL4c+k01ahffdIKVLxujJtjR+ah4BkzdwqGL0Uwd2oIHS+0zbpR184KRq6DGnXaNRxQPtiSfYxjD6OwEkpRSqZaPwglPiGJqyxfg6gFtHyvc/SgFTQfB4/8YN2punQKTW8P+X4yedoXsyOUYHpiyhSsxicwZ1Ya7Y5cZ0yEE1jG6UgfVK/QYRPFkS5vPD0AA8CTS4UCInMVcMkY0aDYU/ILss0+fstD7c6MTwm9Pw0/DjKF87v3YGLanEOw4fY2Rs8LxdHPhx7FtqP/vx/D3ZKjTEwZMNy4PCpEDW5JPS6C11jq7wUWFEGm2fg2mFGj/hP33XbUVjFkP26fBuvdgSjujh1mHJwuu0wPw56HLjJ+3k0oB3sx5tDFV1j8JB5ZCqzHQ80NwkSvzIne2XHY7AEjnfCFyk3ADwmdAg76FVuPIk6sbtBtvXIqrcw+sexe+7gAnNhTI5hfvOMeY2TuoHeTPokdrU+XXh43Ec/e7Rk1LEo+wgi3J51XgU6VUN6VUBaVUWctHYQUoRLESPgMSo3MeQNSeSlWGB7+HIYuNmtjsPrB4NMRczvcmp208zrM/7aFtzbIsGFCecgvug4t7jGki2j8h9/AIq9ly2W2F+ecqMrb3KPNz+bojnFtygnHJreZdULmpo6O5pXY3GP83/PWZ8TiyCrq+Bi1HWl1L0Vrzv98P8c3GE/QKq8Rn7RLwmH2PsXLYMqjWphAPQJREtiSfuwotCiFKgr0L4OZluH+aoyPJyt0b7nrZmCl0xbOw4jnYPQ96fQrB2U3TdUtKqomJi/9l8c5zPNouhDdCj+I69z/G2GxDFkG5UDsdhChJbJpSoSRr2bKlDg8Pd3QYorgypcLkVsY0AWPXF+3LT1rDvsXwx8twMwJajTZqQl7GyO5TNxwnrEoA7UMDiU9K5fH5O1l7KII7Qssxp8F21OrXoEprGLQAfMs5+GBEUZXXlAq51nyUUs2B3Vprk/n3HMmwO8KpHVwG144bbR9FOfGAEV/jAVC7O/z5LvzzHRz8FXq8D40eIKxKAI/P38WH94fxzcbjhJ++jr8HfOw7B7V6rtGZov83Rm1KiHzKteajlDJhzNsTYf5dY7TxZKa11kWizUcpVRWYgzHnUArwjtb6p7xeJzUfkW9aw7d3QUK00cOsuPX2urALlj9t/KzRCXr9H1P+VXy/aitfuH/JG2o886v8QtnzfxqdCrq97fBx5ETRd1s1H6AGcMXi9+IgBXhKa71bKVUR2KGUWqG1jnV0YKKEOrnR+OC+7/Pil3gAKjczZlgNn4Fp7duYvmpHcvJ9vOAZTSt9mMXur+N7IRru/QRaj3F0tKKEyDX5aK1PWz4FzupsqkpKqWoFHVh+aa0vAhfNv19SSkUCZQFJPqJwbP4cfIOgySBHR5JvWrnwq8e9TE4OYKVpLBPclhgrFPimRBm/r3pFko8oMLbUnU8C5TMvVEqVM6/Lk1Kqo1LqV6XUeaWUVkoNz6bMeKXUSaVUglJqh1Iq36MSKqVaAK5a6+I3/7AoHi7shuN/Gjd1uns5Opp8uRAVz6jvw5mwYDc+5YJZ3u1PttEIbb7CbnLx4Dfu5J9+BXOTqhBgW/JJu58nMz8gwcpt+AH7MEbIjs+yA6UeAiYB7wPNgC3A75Y1K6XUbqXUvmwelTNtqyzGBHhjrYxNCNttngSepYx7ZooZk0kzZ+tp7v5sI38fv8pr9zXg58fac9EUQLXaYSilwM0TF51C8zrV2HHVw9EhixIkz/t8lFJfmH/VGFMqxFmsdgVaA7ut2ZnWegXmm1WVUrOyKfIMMEtr/a35+RNKqXuAx4CXzNtoakXMnsAvwP+01kV3vmFRvF07AQd+MRrhzd2Ui4vjV27y0uJ/2X7qGnfUCuSD+xtTtawPAOM6hcKCaGgxAlqOgPCZVLp52VguRAGx5ibTxuafCqgPJFmsS8KYYuGT2w1EKeUBtMhmW6uA9jZsRwGzgD+11nPyKDsWc82oWrUi02wliostk8HFDdqOd3QkVktONTFt4wkmrT2Kl5sLHw0IY2CLKkYtx9LD8279ft+n9g1SOIU8k4/W+i4ApdRMYILWOrqQYgnEqEllHnjqMtDNhu10AB4C9iql+pmXPaK1zjLNo9Z6GjANjK7WtgYsnNjNCNg11+hk4F/R0dFYZd/5G7ywaC8HLkZzb+OKvNmnIUH+xbOdShR/Vg+vo7UeUZiBFBSt9V/IdN+isG2bCqlJ0P5JR0eSp4TkVD5bc4TvNp2krK8HU4e24J5GxSNhipLLlrHdClskkApUyLS8AnCpsHaqlOoN9K5Vq1Zh7UKUNAnRxqgA9XtDYNE+b7aeuMpLP//LychYHmpZlZfvrU+Aj7ujwxKi6NQQtNZJwA6ge6ZV3TF6vRXWfpdprccGBBSvBmPhQDtmGfP23PGUoyPJUXRCMi/9/C8PT9tKqkkzb3QbPhwQJolHFBl2rfkopfyAtK+KLkA1pVRT4JrW+gzwKTBHKbUd2AyMAyoDU+0ZpxA5SkmErVOgRkcIbuHoaLK1+sBlXv3lX67EJDLmzho8070u3h7FcOQFUaLZ+7JbS2CdxfO3zI/vgeFa64Xmm1ZfBSph3BN0b6aRFoRwnL0/QsxF6PuVoyPJIvJmIm/+up/ley9Sr6I/0x5pSZOqpR0dlhDZsmvy0VqvJ/uBSS3LTAGm2CUgpM1H2MBkMm4qrRgGoV0cHU06rTVLdp3n7eUHiEtM5dnudfhPp1A83IrMVXUhsihKHQ4cQmu9DFjWsmVLGbRK5O7wb3D1KAyYUWSmTTh3PY6Xl+xj45ErtAgpw4cPNKZWkL+jwxIiT06ffISwitbw1+dQpjrU7+voaEg1aeb8fYqP/jgMwFt9GvJI2xBcXIpGUhQiL5J8hLDG6c1wPhx6/R+4Ovbf5ujlGCYu3svOM1F0qlOe9/o3okoZH4fGJIStnD75SJuPsMpfn4NveWg6xGEhJKWYmLrhOJP/PIaPpyufPdSEfk2Dsw6NI0Qx4PTJR9p8RJ4u/QvHVkOX1xw2dfSes1FMXLyXQ5di6N2kMm/0bkCgn6dDYhGiIDh98hEiT5sngYcftBpl913HJ6Xy6erDTP/rJEH+Xnz3aEu6Ncg8CIgQxY8kHyFyc/007PsZ2j4G3mXsuuvNxyJ56ed/OXMtjsFtqvFiz3qU8pIRCkTJIMlHiNz8PRmUC7T7r912eSMumfdWHODH8HPUCPRlwdi2tK1Zzm77F8IeJPkIkZPYSNg5B5o8BKUq512+AKzcd5HXlu7nWmwS4zqF8lS32ni5y9A4ouRx+uQjvd1EjrZ9AykJ0H5Coe8qIiaBN5bu5/d9l2hQqRQzh7eiUbAMditKLqdPPtLbTWQr8SZsnwb1ekH5OoW2G601P+04x7vLD5CQYuKFe+oy5s6auLvK0DiiZHP65CNEtnZ+DwlR0OGpAtvk1A3HCasSQPvQQADOXI1j/Lwd7LsQTevqZfnggcaElvcrsP0JUZRJ8hEis5Qk+PsrCLkDqrYqsM2GVQng8fm7+OLhZhy6FM1HKw+TlGpiZIfqvNqrgQyNI5yKJB8hMtu3CKLPQ+9JBbrZ9qGBfDQgjOEzt5Ni0ri7KiYPbsZ9YfbpzCBEUSIXloWwlDZtQoVGUKtbgW46LimFbzYcJ9WkARjXKVQSj3BaTp98lFK9lVLTbty44ehQRFFwZCVcOWS09RTgmGkJyan8Z84Owk9dx9fTjSe71GLetjNsOR5ZYPsQojhx+uSjtV6mtR4bECDdWgWw+XMoXQ0a9i+wTSanmnjih11sOhqJj4cr0x5twTN312Xy4GY8Pn+XJCDhlJw++QiR7vTfcHYbtHuiwKZNSDVpnv1xD6sPXKZ7gwp8O6xlem+39qGBTB7cjL3npNYtnI90OBAizebPwaccNBtaIJvTWvPKkn/5dc8FXuxZj3GdQrOUaR8amJ6MhHAmUvMRAuDyAaO9p8048Lj9idm01ry9/AAL/jnLE11qZZt4hHBmknyEAKOHm7svtBpdIJv7dPURZm4+xcgONXime+GNkCBEcSXJR4ioM8a9PS2GgU/Z297c1+uP8+Wfx3i4VVVeu6++zDQqRDacPvlIV2vB318ZPwtg2oTZf5/iw5WH6NOkMu/1byyJR4gcOH3yka7WTi7uGuycDY0fhIAqt7WpRTvO8frS/XRvUIH/e7AJrjJcjhA5cvrkI5zc9mmQHAcdbm/ahN/2XuSFRXu4s3YgXw5qJqNSC5EH+Q8Rzisp1pizp+69EFQv35v589BlJizYRYuQMnzzSAuZ/E0IK0jyEc5r5xyIv3Zb0yZsORbJuLk7qV+pFNOHt8LHQ26dE8IaknyEc0pNhr8nQ7V2UK1Nvjax4/R1Rs8Op0Y5X2aPbE0pL/cCDlKIkkuSj3BO+36GG2fzXevZd/4Gw2duJ8jfkzmjW1PG16Ng4xOihJPkI5yP1sZQOkENoPbdNr/8WEQMj87YTikvd+aNaUuQv1fBxyhECSfJRzifo6sg4oDRw83Ftn+BM1fjGPLdNlxdFHNHtyG4tHchBSlEySbJRzifvz6HgKrQ6AGbXnbxRjyDv9tKYoqJuaPaUCPQt3DiE8IJOH3ykREOnMzZ7XBmizGagav1HQQibyYy5Ltt3IhLZs7INtSt6F+IQQpR8jl98pERDpzMX5+Ddxlo/qjVL4mKS2Lod9u4EBXPjBGtaFxFzhUhbpfTJx/hRCIOweHfoPV/wMO6S2Y3E1MYNvMfTlyJ5dtHW9Kq+u0PPCqEkMnkhDPZ8gW4eUPrsVYVj09KZdSsf9h3/gZTh7bgztrlCzlAIZyH1HyEc7hxDvb+aEyb4Fsuz+KJKamMm7uD7aeu8emDTejeoIIdghTCeUjyEc7h7ymgTVZNm5CSamLCD7vZcOQK/7u/MX2bBtshQCGciyQfUfLFXYMds6DxAChdLdeiJpPmhUV7Wbn/Eq/f14CHWuVeXgiRP5J8RMn3z3RIjs1z2gStNa8t3cfPu87z3N11GHlHDTsFKITzkeQjSrakONg2FWr3gAoNcyymteaD3w8xb9sZHuscyn/vqmXHIIVwPpJ8RMm2ex7ERcIdT+Va7Iu1x5i28QTD2oXwQo+6Mv21EIVMko8ouVJTjO7VVVobUyfk4LtNJ/hszREGtKjCG70bSuIRwg4k+YiS68AvEHXGqPXkkFDmbzvDu78dpFfjSnz4QBguLpJ4hLAHST6iZNLaGEonsC7U6ZltkSW7zvHKL//SpV4Qnz3UFFdJPELYjdMnHxlYtIQ6thYu/5vjtAkr913iuZ/20rZGOaYMaY6Hm9P/KwhhV07/HycDi5ZQmz+HUsHQeGCWVesPR/DEDztpUiWA74a1xMvd1f7xCeHknD75iBLo3A44tckYzcAt4/TW205c5T9zdlA7yJ+ZI1rj6ynDGwrhCJJ8RMmz+TPwKg3Nh2VYvPtsFKO+D6dqWR/mjGpNgLf18/kIIQqWJB9RskQehYPLofUY8PRLX3zwYjTDZmynrK8Hc0e1oZyfpwODFEJI8hEly+ZJ4OZpzNljdvzKTR6Zvg1vd1fmjW5DxQAvBwYohACZz0eUFDGXYMEQuLAbWo4AP2PunbPX4hj63TYA5o1pQ9WyPg4MUgiRRpKPKBk2fATnw43f2z8OwOXoBIZ8t424pFQWjG1LaHm/XDYghLAnST6ieHsnCFITMy6b1ATt6slQ35+4ejOReWPaUr9SKcfEJ4TIliQfUTykJBqdCa4cgogDEHHQeGROPG6eJNXpzcgLfTkTGcf3I1vTtGpph4QshMiZJJ98mrrhOGFVAmgflAKLRsCAWWyJcGXvuRuM6xTq6PCKr9QUuHbCSDCWiebqcdCpRhnlCoG1oVIT/gnoQa3EfZS5uBncPNCpyaw8epMtN12ZMbwFbWvmPWW2EML+JPnkU1iVAB6fv4vfQpdQ6cxWLi57i8eP92fy4GaODq14MJkg6rS5BpOWaA5C5BFITTIXUlC2BgQ1gPp9IKi+8ShXy+jRBiQfj2TnnEE0qDOYsh3/w+o5/8Mj7goTutamc90gxx2fECJXSmvt6BiKhJYtW+rw8HDrX/BukHEpKBOtXInv+Cre/mVQXgHgVcq44dGzFKQ9d/PKcZTlEkdriD4PERa1mCsH4cphSI67VS6g6q3kUt78M7AOeOTeO01rzR/7L/H8or2U9fXg9NU4xncO5YV76hXygQkhcqOU2qG1bpnTeqn55NeEvfDHq6TsW4IbKZg0JOOGq07FZ8Nbub5Uu3qAVwDKMiF5BVgkqIBsnluU8SyV7WCZhSLmUvplRfwr5HJQGmKvmBOMZaI5BInRt8r5VYSgetBiOJSvZ9Rqytc1ji8XSSkmTl+N5fiVWE5E3uTElVhOXLnJichYouKSjVATUuhct7wkHiGKAUk++eVfkYuJ7lQglRTlgQvJnK56Pydav83lq9e4fu0KN65HcvPGNRJvXoeEaEqpWPyJp1RKLAFJcZR3TyTQLYHSrlfw5xQ+pjg8U2JwTY3PY+cKPP1zT1BZnpfO+NzdyhstN3wEZ7bChg/hvk+NZXHXLNpjDt26dBZ/7dbrvMsaiSXswYy1GZ+yOe5Ka03kzSROXLlpJBlzcjlx5SZnr8eTarpVSw/y96RmeV96Na6Ei1Is2XWegS2qsHTPBbYcj6R9aKB1xyeEcAhJPvm05Xgk8UePQZ3BVOryGBf//JqzR45SqrM79zRumKV8fFIqF27Ec/56POej4rkQFU+4+ffzUfFcupFAivnD1Y0U/ImjincSNfxMhPglU8UrmYqeiZT3SKSsazylVDzeqTGohGijZhF9DiKiIeGG8Vybcj8AV8/cE9bWr8GUcqt8+HTjkZmHv5FU6vfOeNnMLyjHS4sJyamcvhpnTjJGLea4OcnEJNzap6ebCzUCfWlYOYDeTSoTWt6PmuV9qRHoi7+Xe/r78Pj8XUx7tAXtQwPp3rACj8/fxeTBzSQBCVGESZuPma1tPum93Sw+4LYcj8x3b7dUkyYiJiE9OZ2PMhLVBYvfY5NSM7zGw82F4NLeBJf2pnJpL4JL+5h/elHF10RFj0Q8Um7eSkgJN249MjyPzrQsGlKyqX15lYaad0Fw81uJplRwtklGa01ETOKt5GL+eSLyJueux2N52lUK8KJmeV9qBhrJpWZ5P0LL+1I5wDvPmUUL+n0QQhSMvNp8SlzyUUqVBtZg1OrcgEla62/zep3NHQ7sTGtNdHyKRWKK48KNjMnqSkzGDhBKGZenKpsTVHBpb4LLpCUr4/dSXtmP7Dxt3SH6nv2QCieWgKs7mFK4WHsQS4OfzfChHp+UysnIjO0wx6/EcjIylpuJt2ox3u6u1Aj0JTTIj5qBvtQs70toeT9qBPrKtAZClEDOmHxcAU+tdZxSyhfYB7TUWl/N7XVFPflYIyE5lUs3EjLUnNIu8Z2PiudiVAJJqRkvx/l7umVJSJVLe3MtNomqq8bQoHZtKnYZx6lVUzh+8jh/Nf8cIL0mcz4qYw0puLS3uRaTlmiM2kzFUl551mKEECWH0yUfS0qpssBOjOQTmVvZkpB88mIyaSJvJnIuLSFZXtaLSuD89TiiLdpc0ri5qPT2KABfD1dqmttfbl0qM9pifDykFiOEKGJdrZVSHYHngBZAZWCE1npWpjLjgeeBSsB+4Cmt9SYb91Ma2ADUBp7PK/E4CxcXRVApL4JKedG8Wplsy8QkJHMhKoHzUXGcj0rgl53n2XHmOp3rlmfsnTWpWd6PCqU8Uc5yn5IQolDYez4fP4zLYBOALC3aSqmHgEnA+0AzYAvwu1KqmkWZ3Uqpfdk8KqeV0VpHaa2bADWAwUqpXG5QEZb8vdypW9GfLvUqEFrel5NXY3mySy32nrsBCioGeEniEULcNrvWfLTWK4AVAEqpWdkUeQaYZdFB4Aml1D3AY8BL5m00tWF/l5VSe4A7gUX5j9z5pHVhTuuy3Da0nHRhFkIUmCIzk6lSygPjctyqTKtWAe1t2E4FpZS/+fcAoCNwOIeyY5VS4Uqp8CtXruQv8BJq77kbGRJN+9BAJg9uZtSAhBDiNhWl1uFAwBW4nGn5ZaCbDdsJAaYp49qQAr7UWv+bXUGt9TRgGhgdDmyOuATL7h6Z9qGBUusRQhSIopR8CoTWejvQ1NFxCCGEyFmRuewGRAKpQObOARWAS4W1U6VUb6XUtBs35HKSEELYS5FJPlrrJGAH0D3Tqu4Yvd4Ka7/LtNZjAwICCmsXQgghMrH3fT5+QC3zUxegmlKqKXBNa30G+BSYo5TaDmwGxmHcDzTVnnEKIYQoXPZu82kJrLN4/pb58T0wXGu9UClVDngV4ybTfcC9WuvTdo5TCCFEISrRw+vYQil1BTgNBAA5NQDltC4Qo82qOMjt+HJiy/HlZ/sFtR1b3wdr9pFXmfycL1B8zhl7xFkQ50x+47Rl39aWzatcbrEW1P9PQbjdv2mI1rp8jqW01vKweADTbF0HhDs67oI4vlxeY/Xx5Wf7jojT2n3kVSY/50t+YnXUwx5xFsQ5k984bdm3tWWtOGdyjLWg/n8c+d5bewxFpsNBEbIsn+uKi8I+hoLavj3+1tbsI68yJf18sQdH/p1s2be1ZW/neErCOWPVMchltwKglArXuYzeWtwVl+MrLnFC8YlV4ix4xSXWwo5Taj4FY5qjAyhkxeX4ikucUHxilTgLXnGJtVDjlJqPEEIIu5OajxBCCLuT5COEEMLuJPlYSSnVUSn1q1LqvFJKK6WGZ1qvlFJvKqUuKKXilVLrlVINHRSuTZRSLyml/lFKRSulriillimlGmUqM8t83JaPrQ6I9c1s4rhksd4h70NBnB9KqTJKqTlKqRvmxxzzrLwFGac173WRiDWbuLVSanJRi1Mp5aqUekcpdVIplWD++a5Sys2ijN1jzeucNJepo5T6WSkVpZSKU0rtVErVt1jvqZT6UikVqZSKNW+vSqZtVDOfR7Hmcl8oY4qcXEnysV6us7ACLwDPAk8ArYAIYLUyzy1UxHUGpmDMm9QFSAHWKKXKZiq3BmPkibTHvXaM0dLhTHE0tljnqPehIM6P+UBz4B7zozkwp4Dj7Eze73VRiRUApVRbYCywN9OqohLnROC/wJNAPYxz4L+YJ8B0YKx5zRxdA2MYs5MY50IjjNFlbloU+xx4ABiEMSlnKWC5UsrVvA1X4DfA37x+EDAA+L88o3P0jUzF8WF+c4ZbPFfAReAVi2XeQAzwH0fHm4/j88MYYby3xbJZwPIiENubwL4c1hWJ9yE/5wdQH9BAB4syd5iX1bXXe13UYsW4W/44cBewHphc1OIElgPfZ1r2fdr/S1GINfM5aV42H5iXx98+CRhisawqYAJ6mJ/3ND+valFmKJAAlMotJqn5FIwaQEUsZmHVWscDG7FhFtYixB+jVnw90/I7lFIRSqkjSqlvlVJBDogNoKb58sVJpdQCpVRN8/Ki+j5YE1c7jA8IyxHcNwOxFG7smd/rohbrNGCR1npdpuVFKc6/gLuUUvUAlFINMGoSK4pgrJhjdAF6AweUUivNl2D/UUo9ZFGsBeCeKe6zwMFMcR80L0/zB+Bpfn2OJPkUjIrmn9nNwlqR4mcSsBv422LZSuBRoCvG5YPWwJ9KKU87x7YNGI5xWWIMxt93izIGpC2q74M1cVUErmjzV0cA8+8RFG7smd/rIhOrUmoMxij4r2azusjECXyIcXnsgFIqGdiPUROaUgRjTROEUet9GSO5dAd+AOYppXpZxJRK1vHdMsed+bjS5mbLNe4SN5OpuD1KqU8xqvt3aK1T05ZrrRdYFPtXKbUDYyDWXsDP9opPa/275XNldHo4AQwD7N4BojjL6b0uCpRSdYH3MWJLdnQ8eXgI44vZYIzE0xSYpJQ6qbWe7sjAcpFW8Viqtf7U/PtupVRL4HGMdhy7BCBuT1pvK7vOwlrQlFKfYTQYdtFan8itrNb6AnAOqG2P2HKJ4ybGP3xtiu77YE1cl4DySimVttL8exCFEHsu73VRibUdxqjK+5VSKUqpFKATMN78+9UiEifAx8AnWusFWut/tdZzMOYmS+twUFT+ppYiMTqbHMi0/CBQzSImV4z3wVLmuDMfV6D5dbnGLcmnYJzE+EOnz8KqlPLC6P1RaLOwFiSl1CRufRgdsqJ8IBCM0ZDqMOa/cz1zHEX1fbAmrr8xLoO0s3hdO8CXAo49j/e6qMT6C0YvxqYWj3Bggfn3I0UkTgAfjMtMllK59flaVP6m6bQxc/Q/QN1Mq+pgXNEAY2bp5ExxV8HoHGEZd/1M3a+7A4nm1+cahDys6y3ix61/gjjgdfPv1czrJ2LMYXE/RpfFBcAFwN/RsVtxbF8B0RiNpBUtHn4Wx/4Jxj9DdYzuun9j1HzsenzmODphNOK2wehpFI0xd4jD3oeCOD+A34F/zX/ndubfl9nzvS5KsWYT+3rMvd2KUpwYPUHPYVyCrg70B64A/+fIWK04J/th9GYbi9G2NgYj2fSy2MbX5mPrBjTDmAx0N+BqXu9qjvNP8/puwHngyzzjK8yTpSQ9MD5wdTaPWeb1CqMb8EWMboYbgEaOjtvKY8vuuDTwpnm9N0YPlgjzyXra/A9X1QGxpv3TJplP8sVAA4v1DnkfCuL8AMoAczGSQ7T599L2fK+LUqzZxL6ejMmnSMSJ0WPwc/P/RTxGG+T7gJcjY83rnDSXGY5Ri4zHuI9qUKZteAJfYlzmjMOYLqFqpjLVML4ExpnLfQF45hWfDCwqhBDC7qTNRwghhN1J8hFCCGF3knyEEELYnSQfIYQQdifJRwghhN1J8hFCCGF3knyEEELYnSQfIYQQdifJRwghhN3JlApCFHFKqfUYow9HYYzDZQJmAy9orU2Oi0yI/JOajxDFwxCMIfDbY8y38hTGPDJCFEsytpsQRZy55uOptW5nsWw1cFprPdphgQlxG6TmI0TxsDfT8wsYE40JUSxJ8hGieMg8lbRG/n9FMSYnrxBCCLuT5COEEMLuJPkIIYSwO+ntJoQQwu6k5iOEEMLuJPkIIYSwO0k+Qggh7E6SjxBCCLuT5COEEMLuJPkIIYSwO0k+Qggh7E6SjxBCCLuT5COEEMLu/h8RySdJ3l4jKwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "1.4752284113717873"
-      ]
-     },
-     "execution_count": 263,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "fig1, ax1 = plt.subplots()\n",
-    "\n",
-    "datatype = 0; print(datatypes[datatype])\n",
-    "m = 0; plt.plot(nSizes,data_mkl[m,:,datatype],'x-',label=methods[m])\n",
-    "m = 1; plt.plot(nSizes,data_mkl[m,:,datatype],'*-',label=methods[m])\n",
-    "\n",
-    "ax1.set_xscale(\"log\")\n",
-    "ax1.set_yscale(\"log\")\n",
-    "ax1.set_xticks(nSizes)\n",
-    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
-    "\n",
-    "plt.xlabel(\"n\")\n",
-    "plt.ylabel(\"time (s)\")\n",
-    "plt.legend()\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.savefig(\"curvesWithMKL.pdf\")\n",
-    "plt.show()\n",
-    "\n",
-    "rate = (np.log(data_mkl[m,-1,datatype])-np.log(data_mkl[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
-    "rate"
+    "data_mdspan"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 264,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "double\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEQCAYAAABvBHmZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/av/WaAAAACXBIWXMAAAsTAAALEwEAmpwYAABKf0lEQVR4nO3dd3gUVdvA4d/Z9BBIgBBKgAChEyIlUhWQKlIVsIAIyosfoq9ixYK9Ky+KIiIKRBAUBZEivSMgGJDekZpAQighIT17vj92E5OQshs2u5vkua9rr+zOnJ15Zmeyz86ZM+corTVCCCGEPRkcHYAQQoiyR5KPEEIIu5PkI4QQwu4k+QghhLA7ST5CCCHsTpKPEEIIu5PkI4QQwu4k+QghhLC7Upd8lFJ9lVJHlVLHlVL/cXQ8QgghbqZKUw8HSilX4BBwFxAH7AI6aK0vOzQwIYQQObg6OgAbawMc1FpHAiilVgA9gR8Le6O/v7+uU6dO8UYnhBBlxK5du2K11lXym+9UyUcp1Ql4AWgN1AAe1VqH5yozFngRqA4cBMZprbeYZ9cAIrMVjwQCLVl3nTp1iIiIuKX4hRBCmCilzhQ039mu+fgAB4BngKTcM5VSDwCTgQ+AlsA2YIVSqrY9gxRCCHFrnCr5aK2Xa61f1VovAIx5FHkOCNdaf6u1Pqy1/i9wAXjCPD+KnGc6geZpQgghnIhTJZ+CKKXcMVXHrc41azXQwfx8JxCilApUSvkAvYFVBSzzcaVUhFIq4tKlS8URthBCiDyUmOQD+AMuQHSu6dFANQCtdTrwPLAB2AP8r6CWblrr6VrrMK11WJUq+V4XE0IIYWNO1eDAFrTWS4AllpZXSvUD+tWvX7/4ghJCCJFDSUo+sUAGUDXX9KrAxaIuVGu9FFgaFhY2uqBy169fJyYmhrS0tKKuSgghrOLm5kZAQAAVKlSwy/qmbTpJaE1fOgSkw4JHYXA422Jc2Hc+jjGdg226rhKTfLTWqUqpXUAP4Jdss3oAC4u6XEvOfK5fv050dDSBgYF4eXmhlCrq6oQQwiJaa5KSkoiMNN09Yo8EFFrTl6fm/c3vwYuodvZPLi59m6dO3suUoS1tvi6n6uHA3EggMwtsAz7CVIV2RWt91tzUeg4wFtgKjAFGAc201gW2KS9MWFiYzu8+nxMnTlCjRg28vb1vZRVCCGG1xMREoqKisMulgfcCID3l5umuHjAhxqpFKaV2aa3D8pvvbA0OwoC/zQ8v4G3z83cAtNbzgXHABEwNCu4A7rnVxFOYtLQ0vLy8inMVQgiRJy8vL7tU9x+OimO235MkaI+saWkGD2g+BJ7Zb/P1OVW1m9Z6I1BgnZbWeiow1VbrtLTBgVS1CSEcobi/e45ejGfxst/oevYLHjEc44aLD0ZjKkblhosxlQsp7lQvn/tS+61ztjMfu9NaL9VaP+7r6+voUIQQwm6OR8fzZvhSTnw1iJfOP0Vjj8scav0uO4xNiG44FNf/W090w6EcOnacbSdjbb5+pzrzEUIIUbxOxCTw3epd1D/yNRNcVqPd3Ehq9yI+ncex+c9oQocPpXqwPwDVh07l1MlY9p2Po4N5mq2U+eQj9/kIIcqCfy4lMHXtISoeDOcVl98o75pEauhQPLtPgArVARjT2eem93UI9rd54gGpdisz1W5Tp07l9OnTFpcPDw/n0KFDxReQcFojR46kb9++jg5D2Mjp2Bs8N/9vPv/8Q8YdGcprrnPxqtcOwxNb8bzvq6zEY29lPvmUBWfPnmXcuHH4+fmhlCrwMXLkSAAiIiKYOjVnuw5Lv5R2796Ni4sLHTt2vGneyJEjs9bl5uZGvXr1eOGFF7hx44ZVywGIjo7mmWeeITg4GA8PDwIDA+nduzfLly8vMOZly5bh7e3NhAkTCt2WwlgSQ0kzefJkfvjhh2JfT+axMGrUqJvmjR8/HqVUjn1nyb4sSuLMfkwqpfD396dv374cOXKkwHXnpbBj9tKlS4wdO5Y6derg4eFB1apV6datG2vWrLEqZkucvZzIi7/s5eXPpjHy0Ci+cJtCtYAAGL4I9xG/QtWmNl+nNST5lAGLFy+mU6dO+Pn5ceHChazHt99+C5Bj2uTJkwEYMGAAixcvLtL6vvvuO8aOHcuBAwc4fPjwTfO7d+/OhQsX+Oeff3jvvfeYOnUqL7zwglXLOX36NK1atWLVqlV8+OGH7Nu3j7Vr19KnTx/GjBmTb2xz5sxh0KBBfPjhh7z33ntF2r5bjWHkyJG89dZbFq/H2vK3ytfXFz8/P7usq1atWvz88885fnykp6cze/ZsatcueKQUW+7LzGPywoULrF69mqSkJO69916rl1PYsT9o0CB27tzJjBkzOHbsGMuWLaN3795cvmy7wZbPXUnk5YX7eOx/P9Jz//P85PYOzconwsCvcX1iCwR3tdm6boVc87HTNZ+sbiuy1Z1uM1/Is3W3FbktXryYAQMGAFCtWrWs6ZlfMNmnZerSpQvx8fHs2rWL1q1bW7yupKQk5s2bx5YtW0hMTGTGjBlMnDgxRxkPD4+sdQ4dOpQNGzbw22+/8fXXX1u8nLFjxwKmMzQfn3/rqZs0acLDDz+cZ2yff/4548ePZ8aMGfmWsUZRYrCHLl26EBISwpQpU7KmjRw5ktjYWJYtWwbA5s2beemllzhw4AAuLi40atSImTNnEhISclPZLl260LRpU/z8/Jg+fToGg4FHHnmETz75BIPB9Pv1xo0bPPHEE/z666+UK1eOcePGsXXrVvz9/QkPD8831tDQUKKiovj555959NFHAfj999/x9PSkU6dO+X4p23pfZj8mq1WrxrPPPku/fv1ISkqy+B6/wo7Za9eusWXLFtasWUO3bt0ACAoK4vbbb7/l+AEiryUxZf0J1kUc5GnXhbzvvg7l5gl3vo5Lu7Hg7lw3yZf5Mx97XfPJ7LYis8nitpOxPDXvb0JrFu96r127xubNm+nfv79V73Nzc6N379789ttvVr1vwYIFBAUF0bx5c4YPH87s2bMLvUEur5voClrOlStXWLlyJU8++WSOL/1Mef1qnzBhAq+++iqLFi2yyZdVUWJwFunp6QwYMIA77riDvXv3smPHDsaNG4eLi0u+75k7dy6urq5s27aNKVOm8PnnnzN//vys+c8//zybNm1i0aJFrF+/nr1797Jly5Z8l5fdqFGjmDlzZtbrmTNn8uijj+Z7f4ut92Vu8fHxzJ8/n+bNm1t1c3lhx76Pjw8+Pj4sWbKE5ORkm8V7IS6JCb/tp9enq/D/ewqbPZ9lmMs6XMJGYnhmD3R6wekSD8iZT5G9vfQgh6KuW/WegPIePDJjJ1UreBB9PYX6AT5MXnucyWuPW/T+pjUq8Ga/Zlatc9myZTRr1oygoCCr3gemqrf333+fd9991+L3zJgxg+HDhwPQuXNnvL29Wbx4MYMHD86z/M6dO5k3b17WL0FLlnPixAm01jRp0sSimNasWcPvv//OsmXLuOeeeyzeloJYG4MzuX79OteuXaNfv34EB5vOuhs3blzge5o2bco777wDQMOGDfn2229Zt24dDz30EAkJCcycOZPZs2fTo0cPwLT/atasaVE8Q4cO5YUXXuD48eOUL1+elStX8uWXX/LGG2/cVLY49iXAypUrs35E3Lhxg1q1all93a6wY9/V1ZXw8HBGjx7N9OnTadmyJR07dmTIkCG0bdvW6pgvxiUzdeMJ5u88Q3+1hT+8F+KXFgMN7oHub0OVhlYv057K/JmPPfl6uVG1ggeR15KpWsEDXy+3Yl/n8uXLi/xP2rt3bw4ePMjZs2ctKn/ixAn++OMPhg4dCpjuzB42bBgzZszIUS7zH93T05P27dvTqVMnvvzyS4uXY21/hCEhIQQHB/P2229z7dq1QsvPnTs361eqj49Pnr/grYnhgw8+yLG8uXPn3jQt+zqsLW+tSpUqMXLkSHr16kWfPn2YNGlSofs4NDQ0x+saNWoQE2Pq6+vkyZOkpaXRpk2brPnlypUjJCTEongqVqzIvffey8yZM/n+++/p0qVLvtd7rN2XlurUqRN79uxhz5497Ny5k27dutGzZ0/OnTtn0fstPfYHDRpEVFQUS5cupXfv3mzbto127drxwQcfWBxrzPVk3lpykE6fbuDUzuWsL/8Wn7p+jV+VQBj5Ozz0o9MnHpAznyKz9gwE/q1qe7prfX7YcZZnujcolvbz2dWpU8eqJtbZnTlzBm9vbwICAiwq/91335GRkZHjiyPzS/rcuXPUqlULMP2jT58+HTc3N2rUqIGbm5tVy2nQoAFKKQ4fPmzRReHq1auzZMkSunbtSvfu3VmzZg0VK1bMt3z//v1z/BINDAy8qYw1MYwZM4b7778/6/X48eMJDAzk6aefznMd1pbPzWAw3JQcc1drzpo1i3HjxrFy5UqWLFnCa6+9xm+//UavXr3yXGbufaSUwmjMa6T7onnssccYMWIEPj4+WWdYebF2X1rK29s7R8ed3333Hb6+vkyfPt2iM39Lj30AT09PevToQY8ePXjjjTf4z3/+w1tvvcULL7yAu7t7vuuIiU9m2sZ/mLvjDHX1WRZX/JUmCX+CR2245zsIGQSGknM+UXIiLSZKqX5KqelxcXHFup7MxDNlaEue69mIKUNb5rgGVFwGDhzI8uXLSU9Pt/q9ixcvplevXnh6ehZaNj09ne+//54PP/ww6xfknj172Lt3L6GhocyaNSurbOY/elBQ0E1fapYsp1KlSvTq1YspU6aQkJBwUyx5/SIODAxk48aN3Lhxg27duhXYuqh8+fLUr18/65FXvb81MVSqVCnH8sqXL3/TtOzrsLZ8blWqVOHChQs5pu3du/emcrfddhvjx49n48aNdOnShe+//z7fZRYkODgYNzc3/vrrr6xpiYmJHDhwwOJldOvWDXd3d2JjYxk4cGCBZa3Zl0WllMJgMJCYmFhoWWuO/bw0bdqU9PT0fK8DpWUYiUtKo9MnG/h9+x7Cq8xlhfvLNEk7DD3egaf+gtAhJSrxgJz5WDyY3K3adz6OKUNbZp3pdAj2Z8rQlsXSbUV2t99+O97e3mzatOmm6yqFWbx4cY5f22C6XrBnz54c0/z8/Ni7dy+xsbGMHj2aypUr55j/4IMPMm3aNF5//fVC1/n7779btJyvvvqKjh07EhYWxrvvvktoaChaazZs2MCHH36YZzVS9erV2bhxI926daNr166sW7cOf/+if/ZFicEeunbtyrhx41iyZAmNGjXim2++4dy5c9SpUweAU6dO8c0339C/f38CAwP5559/2LdvH0888USR1ufj48Njjz3G+PHj8ff3p3r16rz33nsYjUaLO8VUSrFv3z601nh4eBRavqB9md8xmrn9eUlJSeHiRdOYlFevXs36UdGvX7+sMrd67F+5coUhQ4bw2GOPERoaSvny5YmIiOCTTz6hW7duN43Xk55h5FJCCpcTUrmRnMbn1VbR89p8DHGp0Ob/oPNL4F2p0M/KWZX55GMveTWnLq5uK7JTStG/f38WL15sVfI5f/48e/fuvenGui1bttCyZc6BpQYNGkRqaip33XXXTf98AEOGDOHll1+26Ea6GTNmWLScnj17snv3bj744APGjx9PZGQklStX5rbbbmP69On5Lr9q1aps2LCB7t27c9ddd7Fu3TqLqxVzq1evXpFiKG6PPfYY+/bt47HHHgPgySef5N577yU21nSW7e3tzbFjxxgyZAixsbFUrVqVYcOGMX78+CKvc+LEidy4cYP+/fvj4+PDs88+S3R0tEVnzZnKly9v1Trz2peQ/zG6YMGCfJe1du1aqlevnhVH48aN+eWXX+jSpUtWmVs99jt37ky7du2YPHkyJ06cICUlhcDAQIYOHZrjhufsSUdrTQ33RAyGqzS9NAuaDoBub0Ll4r09wx6cajA5RypoMLnDhw+XyFZNmVauXMmYMWOsuvYzdepUfvnlFzZs2FB8gYlSKyUlhaCgIF588UWef/55R4dTIqRnGIlNSCU2IQWj1lTzSMXfeBlDRjKHz8fRpJoX1La+VZyjFDaYnJz5lAFdu3bl6tWr7NmzhxYtWlj0nsWLFxda9y5Epr///pvDhw/Tpk0b4uPj+fjjj4mPj+eBBx5wdGhOLzPpXE5IIUNrqngaCdCXcUlLABd3qFgH4i5C7ZL7AzgvZT75lIVerd3d3bG2QcWqVauKKRpRWk2aNImjR4/i6upKixYt2Lx5s8X3+pR2MfHJeLu54OP5bwOb60lpxCakkJSWQYZRU8lTUU1dwzXlKigXqBAI5fxBGYCLjgu+mJT55GOvBgdClGYtW7Ykv2prAd5uLpy9kkTtSuDl7kLUtWSuJqYC4OfpQnXX67glxgIaygVA+apgKN1fz6V764QQwgn4eLpRqxKcvmxqum3UmnLuLtTyTMI9MRpS08Gzoml4A9fCW/uVBpJ8hBCimKWmG4m5noJBp1NbxZDq4UclfRUSUsDdByrUAPdyjg7TriT5CCFEMYpLSuP81US0hlrqMuVUMj5pF8kweOBSsS54+oKF90OVJpJ8hBCiGBiNmgtxyVy+kUKI4TQGlfO2FhdjCvrqaVSNFo4J0MEk+QghhI0lp2Vw9koiyWkZVC3nQnqKJ+7GpGwlDKS5VyDOrQrFe5u585LkI4QQNqK15mpiKlHXkjEoRf0KRrwTz4E2mq7tpCYACjDi5uqKv+/NY0GVFZJ8hBDCBjKMRiKvJnEtKY3yHi7UdovDJeESuHqZbhSNjwJvfyhXGW5cBmPBgyyWdmU++ZSFm0yFEMUrMSWds1cTSUvXBJZ3oVJqFCox0ZRsKgSaepyuVO/fN/g538ii9lay+uAuBvYaRttZ1alTJ8c488J5jRw58qaOXoVjaa2JiU/m5KUboKFhhTQqJ55CpadAxbrgV6vEDXVgL/KplGIjR45EKXXTo127dlll/vrrL8aOHWv32H755RfCwsLw8/OjXLlytGjRosjjyeTl5MmTjBo1ilq1auHh4UFQUBCDBw9m27ZtNluHvU2ePJkffvih2NcTHh6OUooGDRrcNG/FihUopbKGnAbYuHEjSqmsXrMBLl26ROvWrWnVqhUxMTGcPn0apVSp6gUhLcPIqdgbXIxLxtfLhYaeV/FIOAeunlClEXj5OTpEpybJp5Tr3r07Fy5cyPHIPjZ9lSpV8Pa2fxVA5cqVmTBhAn/++Sf79u3j0UcfZdSoUTliK6qIiAhatWrFwYMH+frrrzl06BBLly6ldevW/Pe//833fUopi3v+3rhxY4HjwxQHX19f/Pz87LIuT09Prl27xqZNm3JMnzFjRr5DXGc6c+YMd9xxBxUqVGDjxo1FHrLCmcUnp3E8OoHE1AyCKhiolXEOQ9IV8KkK/g3KTC8Ft0KSj73FX4RZvSE+2i6r8/DwoFq1ajkelSr9OwBV7mq3Y8eO0blzZzw9PWnUqBHLly/Hx8eH8PDwrDKRkZE8+OCDVKxYkYoVK9KnTx+OHz+eNf+tt94iJCSEn376ieDgYMqXL8/AgQNz/DLu2rUrAwcOpHHjxgQHB/PMM88QGhrKli1bbml7tdaMHDmSevXqsXXrVvr27UtwcDChoaG88sorWWO+2Ft+v/yVUjnGmXnnnXcICgrK2m+PPPJI1rzc1W5dunRh7NixvPrqq/j7+xMQEMALL7yQY3jr6Oho+vfvj5eXF0FBQcyaNYuQkBDeeuutAuN1cXFh+PDhzJw5M2tabGwsy5YtY8SIEfm+79ChQ3Ts2JGmTZuyYsWKmwZIs4YtjkUg64eHp6cndevW5bXXXiM1NTVr/q+//kpoaCheXl5UqlSJzp07Ex2d9/+nUWsuxCVxKvYGrgZFo/Ip+Cb8gzKmQ+X6pp4KyuANo0UhycfeNn0CZ/+ETR87OpKbGI1G7r33XlxdXfnzzz8JDw/n7bffJiUlJatMYmIid911F56enmzatInt27dTvXp1unfvnmPI4dOnTzN//nwWLVrE6tWr+fvvv3nttdfyXK/WmnXr1nH06FE6dep0S9uwZ88eDh48yIsvvoiLi8tN8+115lAUCxcuZOLEiUydOpXjx4+zbNky2rRpU+B75s6di6urK9u2bWPKlCl8/vnnzJ8/P2v+iBEjOHPmDOvXr2fx4sX88MMPnDlzxqJ4Ro0axcKFC4mPjwdgzpw5dOjQgXr16uVZfseOHdx555306tWLBQsWWDWQXG62OhZXrVrFsGHDeOqppzh48CAzZ85kwYIFvPrqqwBcvHiRBx98kBEjRnD48GE2b97M8OHD84wpJT2Dfy4lcCk+BX9vVxq4X8ItIRI8fKBKY/CwbjC8sq7Mt3YrshUvw8X9lpc/uxWyD9wXMcP0UApqd7RsGdWaQ++PrApz5cqVOernwTSy5ccf35z81qxZw9GjR1m9ejWBgYEAfPbZZ3Ts+G98P/30E1prZs2alTVE8jfffENAQADLli3j/vvvB0zj2oeHh5PZkOPxxx+/aSz7uLg4AgMDSUlJwcXFha+++orevXtbtX25Zf7qLYmD/505c4bq1avTs2dP3NzcqF27NmFh+Y7FBUDTpk155513AGjYsCHffvst69at46GHHuLo0aOsWrWK7du3Z13nCw8Pt7i6sFmzZjRr1oyffvqJ0aNHM2PGDF5++WXS09PzLH/fffcxYMAAZsyYYflG58NWx+L777/Piy++yKOPPgpAcHAwH3/8MQ8//DCffvopUVFRpKWlMXjwYIKCggAICQm5KZ5rialEXk0CBfV8FT6JZyAjzXSmUy5AznaKQJKPvdS4Ha6egqTLphvOlAG8K5taxBSjTp063TSkc36//o8cOUKNGjWy/tkBbr/9dgzZWuvs2rWLU6dO3TTkcWJiIidPnsx6HRQURPYWhDVq1CAmJibHe8qXL8+ePXtISEhg3bp1PPfcc9SpUyff4b6bNWuW9av9zjvvZMWKFTeVsWZk3uzLyz4t84ssKCiIgwcPAnD27FmaNm2aVS4jI4OUlJQcif3hhx9m2rRpFq8/tyFDhjB58mTq1q1Lr169uPvuu+nfvz8eHvlfPwgNDc3xOvvnfOTIEQwGQ44EVqtWLWrUqGFxTKNGjWLmzJmEhoZy/vx5Bg0alOPMKruBAweydOlS1q5dS/fu3S1eR15sdSzu2rWLnTt35vixZTQaSUpK4uLFi9x22210796dkJAQevbsSffu3Rk8eDBVqlQBIMOoibqWxNXEVMq5uxDkkYBr/EXTIG/+DcpcZ6C2VGqTj1JqEdAFWKe1HmzzFVh5BgLA0mdhd7ipNUxGKjTpD30n2Ty07Ly9vbHlPUxGo5EWLVrw008/3TQv+7UkNze3HPOUUjmuRQAYDIas2Fq0aMHhw4f54IMP8k0+y5cvJy3NdGOel5dXnmUaNmwImIY+b9myZYHbkn15AA0aNGD58uVZX3jZt6FGjRrs2bMn6/WOHTsYP348GzduzJpW0PWNzC/N7Mkx+7rBlBiOHj3KunXrWLt2Lc8//zxvv/02O3bsoFy5vL/kLPmcb8WDDz7Is88+y8svv8xDDz2U7+cOMGXKFKpUqUK/fv1YvHgxPXv2tFkcebHkWDQajbz55psMGTLkpjJVqlTBxcWF1atX8+eff7J69WpmzJjBK6+8wqZNm2jYpBlnrySRkp5BNR9XqqRfRN2IB08/cxPqUvv1aRel+dObDMwE8r86am83YqD1oxD2KETMggT7NDqwVOPGjYmKiiIqKirr13FERESOL7NWrVrx448/4u/vb/PrJ0ajMUedfm6Z1SIFadGiBU2bNuXTTz/lgQceuOm6z7Vr17Lizmt5QUFBeVZLubq65kji58+fv2laQTJ/SV+4cCFrWvZklsnT05M+ffrQp08fXn75ZapVq8bWrVuL9EXeuHFjjEYju3btom3btllxR0VFWbyMChUqMHjwYGbPns2nn35aYFmlFFOmTMHNzY3+/fuzaNGiIlej2upYbNWqFUeOHClwPymlaN++Pe3bt+eNN96gWbNmzJozl1HPvoarQdHAV+N14xQYjeBby1RjIdVst6zUJh+t9UalVBdHx5HDg3P/fV7MZzyZUlJSuHgx5xC8Li4uWV+G2fXo0YNGjRoxYsQIJk6cSFJSEs899xyurq5ZVVHDhg1j4sSJDBgwgHfeeYfatWtz7tw5Fi9ezJgxY/K8NyQv77//Pm3btqVevXqkpKSwfPly5syZw5dffnlL26uUYtasWXTv3p077riD1157jSZNmpCYmMiKFSv4+eefHXKviZeXF+3atePjjz8mODiYuLg4XnnllRxlwsPDSU9Pp23btvj4+DB//nzc3Nws/kxza9SoEb169WLMmDF8/fXXeHp68uKLL+Lt7Z21Py3xzTffMGnSJCpXrmxR+c8++wxXV1fuvfdeFixYkKOF3rFjx3B1zfm107hx45saJ9jqWHzjjTfo27cvQUFB3H///bi6unLgwAF27tzJJ598wp9//snatWvp1asXVatWJWLXLs6ePUdA7eCsLnIM8TGm2orKdcAt/zM/YR27t3ZTSnVSSi1RSkUqpbRSamQeZcYqpU4ppZKVUruUUnfaO87SYu3atVSvXj3HI7/qKIPBwKJFi0hJSaFNmzaMGDGC1157DaVU1peDt7c3mzdvpl69egwZMoTGjRszYsQIrl69SsWKFS2OKyEhgSeeeIJmzZrRsWNHFi5cyOzZsxkzZswtb3ObNm3YtWsXjRs3ZsyYMTRp0oS+ffuyc+dOpkyZcsvLL6rMZsu33347//d//8d7772XY76fnx8zZszgzjvvJCQkhIULF/Lrr79St27RrwuGh4dTs2ZNunTpQv/+/Rk2bBgBAQFWtUTz9PS0OPFk+vTTT3nuuecYNGgQixcvzpo+bNgwWrZsmeNx4sSJm95vq2OxV69e/P7772zYsIE2bdrQpk0bPvroo6x7lXx9fbOa5Ddo0IBxzz3P6GdeZMzIoQTpSAw3YkxnOv6NJPHYmtbarg/gHuADYDCQCIzMNf8BIA0YDTQBvgQSgNrZyuwBDuTxqJFrWV2ABZbE1bp1a52fQ4cO5TuvtNuzZ48GdEREhKNDETZw6dIl7ebmphcsWODoUKxWXMei0WjUF+KS9L5zV/WRC9d18vVYraP2mh6JV2y6rqIqid9BQIQu4DvX7tVuWuvlwHIApVR4HkWeA8K11t+aX/9XKXU38ATwinkZLYo/0rJp0aJFlCtXjgYNGnD69Gmee+45brvtNlq1auXo0EQRrF+/nvj4eJo3b05MTAyvvfYa/v7+3H333Y4OrVD2OBZT042cu5LIjdR0Knm7UcNwGUP8ZXDzNvVELT0VFBunuuajlHIHWgO5e7pcDXQohvU9DjwOFNplSFkRHx/P+PHjOXfuHBUrVqRLly589tlnVl0jEM4jLS2NCRMm8M8//+Dt7U27du3YvHlzvq3nnElxH4vZh7eu4+tChaSzkJ4MPgFQvrrpdghRbJS24r4Im69cqQTgKa11uPl1DSAS6Ky13pyt3BvAMK11IyuWvRa4DSgHXAGGaK2351c+LCxM53ch+vDhwyXypkUhxM2yD2/t5eZCHe9k3OKjTL1P+wWBZ9G7BCouJfE7SCm1S2ud713STnXmY0taa4vucpPxfIQoO7IPbx1Qzo2qOgYVfw3cy0PFIHBxK3QZwjac7bwyFsgAquaaXhW4eHPxW6fL+Hg+QpQFWmuu3EjhREwC6RmaYD9FtdTTqORrpiq2ysGSeOzMqZKP1joV2AX0yDWrB1AsA7EopfoppabHxcUVWM6Wd40LIewnw2hqVHD+ahLe7i408kmk3PVTppn+DaF8Nae+abS0fvc44j4fH6VUC6VUC/P6a5tfZ17xnwSMVEr9RynVRCk1GagBFL3TrAJYcuZTrlw5IiMjSU1NtarvMCGEYyWmpHM8JoG4pHRqlHejruEiLgkXTNd1qjRy6r7ZtNakpqYSGRlZIhqIWMsR13zCgA3ZXr9tfnyP6Z6f+UqpysAEoDqm+3fu0Vpb1g98MahZsyaxsbGcOXMm3x59hRDOQ2tISEnjelI6LgZFZU8jlyKvckkbwbMieKRA9PHCF+Rgrq6u+Pr64u/v7+hQbM6hrd2cQbYGB6NzD0IlhCh5YuKTef7nvWw5Hku/kCp8WmU5nts/N1WxDZkFVZs5OsQyobDWbk51zccRpMGBECXTtE0n2XYy9qZpXT7dyF+nrzC5d2W+SJmA5/bPoNVweHyDJB4nUuaTjxCiZAqt6ctT8/5m28lYUtONPDVvNx+tOELlcu6sv+c6A7bfj4o+BINmQP8vnfr6TllUau/zsZTc5yNEydQh2J8pQ1vyxA+78XQ1EB2fwt0NfZnivxDXVTOhRisYPAMq5T3st3CsMn/mI9VuQpRMRqPm8IV4vJJj+CLlNf4bHMO05Jdw3T0TOvwXHlsliceJlfkzHyFEyXP2ciIvLNjLzlNXeN9tEW0MR2kd+RxpHn64DVsADXLfKiicjSQfIUSJobXmhx1n+XD5YXarh/H0/Hcoclc0pFzB+NMwDK/HODBKYYkyX+1maQ8HQgjHiryWxPAZO3n9twO0r+XF/ur3ocnWM4GrFzF1BzCn7VLHBSksVuaTj1zzEcK5aa35+a9z3P3ZZnafvcL3HWL4LuFJbr84H1WpHqBMw1xnpBBQ2Z8RPds6OmRhAal2E0I4rejryby8cB8bjl6if61kPi43F6/d6yCgKYxcDn9OhXpdIOxRiJgFCdGODllYSJKPEMLpaK1ZvCeKN5cchPQkFjXdSosz4ag4N+j1AbR53NQLdZ2O/76p7yTHBSysJslHCOFULsWnMOG3/aw6GM3oqkd5Sc/C7Z+zEDIYer4HFao7OkRhA2U++chNpkI4j9/3XeD1xQfwS4liY82F1IndBP6NYMRSqNvJ0eEJGyrzHYtmKmgYbSFE8bp6I5XXFx9gzb4zvFFpLQ+l/ILB4ApdxkPbJ8DV3dEhCiuV2WG0hRAlw5pD0bzy635Ck3eyw28efonnoNm90PN98A10dHiimEjyEUI4RFxSGm8vPcifu/fyefmfuMN1G5SrD0MWQXBXR4cnipkkHyGE3W08GsOEBbvpn7SITd6/4aoVdHsD2j8Frh6ODk/YQZlPPtLgQAj7SUhJ5/3fD3E2YjnzPGdT2zUSGvaFuz8Cv1qODk/YkTQ4MJMGB0IUr20nYvnkl/X8J3EGfV3+xFixLoZ7PpVOQEspaXAghHCoxNR0Pv19P24R3/Cj2yI83DV0eg1Dh6fBzdPR4QkHkeQjhCg2f52+wtyffuDJxGk0cIsko0FvDPd8BBXrODo04WCSfIQQNpeclsG0pX9Q9++P+NxlG8kVakG/+bg0utvRoQknIclHCGFTf5+OYfuPHzIq+Uc8XTNI7fAinl2eBzcvR4cmnIgkHyGETaSkZ7Dw159pdeB9xhrOcSWwM+UHfQaVgx0dmnBCViUfpVRdoA7gBVwC9mutk4shLiFECXL4+Akif36BoWkbuOpRlcR+s6nUvD8oVfibRZlUaPJRStUBngAeAgIh+9CBpCqltgDTgYVaa2NxBCmEcE5paan88ePHhJ38ivoqjdNNx1Bn4Jvg7u3o0ISTK3AkU6XUF8BeoB7wGtAU8AXcgWrAPcAfwLvAPqXU7cUabTGQYbSFKJozezZw9qO23PXPRCLLNSPpP39Q5/6PJfEIixR4k6lS6hPgE611bKELUuoewFtrvcCG8dmN3GQqhGXSr0dzfN4LNLm4hItU5kK7N2jZa4RUsYkcbukmU631S5auSGu93JrAhBAljDGDmI3T8N7yAfWNSayq9CBhwz+gZaXKjo5MlEAWNzhQShkAMq/rKKWqAX2Bw1rrrcUTnhDCYeIvwoJHYXA4GdfOceXnpwiIP8wOQrjR/SN63nEHSs52RBFZ09rtd2AlMFkp5QNEAOUAH6XUKK317OIIUAhhX9M2nSS0pi8dDn8CZ7aTOrMPrldPkKH9+CZgAvcOf4qACnLPjrg11iSfMCCzGu4+4DpQFxgGvABI8hGiFHh8c3sMGSlZr92vHgfA33CDx8e+IGc7wiYKbO2Wiw9wzfy8J7BIa50GrAfkLjIhSgnDkztJ8P53eINk7cb5Wn1xfe6AJB5hM9Ykn7NAR6VUOaAXsMY8vRKQaOvAhBD2p2OPcy38fnwSz6G1KfG4q3RqVq0K5as6OjxRilhT7TYJmAMkAGeAzebpnYD9No7rliilamGKNQBIB97VWv/i2KiEcG7XI37G7fdn0EYDB10bsz8jiNTbhuOxdw7do88hbdqELVmcfLTW3yilIoDawJpsvRmcBF4vjuBuQTowTmu9x9wqb5dSarnW+oajAxPC6aSncObHcQSdnMdu3YB1TT/kx6MwZXhLOgT7sy20PT3m/c2Uk7F0CPZ3dLSilLCqbzet9S5gV65pv9s0IhvQWl8ALpifX1RKxWKqHpTkI0Q21y8cJ+77YQQlH+VXz3tp/sgkyh+/ypQw36xE0yHYnylDW7LvfJwkH2EzhXWv87Cy8AqjUipIKXWnBeU6KaWWKKUilVJaKTUyjzJjlVKnlFLJSqldliy3gPW1Bly01ueKugwhSqND6+eivulEhaTzLG48kX4vzqRBjUqM6Rx8U5LpEOzPmM7SrkjYTmENDh4DjiqlXlVKNc+diJRSlZRS/ZVSPwN/Yer3rTA+wAHgGSAp90yl1APAZOADoCWwDVihlKqdrcwepdSBPB41cseHqQn44xbEJUSZkJiUyLavRtN081giDYFEPbiSAQ+Oxs3FmvZHQtyaAvt2A1BK9QGeBroDyUCM+W9FoIr59SzgM631JatWrlQC8JTWOjzbtB3APq316GzTjgMLtNavWLFsD0wt8r7VWs8prLz07SbKgv0H9+GycBRNjcfYGTCE0Ee/wNNLOgIVtndLfbtB1jWd35VS/sAdQBCm8Xxigb+Bv201lIJSyh1oDUzMNWs10MGK5SggHFhfUOJRSj2O+ayodu3a+RUTosRLSc9gyc+z6HH0DVyV5ljnKbS5a7ijwxJlmDWt3WKB34ovFAD8ARcgOtf0aExnXpbqCDyAaZiHgeZpw7XWOZqEa62nYxqLiLCwsIJPAYUooQ6dv8zBOS8wJOVXorwa4DtiHg2rN3R0WKKMK5XDaGut/8DCG2iVUv2AfvXr1y/eoISws/QMIz+s2U7ItmcZYjjK+foPUfOBz8HN09GhCWFVDwf2EAtkALlvpa4KXCyOFWqtl2qtH/f1taSthBAlwz+XEvjgiy/pt/0BQlzOktD3G2o+PE0Sj3AaTnXmo7VOVUrtAnoA2Xsk6AEsdExUQpQcRqNmztYTJK55nzcMi7ju2xDPR+aBfwNHhyZEDnZPPubhGDLruAxAbaVUC+CK1vos5m58lFI7ga3AGKAGMK2Y4pFqN1EqRF5L4v2f1vNI1Lu0MxwmKWQoFfr/T4a1Fk6p0KbWNl+hUl2ADXnM+l5rPdJcZiym4RuqY7on6Fmt9eY83mMz0tRalFRaaxbujmTlkp/4iC/wc03Fpd8kVIuhjg5NlGG33NQ618LGAk9iGscnRGv9j1LqZeAfrfXPlixDa70RKLDXBK31VGCqNbEVlZz5iJIsNiGFVxfuocmxb5ju9isZFevj+tAPENDY0aEJUSCLGxwopcYBEzA1Tc6ePCKBp2wblv1IgwNRUq08cIEHJy1hxMnnedZtISr0ftye2CSJR5QI1pz5jAFGa61/V0q9l236bqCZbcMSQuQnLimNt5YcJHLPWuZ7fkVFtxvQ50tUy+Egg72JEsKa5BOE6fpLbmmYejwokaTaTZQkm49dYvwve7gv6Rf+5/ELqmI91P1LoVqIo0MTwirWJJ9/gFaYBpLL7h7gkM0isjOt9VJgaVhY2OhCCwvhIImp6Xy4/AjL/tzPNJ9vaeu6C0IGQb/J4FHe0eEJYTVrks9EYIpSyhvTNZ/2SqnhmFqlPVYcwQkhYNeZKzz/814qX93DpvJTKW+8Bn3+B2GjpJpNlFjW9O02SynlimmoA29Mw1RHAU9rrecXU3xClFkp6Rl8tuY40zef4Plyq3nCYy4Gn5ow5Beo0cLR4QlxS6wdyfRb4FtzD9cGrXVM8YRlP3LNRzijg1FxPP/zXqIuXmBZwGyaXv8DmvSDAV+Bp7TMFCVfkfp201rHlobEA9LUWjiX9AwjU9YfZ+BXW6kWf5Adld6macIOuPtjuH+OJB5Ralh85qOUqgi8BdwFBJArcWmtA2wamRBlzD+XEnju573sOXeVT2ttZ/Dlb1Bu1WHoKqjZ2tHhCWFT1lS7zcZ0P8/3mMbXkfFvhLABo1Eze/tpPlp5BH/XZLbVm0eNqNXQsDcMnArelRwdohA2Z03y6QJ01lrvLqZYhChzIq8l8eIve9l28jIj61zj9aSPcblwHnq+B+2fktZsotSyJvmcxPnG/7ll0uBA2Mu0TScJrelLh2B/tNYs2HWeNxYfIN1oZEHrQ7Q+8gmqXBV4dAXUbuvocIUoVtYkk2eAD5VStymlXIorIHuTBgfCXkJr+vLUvL9Zsf8Co2fv4sUF+3DPSGRDnTmEHXwPVbcz/N8WSTyiTLDmzOcEpm50dgOoXNUBWutSk5CEKA4dgv15s29T3pq3ji/cviTdfQhf+/6AV9QZ6PYGdHwWDKWuckGIPFmTfH4EfIGnkQYHQlgt5noyk9Ye42nXRdyujnC7eh+DDoARy6BOR0eHJ4RdWZN8woA2Wuu8OhcVQhTg6o1UfCfVZBNpkFVHYISEi/DDvTChVNw2J4TFrDnHPwRUKK5AhCit4pPTGDlrJ91SJxFJlazpGS6e/M6d/DVwkwOjE8IxrEk+E4BJSqnuSqmqSqlK2R/FFWBxU0r1U0pNj4uLc3QoohRKSs1g1PcRHIm6ypf+iwjkEqDA1RMXYyqtGtZm12V3R4cphN0prS27dKOUMmZ7mf1NCtAlvcFBWFiYjoiIcHQYohRJTTfy+JwI/jh2kU315hEYuQKqNIGgDhD2KETMgoRoeHCuo0MVwuaUUru01mH5zbfmms9dNohHiDIhw6h5dv4e/jh6gfV1fiAwcjX0eBc6Pv1vob6THBegEA5mzZAKUjEthAWMRs3LC/exav85VteeTe2La6Hn+9DhKUeHJoTTKDD5KKVaAXu01kbz83xJtztCgNaad5YdYtGu06wIDKdezHro9QG0f9LRoQnhVAo784kAqgEx5uca0zWe3DTZGpAKUVZ9tuYYc7edYFm1GTS4vAnu/gjaPeHosIRwOoUln7rApWzPhRD5mL75JF+vP8KiKt/S+NoW0xg87cY4OiwhnFKByUdrfSb7S+CczqN5nFKqtq0DE6IkmbfjLJ8uP8CCyt8QEr8Ven8KbR93dFhCOC1r7vM5BdnukDNTSlU2zyuR5D4fcasW74nk7d9283PFr7ntxla4Z6IkHiEKYU3yUeTdn5sPkGybcOxPerUWt2LNoWhe/jmCeRWm0jJpO/T5H7QZ7eiwhHB6hTa1Vkp9YX6qMQ2pkJhttgvQBthj+9CEcG5bT8Qybt4OZvt8SeuUv6DPJLh9lKPDEqJEsOQ+n+bmvwpoAqRmm5eKaYiFiTaOSwintuvMVZ6cvY2ZnpO5PTUC+n5u6rVACGGRQpOP1vouAKXULOAZrfX1Yo9KCCd2KOo6/zfrD6a5fUbb9N3QbzK0HunosIQoUazp4UB+1oky7+SlBP4zYwtT1ETaZuyF/l9Cq0ccHZYQJY41fbsJUaadv5rIqG838z/jx7TV+1D9v4RWwx0dlhAlkiQfISwQE5/MY99u5oPUD2nHftSAKdDyYUeHJUSJVeoGjFdK+SmlIpRSe5RSB5RS0u5V3JJrian859vNvHXjPdqzHzVwqiQeIW5RaTzziQc6aa0TlVLlgANKqV+11pcdHZgoeRJS0hk9YzOvXHuLdoZDqIFfQ4uHHB2WECVeqUs+WusMIPNeJA9MTcTz6gxViAIlp2UwduYWnrv0Ou0Mh1H3ToPbHnR0WEKUCnatdlNKdVJKLVFKRSqltFJqZB5lxiqlTimlkpVSu5RSdxZhPX5Kqb3AeeBTrXWsDcIXZUhqupFnZv/BExdepZ3hCOrebyTxCGFD9r7m4wMcAJ4BknLPVEo9AEwGPgBaAtuAFdk7Ls12LSf3o0ZmGa31Na31bZh64h6qlKpavJslSpMMo2b8T9t59Mx42hqOoO6bDrc94OiwhChV7FrtprVeDiwHUEqF51HkOSBca/2t+fV/lVJ3A08Ar5iX0cKK9UWbz4DuBBYUPXJRVhiNmjd/+ZMHjz3H7YZjGAZ9C80HOzosIUodp2ntppRyB1oDq3PNWg10sGI5VZVS5c3PfYFOwNF8yj5ubhkXcenSpbyKiDJEa83HS3bR7+A4bjccxzD4O0k8QhQTp0k+gD+mjkqjc02PxjSaqqWCgC3mM54twJda6/15FdRaT9dah2mtw6pUuWm0CFHGfLVyD912j+V2w3HU4O8gZJCjQxKi1CqNrd12Ai0sLa+U6gf0q1+/frHFJJxf+Pr9tN3+OK0MJ2HwDFTIvY4OSYhSzZnOfGKBDCB344CqwMXiWqmM5yN+2XqIkI2PmRLPkJkYJPEIUeycJvlorVOBXUCPXLN6YGr1JoTNLY84SvCq4bQwnMQ4eBYuzQY6OiQhygS7VrsppXyAzPotA1BbKdUCuKK1PgtMAuYopXYCW4ExQA1gWjHGJNVuZdSGPSeosWQoIYZTGAfNwj1kgKNDEqLMUFrnNTJ2Ma1MqS7Ahjxmfa+1HmkuMxZ4CaiO6Z6gZ7XWm4s7trCwMB0REVHcqxFOYsehf/CcP5hm6jRp983CK1QSjxC2pJTapbUOy2++ve/z2UghXd1oracCU+0SEHLmUxbtPX4ar/mDaaLOkDxwFj6SeISwO6e55uMo0uCgbDl6+iwuc++jiTrDjQEz8WkhiUcIRyjzyUeUHafPnScjfAANOcO1fjPxaymJRwhHKfPJRynVTyk1PS4uztGhiGIUdTGK5Jn9qM9ZLveZQZXWkniEcKQyn3yk2q30uxRzgYTpfainz3Lh7u+ofvtAR4ckRJlX5pOPKN3iLl8k7pt7CMo4x5ke3xHUTm4gFcIZSPIRpVbC1WguT+1NrfRzHO86nQYdJfEI4SzKfPKRaz6lU3JcDJe/6kWN9HMc6DSNkM73OTokIUQ2ZT75yDWf0iftegyXpvSkatp5dnX4mtbdZFgEIZxNqevVWpQ90zadJLSmLx0C0tHzH+Zy9EWqpF7k6xrv82yvIY4OTwiRhzJ/5iNKvtCavjw172+iF70C5//CPzWSJ4zjadtdxuMRwlnZtW83ZyZ9u5Vg7wVAesrN0109YEKM/eMRQhTat1uZP/ORBgclXHw0cUE90UDm76g0gwc0HwLP5DmArRDCCZT55CMNDkqo9BRSN/2PlM9a4HViOUcIQqNIV+64GFO5kOIO5XOPSyiEcBZlPvmIEkZrOLyMxM9a477hHTanNeH1Gt8RRVWiGw3F9f/WE91wKIeOHWfbyVhHRyuEyIe0dhMlR/RBUpa9hMe5PzhnrMlMn7cZNOQR6p69ilf3H6ke7A9A9aFTOXUyln3n4+hgniaEcC6SfITzu3EZ44b3IWIWSdqbj/WjVOkyhnc7NcTd1UCbupVuekuHYH9JPEI4MUk+wnllpMFfM0hf/z4qNYHZ6T2IqPM4L9/XgVqVvB0dnRDiFpT55CMjmTqp42vJWPkKLpePsd3YnK/cH+ORQb2ZElINpQocDFcIUQKU+eSjtV4KLA0LCxvt6FgEEHsCvepV1PFVRFKNd9Kep2ab+/i2VyPKe7o5OjohhI2U+eQjnETSNdj8KXrHNJK0O5+lDSWi6v28fV9LQmv6OTo6IYSNSfIRjmXMgN2z0evfg8TL/GK8i6/Ug4y8pw0L2tfBxSBVbEKURpJ8hOOc/gNWvAzR+9nv0pRXUp4jKKQd8/s2o5qvp6OjE0IUI0k+wv6unoE1r8OhxVx1q8qE1KfZW6EL745ozl2NAxwdnRDCDiT5CPtJSYA/PkNv+5IMDExXD/DVjXt4pFNjJnZtgJe7i6MjFELYiSQfUfyMRtj/M6x9C+Iv8IfnXbx47T5qBtXn13ub06haeUdHKISwszKffOQ+n2J2PgJWjIfICC6Ua8rT6WM4ntqUVwY1ZkjrWhikQYEQZZKM52Mm4/nY2PUoWPs27PuJFK8AJmY8xHfXb+e+VrV59Z7GVPbxcHSEQohiVNh4PmX+zEfYWFoSbJ8CWyahjRmsqjSM56K6Ua1KZeaNbk774MqOjlAI4QQk+Qjb0BoOLYbVr0PcWc4EdGNM9EBOxlThvz3q83jneni4SoMCIYSJJB9x6y7sg5Uvw5mtJFVqwvsVPuCHs3W4s4E/Xw8IoY5/OUdHKIRwMpJ8RNElXIIN78Gu79Felfi99kuMOx6KXzkvvnioKf1Cq0snoEKIPEnyEdZLT4Wd38CmT9BpiZxp8Aj/Od2dk8ddGNa2Ni/2aoyvl3QCKoTInyQfUbD4i7DgURgcDj4BcGwVrHoVrpwkqU433ksdxtz9njSpXoFfh4fQsnZFR0cshCgBSm3yUUp5A4eBX7TWLzg6nhJr0ydw9k9Y9Yqp5+mT69CVG7Ai9Aue/7sqSsGEPg0Z2aEOri4GR0crhCghSm3yAV4D/nR0ECXWewGQnvLv6wMLAdDKlT5pn3BoZxI9m/rzZv9mBPp5OShIIURJVSp/qiqlGgCNgRWOjqXEyUiH01s5ENCPdDefrMlauRDhfSdtkr7gWorm20fCmP5ImCQeIUSR2PXMRynVCXgBaA3UAB7VWofnKjMWeBGoDhwExmmtt1i5qonmZXS41ZjLhKSrcGIdHFsJx9dA8jWaGtyIMZanKgqjwQ1lTOPwdQ/ahjbh40GhlPMozSfNQojiZu9vEB/gADDb/MhBKfUAMBkYC/xh/rtCKdVUa33WXGYPecfdU2sdpZQaABzTWh9TSknyyYvWEHvMlGyOrTJd09EZaG9/rtfuwaHyHdiYHsKdB19ndbIPP2Z0Y5jreroEGhk+tJWjoxdClAJ2TT5a6+XAcgClVHgeRZ4DwrXW35pf/1cpdTfwBPCKeRktCllNO+BBpdQQTMnOTSl1XWv9zq1vQQmWngpntpqSzbEVcPU0ANcqNGJvwMOsSL2NJbHVSNxnKu7tfoXdNd4kNd3I4fNxRN/xPrV6NXJc/EKIUsVp6k6UUu6YquMm5pq1Giuqz7TWr2BOVEqpkUBIfolHKfU48DhA7dq1rQ/a2SVcguOrMR5diT65Hpe0BNKUO3vdbmOZsSurU1sQlexPOXcXmtXw5cE2vjSvWYHmgb7U9fdhx6nLPDXvb57uWp8fdpylff3KdAj2d/RWCSFKAadJPoA/4AJE55oeDXQvjhVqracD08HUq3VxrMOutCYtah9X/16K4cRqKl3bhwHNJV2RdRltWGdsyT6326hbOYDmgb68FOhLSKAv9fzL3TS0wbaTsTw172+mDG1Jh2B/2gVXzvFaCCFuhTMlH5vL3ZghLyV5PJ+0DCPHIy8Ru28NHqfWEHz1D/yNsQQAe4z1+EkN4VyVTpQPakXzWn68GuhL3co3J5q87DsflyPRdAj2Z8rQluw7HyfJRwhxyxw2no9SKgF4KjNBmKvdEoGHtNa/ZCv3Faaqs87FGY+zj+eTmm7kWHQ8ByLjOHP6BD5n19H4+nY6qP14qVQStQcHvFoTU60Lro170TC4PnUsTDRCCGFrJWY8H611qlJqF9AD+CXbrB7AQsdE5RiZiWZ/ZBz7I+M4eP4qrtH76EQE3Qx/86DhNADXPKtzoeYQvEP6EBDSjTbuno4NXAghLGTv+3x8gMz6LQNQWynVArhibko9CZijlNoJbAXGYLofaFoxxuTQareU9AyOXUzISjQHIuM4ejEet4wb3GE4QC/3Pbxk2IOf61U0BlKqh6GbjkQ1uhu/Ko3xk16jhRAlkF2r3ZRSXYANecz6Xms90lxmLPASpptMDwDPaq03F3ds9qh2S0nP4OjF+Kwks9+caNIyTPugqecVHvA7xJ16F0Hxu3ExpqE9KqDqd4dGvaF+d/CuVKwxCiGELRRW7eawaz7OItuZz+jjx49b/L5pm04SWtM3x8X3bSdj2Xc+jjGdg0lOy+DIRdM1msxEcyz630Tj5+3GbTV86FHhLO3TI6gduxm3K0dNC6rcABr2goZ3Q+124CLDEwghShZJPhay9swne1PkVrUr8nPEOT5acYQ2dSoSHZ/K8eh40o2mz7aitxshgb40D/SlZRVFy7RdVI7cgDqxxtS1jcEVgjqYkk3Du6FycHFtphBC2EWJaXBQ0mQ2PR49exeJKelkpvB9kdcJCfSla+MqNA/0JaRGBQIzIlHHV5l6F9ixDXQGeFc2J5teENwVPH0duj1CCGFPknxuQYdgf4Y3c+euA2+wKPh9/jugIzV8PVEZaXB2Oxz7HtavhCv/mN4Q0Aw6PmO6fhPYGgwujt0AIYRwkDKffG6ltdu2k7HUOzSV2w1HuXjqSxJ3/oO6thVOroeU6+DiAXU7QbuxpjMcv1LYhY8QQhSBXPMxs/aaj/HdAAwZKTdN14Bq9Qg07A31OoN7ORtGKYQQJUNh13xK5WBy9vBD2yVcqtPfdHYDYHDlSo1OzG6/Evp/CY3vkcQjhBD5KPPJRynVTyk1PS4uzqr3PdKzHVUq+4MxDVw9QRupVKMBI3q1L6ZIhRCi9CjzyUdrvVRr/bivbxFam92IgdaPwn/Wmv4m5O6QWwghRF7KfIODW/Lg3H+f953kuDiEEKKEKfNnPkIIIexPko8QQgi7K/PJp6gNDoQQQhRdmU8+t9TgQAghRJGU+eQjhBDC/iT5CCGEsDvpXsdMKXUJOAP4AvldAMpvnj8QW0yh2VpB25cfa7avKMu35XJsHWthZYpyvEDJOWbsEactjpmixmnNui0tW1i5gmK11f+PLdzqZxqkta6SbymttTyyPYDp1s4DIhwdty22r4D3WLx9RVm+LZdj61gLK1OU48XaOB35sEectjhmihqnNeu2tKwFx0y+sdrq/8eR+97SbZBqt5stLeK8kqK4t8FWy7fHZ23JOgorU9qPF3tw5OdkzbotLXsr21MajhmLtkGq3WxAKRWhC+i9taQrSdtXUmKVOG2rpMQJJSfW4o5TznxsY7qjAyhmJWn7SkqsEqdtlZQ4oeTEWqxxypmPEEIIu5MzHyGEEHYnyUcIIYTdSfKxkFKqk1JqiVIqUimllVIjc81XSqm3lFJRSqkkpdRGpVQzB4VrFaXUK0qpv5RS15VSl5RSS5VSIbnKhJu3O/vjTwfE+lYecVzMNt8h+8EWx4dSqqJSao5SKs78mKOU8rNxnJbsa6eINY+4tVJqirPFqZRyUUq9q5Q6pZRKNv99Tynlmq2M3WMt7Jg0l2molPpVKXVNKZWolNqtlGqSbb6HUupLpVSsUuqGeXk1cy2jtvk4umEu94VSyr2w+CT5WM4HOAA8AyTlMf8l4Hngv8DtQAywRilV3m4RFl0XYCrQAegKpANrlVKVcpVbC1TP9rjHjjFmdzRXHM2zzXPUfrDF8TEPaAXcbX60AubYOM4uFL6vnSVWAJRS7YDHgX25ZjlLnOOBJ4GngcaYjoEngVccHGuBx6RSqi6wFTiF6VgIASYACdmKfQ4MAh4C7gQqAMuUUi7mZbgAvwPlzfMfAgYD/ys0OkffyFQSH+adMzLbawVcAF7LNs0LiAf+z9HxFmH7fIAMoF+2aeHAMieI7S3gQD7znGI/FOX4AJoAGuiYrcwd5mmN7LWvnS1WTHfLnwTuAjYCU5wtTmAZ8H2uad9n/r84Q6y5j0nztHnA3EI++1RgWLZptQAj0Mv8urf5da1sZR4GkoEKBcUkZz62UReoBqzOnKC1TgI2Y/qFWdKUx3RWfDXX9DuUUjFKqWNKqW+VUgEOiA2gnrn64pRS6ielVD3zdGfdD5bE1R7TF8S2bO/bCtygeGPPva+dLdbpwAKt9YZc050pzj+Au5RSjQGUUk0xnUksd8JYMcdoAPoBh5RSK81VsH8ppR7IVqw14JYr7nPA4VxxHzZPz7QK8DC/P1+SfGyjmvlvdK7p0dnmlSSTgT3A9mzTVgKPAN0wVR+0AdYrpTzsHNsOYCSmaonRmD7fbUqpyjjvfrAkrmrAJW3+6Qhgfh5D8caee187TaxKqdFAfUxVQbk5TZzAx5iqxw4ppdKAg5jOhKY6YayZAjCd9b6KKbn0AH4E5iql+mSLKYOb+3fLHXfu7Yo1v6/AuF0LminKHqXUJEyn+3dorTMyp2utf8pWbL9Sahemjlj7AL/aKz6t9Yrsr5Wp0cM/wAjA7g0gSrL89rUzUEo1Aj7AFFuao+MpxAOYfpgNxZR4WgCTlVKntNYzHBlYATJPPBZrrSeZn+9RSoUBT2G6jmOXAMStyWxtVTXX9KrZ5jk9pdRnmC4YdtVa/1NQWa11FHAeaGCP2AqIIwHTP3wDnHc/WBLXRaCKUkplzjQ/D6AYYi9gXztLrO0x9ap8UCmVrpRKBzoDY83PLztJnACfAhO11j9prfdrrecAk/i3wYGzfKbZxWJqbHIo1/TDQO1sMblg2g/Z5Y4793b5m99XYNySfGzjFKYPukfmBKWUJ6bWH9vye5MzUUpN5t8voyMWlPcHAjFdSHUY8+fc2ByHs+4HS+LajqkapH2297UHymHj2AvZ184S62+YWjG2yPaIAH4yPz/mJHECeGOqZsoug3+/X53lM82itU4F/gIa5ZrVEFONBsAuIC1X3DUxNY7IHneTXM2vewAp5vcXGIQ8LGst4sO//wSJwBvm57XN88djGsPiPkxNFn8CooDyjo7dgm37CriO6SJptWwPn2zbPhHTP0MdTM11t2M687Hr9pnj6IzpIm5bTC2NrmMaO8Rh+8EWxwewAthv/pzbm58vtee+dqZY84h9I+bWbs4UJ6aWoOcxVUHXAe4FLgH/c2SsFhyTAzG1Znsc07W10ZiSTZ9sy/javG3dgZbABkzXCF3M813Mca43z+8ORAJfFhpfcR4spemB6QtX5/EIN89XmJoBX8DUzHATEOLouC3ctry2SwNvmed7YWrBEmM+WM+Y/+FqOSDWzH/aVPNBvhBomm2+Q/aDLY4PoCLwA6bkcN383M+e+9qZYs0j9o3kTD5OESemFoOfm/8vkjBdg/wA8HRkrIUdk+YyIzGdRSZhuo/qoVzL8AC+xFTNmYhpuIRaucrUxvQjMNFc7gvAo7D4pGNRIYQQdifXfIQQQtidJB8hhBB2J8lHCCGE3UnyEUIIYXeSfIQQQtidJB8hhBB2J8lHCCGE3UnyEUIIYXeSfIQQQtidDKkghJNTSm3E1PvwNUz9cBmB2cBLWmuj4yIToujkzEeIkmEYpi7wO2Aab2UcpnFkhCiRpG83IZyc+czHQ2vdPtu0NcAZrfV/HBaYELdAznyEKBn25XodhWmgMSFKJEk+QpQMuYeS1sj/ryjB5OAVQghhd5J8hBBC2J0kHyGEEHYnrd2EEELYnZz5CCGEsDtJPkIIIexOko8QQgi7k+QjhBDC7iT5CCGEsDtJPkIIIexOko8QQgi7k+QjhBDC7iT5CCGEsLv/B6UQC7Jfu8ryAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "1.650615023237321"
-      ]
-     },
-     "execution_count": 264,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "fig1, ax1 = plt.subplots()\n",
+    "data_mkl_mdspan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers = ['x-','*-','+-']\n",
+    "plt.rcParams['font.size'] = 12\n",
     "\n",
-    "datatype = 1; print(datatypes[datatype])\n",
-    "m = 0; plt.plot(nSizes,data_mkl[m,:,datatype],'x-',label=methods[m])\n",
-    "m = 1; plt.plot(nSizes,data_mkl[m,:,datatype],'*-',label=methods[m])\n",
+    "for datatype in range(NT):\n",
+    "    print(datatypes[datatype])\n",
     "\n",
-    "ax1.set_xscale(\"log\")\n",
-    "ax1.set_yscale(\"log\")\n",
-    "ax1.set_xticks(nSizes)\n",
-    "ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "    fig1, ax1 = plt.subplots()\n",
     "\n",
-    "plt.xlabel(\"n\")\n",
-    "plt.ylabel(\"time (s)\")\n",
-    "plt.legend()\n",
+    "    plt.plot(nSizes,data[0,:,datatype],markers[0],label=r\"Eigen::Matrix\")\n",
+    "    plt.plot(nSizes,data_mdspan[:,datatype],markers[1],label=r\"kokkos::mdspan\")\n",
     "\n",
-    "plt.tight_layout()\n",
-    "plt.savefig(\"curvesWithMKL.pdf\")\n",
-    "plt.show()\n",
+    "    plt.plot(nSizes,data_mkl[0,:,datatype],markers[0],label=r\"Eigen::Matrix (MKL BLAS)\")\n",
+    "    plt.plot(nSizes,data_mkl_mdspan[:,datatype],markers[1],label=r\"kokkos::mdspan (MKL BLAS)\")\n",
     "\n",
-    "rate = (np.log(data_mkl[m,-1,datatype])-np.log(data_mkl[m,-2,datatype]))/(np.log(nSizes[-1])-np.log(nSizes[-2]))\n",
-    "rate"
+    "    ax1.set_xscale(\"log\")\n",
+    "    ax1.set_yscale(\"log\")\n",
+    "    ax1.set_xticks(nSizes)\n",
+    "    ax1.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "\n",
+    "    plt.xlabel(\"n\")\n",
+    "    plt.ylabel(\"time (s)\")\n",
+    "    plt.legend()\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.savefig(\"curves_mdspan_\"+datatypes[datatype]+\".pdf\")\n",
+    "    plt.show()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -791,7 +640,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.8.10"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"

--- a/include/tlapack/base/arrayTraits.hpp
+++ b/include/tlapack/base/arrayTraits.hpp
@@ -177,6 +177,16 @@ namespace tlapack {
 
         template< class T, class = int >
         struct TransposeTypeImpl;
+    
+        /**
+         * @brief Trait to determine if a given list of data allows optimization
+         * using a optimized BLAS library.
+         */
+        template<class...>
+        struct AllowOptBLASImpl {
+            static constexpr bool value = false;    ///< True if the list of types
+                                                    ///< allows optimized BLAS library.
+        };
 
         /**
          * @brief Functor for data Creation
@@ -358,6 +368,10 @@ namespace tlapack {
     /// define @c vector_type<>::type alias
     template< typename... vector_t >
     using vector_type = typename internal::vector_type_traits< vector_t..., int >::type;
+
+    /// Alias for @c AllowOptBLASImpl<>::value.
+    template<class... Ts>
+    constexpr bool allow_optblas = internal::AllowOptBLASImpl< Ts..., int >::value;
 
 }
 

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -12,6 +12,8 @@
 
 #include "tlapack/base/utils.hpp"
 
+#include "tlapack/blas/gemm.hpp"
+#include "tlapack/lapack/laset.hpp"
 #include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/larf.hpp"
 #include "tlapack/lapack/lahqr.hpp"
@@ -188,8 +190,10 @@ namespace tlapack
 
         // Assertions
         assert(nrows(A) == n);
-        assert(ncols(Z) == n);
-        assert(nrows(Z) == n);
+        if(want_z) {
+            assert(ncols(Z) == n);
+            assert(nrows(Z) == n);
+        }
         assert((idx_t) size(s) == n);
 
         // s is the value just outside the window. It determines the spike

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -81,6 +81,9 @@ namespace tlapack
         using idx_t = size_type<matrix_t>;
         using pair = pair<idx_t, idx_t>;
 
+        // Functor
+        Create< vector_type<matrix_t,matrix_t> > new_vector;
+
         // constants
         const real_t rzero(0);
         const TA one(1);
@@ -295,7 +298,7 @@ namespace tlapack
             // If it has split, we can introduce any shift at the top of the new subblock.
             // Now that we know the specific shift, we can also check whether we can introduce that shift
             // somewhere else in the subblock.
-            std::vector<TA> v(3);
+            std::vector<TA> v_; auto v = new_vector(v_,3);
             TA t1;
             auto istart2 = istart;
             if (istart + 3 < istop)
@@ -324,8 +327,8 @@ namespace tlapack
                     auto H = slice(A, pair{i, i + nr}, pair{i, i + nr});
                     auto x = slice(v, pair{0, nr});
                     lahqr_shiftcolumn(H, x, s1, s2);
-                    x = slice(v, pair{1, nr});
-                    larfg(v[0], x, t1);
+                    auto y = slice(v, pair{1, nr});
+                    larfg(v[0], y, t1);
                     if (i > istart)
                     {
                         A(i, i - 1) = A(i, i - 1) * (one - conj(t1));

--- a/include/tlapack/lapack/lahr2.hpp
+++ b/include/tlapack/lapack/lahr2.hpp
@@ -11,6 +11,7 @@
 
 #include "tlapack/base/utils.hpp"
 
+#include "tlapack/blas/gemm.hpp"
 #include "tlapack/blas/gemv.hpp"
 #include "tlapack/blas/trmm.hpp"
 #include "tlapack/blas/trmv.hpp"

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -11,6 +11,7 @@
 #define TLAPACK_QR_SWEEP_HH
 
 #include "tlapack/base/utils.hpp"
+#include "tlapack/blas/gemm.hpp"
 #include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/lahqr_shiftcolumn.hpp"
 #include "tlapack/lapack/move_bulge.hpp"
@@ -110,8 +111,10 @@ namespace tlapack
         // Assertions
         assert(n >= 12);
         assert(nrows(A) == n);
-        assert(ncols(Z) == n);
-        assert(nrows(Z) == n);
+        if(want_z) {
+            assert(ncols(Z) == n);
+            assert(nrows(Z) == n);
+        }
 
         // Allocates workspace
         vectorOfBytes localworkdata;

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -16,6 +16,7 @@
 #include "tlapack/blas/swap.hpp"
 #include "tlapack/blas/rot.hpp"
 #include "tlapack/blas/rotg.hpp"
+#include "tlapack/lapack/lange.hpp"
 #include "tlapack/lapack/lasy2.hpp"
 #include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/lahqr_schur22.hpp"

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -388,7 +388,7 @@ namespace tlapack{
         return Eigen::Block< XprType, 1, Eigen::Dynamic, InnerPanel >
         (   x.nestedExpression(),
             x.startRow(), x.startCol() + range.first,
-            range.second-range.first, 1 );
+            1, range.second-range.first );
     }
 
     template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
@@ -500,7 +500,7 @@ namespace tlapack{
         return Eigen::Block< const XprType, 1, Eigen::Dynamic, InnerPanel >
         (   x.nestedExpression(),
             x.startRow(), x.startCol() + range.first,
-            range.second-range.first, 1 );
+            1, range.second-range.first );
     }
 
     template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -367,11 +367,28 @@ namespace tlapack{
             rows.second-rows.first, 1 );
     }
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
+    template<class XprType, int BlockRows, bool InnerPanel, typename SliceSpec>
     inline constexpr auto
-    slice( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& x, SliceSpec&& range ) noexcept
+    slice( Eigen::Block<XprType,BlockRows,1,InnerPanel>& x, SliceSpec&& range ) noexcept
     {
-        return x.segment( range.first, range.second-range.first );
+        assert( range.second <= x.size() );
+
+        return Eigen::Block< XprType, Eigen::Dynamic, 1, InnerPanel >
+        (   x.nestedExpression(),
+            x.startRow() + range.first, x.startCol(),
+            range.second-range.first, 1 );
+    }
+
+    template<class XprType, int BlockCols, bool InnerPanel, typename SliceSpec>
+    inline constexpr auto
+    slice( Eigen::Block<XprType,1,BlockCols,InnerPanel>& x, SliceSpec&& range ) noexcept
+    {
+        assert( range.second <= x.size() );
+
+        return Eigen::Block< XprType, 1, Eigen::Dynamic, InnerPanel >
+        (   x.nestedExpression(),
+            x.startRow(), x.startCol() + range.first,
+            range.second-range.first, 1 );
     }
 
     template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
@@ -462,11 +479,28 @@ namespace tlapack{
             rows.second-rows.first, 1 );
     }
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
+    template<class XprType, int BlockRows, bool InnerPanel, typename SliceSpec>
     inline constexpr auto
-    slice( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& x, SliceSpec&& range ) noexcept
+    slice( const Eigen::Block<XprType,BlockRows,1,InnerPanel>& x, SliceSpec&& range ) noexcept
     {
-        return x.segment( range.first, range.second-range.first );
+        assert( range.second <= x.size() );
+
+        return Eigen::Block< const XprType, Eigen::Dynamic, 1, InnerPanel >
+        (   x.nestedExpression(),
+            x.startRow() + range.first, x.startCol(),
+            range.second-range.first, 1 );
+    }
+
+    template<class XprType, int BlockCols, bool InnerPanel, typename SliceSpec>
+    inline constexpr auto
+    slice( const Eigen::Block<XprType,1,BlockCols,InnerPanel>& x, SliceSpec&& range ) noexcept
+    {
+        assert( range.second <= x.size() );
+
+        return Eigen::Block< const XprType, 1, Eigen::Dynamic, InnerPanel >
+        (   x.nestedExpression(),
+            x.startRow(), x.startCol() + range.first,
+            range.second-range.first, 1 );
     }
 
     template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -117,6 +117,13 @@ namespace tlapack{
             static constexpr Layout layout = tlapack::layout<PlainObjectType>;
         };
 
+        /// Implementation of AllowOptBLASImpl for Eigen datatypes
+        template< class matrix_t >
+        struct AllowOptBLASImpl< matrix_t, typename std::enable_if< is_eigen_dense<matrix_t>, int >::type >
+        {
+            static constexpr bool value = allow_optblas<typename matrix_t::Scalar>;
+        };
+
         /// Transpose for Eigen::Matrix
         template< class matrix_t >
         struct TransposeTypeImpl< matrix_t, typename std::enable_if<

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -212,9 +212,16 @@ namespace tlapack{
     // Data descriptors for Eigen datatypes
 
     // Size
-    template<class T>
+    template< class Derived
+    #if __cplusplus >= 201703L
+        // Avoids conflict with std::size
+        , std::enable_if_t<
+            !std::is_same_v< complex_type<typename Derived::Scalar>, typename Derived::Scalar >
+        ,int> = 0
+    #endif
+    >
     inline constexpr auto
-    size( const Eigen::EigenBase<T>& x ) {
+    size( const Eigen::EigenBase<Derived>& x ) {
         return x.size();
     }
     // Number of rows

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -51,6 +51,18 @@ namespace tlapack {
             static constexpr Layout layout = Layout::BandStorage;
         };
 
+        /// Implementation of AllowOptBLASImpl for legacy datatypes
+        template< typename T, class idx_t, Layout L >
+        struct AllowOptBLASImpl< legacyMatrix<T,idx_t,L>, int >
+        {
+            static constexpr bool value = allow_optblas<T>;
+        };
+        template< typename T, class idx_t, class int_t, Direction D >
+        struct AllowOptBLASImpl< legacyVector<T,idx_t,int_t,D>, int >
+        {
+            static constexpr bool value = allow_optblas<T>;
+        };
+
         /// Transpose type for legacyMatrix
         template< class T, class idx_t >
         struct TransposeTypeImpl< legacyMatrix<T,idx_t,Layout::ColMajor>, int > {

--- a/include/tlapack/plugins/mdspan.hpp
+++ b/include/tlapack/plugins/mdspan.hpp
@@ -47,6 +47,18 @@ namespace tlapack {
             static constexpr Layout layout = Layout::RowMajor;
         };
 
+        /// Implementation of AllowOptBLASImpl for mdspan datatypes
+        template< class ET, class Exts, class LP, class AP >
+        struct AllowOptBLASImpl< std::experimental::mdspan<ET,Exts,LP,AP>,
+            std::enable_if_t<
+            /* Requires: */
+                LP::template mapping<Exts>::is_always_strided()
+            , int >
+        >
+        {
+            static constexpr bool value = allow_optblas<ET>;
+        };
+
         /// Transpose type for legacyMatrix
         template< class ET, class Exts, class AP >
         struct TransposeTypeImpl< std::experimental::mdspan<ET,Exts,std::experimental::layout_left,AP>, int > {

--- a/include/tlapack/plugins/mdspan.hpp
+++ b/include/tlapack/plugins/mdspan.hpp
@@ -139,22 +139,24 @@ namespace tlapack {
                 assert( m >= 0 && n >= 0 );
                 
                 // Variables to be forwarded to the returned matrix
-                array<idx_t,2> strides;
-                if( W.isContiguous() )
+                array<idx_t,2> strides = [&]( Workspace& rW )
                 {
-                    rW = W.extract( m*sizeof(ET), n );
-                    strides = {1,m};
-                }
-                else if( W.getM() >= m*sizeof(ET) && W.getN() >= n )
-                {
-                    rW = W.extract( m*sizeof(ET), n );
-                    strides = {1,W.getLdim()/sizeof(ET)};
-                }
-                else
-                {
-                    rW = W.extract( n*sizeof(ET), m );
-                    strides = {W.getLdim()/sizeof(ET),1};
-                }
+                    if( W.isContiguous() )
+                    {
+                        rW = W.extract( m*sizeof(ET), n );
+                        return array<idx_t,2>{1,m};
+                    }
+                    else if( W.getM() >= m*sizeof(ET) && W.getN() >= n )
+                    {
+                        rW = W.extract( m*sizeof(ET), n );
+                        return array<idx_t,2>{1,W.getLdim()/sizeof(ET)};
+                    }
+                    else
+                    {
+                        rW = W.extract( n*sizeof(ET), m );
+                        return array<idx_t,2>{W.getLdim()/sizeof(ET),1};
+                    }
+                }(rW);
                 mapping map = mapping( extents_t(m,n), std::move(strides) );
 
                 return matrix_t( (ET*) W.data(), std::move(map) );
@@ -171,22 +173,24 @@ namespace tlapack {
                 assert( m >= 0 && n >= 0 );
                 
                 // Variables to be forwarded to the returned matrix
-                array<idx_t,2> strides;
-                if( W.isContiguous() )
+                array<idx_t,2> strides = [&]()
                 {
-                    tlapack_check( W.contains( m*sizeof(ET), n ) );
-                    strides = {1,m};
-                }
-                else if( W.getM() >= m*sizeof(ET) && W.getN() >= n )
-                {
-                    tlapack_check( W.contains( m*sizeof(ET), n ) );
-                    strides = {1,W.getLdim()/sizeof(ET)};
-                }
-                else
-                {
-                    tlapack_check( W.contains( n*sizeof(ET), m ) );
-                    strides = {W.getLdim()/sizeof(ET),1};
-                }
+                    if( W.isContiguous() )
+                    {
+                        tlapack_check( W.contains( m*sizeof(ET), n ) );
+                        return array<idx_t,2>{1,m};
+                    }
+                    else if( W.getM() >= m*sizeof(ET) && W.getN() >= n )
+                    {
+                        tlapack_check( W.contains( m*sizeof(ET), n ) );
+                        return array<idx_t,2>{1,W.getLdim()/sizeof(ET)};
+                    }
+                    else
+                    {
+                        tlapack_check( W.contains( n*sizeof(ET), m ) );
+                        return array<idx_t,2>{W.getLdim()/sizeof(ET),1};
+                    }
+                }();
                 mapping map = mapping( extents_t(m,n), std::move(strides) );
 
                 return matrix_t( (ET*) W.data(), std::move(map) );

--- a/test/src/test_optBLAS.cpp
+++ b/test/src/test_optBLAS.cpp
@@ -39,12 +39,12 @@ TEST_CASE("has_compatible_layout gives the correct result", "[optBLAS]")
     CHECK( has_compatible_layout< matrixB_t, matrixB_t, matrixB_t > );
 }
 
-TEST_CASE("allow_optblas_v does not allow bool, int, long int, char", "[optBLAS]")
+TEST_CASE("allow_optblas does not allow bool, int, long int, char", "[optBLAS]")
 {
-    CHECK(!allow_optblas_v<bool> );
-    CHECK(!allow_optblas_v<int> );
-    CHECK(!allow_optblas_v<long double> );
-    CHECK(!allow_optblas_v<char> );
+    CHECK(!allow_optblas<bool> );
+    CHECK(!allow_optblas<int> );
+    CHECK(!allow_optblas<long double> );
+    CHECK(!allow_optblas<char> );
 }
 
 // TEMPLATE_TEST_CASE("legacy_matrix() exists", "[utils]", TLAPACK_TYPES_TO_TEST)
@@ -55,28 +55,28 @@ TEST_CASE("allow_optblas_v does not allow bool, int, long int, char", "[optBLAS]
 //     CHECK ( is_same_v< matrix_t, legacy_t > );
 // }
 
-TEMPLATE_TEST_CASE("allow_optblas_v gives the correct result", "[optBLAS]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("allow_optblas gives the correct result", "[optBLAS]", TLAPACK_TYPES_TO_TEST)
 {
     using matrix_t  = TestType;
     using T = type_t<matrix_t>;
 
     // Test matrix_t and pair< matrix_t, T >
-    CHECK( allow_optblas_v<matrix_t> == allow_optblas_v<T> );
-    CHECK( allow_optblas_v< pair< matrix_t, T > > == allow_optblas_v<T> );
+    CHECK( allow_optblas<matrix_t> == allow_optblas<T> );
+    CHECK( allow_optblas< pair< matrix_t, T > > == allow_optblas<T> );
 
     // Test pairs of convertible types
-    CHECK( allow_optblas_v< pair< float, double > > == allow_optblas_v<double> );
-    CHECK( allow_optblas_v< pair< int, float > > == allow_optblas_v<float> );
-    CHECK( allow_optblas_v< pair< double, std::complex<double> > > == allow_optblas_v<std::complex<double>> );
-    CHECK( allow_optblas_v< pair< double, long double > > == allow_optblas_v<long double> );
-    CHECK( allow_optblas_v< pair< std::complex<double>, double > > == false );
+    CHECK( allow_optblas< pair< float, double > > == allow_optblas<double> );
+    CHECK( allow_optblas< pair< int, float > > == allow_optblas<float> );
+    CHECK( allow_optblas< pair< double, std::complex<double> > > == allow_optblas<std::complex<double>> );
+    CHECK( allow_optblas< pair< double, long double > > == allow_optblas<long double> );
+    CHECK( allow_optblas< pair< std::complex<double>, double > > == false );
     
     // Test pair< matrix_t, T > and pairs of convertible types
-    CHECK( allow_optblas_v< pair< matrix_t, T >, pair< T, T > > == allow_optblas_v<T> );
-    CHECK( allow_optblas_v< pair< matrix_t, T >, pair< int, T > > == allow_optblas_v<T> );
-    CHECK( allow_optblas_v< pair< matrix_t, T >, pair< float, T > > == allow_optblas_v<T> );
-    CHECK( allow_optblas_v< pair< matrix_t, T >, pair< long double, T > > == allow_optblas_v<T> );
+    CHECK( allow_optblas< pair< matrix_t, T >, pair< T, T > > == allow_optblas<T> );
+    CHECK( allow_optblas< pair< matrix_t, T >, pair< int, T > > == allow_optblas<T> );
+    CHECK( allow_optblas< pair< matrix_t, T >, pair< float, T > > == allow_optblas<T> );
+    CHECK( allow_optblas< pair< matrix_t, T >, pair< long double, T > > == allow_optblas<T> );
     
     // Test pair< matrix_t, T > and pair< matrix_t, T >
-    CHECK( allow_optblas_v< pair< matrix_t, T >, pair< matrix_t, T > > == allow_optblas_v<T> );
+    CHECK( allow_optblas< pair< matrix_t, T >, pair< matrix_t, T > > == allow_optblas<T> );
 }


### PR DESCRIPTION
This is another example testing the multishift QR. This time, we compare with the implementations in Eigen.

- When the flag `EIGEN_USE_MKL_ALL` is activated, Eigen uses `gees` from MKL.
- I have added a Jupyter notebook to this example, so the results are easier to reproduce.