### PR TITLE
Constants 'one' and 'zero' have always real type

### DIFF
--- a/include/tlapack/blas/dot.hpp
+++ b/include/tlapack/blas/dot.hpp
@@ -42,7 +42,7 @@ auto dot( const vectorX_t& x, const vectorY_t& y )
     // check arguments
     tlapack_check_false( size(y) != n );
 
-    return_t result( 0.0 );
+    return_t result( 0 );
     for (idx_t i = 0; i < n; ++i)
         result += conj(x[i]) * y[i];
 

--- a/include/tlapack/blas/dotu.hpp
+++ b/include/tlapack/blas/dotu.hpp
@@ -42,7 +42,7 @@ auto dotu( const vectorX_t& x, const vectorY_t& y )
     // check arguments
     tlapack_check_false( size(y) != n );
 
-    return_t result( 0.0 );
+    return_t result( 0 );
     for (idx_t i = 0; i < n; ++i)
         result += x[i] * y[i];
 

--- a/include/tlapack/blas/hemm.hpp
+++ b/include/tlapack/blas/hemm.hpp
@@ -101,7 +101,7 @@ void hemm(
                 for(idx_t i = 0; i < m; ++i) {
 
                     auto alphaTimesBij = alpha*B(i,j);
-                    scalar_t sum( 0.0 );
+                    scalar_t sum( 0 );
 
                     for(idx_t k = 0; k < i; ++k) {
                         C(k,j) += A(k,i) * alphaTimesBij;
@@ -120,7 +120,7 @@ void hemm(
                 for(idx_t i = m-1; i != idx_t(-1); --i) {
 
                     auto alphaTimesBij = alpha*B(i,j);
-                    scalar_t sum( 0.0 );
+                    scalar_t sum( 0 );
 
                     for(idx_t k = i+1; k < m; ++k) {
                         C(k,j) += A(k,i) * alphaTimesBij;

--- a/include/tlapack/blas/iamax.hpp
+++ b/include/tlapack/blas/iamax.hpp
@@ -40,14 +40,14 @@ iamax_ec( const vector_t& x )
     using real_t = real_type< T >;
 
     // constants
-    const real_t oneFourth( 0.25f );
+    const real_t oneFourth( 0.25 );
     const idx_t n = size(x);
 
     // quick return
     if( n <= 0 ) return 0;
 
     bool scaledsmax = false; // indicates whether |Re(x_i)| + |Im(x_i)| = Inf
-    real_t smax( -1.0f );
+    real_t smax( -1 );
     idx_t index = -1;
     idx_t i = 0;
     for (; i < n; ++i) {
@@ -127,14 +127,14 @@ iamax_nc( const vector_t& x )
     using real_t = real_type< T >;
 
     // constants
-    const real_t oneFourth( 0.25f );
+    const real_t oneFourth( 0.25 );
     const idx_t n = size(x);
 
     // quick return
     if( n <= 0 ) return 0;
 
     bool scaledsmax = false; // indicates whether |Re(x_i)| + |Im(x_i)| = Inf
-    real_t smax( -1.0f );
+    real_t smax( -1 );
     idx_t index = -1;
     idx_t i = 0;
     for (; i < n; ++i) {

--- a/include/tlapack/blas/rotg.hpp
+++ b/include/tlapack/blas/rotg.hpp
@@ -112,9 +112,8 @@ void rotg(
     typedef T scalar_t;
 
     // Constants
-    const real_t r_one = 1;
-    const real_t r_zero = 0;
-    const scalar_t zero = 0;
+    const real_t one(1);
+    const real_t zero(0);
 
     // Scaling constants
     const real_t safmin = safe_min<real_t>();
@@ -124,13 +123,13 @@ void rotg(
 
     // quick return
     if ( b == zero ) {
-        c = r_one;
+        c = one;
         s = zero;
         return;
     }
 
     if ( a == zero ) {
-        c = r_zero;
+        c = zero;
         real_t g1 = max( tlapack::abs(real(b)), tlapack::abs(imag(b)) );
         if ( g1 > rtmin && g1 < rtmax ) {
             // Use unscaled algorithm
@@ -142,7 +141,7 @@ void rotg(
         else {
             // Use scaled algorithm
             real_t u = min( safmax, max( safmin, g1 ) );
-            real_t uu = r_one / u;
+            real_t uu = one / u;
             scalar_t gs = b*uu;
             real_t g2 = real(gs)*real(gs) + imag(gs)*imag(gs);
             real_t d = sqrt( g2 );
@@ -162,7 +161,7 @@ void rotg(
             real_t d = ( f2 > rtmin && h2 < rtmax )
                        ? sqrt( f2*h2 )
                        : sqrt( f2 )*sqrt( h2 );
-            real_t p = r_one / d;
+            real_t p = one / d;
             c  = f2*p;
             s  = conj( b )*( a*p );
             a *= h2*p ;
@@ -170,7 +169,7 @@ void rotg(
         else {
             // Use scaled algorithm
             real_t u = min( safmax, max( safmin, f1, g1 ) );
-            real_t uu = r_one / u;
+            real_t uu = one / u;
             scalar_t gs = b*uu;
             real_t g2 = real(gs)*real(gs) + imag(gs)*imag(gs);
             real_t f2, h2, w;
@@ -178,7 +177,7 @@ void rotg(
             if ( f1*uu < rtmin ) {
                 // a is not well-scaled when scaled by g1.
                 real_t v = min( safmax, max( safmin, f1 ) );
-                real_t vv = r_one / v;
+                real_t vv = one / v;
                 w = v * uu;
                 fs = a*vv;
                 f2 = real(fs)*real(fs) + imag(fs)*imag(fs);
@@ -186,7 +185,7 @@ void rotg(
             }
             else {
                 // Otherwise use the same scaling for a and b.
-                w = r_one;
+                w = one;
                 fs = a*uu;
                 f2 = real(fs)*real(fs) + imag(fs)*imag(fs);
                 h2 = f2 + g2;
@@ -194,7 +193,7 @@ void rotg(
             real_t d = ( f2 > rtmin && h2 < rtmax )
                        ? sqrt( f2*h2 )
                        : sqrt( f2 )*sqrt( h2 );
-            real_t p = r_one / d;
+            real_t p = one / d;
             c = ( f2*p )*w;
             s = conj( gs )*( fs*p );
             a = ( fs*( h2*p ) )*u;

--- a/include/tlapack/blas/symm.hpp
+++ b/include/tlapack/blas/symm.hpp
@@ -96,7 +96,7 @@ void symm(
                 for(idx_t i = 0; i < m; ++i) {
 
                     auto alphaTimesBij = alpha*B(i,j);
-                    scalar_t sum( 0.0 );
+                    scalar_t sum( 0 );
 
                     for(idx_t k = 0; k < i; ++k) {
                         C(k,j) += A(k,i) * alphaTimesBij;
@@ -115,7 +115,7 @@ void symm(
                 for(idx_t i = m-1; i != idx_t(-1); --i) {
 
                     auto alphaTimesBij = alpha*B(i,j);
-                    scalar_t sum( 0.0 );
+                    scalar_t sum( 0 );
 
                     for(idx_t k = i+1; k < m; ++k) {
                         C(k,j) += A(k,i) * alphaTimesBij;

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -175,8 +175,8 @@ namespace tlapack
         using std::min;
 
         // Constants
-        const T one(1);
-        const T zero(0);
+        const real_t one(1);
+        const real_t zero(0);
         const idx_t n = ncols(A);
         // Because we will use the lower triangular part of A as workspace,
         // We have a maximum window size

--- a/include/tlapack/lapack/gehrd.hpp
+++ b/include/tlapack/lapack/gehrd.hpp
@@ -112,12 +112,13 @@ namespace tlapack
         using work_t    = matrix_type<matrix_t,vector_t>;
         using pair = pair<idx_t, idx_t>;
         using TA   = type_t< matrix_t >;
+        using real_t = real_type< TA >;
 
         // Functor
         Create<work_t> new_matrix;
 
         // constants
-        const TA one(1);
+        const real_t one(1);
         const idx_t n = ncols(A);
 
         // Blocksize

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -86,14 +86,13 @@ namespace tlapack
         Create< vector_type<matrix_t,matrix_t> > new_vector;
 
         // constants
-        const real_t rzero(0);
-        const TA one(1);
-        const TA zero(0);
+        const real_t zero(0);
+        const real_t one(1);
         const real_t eps = ulp<real_t>();
         const real_t small_num = safe_min<real_t>() / ulp<real_t>();
         const idx_t non_convergence_limit = 10;
-        const real_t dat1( 0.75f );
-        const real_t dat2( -0.4375f );
+        const real_t dat1( 0.75 );
+        const real_t dat2( -0.4375 );
 
         const idx_t n = ncols(A);
         const idx_t nh = ihi - ilo;
@@ -177,7 +176,7 @@ namespace tlapack
                 }
 
                 real_t tst = abs1(A(i - 1, i - 1)) + abs1(A(i, i));
-                if (tst == rzero)
+                if (tst == zero)
                 {
                     if (i >= ilo + 2)
                     {
@@ -286,7 +285,7 @@ namespace tlapack
             complex_type<real_t> s1;
             complex_type<real_t> s2;
             lahqr_eig22(a00, a01, a10, a11, s1, s2);
-            if ((imag(s1) == rzero and imag(s2) == rzero) or is_complex<TA>::value)
+            if ((imag(s1) == zero and imag(s2) == zero) or is_complex<TA>::value)
             {
                 // The eigenvalues are not complex conjugate, keep only the one closest to A(istop-1, istop-1)
                 if (abs1(s1 - A(istop - 1, istop - 1)) <= abs1(s2 - A(istop - 1, istop - 1)))
@@ -441,13 +440,12 @@ namespace tlapack
         using idx_t = size_type<matrix_t>;
 
         // constants
-        const real_t rzero(0);
-        const TA zero(0);
+        const real_t zero(0);
         const real_t eps = ulp<real_t>();
         const real_t small_num = safe_min<real_t>() / ulp<real_t>();
         const idx_t non_convergence_limit = 10;
-        const real_t dat1 = 3.0 / 4.0;
-        const real_t dat2 = -0.4375;
+        const real_t dat1( 0.75 );
+        const real_t dat2( -0.4375 );
 
         const idx_t n = ncols(A);
         const idx_t nh = ihi - ilo;
@@ -526,7 +524,7 @@ namespace tlapack
                 }
 
                 real_t tst = abs1(A(i - 1, i - 1)) + abs1(A(i, i));
-                if (tst == rzero)
+                if (tst == zero)
                 {
                     if (i >= ilo + 2)
                     {

--- a/include/tlapack/lapack/lahqr_eig22.hpp
+++ b/include/tlapack/lapack/lahqr_eig22.hpp
@@ -38,12 +38,11 @@ namespace tlapack
         using real_t = real_type<T>;
         
         // Constants
-        const real_t rzero(0);
+        const real_t zero(0);
         const real_t two(2);
-        const T zero(0);
 
         auto s = abs1(a00) + abs1(a01) + abs1(a10) + abs1(a11);
-        if (s == rzero)
+        if (s == zero)
         {
             s1 = zero;
             s2 = zero;

--- a/include/tlapack/lapack/lahqr_shiftcolumn.hpp
+++ b/include/tlapack/lapack/lahqr_shiftcolumn.hpp
@@ -48,7 +48,7 @@ namespace tlapack
       using TH    = type_t<matrix_t>;
       
       // Constants
-      idx_t n = ncols(H);
+      const idx_t n = ncols(H);
       const TH zero(0);
 
       // Check arguments
@@ -125,9 +125,8 @@ namespace tlapack
       using real_t = real_type<TH>;
   
       // Constants
-      idx_t n = ncols(H);
-      const real_t rzero(0);
-      const TH zero(0);
+      const idx_t n = ncols(H);
+      const real_t zero(0);
 
       // Check arguments
       tlapack_check_false((n != 2 and n != 3) );
@@ -137,7 +136,7 @@ namespace tlapack
       if (n == 2)
       {
          auto s = abs1(H(0, 0) - s2) + abs1(H(1, 0));
-         if (s == rzero)
+         if (s == zero)
          {
             v[0] = zero;
             v[1] = zero;
@@ -152,7 +151,7 @@ namespace tlapack
       else
       {
          auto s = abs1(H(0, 0) - s2) + abs1(H(1, 0)) + abs1(H(2, 0));
-         if (s == rzero)
+         if (s == zero)
          {
             v[0] = zero;
             v[1] = zero;

--- a/include/tlapack/lapack/lahr2.hpp
+++ b/include/tlapack/lapack/lahr2.hpp
@@ -59,18 +59,17 @@ namespace tlapack
         using TA = type_t<matrix_t>;
         using idx_t = size_type<matrix_t>;
         using pair = pair<idx_t, idx_t>;
-
+        using real_t = real_type<TA>;
                             
         // constants
-        const TA one(1);
-        const TA zero(0);
+        const real_t one(1);
         const idx_t n = nrows(A);
 
         // quick return if possible
         if (n <= 1)
             return 0;
 
-        TA ei = zero;
+        TA ei(0);
         for (idx_t i = 0; i < nb; ++i)
         {
             if (i > 0)

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -65,7 +65,7 @@ void larfg( alpha_t& alpha, vector_t& x, tau_t& tau )
     // constants
     const idx_t n = size(x) + 1;
     const real_t one( 1 );
-    const real_t rzero( 0 );
+    const real_t zero( 0 );
     const real_t safemin  = safe_min<real_t>() / uroundoff<real_t>();
     const real_t rsafemin = one / safemin;
 
@@ -74,12 +74,12 @@ void larfg( alpha_t& alpha, vector_t& x, tau_t& tau )
     {
         idx_t knt = 0;
         real_t xnorm = nrm2( x );
-        if ( xnorm > rzero || (imag(alpha) != rzero) )
+        if ( xnorm > zero || (imag(alpha) != zero) )
         {
             real_t temp = ( ! is_complex<alpha_t>::value )
                         ? lapy2(real(alpha), xnorm)
                         : lapy3(real(alpha), imag(alpha), xnorm);
-            real_t beta = (real(alpha) < rzero) ? temp : -temp;
+            real_t beta = (real(alpha) < zero) ? temp : -temp;
             if (abs(beta) < safemin)
             {
                 while( (abs(beta) < safemin) && (knt < 20) )
@@ -93,7 +93,7 @@ void larfg( alpha_t& alpha, vector_t& x, tau_t& tau )
                 temp = ( ! is_complex<alpha_t>::value )
                      ? lapy2(real(alpha), xnorm)
                      : lapy3(real(alpha), imag(alpha), xnorm);
-                beta = (real(alpha) < rzero) ? temp : -temp;
+                beta = (real(alpha) < zero) ? temp : -temp;
             }
             tau = (beta - alpha) / beta;
             scal( one/(alpha-beta), x );

--- a/include/tlapack/lapack/larft.hpp
+++ b/include/tlapack/lapack/larft.hpp
@@ -88,6 +88,7 @@ int larft(
 {
     // data traits
     using scalar_t  = type_t< matrixT_t >;
+    using real_t    = real_type<scalar_t>;
     using tau_t     = type_t< vector_t >;
     using idx_t     = size_type< matrixV_t >;
 
@@ -95,9 +96,8 @@ int larft(
     using pair = pair<idx_t,idx_t>;
 
     // constants
-    const scalar_t one(1);
-    const scalar_t zero(0);
-    const tau_t    tzero(0);
+    const real_t one(1);
+    const real_t zero(0);
     const idx_t n = (storeMode == StoreV::Columnwise) ? nrows( V ) : ncols( V );
     const idx_t k = size( tau );
 
@@ -143,7 +143,7 @@ int larft(
             // Column vector t := T(0:i,i)
             auto t = slice( T, pair{0,i}, i );
 
-            if (tau[i] == tzero) {
+            if (tau[i] == tau_t(0)) {
                 // H(i) =  I
                 for (idx_t j = 0; j < i; ++j)
                     t[j] = zero;
@@ -206,7 +206,7 @@ int larft(
             // Column vector t := T(0:i,i)
             auto t = slice( T, pair{i+1,k}, i );
 
-            if (tau[i] == tzero) {
+            if (tau[i] == tau_t(0)) {
                 // H(i) =  I
                 for (idx_t j = 0; j < k-i-1; ++j)
                     t[j] = zero;

--- a/include/tlapack/lapack/larnv.hpp
+++ b/include/tlapack/lapack/larnv.hpp
@@ -47,9 +47,9 @@ void larnv( Sseq& iseed, vector_t& x )
 
 
     // Constants
-    const idx_t n      = size(x);
-    const real_t one   = 1.0;
-    const real_t eight = 8.0;
+    const idx_t n = size(x);
+    const real_t one(1);
+    const real_t eight(8);
     const real_t twopi = eight * atan(one);
 
     // Initialize the Mersenne Twister generator

--- a/include/tlapack/lapack/lauum_recursive.hpp
+++ b/include/tlapack/lapack/lauum_recursive.hpp
@@ -83,8 +83,8 @@ namespace tlapack
                 auto C11 = slice(C, range(n0, n), range(n0, n));
 
                 lauum_recursive(uplo, C00);
-                herk(Uplo::Lower, Op::ConjTrans, real_t(1.0), C10, real_t(1.0), C00);
-                trmm(Side::Left, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1.0), C11, C10);
+                herk(Uplo::Lower, Op::ConjTrans, real_t(1), C10, real_t(1), C00);
+                trmm(Side::Left, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1), C11, C10);
                 lauum_recursive(uplo, C11);
 
             }
@@ -96,8 +96,8 @@ namespace tlapack
                 auto C11 = slice(C, range(n0, n), range(n0, n));
 
                 lauum_recursive(uplo, C00);
-                herk(Uplo::Upper, Op::NoTrans, real_t(1.0), C01, real_t(1.0), C00);
-                trmm(Side::Right, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1.0), C11, C01);
+                herk(Uplo::Upper, Op::NoTrans, real_t(1), C01, real_t(1), C00);
+                trmm(Side::Right, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1), C11, C01);
                 lauum_recursive(Uplo::Upper, C11);
 
             }

--- a/include/tlapack/lapack/move_bulge.hpp
+++ b/include/tlapack/lapack/move_bulge.hpp
@@ -41,7 +41,7 @@ namespace tlapack
 
         using idx_t = size_type<matrix_t>;
         using pair = std::pair<idx_t, idx_t>;
-        const T zero(0);
+        const real_t zero(0);
         const real_t eps = ulp<real_t>();
 
         Create<vector_t> new_vector;

--- a/include/tlapack/lapack/multishift_qr.hpp
+++ b/include/tlapack/lapack/multishift_qr.hpp
@@ -204,11 +204,11 @@ namespace tlapack
         using pair = std::pair<idx_t, idx_t>;
 
         // constants
-        const TA zero(0);
+        const real_t zero(0);
         const idx_t non_convergence_limit_window = 5;
         const idx_t non_convergence_limit_shift = 6;
-        const real_t dat1( 0.75f );
-        const real_t dat2( -0.4375f );
+        const real_t dat1( 0.75 );
+        const real_t dat2( -0.4375 );
 
         const idx_t n = ncols(A);
         const idx_t nh = ihi - ilo;

--- a/include/tlapack/lapack/potrf.hpp
+++ b/include/tlapack/lapack/potrf.hpp
@@ -80,7 +80,7 @@ int potrf(
     using std::min;
 
     // Constants
-    const real_t one( 1.0 );
+    const real_t one( 1 );
     const idx_t n  = nrows(A);
     const idx_t nb = opts.nb;
 

--- a/include/tlapack/lapack/potrf2.hpp
+++ b/include/tlapack/lapack/potrf2.hpp
@@ -77,8 +77,8 @@ int potrf2( uplo_t uplo, matrix_t& A, const ec_opts_t& opts = {} )
     using pair   = pair<idx_t,idx_t>;
 
     // Constants
-    const real_t one( 1.0 );
-    const real_t rzero( 0.0 );
+    const real_t one( 1 );
+    const real_t zero( 0 );
     const idx_t n = nrows(A);
 
     // check arguments
@@ -94,7 +94,7 @@ int potrf2( uplo_t uplo, matrix_t& A, const ec_opts_t& opts = {} )
     // Stop recursion
     else if (n == 1) {
         const real_t a00 = real( A(0,0) );
-        if( a00 > rzero ) {
+        if( a00 > zero ) {
             A(0,0) = sqrt( a00 );
             return 0;
         }

--- a/include/tlapack/lapack/potrs.hpp
+++ b/include/tlapack/lapack/potrs.hpp
@@ -54,9 +54,10 @@ template< class uplo_t, class matrixA_t, class matrixB_t >
 int potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
 {
     using T = type_t< matrixB_t >;
+    using real_t = real_type< T >;
 
     // Constants
-    const T one( 1.0 );
+    const real_t one( 1 );
 
     // Check arguments
     tlapack_check_false(    uplo != Uplo::Lower &&

--- a/include/tlapack/lapack/schur_move.hpp
+++ b/include/tlapack/lapack/schur_move.hpp
@@ -48,9 +48,10 @@ namespace tlapack
     {
         using idx_t = size_type<matrix_t>;
         using T = type_t<matrix_t>;
+        using real_t = real_type<T>;
 
         const idx_t n = ncols(A);
-        const T zero(0);
+        const real_t zero(0);
 
         // Quick return
         if (n == 0)

--- a/include/tlapack/lapack/trtri_recursive.hpp
+++ b/include/tlapack/lapack/trtri_recursive.hpp
@@ -53,8 +53,7 @@ namespace tlapack
         using real_t = real_type<T>;
 
         const idx_t n = nrows(C);
-
-        const T zero(0.0);
+        const real_t zero(0);
 
         // check arguments
         tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -72,12 +72,13 @@ int ung2r(
     size_type< matrix_t > k, matrix_t& A, const vector_t &tau, const workspace_opts_t<>& opts = {} )
 {
     using T      = type_t< matrix_t >;
+    using real_t = real_type< T >;
     using idx_t  = size_type< matrix_t >;
     using pair  = pair<idx_t,idx_t>;
     
     // constants
-    const T zero( 0.0 );
-    const T one ( 1.0 );
+    const real_t zero( 0 );
+    const real_t one ( 1 );
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 

--- a/include/tlapack/lapack/unghr.hpp
+++ b/include/tlapack/lapack/unghr.hpp
@@ -39,12 +39,13 @@ int unghr(
     const workspace_opts_t<>& opts = {} )
 {
     using T      = type_t< matrix_t >;
+    using real_t = real_type< T >;
     using idx_t  = size_type< matrix_t >;
     using pair  = pair<idx_t,idx_t>;
     
     // constants
-    const T zero( 0.0 );
-    const T one ( 1.0 );
+    const real_t zero( 0 );
+    const real_t one ( 1 );
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
     const idx_t nh = ihi > ilo +1 ? ihi-1-ilo : 0;

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE("sylvester solver gives correct result", "[sylvester]", TLAPA
     // Once 1x2 solver is finished, generate n2 independantly
     idx_t n2 = n1;
     const real_t eps = uroundoff<real_t>();
-    const real_t tol = real_t(1.0e2f) * eps;
+    const real_t tol = real_t(1.0e2) * eps;
 
     std::vector<T> TL_; auto TL = new_matrix( TL_, n1, n1 );
     std::vector<T> TR_; auto TR = new_matrix( TR_, n2, n2 );


### PR DESCRIPTION
One old discussion in the development team was:

Should we try to adopt a standard like `rzero` is the constant 0 with real type?
Then we name the variable `zero`, meaning it can have a complex type.

It turns out that, if we use `std::complex<real_t>` as the complex type, then we don't need to make any distinction. This is because
1. `std::complex<real_t>` operates with `real_t`, and
2. `std::complex<real_t>` have a constructor receiving `real_t`.

This PR highlights the assumption: a complex type should satisfy (1) and (2) to be used within \<T\>LAPACK routines. The routines in the master branch are already using those premises.