### PR TITLE
Try establishing clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+# AccessModifierOffset: -1
+# AlignAfterOpenBracket: Align
+# AlignConsecutiveMacros: false
+# AlignConsecutiveAssignments: false
+# AlignConsecutiveDeclarations: false
+# AlignEscapedNewlines: Left
+# AlignOperands:   true
+# AlignTrailingComments: true
+# AllowAllArgumentsOnNextLine: true
+# AllowAllConstructorInitializersOnNextLine: true
+# AllowAllParametersOfDeclarationOnNextLine: true
+# AllowShortBlocksOnASingleLine: Never
+# AllowShortCaseLabelsOnASingleLine: false
+# AllowShortFunctionsOnASingleLine: All
+# AllowShortLambdasOnASingleLine: All
+# AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: false
+# AlwaysBreakAfterDefinitionReturnType: None
+# AlwaysBreakAfterReturnType: None
+# AlwaysBreakBeforeMultilineStrings: true
+# AlwaysBreakTemplateDeclarations: Yes
+# BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+# BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+# BreakBeforeInheritanceComma: false
+# BreakInheritanceList: BeforeColon
+# BreakBeforeTernaryOperators: true
+# BreakConstructorInitializersBeforeComma: false
+# BreakConstructorInitializers: BeforeColon
+# BreakAfterJavaFieldAnnotations: false
+# BreakStringLiterals: true
+# ColumnLimit:     80
+# CommentPragmas:  '^ IWYU pragma:'
+# CompactNamespaces: false
+# ConstructorInitializerAllOnOneLineOrOnePerLine: true
+# ConstructorInitializerIndentWidth: 4
+# ContinuationIndentWidth: 4
+# Cpp11BracedListStyle: true
+# DeriveLineEnding: true
+DerivePointerAlignment: false
+# DisableFormat:   false
+# ExperimentalAutoDetectBinPacking: false
+# FixNamespaceComments: true
+# ForEachMacros:
+#   - foreach
+#   - Q_FOREACH
+#   - BOOST_FOREACH
+# IncludeBlocks:   Regroup
+# IncludeCategories:
+#   - Regex:           '^<ext/.*\.h>'
+#     Priority:        2
+#     SortPriority:    0
+#   - Regex:           '^<.*\.h>'
+#     Priority:        1
+#     SortPriority:    0
+#   - Regex:           '^<.*'
+#     Priority:        2
+#     SortPriority:    0
+#   - Regex:           '.*'
+#     Priority:        3
+#     SortPriority:    0
+# IncludeIsMainRegex: '([-_](test|unittest))?$'
+# IncludeIsMainSourceRegex: ''
+# IndentCaseLabels: true
+# IndentGotoLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth:     4
+# IndentWrappedFunctionNames: false
+# JavaScriptQuotes: Leave
+# JavaScriptWrapImports: true
+# KeepEmptyLinesAtTheStartOfBlocks: false
+# MacroBlockBegin: ''
+# MacroBlockEnd:   ''
+# MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+# ObjCBinPackProtocolList: Never
+# ObjCBlockIndentWidth: 2
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: true
+# PenaltyBreakAssignment: 2
+# PenaltyBreakBeforeFirstCallParameter: 1
+# PenaltyBreakComment: 300
+# PenaltyBreakFirstLessLess: 120
+# PenaltyBreakString: 1000
+# PenaltyBreakTemplateDeclaration: 10
+# PenaltyExcessCharacter: 1000000
+# PenaltyReturnTypeOnItsOwnLine: 200
+# PointerAlignment: Left
+# RawStringFormats:
+#   - Language:        Cpp
+#     Delimiters:
+#       - cc
+#       - CC
+#       - cpp
+#       - Cpp
+#       - CPP
+#       - 'c++'
+#       - 'C++'
+#     CanonicalDelimiter: ''
+#     BasedOnStyle:    google
+#   - Language:        TextProto
+#     Delimiters:
+#       - pb
+#       - PB
+#       - proto
+#       - PROTO
+#     EnclosingFunctions:
+#       - EqualsProto
+#       - EquivToProto
+#       - PARSE_PARTIAL_TEXT_PROTO
+#       - PARSE_TEST_PROTO
+#       - PARSE_TEXT_PROTO
+#       - ParseTextOrDie
+#       - ParseTextProtoOrDie
+#     CanonicalDelimiter: ''
+#     BasedOnStyle:    google
+# ReflowComments:  true
+# SortIncludes:    true
+# SortUsingDeclarations: true
+# SpaceAfterCStyleCast: false
+# SpaceAfterLogicalNot: false
+# SpaceAfterTemplateKeyword: true
+# SpaceBeforeAssignmentOperators: true
+# SpaceBeforeCpp11BracedList: false
+# SpaceBeforeCtorInitializerColon: true
+# SpaceBeforeInheritanceColon: true
+# SpaceBeforeParens: ControlStatements
+# SpaceBeforeRangeBasedForLoopColon: true
+# SpaceInEmptyBlock: false
+# SpaceInEmptyParentheses: false
+# SpacesBeforeTrailingComments: 2
+# SpacesInAngles:  false
+# SpacesInConditionalStatement: false
+# SpacesInContainerLiterals: true
+# SpacesInCStyleCastParentheses: false
+# SpacesInParentheses: false
+# SpacesInSquareBrackets: false
+# SpaceBeforeSquareBrackets: false
+# Standard:        Auto
+# StatementMacros:
+#   - Q_UNUSED
+#   - QT_REQUIRE_VERSION
+# TabWidth:        8
+# UseCRLF:         false
+# UseTab:          Never
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,28 +1,28 @@
 ---
 Language:        Cpp
-BasedOnStyle:  Google
-# AccessModifierOffset: -1
-# AlignAfterOpenBracket: Align
-# AlignConsecutiveMacros: false
-# AlignConsecutiveAssignments: false
-# AlignConsecutiveDeclarations: false
-# AlignEscapedNewlines: Left
-# AlignOperands:   true
-# AlignTrailingComments: true
-# AllowAllArgumentsOnNextLine: true
-# AllowAllConstructorInitializersOnNextLine: true
-# AllowAllParametersOfDeclarationOnNextLine: true
-# AllowShortBlocksOnASingleLine: Never
-# AllowShortCaseLabelsOnASingleLine: false
-# AllowShortFunctionsOnASingleLine: All
-# AllowShortLambdasOnASingleLine: All
-# AllowShortIfStatementsOnASingleLine: WithoutElse
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: false
-# AlwaysBreakAfterDefinitionReturnType: None
-# AlwaysBreakAfterReturnType: None
-# AlwaysBreakBeforeMultilineStrings: true
-# AlwaysBreakTemplateDeclarations: Yes
-# BinPackArguments: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
 BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
@@ -41,128 +41,128 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-# BreakBeforeBinaryOperators: None
+BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
-# BreakBeforeInheritanceComma: false
-# BreakInheritanceList: BeforeColon
-# BreakBeforeTernaryOperators: true
-# BreakConstructorInitializersBeforeComma: false
-# BreakConstructorInitializers: BeforeColon
-# BreakAfterJavaFieldAnnotations: false
-# BreakStringLiterals: true
-# ColumnLimit:     80
-# CommentPragmas:  '^ IWYU pragma:'
-# CompactNamespaces: false
-# ConstructorInitializerAllOnOneLineOrOnePerLine: true
-# ConstructorInitializerIndentWidth: 4
-# ContinuationIndentWidth: 4
-# Cpp11BracedListStyle: true
-# DeriveLineEnding: true
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: false
-# DisableFormat:   false
-# ExperimentalAutoDetectBinPacking: false
-# FixNamespaceComments: true
-# ForEachMacros:
-#   - foreach
-#   - Q_FOREACH
-#   - BOOST_FOREACH
-# IncludeBlocks:   Regroup
-# IncludeCategories:
-#   - Regex:           '^<ext/.*\.h>'
-#     Priority:        2
-#     SortPriority:    0
-#   - Regex:           '^<.*\.h>'
-#     Priority:        1
-#     SortPriority:    0
-#   - Regex:           '^<.*'
-#     Priority:        2
-#     SortPriority:    0
-#   - Regex:           '.*'
-#     Priority:        3
-#     SortPriority:    0
-# IncludeIsMainRegex: '([-_](test|unittest))?$'
-# IncludeIsMainSourceRegex: ''
-# IndentCaseLabels: true
-# IndentGotoLabels: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
 IndentPPDirectives: BeforeHash
 IndentWidth:     4
-# IndentWrappedFunctionNames: false
-# JavaScriptQuotes: Leave
-# JavaScriptWrapImports: true
-# KeepEmptyLinesAtTheStartOfBlocks: false
-# MacroBlockBegin: ''
-# MacroBlockEnd:   ''
-# MaxEmptyLinesToKeep: 1
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
 NamespaceIndentation: Inner
-# ObjCBinPackProtocolList: Never
-# ObjCBlockIndentWidth: 2
-# ObjCSpaceAfterProperty: false
-# ObjCSpaceBeforeProtocolList: true
-# PenaltyBreakAssignment: 2
-# PenaltyBreakBeforeFirstCallParameter: 1
-# PenaltyBreakComment: 300
-# PenaltyBreakFirstLessLess: 120
-# PenaltyBreakString: 1000
-# PenaltyBreakTemplateDeclaration: 10
-# PenaltyExcessCharacter: 1000000
-# PenaltyReturnTypeOnItsOwnLine: 200
-# PointerAlignment: Left
-# RawStringFormats:
-#   - Language:        Cpp
-#     Delimiters:
-#       - cc
-#       - CC
-#       - cpp
-#       - Cpp
-#       - CPP
-#       - 'c++'
-#       - 'C++'
-#     CanonicalDelimiter: ''
-#     BasedOnStyle:    google
-#   - Language:        TextProto
-#     Delimiters:
-#       - pb
-#       - PB
-#       - proto
-#       - PROTO
-#     EnclosingFunctions:
-#       - EqualsProto
-#       - EquivToProto
-#       - PARSE_PARTIAL_TEXT_PROTO
-#       - PARSE_TEST_PROTO
-#       - PARSE_TEXT_PROTO
-#       - ParseTextOrDie
-#       - ParseTextProtoOrDie
-#     CanonicalDelimiter: ''
-#     BasedOnStyle:    google
-# ReflowComments:  true
-# SortIncludes:    true
-# SortUsingDeclarations: true
-# SpaceAfterCStyleCast: false
-# SpaceAfterLogicalNot: false
-# SpaceAfterTemplateKeyword: true
-# SpaceBeforeAssignmentOperators: true
-# SpaceBeforeCpp11BracedList: false
-# SpaceBeforeCtorInitializerColon: true
-# SpaceBeforeInheritanceColon: true
-# SpaceBeforeParens: ControlStatements
-# SpaceBeforeRangeBasedForLoopColon: true
-# SpaceInEmptyBlock: false
-# SpaceInEmptyParentheses: false
-# SpacesBeforeTrailingComments: 2
-# SpacesInAngles:  false
-# SpacesInConditionalStatement: false
-# SpacesInContainerLiterals: true
-# SpacesInCStyleCastParentheses: false
-# SpacesInParentheses: false
-# SpacesInSquareBrackets: false
-# SpaceBeforeSquareBrackets: false
-# Standard:        Auto
-# StatementMacros:
-#   - Q_UNUSED
-#   - QT_REQUIRE_VERSION
-# TabWidth:        8
-# UseCRLF:         false
-# UseTab:          Never
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
 ...
 

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,40 @@
+name: clang-format Check
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+      - '**.h.in'
+      - '**.c'
+  pull_request:
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+      - '**.h.in'
+      - '**.c'
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - 'config'
+          - 'examples'
+          - 'include'
+          - 'src'
+          - 'test/include'
+          - 'test/src'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v4.10.1
+      with:
+        clang-format-version: '10'
+        check-path: ${{ matrix.path }}
+        include-regex: '^.*\.(hpp|cpp|h\.in|c)$'
+        fallback-style: 'Google'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
     - '.github/workflows/deploy_pages.yml'
     - '.github/workflows/doxygen.yml'
+    - '.github/workflows/clang-format-check.yml'
     - '.gitattributes'
     - '.gitignore'
     - '.gitmodules'
@@ -19,6 +20,7 @@ on:
     paths-ignore:
     - '.github/workflows/deploy_pages.yml'
     - '.github/workflows/doxygen.yml'
+    - '.github/workflows/clang-format-check.yml'
     - '.gitattributes'
     - '.gitignore'
     - '.gitmodules'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,12 +200,17 @@ add_subdirectory(config)
 #-------------------------------------------------------------------------------
 # Format code
 find_package(Git QUIET)
-if(GIT_FOUND)
+find_package(ClangFormat QUIET)
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git" AND CLANG_FORMAT_FOUND)
+  message(STATUS "ClangFormat found: ${CLANG_FORMAT_EXECUTABLE} (version ${CLANG_FORMAT_VERSION})")
+  if( ${CLANG_FORMAT_MAJOR_VERSION} NOT EQUAL 10 )
+    message( WARNING "Please use ClangFormat version 10" )
+  endif()
   add_custom_target( format-all-hpp-cpp-files
     COMMAND
       ${GIT_EXECUTABLE} ls-tree -r HEAD --name-only |
       grep -E '\(config/|examples/|include/|src/|test/include/|test/src/\).*\\.\(hpp|cpp|h.in|c\)$$' |
-      xargs clang-format -i -style=file
+      xargs ${CLANG_FORMAT_EXECUTABLE} -i -style=file
       > format-all-hpp-cpp-files.log
       2> format-all-hpp-cpp-files.err
     WORKING_DIRECTORY ${TLAPACK_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,22 +199,18 @@ add_subdirectory(config)
 
 #-------------------------------------------------------------------------------
 # Format code
-add_custom_target( format-all-hpp-cpp-files
-  COMMAND find
-    ${TLAPACK_SOURCE_DIR}/config
-    ${TLAPACK_SOURCE_DIR}/examples
-    ${TLAPACK_SOURCE_DIR}/include
-    ${TLAPACK_SOURCE_DIR}/src
-    ${TLAPACK_SOURCE_DIR}/test/include
-    ${TLAPACK_SOURCE_DIR}/test/src
-    -iname '*.hpp' -not -path '*build*' -o
-    -iname '*.cpp' -not -path '*build*' -o
-    -iname '*.h.in' -not -path '*build*' -o
-    -iname '*.c' -not -path '*build*' |
-    xargs clang-format -i -style=file
-    > ${TLAPACK_SOURCE_DIR}/format-all-hpp-cpp-files.log
-    2> ${TLAPACK_SOURCE_DIR}/format-all-hpp-cpp-files.err
-)
+find_package(Git QUIET)
+if(GIT_FOUND)
+  add_custom_target( format-all-hpp-cpp-files
+    COMMAND
+      ${GIT_EXECUTABLE} ls-tree -r HEAD --name-only |
+      grep -E '\(config/|examples/|include/|src/|test/include/|test/src/\).*\\.\(hpp|cpp|h.in|c\)$$' |
+      xargs clang-format -i -style=file
+      > format-all-hpp-cpp-files.log
+      2> format-all-hpp-cpp-files.err
+    WORKING_DIRECTORY ${TLAPACK_SOURCE_DIR}
+  )
+endif()
 
 #-------------------------------------------------------------------------------
 # C and Fortran wrappers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,25 @@ add_subdirectory(docs)
 add_subdirectory(config)
 
 #-------------------------------------------------------------------------------
+# Format code
+add_custom_target( format-all-hpp-cpp-files
+  COMMAND find
+    ${TLAPACK_SOURCE_DIR}/config
+    ${TLAPACK_SOURCE_DIR}/examples
+    ${TLAPACK_SOURCE_DIR}/include
+    ${TLAPACK_SOURCE_DIR}/src
+    ${TLAPACK_SOURCE_DIR}/test/include
+    ${TLAPACK_SOURCE_DIR}/test/src
+    -iname '*.hpp' -not -path '*build*' -o
+    -iname '*.cpp' -not -path '*build*' -o
+    -iname '*.h.in' -not -path '*build*' -o
+    -iname '*.c' -not -path '*build*' |
+    xargs clang-format -i -style=file
+    > ${TLAPACK_SOURCE_DIR}/format-all-hpp-cpp-files.log
+    2> ${TLAPACK_SOURCE_DIR}/format-all-hpp-cpp-files.err
+)
+
+#-------------------------------------------------------------------------------
 # C and Fortran wrappers
 
 if( BUILD_C_WRAPPERS OR BUILD_CBLAS_WRAPPERS OR BUILD_Fortran_WRAPPERS )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thank you for investing your precious time to contribute to \<T\>LAPACK! Please 
 
 ## Code style
 
+\<T\>LAPACK uses [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to enforce a consistent code style. The configuration file is located at [`.clang-format`](.clang-format). The code style is based on the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and the differences are marked in the configuration file. Make sure you have ClangFormat set up and running properly before marking your pull request as ready for review. You should never modify the [`.clang-format`](.clang-format) file in \<T\>LAPACK, unless this is the reason behind your pull request.
+
 ### Usage of the `auto` keyword
 
 In C++ all types are evaluated at compile time. The `auto` keyword is used to enable the compiler to deduce the type of a variable automatically. For instance, the instructions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,11 @@ Thank you for investing your precious time to contribute to \<T\>LAPACK! Please 
 
 ## Code style
 
-\<T\>LAPACK uses [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to enforce a consistent code style. The configuration file is located at [`.clang-format`](.clang-format). The code style is based on the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and the differences are marked in the configuration file. Make sure you have ClangFormat set up and running properly before marking your pull request as ready for review. You should never modify the [`.clang-format`](.clang-format) file in \<T\>LAPACK, unless this is the reason behind your pull request.
+### Automatic code formatting
+
+\<T\>LAPACK uses [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) (version 10) to enforce a consistent code style. The configuration file is located at [`.clang-format`](.clang-format). The code style is based on the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and the differences are marked in the configuration file. You should never modify the [`.clang-format`](.clang-format) file in \<T\>LAPACK, unless this is the reason behind your pull request.
+
+To format code you are adding or modifying, we suggest using the [git-clang-format](https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/git-clang-format) script that is distributed together with ClangFormat. Use `git clang-format` to format the code that was modified or added before a commit. You can use `git-clang-format --help` to access all options. Mind that one of the tests in the Continuous Integration checks that the code is properly formatted.
 
 ### Usage of the `auto` keyword
 

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -1,0 +1,86 @@
+#
+# .rst: FindClangFormat
+# ---------------
+#
+# The module defines the following variables
+#
+# ``CLANG_FORMAT_EXECUTABLE`` Path to clang-format executable
+# ``CLANG_FORMAT_FOUND`` True if the clang-format executable was found.
+# ``CLANG_FORMAT_VERSION`` The version of clang-format found
+# ``CLANG_FORMAT_VERSION_MAJOR`` The clang-format major version if specified, 0
+# otherwise ``CLANG_FORMAT_VERSION_MINOR`` The clang-format minor version if
+# specified, 0 otherwise ``CLANG_FORMAT_VERSION_PATCH`` The clang-format patch
+# version if specified, 0 otherwise ``CLANG_FORMAT_VERSION_COUNT`` Number of
+# version components reported by clang-format
+#
+# Example usage:
+#
+# .. code-block:: cmake
+#
+# find_package(ClangFormat) if(CLANG_FORMAT_FOUND) message("clang-format
+# executable found: ${CLANG_FORMAT_EXECUTABLE}\n" "version:
+# ${CLANG_FORMAT_VERSION}") endif()
+
+find_program(CLANG_FORMAT_EXECUTABLE
+             NAMES clang-format-10  # First option will be searched first
+                   clang-format
+                   clang-format-7
+                   clang-format-6.0
+                   clang-format-5.0
+                   clang-format-4.0
+                   clang-format-3.9
+                   clang-format-3.8
+                   clang-format-3.7
+                   clang-format-3.6
+                   clang-format-3.5
+                   clang-format-3.4
+                   clang-format-3.3
+             DOC "clang-format executable")
+mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
+
+# Extract version from command "clang-format -version"
+if(CLANG_FORMAT_EXECUTABLE)
+  execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
+                  OUTPUT_VARIABLE clang_format_version
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(clang_format_version MATCHES "^clang-format version .*")
+    # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
+    # (tags/RELEASE_391/rc2)"
+    string(REGEX
+           REPLACE "clang-format version ([.0-9]+).*"
+                   "\\1"
+                   CLANG_FORMAT_VERSION
+                   "${clang_format_version}")
+    # CLANG_FORMAT_VERSION sample: "3.9.1"
+
+    # Extract version components
+    string(REPLACE "."
+                   ";"
+                   clang_format_version
+                   "${CLANG_FORMAT_VERSION}")
+    list(LENGTH clang_format_version CLANG_FORMAT_VERSION_COUNT)
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 0)
+      list(GET clang_format_version 0 CLANG_FORMAT_VERSION_MAJOR)
+    else()
+      set(CLANG_FORMAT_VERSION_MAJOR 0)
+    endif()
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 1)
+      list(GET clang_format_version 1 CLANG_FORMAT_VERSION_MINOR)
+    else()
+      set(CLANG_FORMAT_VERSION_MINOR 0)
+    endif()
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 2)
+      list(GET clang_format_version 2 CLANG_FORMAT_VERSION_PATCH)
+    else()
+      set(CLANG_FORMAT_VERSION_PATCH 0)
+    endif()
+  endif()
+  unset(clang_format_version)
+endif()
+
+if(CLANG_FORMAT_EXECUTABLE)
+  set(CLANG_FORMAT_FOUND TRUE)
+else()
+  set(CLANG_FORMAT_FOUND FALSE)
+endif()

--- a/config/version.cpp
+++ b/config/version.cpp
@@ -7,15 +7,14 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <iostream>
 #include "version.h"
 
-int main(int argc, char const *argv[])
+#include <iostream>
+
+int main(int argc, char const* argv[])
 {
-    std::cout << "<T>LAPACK version "
-    << TLAPACK_VERSION_MAJOR << "."
-    << TLAPACK_VERSION_MINOR << "."
-    << TLAPACK_VERSION_PATCH
-    << std::endl;
+    std::cout << "<T>LAPACK version " << TLAPACK_VERSION_MAJOR << "."
+              << TLAPACK_VERSION_MINOR << "." << TLAPACK_VERSION_PATCH
+              << std::endl;
     return 0;
 }

--- a/config/version.h.in
+++ b/config/version.h.in
@@ -11,9 +11,11 @@
 #define TLAPACK_VERSION_H
 
 // the configured options and settings for <T>LAPACK
+// clang-format off
 #define TLAPACK_VERSION @TLAPACK_VERSION@
 #define TLAPACK_VERSION_MAJOR @TLAPACK_VERSION_MAJOR@
 #define TLAPACK_VERSION_MINOR @TLAPACK_VERSION_MINOR@
 #define TLAPACK_VERSION_PATCH @TLAPACK_VERSION_PATCH@
+// clang-format on
 
-#endif // TLAPACK_VERSION_H
+#endif  // TLAPACK_VERSION_H

--- a/examples/access_types/example_accessTypes.cpp
+++ b/examples/access_types/example_accessTypes.cpp
@@ -10,11 +10,15 @@
 #undef TLAPACK_ERROR_NDEBUG
 #undef NDEBUG
 
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #include <tlapack/plugins/legacyArray.hpp>
+
+// <T>LAPACK
 #include <tlapack/lapack/lascl.hpp>
 
-#include <vector>
+// C++ headers
 #include <iostream>
+#include <vector>
 
 using namespace tlapack;
 

--- a/examples/access_types/example_accessTypes.cpp
+++ b/examples/access_types/example_accessTypes.cpp
@@ -25,25 +25,25 @@ using namespace tlapack;
 //------------------------------------------------------------------------------
 /// Print matrix A in the standard output
 template <typename matrix_t>
-inline void printMatrix( const matrix_t& A )
+inline void printMatrix(const matrix_t& A)
 {
-    using idx_t = size_type< matrix_t >;
+    using idx_t = size_type<matrix_t>;
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     for (idx_t i = 0; i < m; ++i) {
         std::cout << std::endl;
         for (idx_t j = 0; j < n; ++j)
-            std::cout << A(i,j) << " ";
+            std::cout << A(i, j) << " ";
     }
 }
 
 //------------------------------------------------------------------------------
 /// Print banded matrix A in the standard output
 template <typename matrix_t>
-inline void printBandedMatrix( const matrix_t& A )
+inline void printBandedMatrix(const matrix_t& A)
 {
-    using idx_t = size_type< matrix_t >;
+    using idx_t = size_type<matrix_t>;
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
     const idx_t kl = lowerband(A);
@@ -52,110 +52,112 @@ inline void printBandedMatrix( const matrix_t& A )
     for (idx_t i = 0; i < m; ++i) {
         std::cout << std::endl;
         for (idx_t j = 0; j < n; ++j)
-            std::cout << (( i <= kl+j && j <= ku+i ) ? A(i,j) : 0 ) << " ";
+            std::cout << ((i <= kl + j && j <= ku + i) ? A(i, j) : 0) << " ";
     }
 }
 
 //------------------------------------------------------------------------------
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     int m = 5, n = 4;
 
     // Raw data 1:
-    std::vector<int> data1(m*n);
-    for (int i = 0; i < m*n; ++i)
-        data1[i] = i+1;
+    std::vector<int> data1(m * n);
+    for (int i = 0; i < m * n; ++i)
+        data1[i] = i + 1;
 
     // Matrix 1
-    legacyMatrix<int,size_t,Layout::RowMajor> A1( m, n, &data1[0], n );
+    legacyMatrix<int, size_t, Layout::RowMajor> A1(m, n, &data1[0], n);
     printMatrix(A1);
     std::cout << std::endl;
 
     // Raw data 2:
-    std::vector<int> data2(m*n);
-    for (int i = 0; i < m*n; ++i)
+    std::vector<int> data2(m * n);
+    for (int i = 0; i < m * n; ++i)
         data2[i] = data1[i];
 
     // Matrix 2
-    legacyMatrix<int,size_t,Layout::RowMajor> A2( m, n, &data2[0], n );
+    legacyMatrix<int, size_t, Layout::RowMajor> A2(m, n, &data2[0], n);
 
     // Scale all matrix by 3
-    lascl( dense, 1.0, 3.0, A1 );
+    lascl(dense, 1.0, 3.0, A1);
     printMatrix(A1);
     std::cout << std::endl;
 
     // Scale upper triangle by 1/3
-    lascl( upperTriangle, 3.0, 1.0, A1 );
+    lascl(upperTriangle, 3.0, 1.0, A1);
     printMatrix(A1);
     std::cout << std::endl;
 
     // Scale strict lower triangle by 1/3
-    lascl( strictLower, 3.0, 1.0, A1 );
+    lascl(strictLower, 3.0, 1.0, A1);
     printMatrix(A1);
     std::cout << std::endl;
 
     // Test we return to the initial configuration
     bool goodResult = true;
-    for (int i = 0; i < m*n; ++i)
+    for (int i = 0; i < m * n; ++i)
         goodResult = goodResult && (data2[i] == data1[i]);
 
     std::cout << std::endl;
-    std::cout << "Scaling well? " << (goodResult ? "True" : "False") << std::endl;
+    std::cout << "Scaling well? " << (goodResult ? "True" : "False")
+              << std::endl;
 
     // Matrix 3
-    legacyBandedMatrix<int> A3( m, m, n/2, n-n/2-1, &data1[0] );
+    legacyBandedMatrix<int> A3(m, m, n / 2, n - n / 2 - 1, &data1[0]);
     printBandedMatrix(A3);
     std::cout << std::endl;
 
     try {
-        lascl( dense, 1.0, 3.0, A3 );
+        lascl(dense, 1.0, 3.0, A3);
         printBandedMatrix(A3);
         std::cout << std::endl;
     }
-    catch( const tlapack::check_error& e ) {
+    catch (const tlapack::check_error& e) {
         std::cout << std::endl;
         std::cout << "Generates access error as predicted" << std::endl;
         std::cerr << e.what() << std::endl;
     }
 
     try {
-        lascl( MatrixAccessPolicy::UpperHessenberg, 1.0, 3.0, A3 );
+        lascl(MatrixAccessPolicy::UpperHessenberg, 1.0, 3.0, A3);
         printBandedMatrix(A3);
         std::cout << std::endl;
     }
-    catch( const tlapack::check_error& e ) {
+    catch (const tlapack::check_error& e) {
         std::cout << std::endl;
         std::cout << "Generates access error as predicted" << std::endl;
         std::cerr << e.what() << std::endl;
     }
 
     // Scale all matrix by 3
-    lascl( band_t( n/2, n-n/2-1 ), 1.0, 3.0, A3 );
+    lascl(band_t(n / 2, n - n / 2 - 1), 1.0, 3.0, A3);
     printBandedMatrix(A3);
     std::cout << std::endl;
 
     // Scale lower band by 1/3
-    lascl( band_t( n/2, 0 ), 3.0, 1.0, A3 );
+    lascl(band_t(n / 2, 0), 3.0, 1.0, A3);
     printBandedMatrix(A3);
     std::cout << std::endl;
 
     // Scale main diagonal by 3
-    lascl( band_t( 0, 0 ), 1.0, 3.0, A3 );
+    lascl(band_t(0, 0), 1.0, 3.0, A3);
     printBandedMatrix(A3);
     std::cout << std::endl;
 
     // Scale upper band by 1/3
-    lascl( band_t( 0, n-n/2-1 ), 3.0, 1.0, A3 );
+    lascl(band_t(0, n - n / 2 - 1), 3.0, 1.0, A3);
     printBandedMatrix(A3);
     std::cout << std::endl;
 
     // Test we return to the initial configuration
     bool goodResult2 = true;
-    for (int i = 0; i < m*n; ++i)
+    for (int i = 0; i < m * n; ++i)
         goodResult2 = goodResult2 && (data2[i] == data1[i]);
 
     std::cout << std::endl;
-    std::cout << "Scaling well? " << (goodResult2 ? "True" : "False") << std::endl;
+    std::cout << "Scaling well? " << (goodResult2 ? "True" : "False")
+              << std::endl;
 
     return !(goodResult && goodResult2);
 }

--- a/examples/cpp_visualizer/cpp_visualizer_example.cpp
+++ b/examples/cpp_visualizer/cpp_visualizer_example.cpp
@@ -7,14 +7,18 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <tlapack/plugins/legacyArray.hpp>
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #include <tlapack/plugins/debugutils.hpp>
+#include <tlapack/plugins/legacyArray.hpp>
+
+// <T>LAPACK
 #include <tlapack/lapack/laset.hpp>
 
+// C++ headers
+#include <chrono>  // for high_resolution_clock
+#include <iostream>
 #include <memory>
 #include <vector>
-#include <chrono> // for high_resolution_clock
-#include <iostream>
 
 //------------------------------------------------------------------------------
 int main(int argc, char **argv)

--- a/examples/cpp_visualizer/cpp_visualizer_example.cpp
+++ b/examples/cpp_visualizer/cpp_visualizer_example.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 
 //------------------------------------------------------------------------------
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     typedef float T;
 
@@ -32,17 +32,27 @@ int main(int argc, char **argv)
     std::unique_ptr<T[]> A_(new T[n * n]);
     tlapack::legacyMatrix<T> A(n, n, &A_[0], n);
 
-    tlapack::laset( tlapack::Uplo::General, zero, one, A );
+    tlapack::laset(tlapack::Uplo::General, zero, one, A);
 
-    std::cout<<"This example is meant to be used with the debugger"<<std::endl<<std::endl;
-    std::cout<<"GDB should be able to execute the function `tlapack::print_matrix_r(A)`"<<std::endl;
-    std::cout<<"Which will output the matrix A to stdout"<<std::endl<<std::endl;
-    std::cout<<"You can also evaluate the expression `tlapack::visualize_matrix_r(A)`"<<std::endl;
-    std::cout<<"in the tool vscode-debug-visualizer"<<std::endl<<std::endl;
-    std::cout<<"This may require the GDB options `-enable-pretty-printing`, `set print elements 0` and `set print repeats 0`"<<std::endl;
+    std::cout << "This example is meant to be used with the debugger"
+              << std::endl
+              << std::endl;
+    std::cout << "GDB should be able to execute the function "
+                 "`tlapack::print_matrix_r(A)`"
+              << std::endl;
+    std::cout << "Which will output the matrix A to stdout" << std::endl
+              << std::endl;
+    std::cout << "You can also evaluate the expression "
+                 "`tlapack::visualize_matrix_r(A)`"
+              << std::endl;
+    std::cout << "in the tool vscode-debug-visualizer" << std::endl
+              << std::endl;
+    std::cout << "This may require the GDB options `-enable-pretty-printing`, "
+                 "`set print elements 0` and `set print repeats 0`"
+              << std::endl;
 
-    for( int i = 0; i < n; ++i )
-        A(i,i) = i;
+    for (int i = 0; i < n; ++i)
+        A(i, i) = i;
 
     return 0;
 }

--- a/examples/cwrapper_gemm/example_cwrapper_gemm.c
+++ b/examples/cwrapper_gemm/example_cwrapper_gemm.c
@@ -7,26 +7,25 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <tlapack.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <tlapack.h>
 
-#define min(X,Y) ((X) < (Y) ? (X) : (Y))
-#define max(X,Y) ((X) > (Y) ? (X) : (Y))
+#define min(X, Y) ((X) < (Y) ? (X) : (Y))
+#define max(X, Y) ((X) > (Y) ? (X) : (Y))
 
 //------------------------------------------------------------------------------
-int main( int argc, char** argv ) {
-
+int main(int argc, char** argv)
+{
     // Constants
-    const TLAPACK_SIZE_T m = ( argc < 2 ) ? 100 : atoi( argv[1] );
-    const TLAPACK_SIZE_T n = ( argc < 3 ) ? 200 : atoi( argv[2] );
-    const TLAPACK_SIZE_T k = ( argc < 4 ) ?  50 : atoi( argv[3] );
+    const TLAPACK_SIZE_T m = (argc < 2) ? 100 : atoi(argv[1]);
+    const TLAPACK_SIZE_T n = (argc < 3) ? 200 : atoi(argv[2]);
+    const TLAPACK_SIZE_T k = (argc < 4) ? 50 : atoi(argv[3]);
     const TLAPACK_SIZE_T lda = (m > 0) ? m : 1;
     const TLAPACK_SIZE_T ldb = (k > 0) ? k : 1;
     const TLAPACK_SIZE_T ldc = (m > 0) ? m : 1;
-    
+
     // Arrays
     double *A, *B, *C;
 
@@ -34,66 +33,63 @@ int main( int argc, char** argv ) {
     clock_t start, end;
     double cpu_time_used;
 
-    // Views
-    #define A(i_, j_) A[ (i_) + (j_)*lda ]
-    #define B(i_, j_) B[ (i_) + (j_)*ldb ]
-    #define C(i_, j_) C[ (i_) + (j_)*ldc ]
-    
+// Views
+#define A(i_, j_) A[(i_) + (j_)*lda]
+#define B(i_, j_) B[(i_) + (j_)*ldb]
+#define C(i_, j_) C[(i_) + (j_)*ldc]
+
     // Allocate A, B, and C, and initialize all entries with 0
-    A = calloc( lda*k, sizeof(double) ); // m-by-k
-    B = calloc( ldb*n, sizeof(double) ); // k-by-n
-    C = calloc( ldc*n, sizeof(double) ); // m-by-n
+    A = calloc(lda * k, sizeof(double));  // m-by-k
+    B = calloc(ldb * n, sizeof(double));  // k-by-n
+    C = calloc(ldc * n, sizeof(double));  // m-by-n
 
     // Initialize random seed
-    srand( 3 );
+    srand(3);
 
     // Initialize A with junk
     for (TLAPACK_SIZE_T j = 0; j < k; ++j)
         for (TLAPACK_SIZE_T i = 0; i < m; ++i)
-            A(i,j) = (float) 0xDEADBEEF;
-    
+            A(i, j) = (float)0xDEADBEEF;
+
     // Generate a random matrix in a submatrix of A
-    for (TLAPACK_SIZE_T j = 0; j < min(k,n); ++j)
+    for (TLAPACK_SIZE_T j = 0; j < min(k, n); ++j)
         for (TLAPACK_SIZE_T i = 0; i < m; ++i)
-            A(i,j) = ( (float) rand() ) / RAND_MAX;
+            A(i, j) = ((float)rand()) / RAND_MAX;
 
     // Set C using A
-    for (TLAPACK_SIZE_T j = 0; j < min(k,n); ++j)
+    for (TLAPACK_SIZE_T j = 0; j < min(k, n); ++j)
         for (TLAPACK_SIZE_T i = 0; i < m; ++i)
-            C(i,j) = A(i,j);
+            C(i, j) = A(i, j);
 
     // Set the main diagonal of B with ones
-    for (TLAPACK_SIZE_T i = 0; i < min(k,n); ++i)
-        B(i,i) = 1.0;
+    for (TLAPACK_SIZE_T i = 0; i < min(k, n); ++i)
+        B(i, i) = 1.0;
 
     // Record start time
     start = clock();
 
-        // C = -1.0*A*B + 1.0*C
-        dgemm( ColMajor, NoTrans, NoTrans,
-               m, n, k,
-               -1.0, A, lda,
-                     B, ldb,
-                1.0, C, ldc );
-    
+    // C = -1.0*A*B + 1.0*C
+    dgemm(ColMajor, NoTrans, NoTrans, m, n, k, -1.0, A, lda, B, ldb, 1.0, C,
+          ldc);
+
     // Record end time
     end = clock();
 
     // Compute elapsed time in miliseconds
-    cpu_time_used = (1000 * (double) (end - start)) / CLOCKS_PER_SEC;
+    cpu_time_used = (1000 * (double)(end - start)) / CLOCKS_PER_SEC;
 
     // Output
-    printf( "||C-AB||_F = %lf\n", dnrm2( n, C, 1 ) );
-    printf( "time = %lf ms\n", cpu_time_used );
+    printf("||C-AB||_F = %lf\n", dnrm2(n, C, 1));
+    printf("time = %lf ms\n", cpu_time_used);
 
     // Deallocate A, B, C
     free(A);
     free(B);
     free(C);
 
-    #undef A
-    #undef B
-    #undef C
+#undef A
+#undef B
+#undef C
 
     return 0;
 }

--- a/examples/eigen/example_eigen.cpp
+++ b/examples/eigen/example_eigen.cpp
@@ -7,11 +7,10 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <iostream>
-
-#define TLAPACK_PREFERRED_MATRIX_EIGEN
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #include <tlapack/plugins/eigen.hpp>
 
+// <T>LAPACK
 #include <tlapack/blas/trmm.hpp>
 #include <tlapack/blas/syrk.hpp>
 #include <tlapack/lapack/lacpy.hpp>
@@ -20,8 +19,12 @@
 #include <tlapack/lapack/geqr2.hpp>
 #include <tlapack/lapack/ung2r.hpp>
 
+// Eigen
 #include <Eigen/Dense>
 #include <Eigen/Householder>
+
+// C++ headers
+#include <iostream>
 
 int main( int argc, char** argv )
 {

--- a/examples/eigen/example_eigen.cpp
+++ b/examples/eigen/example_eigen.cpp
@@ -11,12 +11,12 @@
 #include <tlapack/plugins/eigen.hpp>
 
 // <T>LAPACK
-#include <tlapack/blas/trmm.hpp>
 #include <tlapack/blas/syrk.hpp>
+#include <tlapack/blas/trmm.hpp>
+#include <tlapack/lapack/geqr2.hpp>
 #include <tlapack/lapack/lacpy.hpp>
 #include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/lansy.hpp>
-#include <tlapack/lapack/geqr2.hpp>
 #include <tlapack/lapack/ung2r.hpp>
 
 // Eigen
@@ -26,10 +26,10 @@
 // C++ headers
 #include <iostream>
 
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     using std::size_t;
-    using pair = std::pair<size_t,size_t>;
+    using pair = std::pair<size_t, size_t>;
     using namespace tlapack;
     using Eigen::Matrix;
 
@@ -39,11 +39,7 @@ int main( int argc, char** argv )
 
     // Input data
     Matrix<float, m, n> A;
-    A << 1,  2,  3,
-         4,  5,  6,
-         7,  8,  9,
-        10, 11, 12,
-        13, 14, 15;
+    A << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
 
     // Matrices
     Matrix<float, m, n> Q = A;
@@ -53,7 +49,7 @@ int main( int argc, char** argv )
     std::cout << "A = " << std::endl << A << std::endl << std::endl;
 
     // <T>LAPACK -----------------------------------------------
-    
+
     std::cout << "--- <T>LAPACK: ---" << std::endl << std::endl;
 
     // Allocates memory
@@ -61,11 +57,11 @@ int main( int argc, char** argv )
     Matrix<float, n, n> orthQ;
 
     // Compute QR decomposision in place
-    geqr2( Q, tau );
+    geqr2(Q, tau);
     // Copy the upper triangle to R
-    lacpy( upperTriangle, slice(Q,pair{0,n},pair{0,n}), R );
+    lacpy(upperTriangle, slice(Q, pair{0, n}, pair{0, n}), R);
     // Generate Q
-    ung2r( n, Q, tau );
+    ung2r(n, Q, tau);
 
     std::cout << "Q = " << std::endl << Q << std::endl;
     std::cout << std::endl;
@@ -74,17 +70,19 @@ int main( int argc, char** argv )
     std::cout << std::endl;
 
     // Checking A = Q R
-    lacpy( dense, Q, QtimesR );
-    trmm( Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, 1.0, R, QtimesR );
+    lacpy(dense, Q, QtimesR);
+    trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, 1.0, R, QtimesR);
     std::cout << "QR = " << std::endl << QtimesR << std::endl;
     QtimesR -= A;
-    std::cout << "\\|QR - A\\|_F/\\|A\\|_F = " << std::endl << lange( frob_norm, QtimesR ) / lange( frob_norm, A ) << std::endl;
+    std::cout << "\\|QR - A\\|_F/\\|A\\|_F = " << std::endl
+              << lange(frob_norm, QtimesR) / lange(frob_norm, A) << std::endl;
     std::cout << std::endl;
 
     // Checking orthogonality of Q
     orthQ = Matrix<float, n, n>::Identity();
-    syrk( Uplo::Upper, Op::Trans, 1.0, Q, -1.0, orthQ );
-    std::cout << "\\|Q^t Q - I\\|_F = " << std::endl << lansy( frob_norm, upperTriangle, orthQ ) << std::endl;
+    syrk(Uplo::Upper, Op::Trans, 1.0, Q, -1.0, orthQ);
+    std::cout << "\\|Q^t Q - I\\|_F = " << std::endl
+              << lansy(frob_norm, upperTriangle, orthQ) << std::endl;
     std::cout << std::endl;
 
     // Eigen -----------------------------------------------
@@ -92,11 +90,11 @@ int main( int argc, char** argv )
     std::cout << "--- Eigen: ---" << std::endl << std::endl;
 
     // Compute QR decomposision in place, possibly allocating memory dynamically
-    Eigen::HouseholderQR<decltype(A)> qrEigen( A );
+    Eigen::HouseholderQR<decltype(A)> qrEigen(A);
     // Generate Q
     Q = qrEigen.householderQ() * Matrix<float, m, n>::Identity();
     // Copy the upper triangle to R
-    R = qrEigen.matrixQR().block(0,0,n,n).triangularView<Eigen::Upper>();
+    R = qrEigen.matrixQR().block(0, 0, n, n).triangularView<Eigen::Upper>();
 
     std::cout << "Q = " << std::endl << Q << std::endl;
     std::cout << std::endl;
@@ -107,12 +105,14 @@ int main( int argc, char** argv )
     // Checking A = Q R
     QtimesR = Q * R;
     std::cout << "QR = " << std::endl << QtimesR << std::endl;
-    std::cout << "\\|QR - A\\|_F/\\|A\\|_F = " << (QtimesR-A).norm() / A.norm() << std::endl;
+    std::cout << "\\|QR - A\\|_F/\\|A\\|_F = "
+              << (QtimesR - A).norm() / A.norm() << std::endl;
     std::cout << std::endl;
 
     // Checking orthogonality of Q
     orthQ = Q.transpose() * Q - Matrix<float, n, n>::Identity();
-    std::cout << "\\|Q^t Q - I\\|_F = " << std::endl << orthQ.norm() << std::endl;
+    std::cout << "\\|Q^t Q - I\\|_F = " << std::endl
+              << orthQ.norm() << std::endl;
     std::cout << std::endl;
 
     return 0;

--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -7,10 +7,12 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #define TLAPACK_PREFERRED_MATRIX_LEGACY
 #include <tlapack/plugins/stdvector.hpp>
 #include <tlapack/plugins/legacyArray.hpp>
 
+// <T>LAPACK
 #include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/laset.hpp>
 #include <tlapack/lapack/lansy.hpp>
@@ -19,6 +21,7 @@
 #include <tlapack/lapack/unghr.hpp>
 #include <tlapack/lapack/multishift_qr.hpp>
 
+// C++ headers
 #include <memory>
 #include <vector>
 #include <chrono> // for high_resolution_clock

--- a/examples/gemm/example_gemm.cpp
+++ b/examples/gemm/example_gemm.cpp
@@ -13,36 +13,44 @@
 #endif
 
 // <T>LAPACK
-#include <tlapack/legacy_api/blas/nrm2.hpp>
 #include <tlapack/legacy_api/blas/gemm.hpp>
+#include <tlapack/legacy_api/blas/nrm2.hpp>
 
 // C++ headers
-#include <vector>
+#include <chrono>  // for high_resolution_clock
 #include <iostream>
-#include <chrono>   // for high_resolution_clock
+#include <vector>
 
 //------------------------------------------------------------------------------
 template <typename T>
-void run( tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k )
+void run(tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k)
 {
     using tlapack::idx_t;
     using tlapack::min;
-    using colmajor_matrix_t = tlapack::legacyMatrix<T,idx_t,tlapack::Layout::ColMajor>;
-    using rowmajor_matrix_t = tlapack::legacyMatrix<T,idx_t,tlapack::Layout::RowMajor>;
+    using colmajor_matrix_t =
+        tlapack::legacyMatrix<T, idx_t, tlapack::Layout::ColMajor>;
+    using rowmajor_matrix_t =
+        tlapack::legacyMatrix<T, idx_t, tlapack::Layout::RowMajor>;
 
     // Functors for creating new matrices
     tlapack::Create<colmajor_matrix_t> new_colmajor_matrix;
     tlapack::Create<rowmajor_matrix_t> new_rowmajor_matrix;
 
     // Column Major Matrices
-    std::vector<T> A_; auto A = new_colmajor_matrix( A_, m, k );
-    std::vector<T> B_; auto B = new_colmajor_matrix( B_, k, n );
-    std::vector<T> C_; auto C = new_colmajor_matrix( C_, m, n );
+    std::vector<T> A_;
+    auto A = new_colmajor_matrix(A_, m, k);
+    std::vector<T> B_;
+    auto B = new_colmajor_matrix(B_, k, n);
+    std::vector<T> C_;
+    auto C = new_colmajor_matrix(C_, m, n);
 
     // Row Major Matrices
-    std::vector<T> Ar_; auto Ar = new_rowmajor_matrix( Ar_, m, k );
-    std::vector<T> Br_; auto Br = new_rowmajor_matrix( Br_, k, n );
-    std::vector<T> Cr_; auto Cr = new_rowmajor_matrix( Cr_, m, n );
+    std::vector<T> Ar_;
+    auto Ar = new_rowmajor_matrix(Ar_, m, k);
+    std::vector<T> Br_;
+    auto Br = new_rowmajor_matrix(Br_, k, n);
+    std::vector<T> Cr_;
+    auto Cr = new_rowmajor_matrix(Cr_, m, n);
 
     // Number of runs to measure the minimum execution time
     int Nruns = 10;
@@ -51,169 +59,160 @@ void run( tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k )
     // Initialize A and Ar with junk
     for (idx_t j = 0; j < k; ++j)
         for (idx_t i = 0; i < m; ++i) {
-            A(i,j)  = T( static_cast<float>( 0xDEADBEEF ) );
-            Ar(i,j) = A(i,j);
+            A(i, j) = T(static_cast<float>(0xDEADBEEF));
+            Ar(i, j) = A(i, j);
         }
-    
+
     // Generate a random matrix in a submatrix of A
-    for (idx_t j = 0; j < min(k,n); ++j)
+    for (idx_t j = 0; j < min(k, n); ++j)
         for (idx_t i = 0; i < m; ++i) {
-            A(i,j) = static_cast<float>( rand() )
-                        / static_cast<float>( RAND_MAX );
-            Ar(i,j) = A(i,j);
+            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+            Ar(i, j) = A(i, j);
         }
-                        
 
     // The diagonal of B is full of ones
-    for (idx_t i = 0; i < min(k,n); ++i) {
-        B(i,i) = 1.0;
-        Br(i,i) = B(i,i);
+    for (idx_t i = 0; i < min(k, n); ++i) {
+        B(i, i) = 1.0;
+        Br(i, i) = B(i, i);
     }
 
     // 1) Using legacy LAPACK interface:
 
     bestTime = std::chrono::nanoseconds::max();
-    for( int run = 0; run < Nruns; ++run ) {
-
+    for (int run = 0; run < Nruns; ++run) {
         // Set C using A
-        for (idx_t j = 0; j < min(k,n); ++j)
+        for (idx_t j = 0; j < min(k, n); ++j)
             for (idx_t i = 0; i < m; ++i)
-                C(i,j) = A(i,j);
+                C(i, j) = A(i, j);
 
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
 
-            // C = -1.0*A*B + 1.0*C
-            tlapack::gemm( tlapack::Layout::ColMajor,
-                        tlapack::Op::NoTrans,
-                        tlapack::Op::NoTrans,
-                        m, n, k,
-                        T(-1.0), &A_[0], m, &B_[0], k, 
-                        T( 1.0), &C_[0], m );
-        
+        // C = -1.0*A*B + 1.0*C
+        tlapack::gemm(tlapack::Layout::ColMajor, tlapack::Op::NoTrans,
+                      tlapack::Op::NoTrans, m, n, k, T(-1.0), &A_[0], m, &B_[0],
+                      k, T(1.0), &C_[0], m);
+
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
 
         // Update best time
-        if( elapsed < bestTime ) bestTime = elapsed;
+        if (elapsed < bestTime) bestTime = elapsed;
     }
 
     // Output
     std::cout << "Using legacy LAPACK interface:" << std::endl
-              << "||C-AB||_F = " << tlapack::nrm2( n, &C_[0], 1 ) << std::endl
+              << "||C-AB||_F = " << tlapack::nrm2(n, &C_[0], 1) << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 
     // Using abstract interface:
 
     bestTime = std::chrono::nanoseconds::max();
-    for( int run = 0; run < Nruns; ++run ) {
-
+    for (int run = 0; run < Nruns; ++run) {
         // Set C using A
-        for (idx_t j = 0; j < min(k,n); ++j)
+        for (idx_t j = 0; j < min(k, n); ++j)
             for (idx_t i = 0; i < m; ++i)
-                C(i,j) = A(i,j);
+                C(i, j) = A(i, j);
 
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
 
-            // C = -1.0*A*B + 1.0*C
-            tlapack::gemm( tlapack::Op::NoTrans,
-                        tlapack::Op::NoTrans,
-                        T(-1.0), A, B,
-                        T( 1.0), C );
-        
+        // C = -1.0*A*B + 1.0*C
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, T(-1.0), A, B,
+                      T(1.0), C);
+
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
 
         // Update best time
-        if( elapsed < bestTime ) bestTime = elapsed;
+        if (elapsed < bestTime) bestTime = elapsed;
     }
 
     // Output
     std::cout << "Using abstract interface:" << std::endl
-              << "||C-AB||_F = " << tlapack::nrm2( n, &C_[0], 1 ) << std::endl
+              << "||C-AB||_F = " << tlapack::nrm2(n, &C_[0], 1) << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 
     // Using abstract interface with row major layout:
 
     bestTime = std::chrono::nanoseconds::max();
-    for( int run = 0; run < Nruns; ++run ) {
-
+    for (int run = 0; run < Nruns; ++run) {
         // Set C using A
-        for (idx_t j = 0; j < min(k,n); ++j)
+        for (idx_t j = 0; j < min(k, n); ++j)
             for (idx_t i = 0; i < m; ++i)
-                Cr(i,j) = Ar(i,j);
+                Cr(i, j) = Ar(i, j);
 
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
 
-            // C = -1.0*A*B + 1.0*C
-            tlapack::gemm( tlapack::Op::NoTrans,
-                        tlapack::Op::NoTrans,
-                        T(-1.0), Ar, Br,
-                        T( 1.0), Cr );
-        
+        // C = -1.0*A*B + 1.0*C
+        tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, T(-1.0), Ar,
+                      Br, T(1.0), Cr);
+
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
 
         // Update best time
-        if( elapsed < bestTime ) bestTime = elapsed;
+        if (elapsed < bestTime) bestTime = elapsed;
     }
 
     // Output
     std::cout << "Using abstract interface with row major layout:" << std::endl
-              << "||C-AB||_F = " << tlapack::nrm2( n, &C_[0], 1 ) << std::endl
+              << "||C-AB||_F = " << tlapack::nrm2(n, &C_[0], 1) << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 }
 
 //------------------------------------------------------------------------------
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     int m, n, k;
 
     // Default arguments
-    m = ( argc < 2 ) ? 100 : atoi( argv[1] );
-    n = ( argc < 3 ) ? 200 : atoi( argv[2] );
-    k = ( argc < 4 ) ?  50 : atoi( argv[3] );
+    m = (argc < 2) ? 100 : atoi(argv[1]);
+    n = (argc < 3) ? 200 : atoi(argv[2]);
+    k = (argc < 4) ? 50 : atoi(argv[3]);
 
-    srand( 3 ); // Init random seed
+    srand(3);  // Init random seed
 
     std::cout.precision(5);
     std::cout << std::scientific << std::showpos;
-    
-    printf( "run< float >( %d, %d, %d )\n", m, n, k );
-    run< float  >( m, n, k );
-    printf( "-----------------------\n" );
 
-    printf( "run< double >( %d, %d, %d )\n", m, n, k );
-    run< double >( m, n, k );
-    printf( "-----------------------\n" );
+    printf("run< float >( %d, %d, %d )\n", m, n, k);
+    run<float>(m, n, k);
+    printf("-----------------------\n");
 
-    printf( "run< complex<float> >( %d, %d, %d )\n", m, n, k );
-    run< std::complex<float>  >( m, n, k );
-    printf( "-----------------------\n" );
+    printf("run< double >( %d, %d, %d )\n", m, n, k);
+    run<double>(m, n, k);
+    printf("-----------------------\n");
 
-    printf( "run< complex<double> >( %d, %d, %d )\n", m, n, k );
-    run< std::complex<double> >( m, n, k );
-    printf( "-----------------------\n" );
+    printf("run< complex<float> >( %d, %d, %d )\n", m, n, k);
+    run<std::complex<float> >(m, n, k);
+    printf("-----------------------\n");
+
+    printf("run< complex<double> >( %d, %d, %d )\n", m, n, k);
+    run<std::complex<double> >(m, n, k);
+    printf("-----------------------\n");
 
 #ifdef USE_MPFR
-    printf( "run< mpfr::mpreal >( %d, %d, %d )\n", m, n, k );
-    run< mpfr::mpreal >( m, n, k );
-    printf( "-----------------------\n" );
+    printf("run< mpfr::mpreal >( %d, %d, %d )\n", m, n, k);
+    run<mpfr::mpreal>(m, n, k);
+    printf("-----------------------\n");
 
-    printf( "run< complex<mpfr::mpreal> >( %d, %d, %d )\n", m, n, k );
-    run< std::complex<mpfr::mpreal> >( m, n, k );
-    printf( "-----------------------\n" );
+    printf("run< complex<mpfr::mpreal> >( %d, %d, %d )\n", m, n, k);
+    run<std::complex<mpfr::mpreal> >(m, n, k);
+    printf("-----------------------\n");
 #endif
 
     return 0;

--- a/examples/gemm/example_gemm.cpp
+++ b/examples/gemm/example_gemm.cpp
@@ -7,16 +7,19 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <tlapack/legacy_api/blas/nrm2.hpp>
-#include <tlapack/legacy_api/blas/gemm.hpp>
-
-#include <vector>
-#include <iostream>
-#include <chrono>   // for high_resolution_clock
-
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #ifdef USE_MPFR
     #include <tlapack/plugins/mpreal.hpp>
 #endif
+
+// <T>LAPACK
+#include <tlapack/legacy_api/blas/nrm2.hpp>
+#include <tlapack/legacy_api/blas/gemm.hpp>
+
+// C++ headers
+#include <vector>
+#include <iostream>
+#include <chrono>   // for high_resolution_clock
 
 //------------------------------------------------------------------------------
 template <typename T>

--- a/examples/geqr2/example_geqr2.cpp
+++ b/examples/geqr2/example_geqr2.cpp
@@ -9,44 +9,44 @@
 
 // Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #define TLAPACK_PREFERRED_MATRIX_LEGACY
-#include <tlapack/plugins/stdvector.hpp>
 #include <tlapack/plugins/legacyArray.hpp>
+#include <tlapack/plugins/stdvector.hpp>
 
 // <T>LAPACK
 #include <tlapack/blas/syrk.hpp>
 #include <tlapack/blas/trmm.hpp>
+#include <tlapack/lapack/geqr2.hpp>
+#include <tlapack/lapack/lacpy.hpp>
 #include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/lansy.hpp>
 #include <tlapack/lapack/laset.hpp>
-#include <tlapack/lapack/lacpy.hpp>
-#include <tlapack/lapack/geqr2.hpp>
 #include <tlapack/lapack/ung2r.hpp>
 
 // C++ headers
+#include <chrono>  // for high_resolution_clock
+#include <iostream>
 #include <memory>
 #include <vector>
-#include <chrono>   // for high_resolution_clock
-#include <iostream>
 
 //------------------------------------------------------------------------------
 /// Print matrix A in the standard output
 template <typename matrix_t>
-inline void printMatrix( const matrix_t& A )
+inline void printMatrix(const matrix_t& A)
 {
-    using idx_t = tlapack::size_type< matrix_t >;
+    using idx_t = tlapack::size_type<matrix_t>;
     const idx_t m = tlapack::nrows(A);
     const idx_t n = tlapack::ncols(A);
 
     for (idx_t i = 0; i < m; ++i) {
         std::cout << std::endl;
         for (idx_t j = 0; j < n; ++j)
-            std::cout << A(i,j) << " ";
+            std::cout << A(i, j) << " ";
     }
 }
 
 //------------------------------------------------------------------------------
 template <typename real_t>
-void run( size_t m, size_t n )
+void run(size_t m, size_t n)
 {
     using std::size_t;
     using matrix_t = tlapack::legacyMatrix<real_t>;
@@ -58,74 +58,78 @@ void run( size_t m, size_t n )
     bool verbose = false;
 
     // Arrays
-    std::vector<real_t> tau ( n );
+    std::vector<real_t> tau(n);
 
     // Matrices
-    std::vector<real_t> A_; auto A = new_matrix( A_, m, n );
-    std::vector<real_t> R_; auto R = new_matrix( R_, n, n );
-    std::vector<real_t> Q_; auto Q = new_matrix( Q_, m, n );
+    std::vector<real_t> A_;
+    auto A = new_matrix(A_, m, n);
+    std::vector<real_t> R_;
+    auto R = new_matrix(R_, n, n);
+    std::vector<real_t> Q_;
+    auto Q = new_matrix(Q_, m, n);
 
     // Initialize arrays with junk
     for (size_t j = 0; j < n; ++j) {
         for (size_t i = 0; i < m; ++i) {
-            A(i,j) = static_cast<float>( 0xDEADBEEF );
-            Q(i,j) = static_cast<float>( 0xCAFED00D );
+            A(i, j) = static_cast<float>(0xDEADBEEF);
+            Q(i, j) = static_cast<float>(0xCAFED00D);
         }
         for (size_t i = 0; i < n; ++i) {
-            R(i,j) = static_cast<float>( 0xFEE1DEAD );
+            R(i, j) = static_cast<float>(0xFEE1DEAD);
         }
-        tau[j] = static_cast<float>( 0xFFBADD11 );
+        tau[j] = static_cast<float>(0xFFBADD11);
     }
-    
+
     // Generate a random matrix in A
     for (size_t j = 0; j < n; ++j)
         for (size_t i = 0; i < m; ++i)
-            A(i,j) = static_cast<float>( rand() )
-                        / static_cast<float>( RAND_MAX );
+            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 
     // Frobenius norm of A
-    auto normA = tlapack::lange( tlapack::frob_norm, A );
+    auto normA = tlapack::lange(tlapack::frob_norm, A);
 
     // Print A
     if (verbose) {
         std::cout << std::endl << "A = ";
-        printMatrix( A );
+        printMatrix(A);
     }
 
     // Copy A to Q
-    tlapack::lacpy( tlapack::dense, A, Q );
+    tlapack::lacpy(tlapack::dense, A, Q);
 
     // 1) Compute A = QR (Stored in the matrix Q)
 
     // Record start time
-    auto startQR = std::chrono::high_resolution_clock::now(); {
-
+    auto startQR = std::chrono::high_resolution_clock::now();
+    {
         // QR factorization
-        tlapack::geqr2( Q, tau );
+        tlapack::geqr2(Q, tau);
 
         // Save the R matrix
-        tlapack::lacpy( tlapack::upperTriangle, Q, R );
+        tlapack::lacpy(tlapack::upperTriangle, Q, R);
 
         // Generates Q = H_1 H_2 ... H_n
-        tlapack::ung2r( n, Q, tau );
+        tlapack::ung2r(n, Q, tau);
     }
     // Record end time
     auto endQR = std::chrono::high_resolution_clock::now();
 
     // Compute elapsed time in nanoseconds
-    auto elapsedQR = std::chrono::duration_cast<std::chrono::nanoseconds>(endQR - startQR);
-    
+    auto elapsedQR =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(endQR - startQR);
+
     // Compute FLOPS
-    double flopsQR = ( 4.0e+00 * ((double) m) * ((double) n) * ((double) n) 
-                     - 4.0e+00 / 3.0e+00 * ((double) n) * ((double) n) * ((double) n)
-                    ) / (elapsedQR.count() * 1.0e-9) ;
+    double flopsQR =
+        (4.0e+00 * ((double)m) * ((double)n) * ((double)n) -
+         4.0e+00 / 3.0e+00 * ((double)n) * ((double)n) * ((double)n)) /
+        (elapsedQR.count() * 1.0e-9);
 
     // Print Q and R
     if (verbose) {
         std::cout << std::endl << "Q = ";
-        printMatrix( Q );
+        printMatrix(Q);
         std::cout << std::endl << "R = ";
-        printMatrix( R );
+        printMatrix(R);
     }
 
     real_t norm_orth_1, norm_repres_1;
@@ -134,83 +138,86 @@ void run( size_t m, size_t n )
 
     {
         std::vector<real_t> work_;
-        auto work = new_matrix( work_, n, n );
+        auto work = new_matrix(work_, n, n);
         for (size_t j = 0; j < n; ++j)
             for (size_t i = 0; i < n; ++i)
-                work(i,j) = static_cast<float>( 0xABADBABE );
-        
+                work(i, j) = static_cast<float>(0xABADBABE);
+
         // work receives the identity n*n
-        tlapack::laset( tlapack::upperTriangle, 0.0, 1.0, work );
+        tlapack::laset(tlapack::upperTriangle, 0.0, 1.0, work);
         // work receives Q'Q - I
-        tlapack::syrk( tlapack::Uplo::Upper, tlapack::Op::Trans, 1.0, Q, -1.0, work );
+        tlapack::syrk(tlapack::Uplo::Upper, tlapack::Op::Trans, 1.0, Q, -1.0,
+                      work);
 
         // Compute ||Q'Q - I||_F
-        norm_orth_1 = tlapack::lansy( tlapack::frob_norm, tlapack::upperTriangle, work );
+        norm_orth_1 =
+            tlapack::lansy(tlapack::frob_norm, tlapack::upperTriangle, work);
 
         if (verbose) {
             std::cout << std::endl << "Q'Q-I = ";
-            printMatrix( work );
+            printMatrix(work);
         }
-
     }
 
     // 3) Compute ||QR - A||_F / ||A||_F
 
     {
         std::vector<real_t> work_;
-        auto work = new_matrix( work_, m, n );
+        auto work = new_matrix(work_, m, n);
         for (size_t j = 0; j < n; ++j)
             for (size_t i = 0; i < m; ++i)
-                work(i,j) = static_cast<float>( 0xABADBABE );
+                work(i, j) = static_cast<float>(0xABADBABE);
 
         // Copy Q to work
-        tlapack::lacpy( tlapack::dense, Q, work );
+        tlapack::lacpy(tlapack::dense, Q, work);
 
-        tlapack::trmm( tlapack::Side::Right, tlapack::Uplo::Upper, tlapack::Op::NoTrans, tlapack::Diag::NonUnit, 1.0, R, work );
+        tlapack::trmm(tlapack::Side::Right, tlapack::Uplo::Upper,
+                      tlapack::Op::NoTrans, tlapack::Diag::NonUnit, 1.0, R,
+                      work);
 
-        for(size_t j = 0; j < n; ++j)
-            for(size_t i = 0; i < m; ++i)
-                work(i,j) -= A(i,j);
+        for (size_t j = 0; j < n; ++j)
+            for (size_t i = 0; i < m; ++i)
+                work(i, j) -= A(i, j);
 
-        norm_repres_1 = tlapack::lange( tlapack::frob_norm, work ) / normA;
+        norm_repres_1 = tlapack::lange(tlapack::frob_norm, work) / normA;
     }
-    
+
     // *) Output
- 
+
     std::cout << std::endl;
     std::cout << "time = " << elapsedQR.count() * 1.0e-6 << " ms"
-            << ",   GFlop/sec = " << flopsQR * 1.0e-9;
+              << ",   GFlop/sec = " << flopsQR * 1.0e-9;
     std::cout << std::endl;
     std::cout << "||QR - A||_F/||A||_F  = " << norm_repres_1
-            << ",        ||Q'Q - I||_F  = " << norm_orth_1;
+              << ",        ||Q'Q - I||_F  = " << norm_orth_1;
     std::cout << std::endl;
 }
 
 //------------------------------------------------------------------------------
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     int m, n;
 
     // Default arguments
-    m = ( argc < 2 ) ? 7 : atoi( argv[1] );
-    n = ( argc < 3 ) ? 5 : atoi( argv[2] );
+    m = (argc < 2) ? 7 : atoi(argv[1]);
+    n = (argc < 3) ? 5 : atoi(argv[2]);
 
-    srand( 3 ); // Init random seed
+    srand(3);  // Init random seed
 
     std::cout.precision(5);
     std::cout << std::scientific << std::showpos;
-    
-    printf( "run< float  >( %d, %d )", m, n );
-    run< float  >( m, n );
-    printf( "-----------------------\n" );
-    
-    printf( "run< double >( %d, %d )", m, n );
-    run< double >( m, n );
-    printf( "-----------------------\n" );
-    
-    printf( "run< long double >( %d, %d )", m, n );
-    run< long double >( m, n );
-    printf( "-----------------------\n" );
+
+    printf("run< float  >( %d, %d )", m, n);
+    run<float>(m, n);
+    printf("-----------------------\n");
+
+    printf("run< double >( %d, %d )", m, n);
+    run<double>(m, n);
+    printf("-----------------------\n");
+
+    printf("run< long double >( %d, %d )", m, n);
+    run<long double>(m, n);
+    printf("-----------------------\n");
 
     return 0;
 }

--- a/examples/geqr2/example_geqr2.cpp
+++ b/examples/geqr2/example_geqr2.cpp
@@ -7,10 +7,12 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #define TLAPACK_PREFERRED_MATRIX_LEGACY
 #include <tlapack/plugins/stdvector.hpp>
 #include <tlapack/plugins/legacyArray.hpp>
 
+// <T>LAPACK
 #include <tlapack/blas/syrk.hpp>
 #include <tlapack/blas/trmm.hpp>
 #include <tlapack/lapack/lange.hpp>
@@ -20,6 +22,7 @@
 #include <tlapack/lapack/geqr2.hpp>
 #include <tlapack/lapack/ung2r.hpp>
 
+// C++ headers
 #include <memory>
 #include <vector>
 #include <chrono>   // for high_resolution_clock

--- a/examples/lu/example_lu.cpp
+++ b/examples/lu/example_lu.cpp
@@ -8,21 +8,23 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <iostream>
-#include <vector>
-
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #define TLAPACK_PREFERRED_MATRIX_LEGACY
 #include <tlapack/plugins/stdvector.hpp>
 #include <tlapack/plugins/legacyArray.hpp>
+#ifdef USE_MPFR
+    #include <tlapack/plugins/mpreal.hpp>
+#endif
 
+// <T>LAPACK
 #include <tlapack/blas/trsm.hpp>
 #include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/lacpy.hpp>
 #include <tlapack/lapack/getrf.hpp>
 
-#ifdef USE_MPFR
-    #include <tlapack/plugins/mpreal.hpp>
-#endif
+// C++ headers
+#include <iostream>
+#include <vector>
 
 //------------------------------------------------------------------------------
 template< class T, tlapack::Layout L >

--- a/examples/mdspan/example_mdspan.cpp
+++ b/examples/mdspan/example_mdspan.cpp
@@ -7,18 +7,20 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-// #include <tlapack.hpp>
-
-#include <vector>
-#include <iostream>
-
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #include <tlapack/plugins/mdspan.hpp>
-#include "tiledLayout.h"
 
+// <T>LAPACK
 #include <tlapack/blas/gemm.hpp>
 #include <tlapack/blas/trsm.hpp>
 #include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/potrf.hpp>
+
+// C++ headers
+#include <vector>
+#include <iostream>
+
+#include "tiledLayout.h"
 
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )

--- a/examples/mdspan/example_mdspan.cpp
+++ b/examples/mdspan/example_mdspan.cpp
@@ -17,99 +17,96 @@
 #include <tlapack/lapack/potrf.hpp>
 
 // C++ headers
-#include <vector>
 #include <iostream>
+#include <vector>
 
 #include "tiledLayout.h"
 
 //------------------------------------------------------------------------------
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     using T = float;
 
     using namespace tlapack;
 
+    using std::experimental::dextents;
+    using std::experimental::layout_stride;
     using std::experimental::mdspan;
     using std::experimental::submdspan;
-    using std::experimental::layout_stride;
-    using std::experimental::dextents;
-    
-    using idx_t = std::size_t;
-    using pair = std::pair<idx_t,idx_t>;
 
-    using my_dextents   = dextents<idx_t,2>;
-    using TiledMapping  = typename TiledLayout::template mapping<my_dextents>;
+    using idx_t = std::size_t;
+    using pair = std::pair<idx_t, idx_t>;
+
+    using my_dextents = dextents<idx_t, 2>;
+    using TiledMapping = typename TiledLayout::template mapping<my_dextents>;
     using strideMapping = typename layout_stride::template mapping<my_dextents>;
-    
+
     // constants
     const idx_t n = 100, k = 40, row_tile = 2, col_tile = 5;
     const idx_t lda = 110, ldc = 120;
-    T one( 1.0 );
-    
-    // raw data arrays
-    T A_[ lda*n ] = {};
-    T C_[ n*ldc ] = {};
+    T one(1.0);
 
-    /// Using dynamic extents: 
+    // raw data arrays
+    T A_[lda * n] = {};
+    T C_[n * ldc] = {};
+
+    /// Using dynamic extents:
 
     // Column Major Matrix A
-    mdspan< T, my_dextents, layout_stride > A (
-        A_, strideMapping( my_dextents(n, n), std::array<idx_t,2>{1,lda} )
-    );
+    mdspan<T, my_dextents, layout_stride> A(
+        A_, strideMapping(my_dextents(n, n), std::array<idx_t, 2>{1, lda}));
     // Column Major Matrix Ak with the first k columns of A
-    auto Ak = submdspan( A, pair{0,n}, pair{0,k} );
+    auto Ak = submdspan(A, pair{0, n}, pair{0, k});
     // Tiled Matrix B with the last k*n elements of A_
-    mdspan< T, my_dextents, TiledLayout > B (
-        &A(n*(lda-k),0), TiledMapping( my_dextents(k, n), row_tile, col_tile )
-    );
+    mdspan<T, my_dextents, TiledLayout> B(
+        &A(n * (lda - k), 0),
+        TiledMapping(my_dextents(k, n), row_tile, col_tile));
     // Row Major Matrix C
-    mdspan< T, my_dextents, layout_stride > C (
-        C_, strideMapping( my_dextents(n, n), std::array<idx_t,2>{ldc,1} )
-    );
+    mdspan<T, my_dextents, layout_stride> C(
+        C_, strideMapping(my_dextents(n, n), std::array<idx_t, 2>{ldc, 1}));
 
     // Init random seed
-    srand( 4539 );
+    srand(4539);
 
     // Initialize A_ and C_ with junk
     for (idx_t j = 0; j < n; ++j) {
         for (idx_t i = 0; i < lda; ++i)
-            A_[i+j*lda] = T( static_cast<float>( 0xDEADBEEF ) );
+            A_[i + j * lda] = T(static_cast<float>(0xDEADBEEF));
         for (idx_t i = 0; i < ldc; ++i)
-            C_[i+j*ldc] = T( static_cast<float>( 0xDEFECA7E ) );
+            C_[i + j * ldc] = T(static_cast<float>(0xDEFECA7E));
     }
-    
+
     // Generate a random matrix in Ak
     for (idx_t j = 0; j < k; ++j)
         for (idx_t i = 0; i < n; ++i)
-            Ak(i,j) = static_cast<float>( rand() )
-                    / static_cast<float>( RAND_MAX );
-                        
+            Ak(i, j) =
+                static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+
     // Initialize B with zeros
     for (idx_t j = 0; j < n; ++j)
         for (idx_t i = 0; i < k; ++i)
-            B(i,j) = 0.0;
+            B(i, j) = 0.0;
     // then put ones in the main diagonal of B
     for (idx_t i = 0; i < k; ++i)
-        B(i,i) = 1.0;
+        B(i, i) = 1.0;
 
     // Initialize the last n-k columns of C with zeros
     for (idx_t j = k; j < n; ++j)
         for (idx_t i = 0; i < n; ++i)
-            C(i,j) = 0.0;
+            C(i, j) = 0.0;
     // Set the first k columns of C with Ak
     for (idx_t j = 0; j < k; ++j)
         for (idx_t i = 0; i < n; ++i)
-            C(i,j) = Ak(i,j);
+            C(i, j) = Ak(i, j);
 
     // gemm:
 
     // C = Ak*B + C
-    gemm( Op::NoTrans, Op::NoTrans, T(-1.0), Ak, B, T(1.0), C );
+    gemm(Op::NoTrans, Op::NoTrans, T(-1.0), Ak, B, T(1.0), C);
 
     std::cout.precision(5);
     std::cout << std::scientific << std::showpos;
-    std::cout << "|| C - Ak B ||_F = " 
-              << tlapack::lange( tlapack::frob_norm, C )
+    std::cout << "|| C - Ak B ||_F = " << tlapack::lange(tlapack::frob_norm, C)
               << std::endl;
 
     // potrf:
@@ -117,63 +114,56 @@ int main( int argc, char** argv )
     // Initialize A_ with junk one more time
     for (idx_t j = 0; j < n; ++j)
         for (idx_t i = 0; i < lda; ++i)
-            A_[i+j*lda] = T( static_cast<float>( 0xDEADBEEF ) );
+            A_[i + j * lda] = T(static_cast<float>(0xDEADBEEF));
 
     // Column Major Matrices U and Asym as submatrices of A
-    auto U    = submdspan( A, pair{0,k}, pair{0,k} );
-    auto Asym = submdspan( A, pair{0,k}, pair{k,2*k} );
-    
+    auto U = submdspan(A, pair{0, k}, pair{0, k});
+    auto Asym = submdspan(A, pair{0, k}, pair{k, 2 * k});
+
     // Fill Asym with random entries
     for (idx_t j = 0; j < k; ++j) {
         for (idx_t i = 0; i < k; ++i)
-            Asym(i,j) = static_cast<float>( rand() )
-                      / static_cast<float>( RAND_MAX );
+            Asym(i, j) =
+                static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     }
-    
+
     // Turns Asym into a symmetric positive definite matrix
     for (idx_t j = 0; j < k; ++j) {
         for (idx_t i = 0; i < j; ++i) {
-            Asym(i,j) = T(0.5) * ( Asym(i,j) + Asym(j,i) );
-            Asym(j,i) = Asym(i,j);
+            Asym(i, j) = T(0.5) * (Asym(i, j) + Asym(j, i));
+            Asym(j, i) = Asym(i, j);
         }
-        Asym(j,j) += k * T( 1.0 );
+        Asym(j, j) += k * T(1.0);
     }
-    
+
     // Copy the upper part of Asym to U
     for (idx_t j = 0; j < k; ++j) {
         for (idx_t i = 0; i <= j; ++i)
-            U(i,j) = Asym(i,j);
+            U(i, j) = Asym(i, j);
     }
 
     // Compute the Cholesky decomposition of U
-    int info = tlapack::potrf( tlapack::upperTriangle, U );
+    int info = tlapack::potrf(tlapack::upperTriangle, U);
 
-    std::cout << "Cholesky ended with info " << info
-              << std::endl;
+    std::cout << "Cholesky ended with info " << info << std::endl;
 
     // Solve U^H U R = A
-    auto R  = submdspan( A, pair{k,2*k}, pair{0,k} );
+    auto R = submdspan(A, pair{k, 2 * k}, pair{0, k});
     for (idx_t j = 0; j < k; ++j)
         for (idx_t i = 0; i < k; ++i)
-            R(i,j) = Asym(i,j);
-    trsm(
-        Side::Left, Uplo::Upper,
-        Op::ConjTrans, Diag::NonUnit,
-        one, U, R );
-    trsm(
-        Side::Left, Uplo::Upper,
-        Op::NoTrans, Diag::NonUnit,
-        one, U, R );
+            R(i, j) = Asym(i, j);
+    trsm(Side::Left, Uplo::Upper, Op::ConjTrans, Diag::NonUnit, one, U, R);
+    trsm(Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, one, U, R);
 
     // error = ||R-Id||_F
     for (idx_t i = 0; i < k; ++i)
-        R(i,i) -= one;
-    T error = tlapack::lange( tlapack::frob_norm, R );
+        R(i, i) -= one;
+    T error = tlapack::lange(tlapack::frob_norm, R);
 
     std::cout.precision(5);
     std::cout << std::scientific << std::showpos;
-    std::cout << "U^H U R = A   =>   ||R-Id||_F / ||Id||_F = " << error / std::sqrt(k)
-              << std::endl;
+    std::cout << "U^H U R = A   =>   ||R-Id||_F / ||Id||_F = "
+              << error / std::sqrt(k) << std::endl;
 
     return 0;
 }

--- a/examples/performance_eigen/performance_eigen.cpp
+++ b/examples/performance_eigen/performance_eigen.cpp
@@ -7,21 +7,26 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+#include <chrono>  // for high_resolution_clock
 #include <iostream>
-#include <chrono>   // for high_resolution_clock
 
 // From Eigen
 #include <Eigen/Dense>
 #include <Eigen/Householder>
 
 template <class T>
-bool complex_comparator(const std::complex<T> &a, const std::complex<T> &b) {
-    return std::real(a) == std::real(b) ? std::imag(a) > std::imag(b) : std::real(a) > std::real(b);
+bool complex_comparator(const std::complex<T>& a, const std::complex<T>& b)
+{
+    return std::real(a) == std::real(b) ? std::imag(a) > std::imag(b)
+                                        : std::real(a) > std::real(b);
 }
 
 //------------------------------------------------------------------------------
 template <typename T>
-void run( int n, bool compute_forwardError, bool compute_backwardError, int matrix_type )
+void run(int n,
+         bool compute_forwardError,
+         bool compute_backwardError,
+         int matrix_type)
 {
     using idx_t = Eigen::Index;
     using ref_T = long double;
@@ -31,149 +36,143 @@ void run( int n, bool compute_forwardError, bool compute_backwardError, int matr
     const idx_t Nshow = 2;
 
     // Matrices
-    Eigen::Matrix<T,-1,-1> A(n,n);
-    Eigen::Matrix<std::complex<T>,-1,1> exact_eig(n);
+    Eigen::Matrix<T, -1, -1> A(n, n);
+    Eigen::Matrix<std::complex<T>, -1, 1> exact_eig(n);
 
     // Generate a random matrix in A
-    if( matrix_type == 0 )
-    {
+    if (matrix_type == 0) {
         for (int j = 0; j < n; ++j)
             for (int i = 0; i < n; ++i)
-                A(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                A(i, j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
     }
-    else
-    {
+    else {
         // Generate a random ill-conditioned matrix
         {
             // D1 is a diagonal matrix containing the desired eigenvalues
-            Eigen::Matrix<T,-1,1> d1(n);
+            Eigen::Matrix<T, -1, 1> d1(n);
             for (int i = 0; i < n; ++i) {
                 d1[i] = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
                 exact_eig[i] = d1[i];
             }
 
-            // D2 is a diagonal matrix, the condition of this matrix will become the condition of the eigenvector matrix
-            Eigen::Matrix<T,-1,1> d2(n);
+            // D2 is a diagonal matrix, the condition of this matrix will become
+            // the condition of the eigenvector matrix
+            Eigen::Matrix<T, -1, 1> d2(n);
             for (int i = 0; i < n; ++i)
-                d2[i] = std::pow( 2.0, i % matrix_type );
+                d2[i] = std::pow(2.0, i % matrix_type);
 
             // Q1 and Q2 are random unitary matrices
-            Eigen::Matrix<T,-1,-1> Q1(n,n);
-            Eigen::Matrix<T,-1,-1> Q2(n,n);
+            Eigen::Matrix<T, -1, -1> Q1(n, n);
+            Eigen::Matrix<T, -1, -1> Q2(n, n);
             for (int j = 0; j < n; ++j) {
                 for (int i = 0; i < n; ++i) {
-                    Q1(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
-                    Q2(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                    Q1(i, j) =
+                        static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                    Q2(i, j) =
+                        static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
                 }
             }
             Q1 = Eigen::HouseholderQR<decltype(A)>(Q1).householderQ();
             Q2 = Eigen::HouseholderQR<decltype(A)>(Q2).householderQ();
 
             // A = Q2^* D2^-1 Q1^* D1 Q1 D2 Q2
-            A = Q2.adjoint()
-                * d2.asDiagonal().inverse()
-                * Q1.adjoint()
-                * d1.asDiagonal()
-                * Q1
-                * d2.asDiagonal()
-                * Q2;
+            A = Q2.adjoint() * d2.asDiagonal().inverse() * Q1.adjoint() *
+                d1.asDiagonal() * Q1 * d2.asDiagonal() * Q2;
         }
     }
 
     // Reference eigenvalues
-    if( compute_forwardError )
-    {
-        if( matrix_type == 0 )
-        {
-            std::cout << "0. Eigen (reference solution using long double)" << std::endl;
-        
-            Eigen::Matrix<ref_T,-1,-1> A_ref(n,n);
+    if (compute_forwardError) {
+        if (matrix_type == 0) {
+            std::cout << "0. Eigen (reference solution using long double)"
+                      << std::endl;
+
+            Eigen::Matrix<ref_T, -1, -1> A_ref(n, n);
             for (int j = 0; j < n; ++j)
                 for (int i = 0; i < n; ++i)
-                    A_ref(i,j) = A(i,j);
+                    A_ref(i, j) = A(i, j);
 
-            Eigen::EigenSolver<decltype(A_ref)> solver( A_ref );
-            solver.compute( A_ref, false );
-            Eigen::Matrix<std::complex<ref_T>,-1,1> ref_eig = solver.eigenvalues();
+            Eigen::EigenSolver<decltype(A_ref)> solver(A_ref);
+            solver.compute(A_ref, false);
+            Eigen::Matrix<std::complex<ref_T>, -1, 1> ref_eig =
+                solver.eigenvalues();
             for (int i = 0; i < n; ++i)
                 exact_eig[i] = ref_eig[i];
         }
 
         // Reorder eigenvalues
-        std::sort(exact_eig.data(), exact_eig.data() + exact_eig.size(), complex_comparator<T>);
+        std::sort(exact_eig.data(), exact_eig.data() + exact_eig.size(),
+                  complex_comparator<T>);
 
         // Output
-        std::cout   << "First eigenvalues:" << std::endl
-                    << exact_eig.segment(0,Nshow) << std::endl;
+        std::cout << "First eigenvalues:" << std::endl
+                  << exact_eig.segment(0, Nshow) << std::endl;
     }
 
     std::cout << "--------------" << std::endl;
     std::cout << "1. Eigen -----" << std::endl;
-    #if defined(EIGEN_USE_MKL_ALL)
-        std::cout << "Using MKL" << std::endl;
-    #elif defined(EIGEN_USE_BLAS)
-        std::cout << "Using MKL BLAS" << std::endl;
-    #endif
+#if defined(EIGEN_USE_MKL_ALL)
+    std::cout << "Using MKL" << std::endl;
+#elif defined(EIGEN_USE_BLAS)
+    std::cout << "Using MKL BLAS" << std::endl;
+#endif
 
     // Compute eigenvalues using Eigen
     {
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
 
-            Eigen::Matrix<std::complex<T>,-1,1> lambda(n);
-            Eigen::Matrix<T,-1,-1> matrixT(n,n);
-            Eigen::Matrix<T,-1,-1> U(n,n);
+        Eigen::Matrix<std::complex<T>, -1, 1> lambda(n);
+        Eigen::Matrix<T, -1, -1> matrixT(n, n);
+        Eigen::Matrix<T, -1, -1> U(n, n);
 
-            if( compute_backwardError )
-            {
-                Eigen::RealSchur<decltype(A)> solverSchur( A, true );
-                matrixT = solverSchur.matrixT();
-                U = solverSchur.matrixU();
-        
-                idx_t i = 0;
-                while (i < n)
-                {
-                    if (i == n-1 || matrixT(i+1,i) == T(0))
-                    {
-                        lambda[i] = matrixT(i, i);
-                        ++i;
-                    }
-                    else
-                    {
-                        T p = T(0.5) * (matrixT(i, i) - matrixT(i+1, i+1));
-                        T z;
+        if (compute_backwardError) {
+            Eigen::RealSchur<decltype(A)> solverSchur(A, true);
+            matrixT = solverSchur.matrixT();
+            U = solverSchur.matrixU();
 
-                        // Compute z = sqrt(abs(p * p + matrixT(i+1, i) * matrixT(i, i+1)));
-                        // without overflow
-                        {
-                            T t0 = matrixT(i+1, i);
-                            T t1 = matrixT(i, i+1);
-                            T maxval = std::max( abs(p), std::max(abs(t0),abs(t1)) );
-                            t0 /= maxval;
-                            t1 /= maxval;
-                            T p0 = p/maxval;
-                            z = maxval * sqrt(abs(p0 * p0 + t0 * t1));
-                        }
-                        
-                        lambda[i]   = std::complex<T>(matrixT(i+1, i+1) + p,  z);
-                        lambda[i+1] = std::complex<T>(matrixT(i+1, i+1) + p, -z);
-                        
-                        i += 2;
+            idx_t i = 0;
+            while (i < n) {
+                if (i == n - 1 || matrixT(i + 1, i) == T(0)) {
+                    lambda[i] = matrixT(i, i);
+                    ++i;
+                }
+                else {
+                    T p = T(0.5) * (matrixT(i, i) - matrixT(i + 1, i + 1));
+                    T z;
+
+                    // Compute z = sqrt(abs(p * p + matrixT(i+1, i) * matrixT(i,
+                    // i+1))); without overflow
+                    {
+                        T t0 = matrixT(i + 1, i);
+                        T t1 = matrixT(i, i + 1);
+                        T maxval = std::max(abs(p), std::max(abs(t0), abs(t1)));
+                        t0 /= maxval;
+                        t1 /= maxval;
+                        T p0 = p / maxval;
+                        z = maxval * sqrt(abs(p0 * p0 + t0 * t1));
                     }
+
+                    lambda[i] = std::complex<T>(matrixT(i + 1, i + 1) + p, z);
+                    lambda[i + 1] =
+                        std::complex<T>(matrixT(i + 1, i + 1) + p, -z);
+
+                    i += 2;
                 }
             }
-            else
-            {
-                Eigen::EigenSolver<decltype(A)> solver( A, false );
-                lambda = solver.eigenvalues();
-            }
-        
+        }
+        else {
+            Eigen::EigenSolver<decltype(A)> solver(A, false);
+            lambda = solver.eigenvalues();
+        }
+
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
-        
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+
         // // Compute backward error before reordering eigenvalues
         // Eigen::Matrix<T,-1,1> bw_error(2);
         // if( compute_backwardError )
@@ -181,60 +180,66 @@ void run( int n, bool compute_forwardError, bool compute_backwardError, int matr
         //     auto V = solverSchur.matrixU() * solver.eigenvectors();
         //     auto R0 = V * lambda.asDiagonal() - A * V;
         //     auto R1 = V * lambda.asDiagonal() * V.inverse() - A;
-            
+
         //     bw_error[0] = R0.norm() / ( A.norm() * V.norm() );
         //     bw_error[1] = R1.norm() / A.norm();
         // }
 
         // Reorder eigenvalues
-        std::sort(lambda.data(), lambda.data() + lambda.size(), complex_comparator< T >);
+        std::sort(lambda.data(), lambda.data() + lambda.size(),
+                  complex_comparator<T>);
 
         // Compute error
-        Eigen::Matrix<std::complex<T>,-1,1> error(N);
-        for( idx_t i = 0; i < N; ++i )
+        Eigen::Matrix<std::complex<T>, -1, 1> error(N);
+        for (idx_t i = 0; i < N; ++i)
             error[i] = lambda[i] - exact_eig[i];
 
         // Output
-        std::cout   << "First eigenvalues:" << std::endl
-                    << lambda.segment(0,Nshow) << std::endl
-                    << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
-        if( compute_forwardError )
-            std::cout
-                    << "||fl(lambda)-lambda||/||lambda|| = " << error.norm() / exact_eig.norm() << std::endl;
-        if( compute_backwardError )
-        {        
+        std::cout << "First eigenvalues:" << std::endl
+                  << lambda.segment(0, Nshow) << std::endl
+                  << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
+        if (compute_forwardError)
+            std::cout << "||fl(lambda)-lambda||/||lambda|| = "
+                      << error.norm() / exact_eig.norm() << std::endl;
+        if (compute_backwardError) {
             // Check the Schur factorization is correct
-            Eigen::Matrix<T,-1,-1> R0 = U.adjoint() * U - Eigen::Matrix<T,-1,-1>::Identity(n,n);
-            Eigen::Matrix<T,-1,-1> R1 = U * U.adjoint() - Eigen::Matrix<T,-1,-1>::Identity(n,n);
-            Eigen::Matrix<T,-1,-1> R2 = U * matrixT * U.adjoint() - A;
+            Eigen::Matrix<T, -1, -1> R0 =
+                U.adjoint() * U - Eigen::Matrix<T, -1, -1>::Identity(n, n);
+            Eigen::Matrix<T, -1, -1> R1 =
+                U * U.adjoint() - Eigen::Matrix<T, -1, -1>::Identity(n, n);
+            Eigen::Matrix<T, -1, -1> R2 = U * matrixT * U.adjoint() - A;
 
-            std::cout
-                    << "||U^H U - I||/||I|| = " << R0.norm() / sqrt(n*T(1)) << std::endl
-                    << "||U U^H - I||/||I|| = " << R1.norm() / sqrt(n*T(1)) << std::endl
-                    << "||U T U^H - A||/||A|| = " << R2.norm() / A.norm() << std::endl;
-                    // << "||V Lambda - A V||/(||A|| ||V||) = " << bw_error[0] << std::endl
-                    // << "||V Lambda V^{-1} - A||/||A|| = " << bw_error[1] << std::endl;
+            std::cout << "||U^H U - I||/||I|| = " << R0.norm() / sqrt(n * T(1))
+                      << std::endl
+                      << "||U U^H - I||/||I|| = " << R1.norm() / sqrt(n * T(1))
+                      << std::endl
+                      << "||U T U^H - A||/||A|| = " << R2.norm() / A.norm()
+                      << std::endl;
+            // << "||V Lambda - A V||/(||A|| ||V||) = " << bw_error[0] <<
+            // std::endl
+            // << "||V Lambda V^{-1} - A||/||A|| = " << bw_error[1] <<
+            // std::endl;
         }
     }
 }
 
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     // Default arguments
-    const int n = ( argc < 2 ) ? 2 : atoi( argv[1] );
-    const bool compute_forwardError = ( argc < 3 ) ? true : (atoi( argv[2] ) != 0);
-    const bool compute_backwardError = ( argc < 4 ) ? true : (atoi( argv[3] ) != 0);
-    const int matrix_type = ( argc < 5 ) ? 0 : atoi( argv[4] );
-    const int seed = ( argc < 6 ) ? 3 : atoi( argv[5] );
+    const int n = (argc < 2) ? 2 : atoi(argv[1]);
+    const bool compute_forwardError = (argc < 3) ? true : (atoi(argv[2]) != 0);
+    const bool compute_backwardError = (argc < 4) ? true : (atoi(argv[3]) != 0);
+    const int matrix_type = (argc < 5) ? 0 : atoi(argv[4]);
+    const int seed = (argc < 6) ? 3 : atoi(argv[5]);
 
     srand(seed);
 
     std::cout << "# Single precision:" << std::endl;
-    run<float>( n, compute_forwardError, compute_backwardError, matrix_type );
+    run<float>(n, compute_forwardError, compute_backwardError, matrix_type);
     std::cout << std::endl;
-    
+
     std::cout << "# Double precision:" << std::endl;
-    run<double>( n, compute_forwardError, compute_backwardError, matrix_type );
+    run<double>(n, compute_forwardError, compute_backwardError, matrix_type);
     std::cout << std::endl;
 
     return 0;

--- a/examples/performance_eigen/performance_tlapack.cpp
+++ b/examples/performance_eigen/performance_tlapack.cpp
@@ -7,23 +7,25 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <iostream>
-#include <chrono>   // for high_resolution_clock
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
+#include <tlapack/plugins/eigen.hpp>
+#ifdef USE_MDSPAN_DATA
+    #include <tlapack/plugins/mdspan.hpp>
+#endif
 
-// From Eigen
+// <T>LAPACK
+#include <tlapack/lapack/gehrd.hpp>
+#include <tlapack/blas/nrm2.hpp>
+#include <tlapack/lapack/unghr.hpp>
+#include <tlapack/lapack/multishift_qr.hpp>
+
+// Eigen
 #include <Eigen/Dense>
 #include <Eigen/Householder>
 
-#include <tlapack/plugins/eigen.hpp>
-
-#ifdef USE_MDSPAN_DATA
-    #include <tlapack/plugins/mdspan.hpp>
-    #include <tlapack/blas/nrm2.hpp>
-#endif
-
-#include <tlapack/lapack/gehrd.hpp>
-#include <tlapack/lapack/unghr.hpp>
-#include <tlapack/lapack/multishift_qr.hpp>
+// C++ headers
+#include <iostream>
+#include <chrono>   // for high_resolution_clock
 
 template <class T>
 bool complex_comparator(const std::complex<T> &a, const std::complex<T> &b) {

--- a/examples/performance_eigen/performance_tlapack.cpp
+++ b/examples/performance_eigen/performance_tlapack.cpp
@@ -14,27 +14,32 @@
 #endif
 
 // <T>LAPACK
-#include <tlapack/lapack/gehrd.hpp>
 #include <tlapack/blas/nrm2.hpp>
-#include <tlapack/lapack/unghr.hpp>
+#include <tlapack/lapack/gehrd.hpp>
 #include <tlapack/lapack/multishift_qr.hpp>
+#include <tlapack/lapack/unghr.hpp>
 
 // Eigen
 #include <Eigen/Dense>
 #include <Eigen/Householder>
 
 // C++ headers
+#include <chrono>  // for high_resolution_clock
 #include <iostream>
-#include <chrono>   // for high_resolution_clock
 
 template <class T>
-bool complex_comparator(const std::complex<T> &a, const std::complex<T> &b) {
-    return std::real(a) == std::real(b) ? std::imag(a) > std::imag(b) : std::real(a) > std::real(b);
+bool complex_comparator(const std::complex<T>& a, const std::complex<T>& b)
+{
+    return std::real(a) == std::real(b) ? std::imag(a) > std::imag(b)
+                                        : std::real(a) > std::real(b);
 }
 
 //------------------------------------------------------------------------------
 template <typename T>
-void run( int n, bool compute_forwardError, bool compute_backwardError, int matrix_type )
+void run(int n,
+         bool compute_forwardError,
+         bool compute_backwardError,
+         int matrix_type)
 {
     using namespace tlapack;
     using ref_T = long double;
@@ -44,80 +49,77 @@ void run( int n, bool compute_forwardError, bool compute_backwardError, int matr
     const int Nshow = 2;
 
     // Matrices
-    Eigen::Matrix<T,-1,-1> A(n,n);
-    Eigen::Matrix<std::complex<T>,-1,1> exact_eig(n);
+    Eigen::Matrix<T, -1, -1> A(n, n);
+    Eigen::Matrix<std::complex<T>, -1, 1> exact_eig(n);
 
     // Generate a random matrix in A
-    if( matrix_type == 0 )
-    {
+    if (matrix_type == 0) {
         for (int j = 0; j < n; ++j)
             for (int i = 0; i < n; ++i)
-                A(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                A(i, j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
     }
-    else
-    {
+    else {
         // Generate a random ill-conditioned matrix
         {
             // D1 is a diagonal matrix containing the desired eigenvalues
-            Eigen::Matrix<T,-1,1> d1(n);
+            Eigen::Matrix<T, -1, 1> d1(n);
             for (int i = 0; i < n; ++i) {
                 d1[i] = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
                 exact_eig[i] = d1[i];
             }
 
-            // D2 is a diagonal matrix, the condition of this matrix will become the condition of the eigenvector matrix
-            Eigen::Matrix<T,-1,1> d2(n);
+            // D2 is a diagonal matrix, the condition of this matrix will become
+            // the condition of the eigenvector matrix
+            Eigen::Matrix<T, -1, 1> d2(n);
             for (int i = 0; i < n; ++i)
-                d2[i] = std::pow( 2.0, i % matrix_type );
+                d2[i] = std::pow(2.0, i % matrix_type);
 
             // Q1 and Q2 are random unitary matrices
-            Eigen::Matrix<T,-1,-1> Q1(n,n);
-            Eigen::Matrix<T,-1,-1> Q2(n,n);
+            Eigen::Matrix<T, -1, -1> Q1(n, n);
+            Eigen::Matrix<T, -1, -1> Q2(n, n);
             for (int j = 0; j < n; ++j) {
                 for (int i = 0; i < n; ++i) {
-                    Q1(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
-                    Q2(i,j) = static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                    Q1(i, j) =
+                        static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
+                    Q2(i, j) =
+                        static_cast<T>(rand()) / static_cast<T>(RAND_MAX);
                 }
             }
             Q1 = Eigen::HouseholderQR<decltype(A)>(Q1).householderQ();
             Q2 = Eigen::HouseholderQR<decltype(A)>(Q2).householderQ();
 
             // A = Q2^* D2^-1 Q1^* D1 Q1 D2 Q2
-            A = Q2.adjoint()
-                * d2.asDiagonal().inverse()
-                * Q1.adjoint()
-                * d1.asDiagonal()
-                * Q1
-                * d2.asDiagonal()
-                * Q2;
+            A = Q2.adjoint() * d2.asDiagonal().inverse() * Q1.adjoint() *
+                d1.asDiagonal() * Q1 * d2.asDiagonal() * Q2;
         }
     }
 
     // Reference eigenvalues
-    if( compute_forwardError )
-    {
-        if( matrix_type == 0 )
-        {
-            std::cout << "0. Eigen (reference solution using long double)" << std::endl;
-        
-            Eigen::Matrix<ref_T,-1,-1> A_ref(n,n);
+    if (compute_forwardError) {
+        if (matrix_type == 0) {
+            std::cout << "0. Eigen (reference solution using long double)"
+                      << std::endl;
+
+            Eigen::Matrix<ref_T, -1, -1> A_ref(n, n);
             for (int j = 0; j < n; ++j)
                 for (int i = 0; i < n; ++i)
-                    A_ref(i,j) = A(i,j);
+                    A_ref(i, j) = A(i, j);
 
-            Eigen::EigenSolver<decltype(A_ref)> solver( A_ref );
-            solver.compute( A_ref, false );
-            Eigen::Matrix<std::complex<ref_T>,-1,1> ref_eig = solver.eigenvalues();
+            Eigen::EigenSolver<decltype(A_ref)> solver(A_ref);
+            solver.compute(A_ref, false);
+            Eigen::Matrix<std::complex<ref_T>, -1, 1> ref_eig =
+                solver.eigenvalues();
             for (int i = 0; i < n; ++i)
                 exact_eig[i] = ref_eig[i];
         }
-        
+
         // Reorder eigenvalues
-        std::sort(exact_eig.data(), exact_eig.data() + exact_eig.size(), complex_comparator<T>);
+        std::sort(exact_eig.data(), exact_eig.data() + exact_eig.size(),
+                  complex_comparator<T>);
 
         // Output
-        std::cout   << "First eigenvalues:" << std::endl
-                    << exact_eig.segment(0,Nshow) << std::endl;
+        std::cout << "First eigenvalues:" << std::endl
+                  << exact_eig.segment(0, Nshow) << std::endl;
     }
 
     std::cout << "-------------------" << std::endl;
@@ -130,50 +132,51 @@ void run( int n, bool compute_forwardError, bool compute_backwardError, int matr
 
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
-            
-            // Hessenberg reduction
-            Eigen::Matrix<T,-1,-1> H = A;
-            Eigen::Matrix<T,-1, 1> tau(n);
-            gehrd( 0, n, H, tau );
 
-            // Save reflectors elsewhere (in Q) to make a true Hessenberg matrix
-            Eigen::Matrix<T,-1,-1> Q(n,n);
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = j + 2; i < n; ++i) {
-                    Q(i,j) = H(i,j);
-                    H(i,j) = T(0);
-                }
-            
-            // Compute eigenvalues
-            Eigen::Matrix<std::complex<T>,-1,1> tlapack_eig(n);
-            Eigen::Matrix<T,-1,-1> U(n,n);
-            Eigen::Matrix<T,-1,-1> matrixT = H;
+        // Hessenberg reduction
+        Eigen::Matrix<T, -1, -1> H = A;
+        Eigen::Matrix<T, -1, 1> tau(n);
+        gehrd(0, n, H, tau);
 
-            // Initialize U
-            if( compute_backwardError )
-            {
-                unghr( 0, n, Q, tau );
-                U = Q;
+        // Save reflectors elsewhere (in Q) to make a true Hessenberg matrix
+        Eigen::Matrix<T, -1, -1> Q(n, n);
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 2; i < n; ++i) {
+                Q(i, j) = H(i, j);
+                H(i, j) = T(0);
             }
-            else
-                U.setIdentity();
 
-            int n_aed, n_sweep, n_shifts_total;
-            {
-                francis_opts_t<idx_t> opts;
-                
-                multishift_qr( compute_backwardError, compute_backwardError, 0, n, matrixT, tlapack_eig, U, opts );
-                
-                n_aed = opts.n_aed;
-                n_sweep = opts.n_sweep;
-                n_shifts_total = opts.n_shifts_total;
-            }
+        // Compute eigenvalues
+        Eigen::Matrix<std::complex<T>, -1, 1> tlapack_eig(n);
+        Eigen::Matrix<T, -1, -1> U(n, n);
+        Eigen::Matrix<T, -1, -1> matrixT = H;
+
+        // Initialize U
+        if (compute_backwardError) {
+            unghr(0, n, Q, tau);
+            U = Q;
+        }
+        else
+            U.setIdentity();
+
+        int n_aed, n_sweep, n_shifts_total;
+        {
+            francis_opts_t<idx_t> opts;
+
+            multishift_qr(compute_backwardError, compute_backwardError, 0, n,
+                          matrixT, tlapack_eig, U, opts);
+
+            n_aed = opts.n_aed;
+            n_sweep = opts.n_sweep;
+            n_shifts_total = opts.n_shifts_total;
+        }
 
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
 
         // Clean the lower triangular part that was used a workspace
         for (idx_t j = 0; j < n; ++j)
@@ -181,38 +184,46 @@ void run( int n, bool compute_forwardError, bool compute_backwardError, int matr
                 matrixT(i, j) = T(0);
 
         // Reorder eigenvalues
-        std::sort(tlapack_eig.data(), tlapack_eig.data() + tlapack_eig.size(), complex_comparator< T >);
+        std::sort(tlapack_eig.data(), tlapack_eig.data() + tlapack_eig.size(),
+                  complex_comparator<T>);
 
         // Compute error
-        Eigen::Matrix<std::complex<T>,-1,1> error(N);
-        for( idx_t i = 0; i < N; ++i )
+        Eigen::Matrix<std::complex<T>, -1, 1> error(N);
+        for (idx_t i = 0; i < N; ++i)
             error[i] = tlapack_eig[i] - exact_eig[i];
 
         // Output
-        std::cout   << "First eigenvalues:" << std::endl
-                    << tlapack_eig.segment(0,Nshow) << std::endl
-                    << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl
-                    << "n_aed = " << n_aed << std::endl
-                    << "n_sweep = " << n_sweep << std::endl
-                    << "n_shifts_total = " << n_shifts_total << std::endl;
-        if( compute_forwardError )
-            std::cout
-                    << "||fl(lambda)-lambda||/||lambda|| = " << error.norm() / exact_eig.norm() << std::endl;
-        if( compute_backwardError )
-        {        
+        std::cout << "First eigenvalues:" << std::endl
+                  << tlapack_eig.segment(0, Nshow) << std::endl
+                  << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl
+                  << "n_aed = " << n_aed << std::endl
+                  << "n_sweep = " << n_sweep << std::endl
+                  << "n_shifts_total = " << n_shifts_total << std::endl;
+        if (compute_forwardError)
+            std::cout << "||fl(lambda)-lambda||/||lambda|| = "
+                      << error.norm() / exact_eig.norm() << std::endl;
+        if (compute_backwardError) {
             // Check the Schur factorization is correct
-            Eigen::Matrix<T,-1,-1> R0 = U.adjoint() * U - Eigen::Matrix<T,-1,-1>::Identity(n,n);
-            Eigen::Matrix<T,-1,-1> R1 = U * U.adjoint() - Eigen::Matrix<T,-1,-1>::Identity(n,n);
-            Eigen::Matrix<T,-1,-1> R2 = Q.adjoint() * Q - Eigen::Matrix<T,-1,-1>::Identity(n,n);
-            Eigen::Matrix<T,-1,-1> R3 = Q * Q.adjoint() - Eigen::Matrix<T,-1,-1>::Identity(n,n);
-            Eigen::Matrix<T,-1,-1> R4 = U * matrixT * U.adjoint() - A;
+            Eigen::Matrix<T, -1, -1> R0 =
+                U.adjoint() * U - Eigen::Matrix<T, -1, -1>::Identity(n, n);
+            Eigen::Matrix<T, -1, -1> R1 =
+                U * U.adjoint() - Eigen::Matrix<T, -1, -1>::Identity(n, n);
+            Eigen::Matrix<T, -1, -1> R2 =
+                Q.adjoint() * Q - Eigen::Matrix<T, -1, -1>::Identity(n, n);
+            Eigen::Matrix<T, -1, -1> R3 =
+                Q * Q.adjoint() - Eigen::Matrix<T, -1, -1>::Identity(n, n);
+            Eigen::Matrix<T, -1, -1> R4 = U * matrixT * U.adjoint() - A;
 
-            std::cout
-                    << "||U^H U - I||/||I|| = " << R0.norm() / sqrt(n*T(1)) << std::endl
-                    << "||U U^H - I||/||I|| = " << R1.norm() / sqrt(n*T(1)) << std::endl
-                    << "||U T U^H - A||/||A|| = " << R4.norm() / A.norm() << std::endl;
-                    // << "||Q^H Q - I||/||I|| = " << R2.norm() / sqrt(n*T(1)) << std::endl
-                    // << "||Q Q^H - I||/||I|| = " << R3.norm() / sqrt(n*T(1)) << std::endl;
+            std::cout << "||U^H U - I||/||I|| = " << R0.norm() / sqrt(n * T(1))
+                      << std::endl
+                      << "||U U^H - I||/||I|| = " << R1.norm() / sqrt(n * T(1))
+                      << std::endl
+                      << "||U T U^H - A||/||A|| = " << R4.norm() / A.norm()
+                      << std::endl;
+            // << "||Q^H Q - I||/||I|| = " << R2.norm() / sqrt(n*T(1)) <<
+            // std::endl
+            // << "||Q Q^H - I||/||I|| = " << R3.norm() / sqrt(n*T(1)) <<
+            // std::endl;
         }
     }
 
@@ -225,71 +236,77 @@ void run( int n, bool compute_forwardError, bool compute_backwardError, int matr
     // Compute eigenvalues using <T>LAPACK with kokkos::mdspan matrices
     {
         using idx_t = size_t;
-        using mdspan_matrix = std::experimental::mdspan< T, std::experimental::dextents<idx_t,2>, std::experimental::layout_left >;
-        using mdspan_vector = std::experimental::mdspan< T, std::experimental::dextents<idx_t,1> >;
-        using mdspan_complexvector = std::experimental::mdspan< std::complex<T>, std::experimental::dextents<idx_t,1> >;
+        using mdspan_matrix =
+            std::experimental::mdspan<T, std::experimental::dextents<idx_t, 2>,
+                                      std::experimental::layout_left>;
+        using mdspan_vector =
+            std::experimental::mdspan<T,
+                                      std::experimental::dextents<idx_t, 1> >;
+        using mdspan_complexvector =
+            std::experimental::mdspan<std::complex<T>,
+                                      std::experimental::dextents<idx_t, 1> >;
 
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
-            
-            // (1) Hessenberg reduction
-            
-            std::vector<T> H_( A.data(), A.data() + n*n );
-            mdspan_matrix H( H_.data(), n, n );
-            
-            std::vector<T> tau_(n);
-            mdspan_vector tau( tau_.data(), n );
-            
-            tlapack::gehrd( 0, n, H, tau );
 
-            // Save reflectors elsewhere (in Q) to make a true Hessenberg matrix
-            std::vector<T> Q_( H.data(), H.data() + n*n );
-            mdspan_matrix Q( Q_.data(), n, n );
+        // (1) Hessenberg reduction
+
+        std::vector<T> H_(A.data(), A.data() + n * n);
+        mdspan_matrix H(H_.data(), n, n);
+
+        std::vector<T> tau_(n);
+        mdspan_vector tau(tau_.data(), n);
+
+        tlapack::gehrd(0, n, H, tau);
+
+        // Save reflectors elsewhere (in Q) to make a true Hessenberg matrix
+        std::vector<T> Q_(H.data(), H.data() + n * n);
+        mdspan_matrix Q(Q_.data(), n, n);
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 2; i < n; ++i)
+                H(i, j) = T(0);
+
+        // (2) Compute eigenvalues
+
+        std::vector<std::complex<T> > tlapack_eig_(n);
+        mdspan_complexvector tlapack_eig(tlapack_eig_.data(), n);
+
+        std::vector<T> U_(n * n);
+        mdspan_matrix U(U_.data(), n, n);
+
+        std::vector<T> matrixT_(&H_[0], &H_[0] + n * n);
+        mdspan_matrix matrixT(matrixT_.data(), n, n);
+
+        // Initialize U
+        if (compute_backwardError) {
+            unghr(0, n, Q, tau);
             for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = j + 2; i < n; ++i)
-                    H(i,j) = T(0);
-            
-            // (2) Compute eigenvalues
+                for (idx_t i = 0; i < n; ++i)
+                    U(i, j) = Q(i, j);
+        }
+        else {
+            for (idx_t j = 0; j < n; ++j)
+                U(j, j) = T(1);
+        }
 
-            std::vector< std::complex<T> > tlapack_eig_(n);
-            mdspan_complexvector tlapack_eig( tlapack_eig_.data(), n );
+        int n_aed, n_sweep, n_shifts_total;
+        {
+            francis_opts_t<idx_t> opts;
 
-            std::vector<T> U_(n*n);
-            mdspan_matrix U( U_.data(), n, n );
+            multishift_qr(compute_backwardError, compute_backwardError, 0, n,
+                          matrixT, tlapack_eig, U, opts);
 
-            std::vector<T> matrixT_( &H_[0], &H_[0] + n*n );
-            mdspan_matrix matrixT( matrixT_.data(), n, n );
-
-            // Initialize U
-            if( compute_backwardError )
-            {
-                unghr( 0, n, Q, tau );
-                for (idx_t j = 0; j < n; ++j)
-                    for (idx_t i = 0; i < n; ++i)
-                        U(i,j) = Q(i,j);
-            }
-            else
-            {
-                for (idx_t j = 0; j < n; ++j)
-                    U(j,j) = T(1);
-            }
-
-            int n_aed, n_sweep, n_shifts_total;
-            {
-                francis_opts_t<idx_t> opts;
-                
-                multishift_qr( compute_backwardError, compute_backwardError, 0, n, matrixT, tlapack_eig, U, opts );
-                
-                n_aed = opts.n_aed;
-                n_sweep = opts.n_sweep;
-                n_shifts_total = opts.n_shifts_total;
-            }
+            n_aed = opts.n_aed;
+            n_sweep = opts.n_sweep;
+            n_shifts_total = opts.n_shifts_total;
+        }
 
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
 
         // Clean the lower triangular part that was used a workspace
         for (idx_t j = 0; j < n; ++j)
@@ -297,49 +314,48 @@ void run( int n, bool compute_forwardError, bool compute_backwardError, int matr
                 matrixT(i, j) = T(0);
 
         // Reorder eigenvalues
-        std::sort(&tlapack_eig_[0], &tlapack_eig_[0] + tlapack_eig.size(), complex_comparator< T >);
+        std::sort(&tlapack_eig_[0], &tlapack_eig_[0] + tlapack_eig.size(),
+                  complex_comparator<T>);
 
         // Compute error
-        std::vector< std::complex<T> > error_(N);
-        mdspan_complexvector error( error_.data(), N );
-        for( idx_t i = 0; i < N; ++i )
+        std::vector<std::complex<T> > error_(N);
+        mdspan_complexvector error(error_.data(), N);
+        for (idx_t i = 0; i < N; ++i)
             error[i] = tlapack_eig[i] - exact_eig[i];
 
         // Output
-        std::cout   << "First eigenvalues:" << std::endl;
-        for( idx_t i=0; i < Nshow; ++i )
+        std::cout << "First eigenvalues:" << std::endl;
+        for (idx_t i = 0; i < Nshow; ++i)
             std::cout << tlapack_eig[i] << std::endl;
-        std::cout
-                    << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl
-                    << "n_aed = " << n_aed << std::endl
-                    << "n_sweep = " << n_sweep << std::endl
-                    << "n_shifts_total = " << n_shifts_total << std::endl;
-        if( compute_forwardError )
-            std::cout
-                    << "||fl(lambda)-lambda||/||lambda|| = " << nrm2(error) / nrm2(exact_eig) << std::endl;
+        std::cout << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl
+                  << "n_aed = " << n_aed << std::endl
+                  << "n_sweep = " << n_sweep << std::endl
+                  << "n_shifts_total = " << n_shifts_total << std::endl;
+        if (compute_forwardError)
+            std::cout << "||fl(lambda)-lambda||/||lambda|| = "
+                      << nrm2(error) / nrm2(exact_eig) << std::endl;
     }
 
 #endif
-
 }
 
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     // Default arguments
-    const int n = ( argc < 2 ) ? 2 : atoi( argv[1] );
-    const bool compute_forwardError = ( argc < 3 ) ? true : (atoi( argv[2] ) != 0);
-    const bool compute_backwardError = ( argc < 4 ) ? true : (atoi( argv[3] ) != 0);
-    const int matrix_type = ( argc < 5 ) ? 0 : atoi( argv[4] );
-    const int seed = ( argc < 6 ) ? 3 : atoi( argv[5] );
+    const int n = (argc < 2) ? 2 : atoi(argv[1]);
+    const bool compute_forwardError = (argc < 3) ? true : (atoi(argv[2]) != 0);
+    const bool compute_backwardError = (argc < 4) ? true : (atoi(argv[3]) != 0);
+    const int matrix_type = (argc < 5) ? 0 : atoi(argv[4]);
+    const int seed = (argc < 6) ? 3 : atoi(argv[5]);
 
     srand(seed);
 
     std::cout << "# Single precision:" << std::endl;
-    run<float>( n, compute_forwardError, compute_backwardError, matrix_type );
+    run<float>(n, compute_forwardError, compute_backwardError, matrix_type);
     std::cout << std::endl;
-    
+
     std::cout << "# Double precision:" << std::endl;
-    run<double>( n, compute_forwardError, compute_backwardError, matrix_type );
+    run<double>(n, compute_forwardError, compute_backwardError, matrix_type);
     std::cout << std::endl;
 
     return 0;

--- a/examples/potrf/example_potrf.cpp
+++ b/examples/potrf/example_potrf.cpp
@@ -18,194 +18,212 @@
 #include <tlapack/lapack/potrs.hpp>
 
 // C++ headers
-#include <vector>
+#include <chrono>  // for high_resolution_clock
 #include <iostream>
-#include <chrono>   // for high_resolution_clock
+#include <vector>
 
 #ifndef USE_MKL
-    // LAPACKE
-    extern "C" {
-        #include <lapacke.h>
-    }
-    typedef float _Complex complex;
-    typedef double _Complex dComplex;
+// LAPACKE
+extern "C" {
+    #include <lapacke.h>
+}
+typedef float _Complex complex;
+typedef double _Complex dComplex;
 #else
-    // MKL LAPACKE
-    extern "C" {
-        #include <mkl_lapacke.h>
-    }
-    typedef _MKL_Complex8 complex;
-    typedef _MKL_Complex16 dComplex;
+// MKL LAPACKE
+extern "C" {
+    #include <mkl_lapacke.h>
+}
+typedef _MKL_Complex8 complex;
+typedef _MKL_Complex16 dComplex;
 #endif
 
-inline
-lapack_int LAPACKE_xpotrf2( int matrix_layout, char uplo, lapack_int n, float* a, lapack_int lda ) {
-    return LAPACKE_spotrf2( matrix_layout, uplo, n, a, lda );
+inline lapack_int LAPACKE_xpotrf2(
+    int matrix_layout, char uplo, lapack_int n, float* a, lapack_int lda)
+{
+    return LAPACKE_spotrf2(matrix_layout, uplo, n, a, lda);
 }
-inline
-lapack_int LAPACKE_xpotrf2( int matrix_layout, char uplo, lapack_int n, double* a, lapack_int lda ) {
-    return LAPACKE_dpotrf2( matrix_layout, uplo, n, a, lda );
+inline lapack_int LAPACKE_xpotrf2(
+    int matrix_layout, char uplo, lapack_int n, double* a, lapack_int lda)
+{
+    return LAPACKE_dpotrf2(matrix_layout, uplo, n, a, lda);
 }
-inline
-lapack_int LAPACKE_xpotrf2( int matrix_layout, char uplo, lapack_int n, std::complex<float>* a, lapack_int lda ) {
-    return LAPACKE_cpotrf2( matrix_layout, uplo, n, reinterpret_cast<complex*>(a), lda );
+inline lapack_int LAPACKE_xpotrf2(int matrix_layout,
+                                  char uplo,
+                                  lapack_int n,
+                                  std::complex<float>* a,
+                                  lapack_int lda)
+{
+    return LAPACKE_cpotrf2(matrix_layout, uplo, n,
+                           reinterpret_cast<complex*>(a), lda);
 }
-inline
-lapack_int LAPACKE_xpotrf2( int matrix_layout, char uplo, lapack_int n, std::complex<double>* a, lapack_int lda ) {
-    return LAPACKE_zpotrf2( matrix_layout, uplo, n, reinterpret_cast<dComplex*>(a), lda );
+inline lapack_int LAPACKE_xpotrf2(int matrix_layout,
+                                  char uplo,
+                                  lapack_int n,
+                                  std::complex<double>* a,
+                                  lapack_int lda)
+{
+    return LAPACKE_zpotrf2(matrix_layout, uplo, n,
+                           reinterpret_cast<dComplex*>(a), lda);
 }
 
 using idx_t = lapack_int;
 
 //------------------------------------------------------------------------------
 template <typename T>
-void run( idx_t n )
+void run(idx_t n)
 {
     using namespace tlapack;
     using real_t = real_type<T>;
 
     // Matrix A
-    std::vector<T> A_( n*n );
-    legacyMatrix<T> A( n, n, &A_[0], n );
+    std::vector<T> A_(n * n);
+    legacyMatrix<T> A(n, n, &A_[0], n);
 
     // // Flops
     // const real_t nFlops = real_t(n*n*n) / 3;
-    
+
     // Fill A with random entries
     for (idx_t j = 0; j < n; ++j) {
         for (idx_t i = 0; i < n; ++i)
-            A(i,j) = static_cast<float>( rand() )
-                    / static_cast<float>( RAND_MAX );
+            A(i, j) = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     }
-    
+
     // Turn the upper part of A into a symmetric positive definite matrix
     for (idx_t j = 0; j < n; ++j) {
         for (idx_t i = 0; i < j; ++i)
-            A(i,j) = T(0.5) * ( A(i,j) + A(j,i) );
-        A(j,j) += n;
+            A(i, j) = T(0.5) * (A(i, j) + A(j, i));
+        A(j, j) += n;
     }
 
     // 1) Using <T>LAPACK interface:
     {
-        std::vector<T> U_( n*n );
-        legacyMatrix<T> U( n, n, &U_[0], n );
+        std::vector<T> U_(n * n);
+        legacyMatrix<T> U(n, n, &U_[0], n);
 
         // Put garbage on U_
-        for (idx_t j = 0; j < n*n; ++j)
-            U_[j] = make_scalar<real_t>( static_cast<float>( 0xDEADBEEF ), static_cast<float>( 0xDEADBEEF ) );
+        for (idx_t j = 0; j < n * n; ++j)
+            U_[j] = make_scalar<real_t>(static_cast<float>(0xDEADBEEF),
+                                        static_cast<float>(0xDEADBEEF));
 
         // U_ receives the upper part of A
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i <= j; ++i)
-                U_[i+j*n] = A(i,j);
+                U_[i + j * n] = A(i, j);
 
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
 
-            int info = potrf2( upperTriangle, U );
-        
+        int info = potrf2(upperTriangle, U);
+
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
-            
-        if( info != 0 ) {
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+
+        if (info != 0) {
             std::cout << "Cholesky ended with info " << info << std::endl;
         }
 
         // Solve U^H U R = A
-        std::vector<T> R_( n*n );
-        legacyMatrix<T> R( n, n, &R_[0], n );
-        lacpy( dense, A, R );
-        potrs( upperTriangle, U, R );
+        std::vector<T> R_(n * n);
+        legacyMatrix<T> R(n, n, &R_[0], n);
+        lacpy(dense, A, R);
+        potrs(upperTriangle, U, R);
 
         // error = ||R-Id||_F / ||Id||_F
         for (idx_t i = 0; i < n; ++i)
-            R(i,i) -= T(1);
-        real_t error = lange( frob_norm, R ) / std::sqrt(n);
+            R(i, i) -= T(1);
+        real_t error = lange(frob_norm, R) / std::sqrt(n);
 
         // Output
         std::cout << "Using <T>LAPACK:" << std::endl
-                << "U^H U R = A   =>   ||R-Id||_F / ||Id||_F = " << error << std::endl
-                << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
+                  << "U^H U R = A   =>   ||R-Id||_F / ||Id||_F = " << error
+                  << std::endl
+                  << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
         // std::cout << nFlops / elapsed.count() << " ";
     }
 
     // 2) Using LAPACKE:
     {
-        std::vector<T> U( n*n );
+        std::vector<T> U(n * n);
 
         // Put garbage on U
-        for (idx_t j = 0; j < n*n; ++j)
-            U[j] = make_scalar<real_t>( static_cast<float>( 0xDEADBEEF ), static_cast<float>( 0xDEADBEEF ) );
+        for (idx_t j = 0; j < n * n; ++j)
+            U[j] = make_scalar<real_t>(static_cast<float>(0xDEADBEEF),
+                                       static_cast<float>(0xDEADBEEF));
 
         // U receives the upper part of A
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i <= j; ++i)
-                U[i+j*n] = A(i,j);
+                U[i + j * n] = A(i, j);
 
         // Record start time
         auto start = std::chrono::high_resolution_clock::now();
 
-            lapack_int info = LAPACKE_xpotrf2( LAPACK_COL_MAJOR, 'U', n, U.data(), n );
-        
+        lapack_int info =
+            LAPACKE_xpotrf2(LAPACK_COL_MAJOR, 'U', n, U.data(), n);
+
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
 
         // Compute elapsed time in nanoseconds
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
-            
-        if( info != 0 ) {
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+
+        if (info != 0) {
             std::cout << "Cholesky ended with info " << info << std::endl;
         }
 
         // Solve U^H U R = A
-        std::vector<T> R_( n*n );
-        legacyMatrix<T> R( n, n, &R_[0], n );
-        lacpy( dense, A, R );
-        potrs( upperTriangle, legacyMatrix<T>( n, n, &U[0], n ), R );
+        std::vector<T> R_(n * n);
+        legacyMatrix<T> R(n, n, &R_[0], n);
+        lacpy(dense, A, R);
+        potrs(upperTriangle, legacyMatrix<T>(n, n, &U[0], n), R);
 
         // error = ||R-Id||_F / ||Id||_F
         for (idx_t i = 0; i < n; ++i)
-            R(i,i) -= T(1);
-        real_t error = lange( frob_norm, R ) / std::sqrt(n);
+            R(i, i) -= T(1);
+        real_t error = lange(frob_norm, R) / std::sqrt(n);
 
         // Output
         std::cout << "Using LAPACKE:" << std::endl
-                << "U^H U R = A   =>   ||R-Id||_F / ||Id||_F = " << error << std::endl
-                << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
+                  << "U^H U R = A   =>   ||R-Id||_F / ||Id||_F = " << error
+                  << std::endl
+                  << "time = " << elapsed.count() * 1.0e-9 << " s" << std::endl;
         // std::cout << nFlops / elapsed.count() << " ";
     }
 }
 
 //------------------------------------------------------------------------------
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     idx_t n;
 
     // Default arguments
-    n = ( argc < 2 ) ? 100 : atoi( argv[1] );
+    n = (argc < 2) ? 100 : atoi(argv[1]);
 
-    srand( 3 ); // Init random seed
+    srand(3);  // Init random seed
 
     std::cout.precision(5);
     std::cout << std::scientific << std::showpos;
-    
+
     std::cout << "run< float >( " << n << " )" << std::endl;
-    run< float >( n );
+    run<float>(n);
     std::cout << "-----------------------" << std::endl;
-    
+
     std::cout << "run< double >( " << n << " )" << std::endl;
-    run< double >( n );
+    run<double>(n);
     std::cout << "-----------------------" << std::endl;
-    
+
     std::cout << "run< complex<float> >( " << n << " )" << std::endl;
-    run< std::complex<float> >( n );
+    run<std::complex<float> >(n);
     std::cout << "-----------------------" << std::endl;
-    
+
     std::cout << "run< complex<double> >( " << n << " )" << std::endl;
-    run< std::complex<double> >( n );
+    run<std::complex<double> >(n);
     std::cout << "-----------------------" << std::endl;
 
     // std::cout << std::endl;

--- a/examples/potrf/example_potrf.cpp
+++ b/examples/potrf/example_potrf.cpp
@@ -7,18 +7,20 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <vector>
-#include <iostream>
-#include <chrono>   // for high_resolution_clock
-
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #include <tlapack/plugins/legacyArray.hpp>
 
 // <T>LAPACK
 #include <tlapack/blas/gemm.hpp>
-#include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/lacpy.hpp>
+#include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/potrf2.hpp>
 #include <tlapack/lapack/potrs.hpp>
+
+// C++ headers
+#include <vector>
+#include <iostream>
+#include <chrono>   // for high_resolution_clock
 
 #ifndef USE_MKL
     // LAPACKE

--- a/include/tlapack.h.in
+++ b/include/tlapack.h.in
@@ -8,11 +8,13 @@
 #define TLAPACK_BLAS_H
 
 // -----------------------------------------------------------------------------
-#include <stdint.h>
-#include <stddef.h>
 #include <complex.h>
+#include <stddef.h>
+#include <stdint.h>
 
+// clang-format off
 @TLAPACK_DEFINES@
+// clang-format on
 
 // -----------------------------------------------------------------------------
 // Integer types TLAPACK_SIZE_T and TLAPACK_INT_T
@@ -27,1108 +29,533 @@
 // -----------------------------------------------------------------------------
 
 #ifdef __cplusplus
-extern "C" {
+    extern "C"
+{
 #endif
 
-// -----------------------------------------------------------------------------
-// Enumerations
-typedef enum Layout { ColMajor = 'C', RowMajor = 'R' } Layout;
-typedef enum Op     { NoTrans  = 'N', Trans    = 'T', ConjTrans = 'C' } Op;
-typedef enum Uplo   { Upper    = 'U', Lower    = 'L', General   = 'G' } Uplo;
-typedef enum Diag   { NonUnit  = 'N', Unit     = 'U' } Diag;
-typedef enum Side   { Left     = 'L', Right    = 'R' } Side;
-
-// =============================================================================
-// Level 1 BLAS
-
-float sasum(
-    TLAPACK_SIZE_T n,
-    float const * x, TLAPACK_INT_T incx );
-
-double dasum(
-    TLAPACK_SIZE_T n,
-    double const * x, TLAPACK_INT_T incx );
-
-float casum(
-    TLAPACK_SIZE_T n,
-    float  _Complex const * x, TLAPACK_INT_T incx );
-
-double zasum(
-    TLAPACK_SIZE_T n,
-    double _Complex const * x, TLAPACK_INT_T incx );
-
-void saxpy(
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * x, TLAPACK_INT_T incx,
-    float * y, TLAPACK_INT_T incy );
-
-void daxpy(
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * x, TLAPACK_INT_T incx,
-    double * y, TLAPACK_INT_T incy );
-
-void caxpy(
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex * y, TLAPACK_INT_T incy );
-
-void zaxpy(
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex * y, TLAPACK_INT_T incy );
-
-void scopy(
-    TLAPACK_SIZE_T n,
-    float const * x, TLAPACK_INT_T incx,
-    float * y, TLAPACK_INT_T incy );
-
-void dcopy(
-    TLAPACK_SIZE_T n,
-    double const * x, TLAPACK_INT_T incx,
-    double * y, TLAPACK_INT_T incy );
-
-void ccopy(
-    TLAPACK_SIZE_T n,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex * y, TLAPACK_INT_T incy );
-
-void zcopy(
-    TLAPACK_SIZE_T n,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex * y, TLAPACK_INT_T incy );
-
-float sdot(
-    TLAPACK_SIZE_T n,
-    float const * x, TLAPACK_INT_T incx,
-    float const * y, TLAPACK_INT_T incy );
-
-double ddot(
-    TLAPACK_SIZE_T n,
-    double const * x, TLAPACK_INT_T incx,
-    double const * y, TLAPACK_INT_T incy );
-
-float  _Complex cdot(
-    TLAPACK_SIZE_T n,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex const * y, TLAPACK_INT_T incy );
-
-double _Complex zdot(
-    TLAPACK_SIZE_T n,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex const * y, TLAPACK_INT_T incy );
-
-float sdotu(
-    TLAPACK_SIZE_T n,
-    float const * x, TLAPACK_INT_T incx,
-    float const * y, TLAPACK_INT_T incy );
-
-double ddotu(
-    TLAPACK_SIZE_T n,
-    double const * x, TLAPACK_INT_T incx,
-    double const * y, TLAPACK_INT_T incy );
-
-float  _Complex cdotu(
-    TLAPACK_SIZE_T n,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex const * y, TLAPACK_INT_T incy );
-
-double _Complex zdotu(
-    TLAPACK_SIZE_T n,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex const * y, TLAPACK_INT_T incy );
-
-TLAPACK_SIZE_T isamax(
-    TLAPACK_SIZE_T n,
-    float const * x, TLAPACK_INT_T incx );
-
-TLAPACK_SIZE_T idamax(
-    TLAPACK_SIZE_T n,
-    double const * x, TLAPACK_INT_T incx );
-
-TLAPACK_SIZE_T icamax(
-    TLAPACK_SIZE_T n,
-    float  _Complex const * x, TLAPACK_INT_T incx );
-
-TLAPACK_SIZE_T izamax(
-    TLAPACK_SIZE_T n,
-    double _Complex const * x, TLAPACK_INT_T incx );
-
-float snrm2(
-    TLAPACK_SIZE_T n,
-    float const * x, TLAPACK_INT_T incx );
-
-double dnrm2(
-    TLAPACK_SIZE_T n,
-    double const * x, TLAPACK_INT_T incx );
-
-float cnrm2(
-    TLAPACK_SIZE_T n,
-    float  _Complex const * x, TLAPACK_INT_T incx );
-
-double znrm2(
-    TLAPACK_SIZE_T n,
-    double _Complex const * x, TLAPACK_INT_T incx );
-
-void srot(
-    TLAPACK_SIZE_T n,
-    float * x, TLAPACK_INT_T incx,
-    float * y, TLAPACK_INT_T incy,
-    float c,
-    float s );
-
-void drot(
-    TLAPACK_SIZE_T n,
-    double * x, TLAPACK_INT_T incx,
-    double * y, TLAPACK_INT_T incy,
-    double c,
-    double s );
-
-void csrot(
-    TLAPACK_SIZE_T n,
-    float  _Complex * x, TLAPACK_INT_T incx,
-    float  _Complex * y, TLAPACK_INT_T incy,
-    float c,
-    float s );
-
-void zdrot(
-    TLAPACK_SIZE_T n,
-    double _Complex * x, TLAPACK_INT_T incx,
-    double _Complex * y, TLAPACK_INT_T incy,
-    double c,
-    double s );
-
-void crot(
-    TLAPACK_SIZE_T n,
-    float  _Complex * x, TLAPACK_INT_T incx,
-    float  _Complex * y, TLAPACK_INT_T incy,
-    float c,
-    float  _Complex s );
-
-void zrot(
-    TLAPACK_SIZE_T n,
-    double _Complex * x, TLAPACK_INT_T incx,
-    double _Complex * y, TLAPACK_INT_T incy,
-    double c,
-    double _Complex s );
-
-void srotg(
-    float * a,
-    float * b,
-    float * c,
-    float * s );
-
-void drotg(
-    double * a,
-    double * b,
-    double * c,
-    double * s );
-
-void crotg(
-    float  _Complex * a,
-    float  _Complex * b,
-    float * c,
-    float  _Complex * s );
-
-void zrotg(
-    double _Complex * a,
-    double _Complex * b,
-    double * c,
-    double _Complex * s );
-
-void srotm(
-    TLAPACK_SIZE_T n,
-    float * x, TLAPACK_INT_T incx,
-    float * y, TLAPACK_INT_T incy,
-    float const * param );
-
-void drotm(
-    TLAPACK_SIZE_T n,
-    double * x, TLAPACK_INT_T incx,
-    double * y, TLAPACK_INT_T incy,
-    double const * param );
-
-void srotmg(
-    float * d1,
-    float * d2,
-    float * a,
-    float b,
-    float * param );
-
-void drotmg(
-    double * d1,
-    double * d2,
-    double * a,
-    double b,
-    double * param );
-
-void sscal(
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float * x, TLAPACK_INT_T incx );
-
-void dscal(
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double * x, TLAPACK_INT_T incx );
-
-void cscal(
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex * x, TLAPACK_INT_T incx );
-
-void zscal(
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex * x, TLAPACK_INT_T incx );
-
-void sswap(
-    TLAPACK_SIZE_T n,
-    float * x, TLAPACK_INT_T incx,
-    float * y, TLAPACK_INT_T incy );
-
-void dswap(
-    TLAPACK_SIZE_T n,
-    double * x, TLAPACK_INT_T incx,
-    double * y, TLAPACK_INT_T incy );
-
-void cswap(
-    TLAPACK_SIZE_T n,
-    float  _Complex * x, TLAPACK_INT_T incx,
-    float  _Complex * y, TLAPACK_INT_T incy );
-
-void zswap(
-    TLAPACK_SIZE_T n,
-    double _Complex * x, TLAPACK_INT_T incx,
-    double _Complex * y, TLAPACK_INT_T incy );
-
-// =============================================================================
-// Level 2 BLAS
-
-void sgemv(
-    Layout layout,
-    Op trans,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * x, TLAPACK_INT_T incx,
-    float beta,
-    float * y, TLAPACK_INT_T incy );
-
-void dgemv(
-    Layout layout,
-    Op trans,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * x, TLAPACK_INT_T incx,
-    double beta,
-    double * y, TLAPACK_INT_T incy );
-
-void cgemv(
-    Layout layout,
-    Op trans,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex beta,
-    float  _Complex * y, TLAPACK_INT_T incy );
-
-void zgemv(
-    Layout layout,
-    Op trans,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex beta,
-    double _Complex * y, TLAPACK_INT_T incy );
-
-void sger(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * x, TLAPACK_INT_T incx,
-    float const * y, TLAPACK_INT_T incy,
-    float * A, TLAPACK_SIZE_T lda );
-
-void dger(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * x, TLAPACK_INT_T incx,
-    double const * y, TLAPACK_INT_T incy,
-    double * A, TLAPACK_SIZE_T lda );
-
-void cger(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex const * y, TLAPACK_INT_T incy,
-    float  _Complex * A, TLAPACK_SIZE_T lda );
-
-void zger(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex const * y, TLAPACK_INT_T incy,
-    double _Complex * A, TLAPACK_SIZE_T lda );
-
-void sgeru(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * x, TLAPACK_INT_T incx,
-    float const * y, TLAPACK_INT_T incy,
-    float * A, TLAPACK_SIZE_T lda );
-
-void dgeru(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * x, TLAPACK_INT_T incx,
-    double const * y, TLAPACK_INT_T incy,
-    double * A, TLAPACK_SIZE_T lda );
-
-void cgeru(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex const * y, TLAPACK_INT_T incy,
-    float  _Complex * A, TLAPACK_SIZE_T lda );
-
-void zgeru(
-    Layout layout,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex const * y, TLAPACK_INT_T incy,
-    double _Complex * A, TLAPACK_SIZE_T lda );
-
-void shemv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * x, TLAPACK_INT_T incx,
-    float beta,
-    float * y, TLAPACK_INT_T incy );
-
-void dhemv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * x, TLAPACK_INT_T incx,
-    double beta,
-    double * y, TLAPACK_INT_T incy );
-
-void chemv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex beta,
-    float  _Complex * y, TLAPACK_INT_T incy );
-
-void zhemv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex beta,
-    double _Complex * y, TLAPACK_INT_T incy );
-
-void sher(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * x, TLAPACK_INT_T incx,
-    float * A, TLAPACK_SIZE_T lda );
-
-void dher(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * x, TLAPACK_INT_T incx,
-    double * A, TLAPACK_SIZE_T lda );
-
-void cher(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex * A, TLAPACK_SIZE_T lda );
-
-void zher(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex * A, TLAPACK_SIZE_T lda );
-
-void sher2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * x, TLAPACK_INT_T incx,
-    float const * y, TLAPACK_INT_T incy,
-    float * A, TLAPACK_SIZE_T lda );
-
-void dher2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * x, TLAPACK_INT_T incx,
-    double const * y, TLAPACK_INT_T incy,
-    double * A, TLAPACK_SIZE_T lda );
-
-void cher2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex const * y, TLAPACK_INT_T incy,
-    float  _Complex * A, TLAPACK_SIZE_T lda );
-
-void zher2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex const * y, TLAPACK_INT_T incy,
-    double _Complex * A, TLAPACK_SIZE_T lda );
-
-void ssymv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * x, TLAPACK_INT_T incx,
-    float beta,
-    float * y, TLAPACK_INT_T incy );
-
-void dsymv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * x, TLAPACK_INT_T incx,
-    double beta,
-    double * y, TLAPACK_INT_T incy );
-
-void csymv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex beta,
-    float  _Complex * y, TLAPACK_INT_T incy );
-
-void zsymv(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex beta,
-    double _Complex * y, TLAPACK_INT_T incy );
-
-void ssyr(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * x, TLAPACK_INT_T incx,
-    float * A, TLAPACK_SIZE_T lda );
-
-void dsyr(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * x, TLAPACK_INT_T incx,
-    double * A, TLAPACK_SIZE_T lda );
-
-void ssyr2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * x, TLAPACK_INT_T incx,
-    float const * y, TLAPACK_INT_T incy,
-    float * A, TLAPACK_SIZE_T lda );
-
-void dsyr2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * x, TLAPACK_INT_T incx,
-    double const * y, TLAPACK_INT_T incy,
-    double * A, TLAPACK_SIZE_T lda );
-
-void csyr2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * x, TLAPACK_INT_T incx,
-    float  _Complex const * y, TLAPACK_INT_T incy,
-    float  _Complex * A, TLAPACK_SIZE_T lda );
-
-void zsyr2(
-    Layout layout,
-    Uplo uplo,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * x, TLAPACK_INT_T incx,
-    double _Complex const * y, TLAPACK_INT_T incy,
-    double _Complex * A, TLAPACK_SIZE_T lda );
-
-void strmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    float const * A, TLAPACK_SIZE_T lda,
-    float * x, TLAPACK_INT_T incx );
-
-void dtrmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    double const * A, TLAPACK_SIZE_T lda,
-    double * x, TLAPACK_INT_T incx );
-
-void ctrmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex * x, TLAPACK_INT_T incx );
-
-void ztrmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex * x, TLAPACK_INT_T incx );
-
-void strsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    float const * A, TLAPACK_SIZE_T lda,
-    float * x, TLAPACK_INT_T incx );
-
-void dtrsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    double const * A, TLAPACK_SIZE_T lda,
-    double * x, TLAPACK_INT_T incx );
-
-void ctrsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex * x, TLAPACK_INT_T incx );
-
-void ztrsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T n,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex * x, TLAPACK_INT_T incx );
-
-// =============================================================================
-// Level 3 BLAS
-
-void sgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * B, TLAPACK_SIZE_T ldb,
-    float beta,
-    float * C, TLAPACK_SIZE_T ldc );
-
-void dgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * B, TLAPACK_SIZE_T ldb,
-    double beta,
-    double * C, TLAPACK_SIZE_T ldc );
-
-void cgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * B, TLAPACK_SIZE_T ldb,
-    float  _Complex beta,
-    float  _Complex * C, TLAPACK_SIZE_T ldc );
-
-void zgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * B, TLAPACK_SIZE_T ldb,
-    double _Complex beta,
-    double _Complex * C, TLAPACK_SIZE_T ldc );
-
-void shemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * B, TLAPACK_SIZE_T ldb,
-    float beta,
-    float * C, TLAPACK_SIZE_T ldc );
-
-void dhemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * B, TLAPACK_SIZE_T ldb,
-    double beta,
-    double * C, TLAPACK_SIZE_T ldc );
-
-void chemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * B, TLAPACK_SIZE_T ldb,
-    float  _Complex beta,
-    float  _Complex * C, TLAPACK_SIZE_T ldc );
-
-void zhemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * B, TLAPACK_SIZE_T ldb,
-    double _Complex beta,
-    double _Complex * C, TLAPACK_SIZE_T ldc );
-
-void sher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * B, TLAPACK_SIZE_T ldb,
-    float beta,
-    float * C, TLAPACK_SIZE_T ldc );
-
-void dher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * B, TLAPACK_SIZE_T ldb,
-    double beta,
-    double * C, TLAPACK_SIZE_T ldc );
-
-void cher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * B, TLAPACK_SIZE_T ldb,
-    float beta,
-    float  _Complex * C, TLAPACK_SIZE_T ldc );
-
-void zher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * B, TLAPACK_SIZE_T ldb,
-    double beta,
-    double _Complex * C, TLAPACK_SIZE_T ldc );
-
-void sherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float beta,
-    float * C, TLAPACK_SIZE_T ldc );
-
-void dherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double beta,
-    double * C, TLAPACK_SIZE_T ldc );
-
-void cherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float beta,
-    float  _Complex * C, TLAPACK_SIZE_T ldc );
-
-void zherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double beta,
-    double _Complex * C, TLAPACK_SIZE_T ldc );
-
-void ssymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * B, TLAPACK_SIZE_T ldb,
-    float beta,
-    float * C, TLAPACK_SIZE_T ldc );
-
-void dsymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * B, TLAPACK_SIZE_T ldb,
-    double beta,
-    double * C, TLAPACK_SIZE_T ldc );
-
-void csymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * B, TLAPACK_SIZE_T ldb,
-    float  _Complex beta,
-    float  _Complex * C, TLAPACK_SIZE_T ldc );
-
-void zsymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * B, TLAPACK_SIZE_T ldb,
-    double _Complex beta,
-    double _Complex * C, TLAPACK_SIZE_T ldc );
-
-void ssyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float const * B, TLAPACK_SIZE_T ldb,
-    float beta,
-    float * C, TLAPACK_SIZE_T ldc );
-
-void dsyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double const * B, TLAPACK_SIZE_T ldb,
-    double beta,
-    double * C, TLAPACK_SIZE_T ldc );
-
-void csyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex const * B, TLAPACK_SIZE_T ldb,
-    float  _Complex beta,
-    float  _Complex * C, TLAPACK_SIZE_T ldc );
-
-void zsyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex const * B, TLAPACK_SIZE_T ldb,
-    double _Complex beta,
-    double _Complex * C, TLAPACK_SIZE_T ldc );
-
-void ssyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float beta,
-    float * C, TLAPACK_SIZE_T ldc );
-
-void dsyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double beta,
-    double * C, TLAPACK_SIZE_T ldc );
-
-void csyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex beta,
-    float  _Complex * C, TLAPACK_SIZE_T ldc );
-
-void zsyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    TLAPACK_SIZE_T n,
-    TLAPACK_SIZE_T k,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex beta,
-    double _Complex * C, TLAPACK_SIZE_T ldc );
-
-void strmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float * B, TLAPACK_SIZE_T ldb );
-
-void dtrmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double * B, TLAPACK_SIZE_T ldb );
-
-void ctrmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex * B, TLAPACK_SIZE_T ldb );
-
-void ztrmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex * B, TLAPACK_SIZE_T ldb );
-
-void strsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float alpha,
-    float const * A, TLAPACK_SIZE_T lda,
-    float * B, TLAPACK_SIZE_T ldb );
-
-void dtrsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double alpha,
-    double const * A, TLAPACK_SIZE_T lda,
-    double * B, TLAPACK_SIZE_T ldb );
-
-void ctrsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    float  _Complex alpha,
-    float  _Complex const * A, TLAPACK_SIZE_T lda,
-    float  _Complex * B, TLAPACK_SIZE_T ldb );
-
-void ztrsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    TLAPACK_SIZE_T m,
-    TLAPACK_SIZE_T n,
-    double _Complex alpha,
-    double _Complex const * A, TLAPACK_SIZE_T lda,
-    double _Complex * B, TLAPACK_SIZE_T ldb );
+    // -----------------------------------------------------------------------------
+    // Enumerations
+    typedef enum Layout { ColMajor = 'C', RowMajor = 'R' } Layout;
+    typedef enum Op { NoTrans = 'N', Trans = 'T', ConjTrans = 'C' } Op;
+    typedef enum Uplo { Upper = 'U', Lower = 'L', General = 'G' } Uplo;
+    typedef enum Diag { NonUnit = 'N', Unit = 'U' } Diag;
+    typedef enum Side { Left = 'L', Right = 'R' } Side;
+
+    // =============================================================================
+    // Level 1 BLAS
+
+    float sasum(TLAPACK_SIZE_T n, float const* x, TLAPACK_INT_T incx);
+
+    double dasum(TLAPACK_SIZE_T n, double const* x, TLAPACK_INT_T incx);
+
+    float casum(TLAPACK_SIZE_T n, float _Complex const* x, TLAPACK_INT_T incx);
+
+    double zasum(TLAPACK_SIZE_T n, double _Complex const* x,
+                 TLAPACK_INT_T incx);
+
+    void saxpy(TLAPACK_SIZE_T n, float alpha, float const* x,
+               TLAPACK_INT_T incx, float* y, TLAPACK_INT_T incy);
+
+    void daxpy(TLAPACK_SIZE_T n, double alpha, double const* x,
+               TLAPACK_INT_T incx, double* y, TLAPACK_INT_T incy);
+
+    void caxpy(TLAPACK_SIZE_T n, float _Complex alpha, float _Complex const* x,
+               TLAPACK_INT_T incx, float _Complex* y, TLAPACK_INT_T incy);
+
+    void zaxpy(TLAPACK_SIZE_T n, double _Complex alpha,
+               double _Complex const* x, TLAPACK_INT_T incx, double _Complex* y,
+               TLAPACK_INT_T incy);
+
+    void scopy(TLAPACK_SIZE_T n, float const* x, TLAPACK_INT_T incx, float* y,
+               TLAPACK_INT_T incy);
+
+    void dcopy(TLAPACK_SIZE_T n, double const* x, TLAPACK_INT_T incx, double* y,
+               TLAPACK_INT_T incy);
+
+    void ccopy(TLAPACK_SIZE_T n, float _Complex const* x, TLAPACK_INT_T incx,
+               float _Complex* y, TLAPACK_INT_T incy);
+
+    void zcopy(TLAPACK_SIZE_T n, double _Complex const* x, TLAPACK_INT_T incx,
+               double _Complex* y, TLAPACK_INT_T incy);
+
+    float sdot(TLAPACK_SIZE_T n, float const* x, TLAPACK_INT_T incx,
+               float const* y, TLAPACK_INT_T incy);
+
+    double ddot(TLAPACK_SIZE_T n, double const* x, TLAPACK_INT_T incx,
+                double const* y, TLAPACK_INT_T incy);
+
+    float _Complex cdot(TLAPACK_SIZE_T n, float _Complex const* x,
+                        TLAPACK_INT_T incx, float _Complex const* y,
+                        TLAPACK_INT_T incy);
+
+    double _Complex zdot(TLAPACK_SIZE_T n, double _Complex const* x,
+                         TLAPACK_INT_T incx, double _Complex const* y,
+                         TLAPACK_INT_T incy);
+
+    float sdotu(TLAPACK_SIZE_T n, float const* x, TLAPACK_INT_T incx,
+                float const* y, TLAPACK_INT_T incy);
+
+    double ddotu(TLAPACK_SIZE_T n, double const* x, TLAPACK_INT_T incx,
+                 double const* y, TLAPACK_INT_T incy);
+
+    float _Complex cdotu(TLAPACK_SIZE_T n, float _Complex const* x,
+                         TLAPACK_INT_T incx, float _Complex const* y,
+                         TLAPACK_INT_T incy);
+
+    double _Complex zdotu(TLAPACK_SIZE_T n, double _Complex const* x,
+                          TLAPACK_INT_T incx, double _Complex const* y,
+                          TLAPACK_INT_T incy);
+
+    TLAPACK_SIZE_T isamax(TLAPACK_SIZE_T n, float const* x, TLAPACK_INT_T incx);
+
+    TLAPACK_SIZE_T idamax(TLAPACK_SIZE_T n, double const* x,
+                          TLAPACK_INT_T incx);
+
+    TLAPACK_SIZE_T icamax(TLAPACK_SIZE_T n, float _Complex const* x,
+                          TLAPACK_INT_T incx);
+
+    TLAPACK_SIZE_T izamax(TLAPACK_SIZE_T n, double _Complex const* x,
+                          TLAPACK_INT_T incx);
+
+    float snrm2(TLAPACK_SIZE_T n, float const* x, TLAPACK_INT_T incx);
+
+    double dnrm2(TLAPACK_SIZE_T n, double const* x, TLAPACK_INT_T incx);
+
+    float cnrm2(TLAPACK_SIZE_T n, float _Complex const* x, TLAPACK_INT_T incx);
+
+    double znrm2(TLAPACK_SIZE_T n, double _Complex const* x,
+                 TLAPACK_INT_T incx);
+
+    void srot(TLAPACK_SIZE_T n, float* x, TLAPACK_INT_T incx, float* y,
+              TLAPACK_INT_T incy, float c, float s);
+
+    void drot(TLAPACK_SIZE_T n, double* x, TLAPACK_INT_T incx, double* y,
+              TLAPACK_INT_T incy, double c, double s);
+
+    void csrot(TLAPACK_SIZE_T n, float _Complex* x, TLAPACK_INT_T incx,
+               float _Complex* y, TLAPACK_INT_T incy, float c, float s);
+
+    void zdrot(TLAPACK_SIZE_T n, double _Complex* x, TLAPACK_INT_T incx,
+               double _Complex* y, TLAPACK_INT_T incy, double c, double s);
+
+    void crot(TLAPACK_SIZE_T n, float _Complex* x, TLAPACK_INT_T incx,
+              float _Complex* y, TLAPACK_INT_T incy, float c, float _Complex s);
+
+    void zrot(TLAPACK_SIZE_T n, double _Complex* x, TLAPACK_INT_T incx,
+              double _Complex* y, TLAPACK_INT_T incy, double c,
+              double _Complex s);
+
+    void srotg(float* a, float* b, float* c, float* s);
+
+    void drotg(double* a, double* b, double* c, double* s);
+
+    void crotg(float _Complex* a, float _Complex* b, float* c,
+               float _Complex* s);
+
+    void zrotg(double _Complex* a, double _Complex* b, double* c,
+               double _Complex* s);
+
+    void srotm(TLAPACK_SIZE_T n, float* x, TLAPACK_INT_T incx, float* y,
+               TLAPACK_INT_T incy, float const* param);
+
+    void drotm(TLAPACK_SIZE_T n, double* x, TLAPACK_INT_T incx, double* y,
+               TLAPACK_INT_T incy, double const* param);
+
+    void srotmg(float* d1, float* d2, float* a, float b, float* param);
+
+    void drotmg(double* d1, double* d2, double* a, double b, double* param);
+
+    void sscal(TLAPACK_SIZE_T n, float alpha, float* x, TLAPACK_INT_T incx);
+
+    void dscal(TLAPACK_SIZE_T n, double alpha, double* x, TLAPACK_INT_T incx);
+
+    void cscal(TLAPACK_SIZE_T n, float _Complex alpha, float _Complex* x,
+               TLAPACK_INT_T incx);
+
+    void zscal(TLAPACK_SIZE_T n, double _Complex alpha, double _Complex* x,
+               TLAPACK_INT_T incx);
+
+    void sswap(TLAPACK_SIZE_T n, float* x, TLAPACK_INT_T incx, float* y,
+               TLAPACK_INT_T incy);
+
+    void dswap(TLAPACK_SIZE_T n, double* x, TLAPACK_INT_T incx, double* y,
+               TLAPACK_INT_T incy);
+
+    void cswap(TLAPACK_SIZE_T n, float _Complex* x, TLAPACK_INT_T incx,
+               float _Complex* y, TLAPACK_INT_T incy);
+
+    void zswap(TLAPACK_SIZE_T n, double _Complex* x, TLAPACK_INT_T incx,
+               double _Complex* y, TLAPACK_INT_T incy);
+
+    // =============================================================================
+    // Level 2 BLAS
+
+    void sgemv(Layout layout, Op trans, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+               float alpha, float const* A, TLAPACK_SIZE_T lda, float const* x,
+               TLAPACK_INT_T incx, float beta, float* y, TLAPACK_INT_T incy);
+
+    void dgemv(Layout layout, Op trans, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+               double alpha, double const* A, TLAPACK_SIZE_T lda,
+               double const* x, TLAPACK_INT_T incx, double beta, double* y,
+               TLAPACK_INT_T incy);
+
+    void cgemv(Layout layout, Op trans, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+               float _Complex alpha, float _Complex const* A,
+               TLAPACK_SIZE_T lda, float _Complex const* x, TLAPACK_INT_T incx,
+               float _Complex beta, float _Complex* y, TLAPACK_INT_T incy);
+
+    void zgemv(Layout layout, Op trans, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+               double _Complex alpha, double _Complex const* A,
+               TLAPACK_SIZE_T lda, double _Complex const* x, TLAPACK_INT_T incx,
+               double _Complex beta, double _Complex* y, TLAPACK_INT_T incy);
+
+    void sger(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, float alpha,
+              float const* x, TLAPACK_INT_T incx, float const* y,
+              TLAPACK_INT_T incy, float* A, TLAPACK_SIZE_T lda);
+
+    void dger(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, double alpha,
+              double const* x, TLAPACK_INT_T incx, double const* y,
+              TLAPACK_INT_T incy, double* A, TLAPACK_SIZE_T lda);
+
+    void cger(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+              float _Complex alpha, float _Complex const* x, TLAPACK_INT_T incx,
+              float _Complex const* y, TLAPACK_INT_T incy, float _Complex* A,
+              TLAPACK_SIZE_T lda);
+
+    void zger(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+              double _Complex alpha, double _Complex const* x,
+              TLAPACK_INT_T incx, double _Complex const* y, TLAPACK_INT_T incy,
+              double _Complex* A, TLAPACK_SIZE_T lda);
+
+    void sgeru(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, float alpha,
+               float const* x, TLAPACK_INT_T incx, float const* y,
+               TLAPACK_INT_T incy, float* A, TLAPACK_SIZE_T lda);
+
+    void dgeru(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, double alpha,
+               double const* x, TLAPACK_INT_T incx, double const* y,
+               TLAPACK_INT_T incy, double* A, TLAPACK_SIZE_T lda);
+
+    void cgeru(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+               float _Complex alpha, float _Complex const* x,
+               TLAPACK_INT_T incx, float _Complex const* y, TLAPACK_INT_T incy,
+               float _Complex* A, TLAPACK_SIZE_T lda);
+
+    void zgeru(Layout layout, TLAPACK_SIZE_T m, TLAPACK_SIZE_T n,
+               double _Complex alpha, double _Complex const* x,
+               TLAPACK_INT_T incx, double _Complex const* y, TLAPACK_INT_T incy,
+               double _Complex* A, TLAPACK_SIZE_T lda);
+
+    void shemv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float alpha,
+               float const* A, TLAPACK_SIZE_T lda, float const* x,
+               TLAPACK_INT_T incx, float beta, float* y, TLAPACK_INT_T incy);
+
+    void dhemv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, double alpha,
+               double const* A, TLAPACK_SIZE_T lda, double const* x,
+               TLAPACK_INT_T incx, double beta, double* y, TLAPACK_INT_T incy);
+
+    void chemv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float _Complex alpha,
+               float _Complex const* A, TLAPACK_SIZE_T lda,
+               float _Complex const* x, TLAPACK_INT_T incx, float _Complex beta,
+               float _Complex* y, TLAPACK_INT_T incy);
+
+    void zhemv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n,
+               double _Complex alpha, double _Complex const* A,
+               TLAPACK_SIZE_T lda, double _Complex const* x, TLAPACK_INT_T incx,
+               double _Complex beta, double _Complex* y, TLAPACK_INT_T incy);
+
+    void sher(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float alpha,
+              float const* x, TLAPACK_INT_T incx, float* A, TLAPACK_SIZE_T lda);
+
+    void dher(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, double alpha,
+              double const* x, TLAPACK_INT_T incx, double* A,
+              TLAPACK_SIZE_T lda);
+
+    void cher(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float alpha,
+              float _Complex const* x, TLAPACK_INT_T incx, float _Complex* A,
+              TLAPACK_SIZE_T lda);
+
+    void zher(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, double alpha,
+              double _Complex const* x, TLAPACK_INT_T incx, double _Complex* A,
+              TLAPACK_SIZE_T lda);
+
+    void sher2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float alpha,
+               float const* x, TLAPACK_INT_T incx, float const* y,
+               TLAPACK_INT_T incy, float* A, TLAPACK_SIZE_T lda);
+
+    void dher2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, double alpha,
+               double const* x, TLAPACK_INT_T incx, double const* y,
+               TLAPACK_INT_T incy, double* A, TLAPACK_SIZE_T lda);
+
+    void cher2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float _Complex alpha,
+               float _Complex const* x, TLAPACK_INT_T incx,
+               float _Complex const* y, TLAPACK_INT_T incy, float _Complex* A,
+               TLAPACK_SIZE_T lda);
+
+    void zher2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n,
+               double _Complex alpha, double _Complex const* x,
+               TLAPACK_INT_T incx, double _Complex const* y, TLAPACK_INT_T incy,
+               double _Complex* A, TLAPACK_SIZE_T lda);
+
+    void ssymv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float alpha,
+               float const* A, TLAPACK_SIZE_T lda, float const* x,
+               TLAPACK_INT_T incx, float beta, float* y, TLAPACK_INT_T incy);
+
+    void dsymv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, double alpha,
+               double const* A, TLAPACK_SIZE_T lda, double const* x,
+               TLAPACK_INT_T incx, double beta, double* y, TLAPACK_INT_T incy);
+
+    void csymv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float _Complex alpha,
+               float _Complex const* A, TLAPACK_SIZE_T lda,
+               float _Complex const* x, TLAPACK_INT_T incx, float _Complex beta,
+               float _Complex* y, TLAPACK_INT_T incy);
+
+    void zsymv(Layout layout, Uplo uplo, TLAPACK_SIZE_T n,
+               double _Complex alpha, double _Complex const* A,
+               TLAPACK_SIZE_T lda, double _Complex const* x, TLAPACK_INT_T incx,
+               double _Complex beta, double _Complex* y, TLAPACK_INT_T incy);
+
+    void ssyr(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float alpha,
+              float const* x, TLAPACK_INT_T incx, float* A, TLAPACK_SIZE_T lda);
+
+    void dsyr(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, double alpha,
+              double const* x, TLAPACK_INT_T incx, double* A,
+              TLAPACK_SIZE_T lda);
+
+    void ssyr2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float alpha,
+               float const* x, TLAPACK_INT_T incx, float const* y,
+               TLAPACK_INT_T incy, float* A, TLAPACK_SIZE_T lda);
+
+    void dsyr2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, double alpha,
+               double const* x, TLAPACK_INT_T incx, double const* y,
+               TLAPACK_INT_T incy, double* A, TLAPACK_SIZE_T lda);
+
+    void csyr2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n, float _Complex alpha,
+               float _Complex const* x, TLAPACK_INT_T incx,
+               float _Complex const* y, TLAPACK_INT_T incy, float _Complex* A,
+               TLAPACK_SIZE_T lda);
+
+    void zsyr2(Layout layout, Uplo uplo, TLAPACK_SIZE_T n,
+               double _Complex alpha, double _Complex const* x,
+               TLAPACK_INT_T incx, double _Complex const* y, TLAPACK_INT_T incy,
+               double _Complex* A, TLAPACK_SIZE_T lda);
+
+    void strmv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               float const* A, TLAPACK_SIZE_T lda, float* x,
+               TLAPACK_INT_T incx);
+
+    void dtrmv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               double const* A, TLAPACK_SIZE_T lda, double* x,
+               TLAPACK_INT_T incx);
+
+    void ctrmv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               float _Complex const* A, TLAPACK_SIZE_T lda, float _Complex* x,
+               TLAPACK_INT_T incx);
+
+    void ztrmv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               double _Complex const* A, TLAPACK_SIZE_T lda, double _Complex* x,
+               TLAPACK_INT_T incx);
+
+    void strsv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               float const* A, TLAPACK_SIZE_T lda, float* x,
+               TLAPACK_INT_T incx);
+
+    void dtrsv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               double const* A, TLAPACK_SIZE_T lda, double* x,
+               TLAPACK_INT_T incx);
+
+    void ctrsv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               float _Complex const* A, TLAPACK_SIZE_T lda, float _Complex* x,
+               TLAPACK_INT_T incx);
+
+    void ztrsv(Layout layout, Uplo uplo, Op trans, Diag diag, TLAPACK_SIZE_T n,
+               double _Complex const* A, TLAPACK_SIZE_T lda, double _Complex* x,
+               TLAPACK_INT_T incx);
+
+    // =============================================================================
+    // Level 3 BLAS
+
+    void sgemm(Layout layout, Op transA, Op transB, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, TLAPACK_SIZE_T k, float alpha, float const* A,
+               TLAPACK_SIZE_T lda, float const* B, TLAPACK_SIZE_T ldb,
+               float beta, float* C, TLAPACK_SIZE_T ldc);
+
+    void dgemm(Layout layout, Op transA, Op transB, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, TLAPACK_SIZE_T k, double alpha,
+               double const* A, TLAPACK_SIZE_T lda, double const* B,
+               TLAPACK_SIZE_T ldb, double beta, double* C, TLAPACK_SIZE_T ldc);
+
+    void cgemm(Layout layout, Op transA, Op transB, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, TLAPACK_SIZE_T k, float _Complex alpha,
+               float _Complex const* A, TLAPACK_SIZE_T lda,
+               float _Complex const* B, TLAPACK_SIZE_T ldb, float _Complex beta,
+               float _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void zgemm(Layout layout, Op transA, Op transB, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, TLAPACK_SIZE_T k, double _Complex alpha,
+               double _Complex const* A, TLAPACK_SIZE_T lda,
+               double _Complex const* B, TLAPACK_SIZE_T ldb,
+               double _Complex beta, double _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void shemm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, float alpha, float const* A,
+               TLAPACK_SIZE_T lda, float const* B, TLAPACK_SIZE_T ldb,
+               float beta, float* C, TLAPACK_SIZE_T ldc);
+
+    void dhemm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, double alpha, double const* A,
+               TLAPACK_SIZE_T lda, double const* B, TLAPACK_SIZE_T ldb,
+               double beta, double* C, TLAPACK_SIZE_T ldc);
+
+    void chemm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, float _Complex alpha, float _Complex const* A,
+               TLAPACK_SIZE_T lda, float _Complex const* B, TLAPACK_SIZE_T ldb,
+               float _Complex beta, float _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void zhemm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, double _Complex alpha,
+               double _Complex const* A, TLAPACK_SIZE_T lda,
+               double _Complex const* B, TLAPACK_SIZE_T ldb,
+               double _Complex beta, double _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void sher2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, float alpha, float const* A,
+                TLAPACK_SIZE_T lda, float const* B, TLAPACK_SIZE_T ldb,
+                float beta, float* C, TLAPACK_SIZE_T ldc);
+
+    void dher2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, double alpha, double const* A,
+                TLAPACK_SIZE_T lda, double const* B, TLAPACK_SIZE_T ldb,
+                double beta, double* C, TLAPACK_SIZE_T ldc);
+
+    void cher2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, float _Complex alpha, float _Complex const* A,
+                TLAPACK_SIZE_T lda, float _Complex const* B, TLAPACK_SIZE_T ldb,
+                float beta, float _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void zher2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, double _Complex alpha,
+                double _Complex const* A, TLAPACK_SIZE_T lda,
+                double _Complex const* B, TLAPACK_SIZE_T ldb, double beta,
+                double _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void sherk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, float alpha, float const* A,
+               TLAPACK_SIZE_T lda, float beta, float* C, TLAPACK_SIZE_T ldc);
+
+    void dherk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, double alpha, double const* A,
+               TLAPACK_SIZE_T lda, double beta, double* C, TLAPACK_SIZE_T ldc);
+
+    void cherk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, float alpha, float _Complex const* A,
+               TLAPACK_SIZE_T lda, float beta, float _Complex* C,
+               TLAPACK_SIZE_T ldc);
+
+    void zherk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, double alpha, double _Complex const* A,
+               TLAPACK_SIZE_T lda, double beta, double _Complex* C,
+               TLAPACK_SIZE_T ldc);
+
+    void ssymm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, float alpha, float const* A,
+               TLAPACK_SIZE_T lda, float const* B, TLAPACK_SIZE_T ldb,
+               float beta, float* C, TLAPACK_SIZE_T ldc);
+
+    void dsymm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, double alpha, double const* A,
+               TLAPACK_SIZE_T lda, double const* B, TLAPACK_SIZE_T ldb,
+               double beta, double* C, TLAPACK_SIZE_T ldc);
+
+    void csymm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, float _Complex alpha, float _Complex const* A,
+               TLAPACK_SIZE_T lda, float _Complex const* B, TLAPACK_SIZE_T ldb,
+               float _Complex beta, float _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void zsymm(Layout layout, Side side, Uplo uplo, TLAPACK_SIZE_T m,
+               TLAPACK_SIZE_T n, double _Complex alpha,
+               double _Complex const* A, TLAPACK_SIZE_T lda,
+               double _Complex const* B, TLAPACK_SIZE_T ldb,
+               double _Complex beta, double _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void ssyr2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, float alpha, float const* A,
+                TLAPACK_SIZE_T lda, float const* B, TLAPACK_SIZE_T ldb,
+                float beta, float* C, TLAPACK_SIZE_T ldc);
+
+    void dsyr2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, double alpha, double const* A,
+                TLAPACK_SIZE_T lda, double const* B, TLAPACK_SIZE_T ldb,
+                double beta, double* C, TLAPACK_SIZE_T ldc);
+
+    void csyr2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, float _Complex alpha, float _Complex const* A,
+                TLAPACK_SIZE_T lda, float _Complex const* B, TLAPACK_SIZE_T ldb,
+                float _Complex beta, float _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void zsyr2k(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+                TLAPACK_SIZE_T k, double _Complex alpha,
+                double _Complex const* A, TLAPACK_SIZE_T lda,
+                double _Complex const* B, TLAPACK_SIZE_T ldb,
+                double _Complex beta, double _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void ssyrk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, float alpha, float const* A,
+               TLAPACK_SIZE_T lda, float beta, float* C, TLAPACK_SIZE_T ldc);
+
+    void dsyrk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, double alpha, double const* A,
+               TLAPACK_SIZE_T lda, double beta, double* C, TLAPACK_SIZE_T ldc);
+
+    void csyrk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, float _Complex alpha, float _Complex const* A,
+               TLAPACK_SIZE_T lda, float _Complex beta, float _Complex* C,
+               TLAPACK_SIZE_T ldc);
+
+    void zsyrk(Layout layout, Uplo uplo, Op trans, TLAPACK_SIZE_T n,
+               TLAPACK_SIZE_T k, double _Complex alpha,
+               double _Complex const* A, TLAPACK_SIZE_T lda,
+               double _Complex beta, double _Complex* C, TLAPACK_SIZE_T ldc);
+
+    void strmm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, float alpha, float const* A,
+               TLAPACK_SIZE_T lda, float* B, TLAPACK_SIZE_T ldb);
+
+    void dtrmm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, double alpha,
+               double const* A, TLAPACK_SIZE_T lda, double* B,
+               TLAPACK_SIZE_T ldb);
+
+    void ctrmm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, float _Complex alpha,
+               float _Complex const* A, TLAPACK_SIZE_T lda, float _Complex* B,
+               TLAPACK_SIZE_T ldb);
+
+    void ztrmm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, double _Complex alpha,
+               double _Complex const* A, TLAPACK_SIZE_T lda, double _Complex* B,
+               TLAPACK_SIZE_T ldb);
+
+    void strsm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, float alpha, float const* A,
+               TLAPACK_SIZE_T lda, float* B, TLAPACK_SIZE_T ldb);
+
+    void dtrsm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, double alpha,
+               double const* A, TLAPACK_SIZE_T lda, double* B,
+               TLAPACK_SIZE_T ldb);
+
+    void ctrsm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, float _Complex alpha,
+               float _Complex const* A, TLAPACK_SIZE_T lda, float _Complex* B,
+               TLAPACK_SIZE_T ldb);
+
+    void ztrsm(Layout layout, Side side, Uplo uplo, Op trans, Diag diag,
+               TLAPACK_SIZE_T m, TLAPACK_SIZE_T n, double _Complex alpha,
+               double _Complex const* A, TLAPACK_SIZE_T lda, double _Complex* B,
+               TLAPACK_SIZE_T ldb);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // TLAPACK_BLAS_H
+#endif  // TLAPACK_BLAS_H

--- a/include/tlapack.hpp
+++ b/include/tlapack.hpp
@@ -52,11 +52,11 @@
 
 #include "tlapack/blas/gemm.hpp"
 #include "tlapack/blas/hemm.hpp"
-#include "tlapack/blas/herk.hpp"
 #include "tlapack/blas/her2k.hpp"
+#include "tlapack/blas/herk.hpp"
 #include "tlapack/blas/symm.hpp"
-#include "tlapack/blas/syrk.hpp"
 #include "tlapack/blas/syr2k.hpp"
+#include "tlapack/blas/syrk.hpp"
 #include "tlapack/blas/trmm.hpp"
 #include "tlapack/blas/trsm.hpp"
 
@@ -68,25 +68,25 @@
 // Auxiliary routines
 // ------------------
 
-#include "tlapack/lapack/larf.hpp"
-#include "tlapack/lapack/larfg.hpp"
-#include "tlapack/lapack/larft.hpp"
-#include "tlapack/lapack/larfb.hpp"
-#include "tlapack/lapack/lapy2.hpp"
-#include "tlapack/lapack/lapy3.hpp"
-#include "tlapack/lapack/ladiv.hpp"
-#include "tlapack/lapack/laset.hpp"
 #include "tlapack/lapack/lacpy.hpp"
+#include "tlapack/lapack/ladiv.hpp"
 #include "tlapack/lapack/lange.hpp"
 #include "tlapack/lapack/lanhe.hpp"
 #include "tlapack/lapack/lansy.hpp"
 #include "tlapack/lapack/lantr.hpp"
+#include "tlapack/lapack/lapy2.hpp"
+#include "tlapack/lapack/lapy3.hpp"
+#include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/larfb.hpp"
+#include "tlapack/lapack/larfg.hpp"
+#include "tlapack/lapack/larft.hpp"
 #include "tlapack/lapack/larnv.hpp"
 #include "tlapack/lapack/lascl.hpp"
+#include "tlapack/lapack/laset.hpp"
 #include "tlapack/lapack/lassq.hpp"
-#include "tlapack/lapack/transpose.hpp"
 #include "tlapack/lapack/lauum_recursive.hpp"
 #include "tlapack/lapack/lu_mult.hpp"
+#include "tlapack/lapack/transpose.hpp"
 
 // SVD
 // ----------------
@@ -105,8 +105,8 @@
 // ----------------
 
 #include "tlapack/lapack/gelq2.hpp"
-#include "tlapack/lapack/ungl2.hpp"
 #include "tlapack/lapack/gelqf.hpp"
+#include "tlapack/lapack/ungl2.hpp"
 
 // Solution of positive definite systems
 // ----------------
@@ -122,21 +122,21 @@
 // Nonsymmetric standard eigenvalue routines
 // ----------------
 
+#include "tlapack/lapack/agressive_early_deflation.hpp"
 #include "tlapack/lapack/gehd2.hpp"
 #include "tlapack/lapack/gehrd.hpp"
-#include "tlapack/lapack/lahr2.hpp"
-#include "tlapack/lapack/unghr.hpp"
-#include "tlapack/lapack/unmhr.hpp"
 #include "tlapack/lapack/lahqr.hpp"
-#include "tlapack/lapack/lahqr_shiftcolumn.hpp"
 #include "tlapack/lapack/lahqr_eig22.hpp"
 #include "tlapack/lapack/lahqr_schur22.hpp"
-#include "tlapack/lapack/schur_swap.hpp"
-#include "tlapack/lapack/schur_move.hpp"
+#include "tlapack/lapack/lahqr_shiftcolumn.hpp"
+#include "tlapack/lapack/lahr2.hpp"
 #include "tlapack/lapack/move_bulge.hpp"
-#include "tlapack/lapack/multishift_qr_sweep.hpp"
-#include "tlapack/lapack/agressive_early_deflation.hpp"
 #include "tlapack/lapack/multishift_qr.hpp"
+#include "tlapack/lapack/multishift_qr_sweep.hpp"
+#include "tlapack/lapack/schur_move.hpp"
+#include "tlapack/lapack/schur_swap.hpp"
+#include "tlapack/lapack/unghr.hpp"
+#include "tlapack/lapack/unmhr.hpp"
 
 // LU
 // ----------------
@@ -152,5 +152,4 @@
 
 #include "tlapack/lapack/getri.hpp"
 
-
-#endif // TLAPACK_HH
+#endif  // TLAPACK_HH

--- a/include/tlapack/base/arrayTraits.hpp
+++ b/include/tlapack/base/arrayTraits.hpp
@@ -14,405 +14,441 @@
 
 namespace tlapack {
 
-    // -----------------------------------------------------------------------------
-    // Access policies
+// -----------------------------------------------------------------------------
+// Access policies
 
-    /**
-     * @brief Matrix access policies
-     * 
-     * They are used:
-     * 
-     * (1) on the data structure for a matrix, to state the what pairs (i,j)
-     * return a valid position A(i,j), where A is a m-by-n matrix.
-     * 
-     * (2) on the algorithm, to determine the kind of access
-     * required by the algorithm.
-     */
-    enum class MatrixAccessPolicy {
-        Dense = 'G',            ///< 0 <= i <= m,   0 <= j <= n.
-        UpperHessenberg = 'H',  ///< 0 <= i <= j+1, 0 <= j <= n.
-        LowerHessenberg = 'h',  ///< 0 <= i <= m,   0 <= j <= i+1.
-        UpperTriangle = 'U',    ///< 0 <= i <= j,   0 <= j <= n.
-        LowerTriangle = 'L',    ///< 0 <= i <= m,   0 <= j <= i.
-        StrictUpper = 'S',      ///< 0 <= i <= j-1, 0 <= j <= n.
-        StrictLower = 's',      ///< 0 <= i <= m,   0 <= j <= i-1.
-    };
+/**
+ * @brief Matrix access policies
+ *
+ * They are used:
+ *
+ * (1) on the data structure for a matrix, to state the what pairs (i,j)
+ * return a valid position A(i,j), where A is a m-by-n matrix.
+ *
+ * (2) on the algorithm, to determine the kind of access
+ * required by the algorithm.
+ */
+enum class MatrixAccessPolicy {
+    Dense = 'G',            ///< 0 <= i <= m,   0 <= j <= n.
+    UpperHessenberg = 'H',  ///< 0 <= i <= j+1, 0 <= j <= n.
+    LowerHessenberg = 'h',  ///< 0 <= i <= m,   0 <= j <= i+1.
+    UpperTriangle = 'U',    ///< 0 <= i <= j,   0 <= j <= n.
+    LowerTriangle = 'L',    ///< 0 <= i <= m,   0 <= j <= i.
+    StrictUpper = 'S',      ///< 0 <= i <= j-1, 0 <= j <= n.
+    StrictLower = 's',      ///< 0 <= i <= m,   0 <= j <= i-1.
+};
 
-    /**
-     * @brief Dense access.
-     * 
-     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= n     in a m-by-n matrix.
-     * 
-     *      x x x x x
-     *      x x x x x
-     *      x x x x x
-     *      x x x x x
-     */
-    struct dense_t {
-        constexpr operator Uplo() const { return Uplo::General; }
-        constexpr operator MatrixAccessPolicy() const { return MatrixAccessPolicy::Dense; }
-    };
-
-    /**
-     * @brief Upper Hessenberg access
-     * 
-     * Pairs (i,j) such that 0 <= i <= j+1, 0 <= j <= n     in a m-by-n matrix.
-     * 
-     *      x x x x x
-     *      x x x x x
-     *      0 x x x x
-     *      0 0 x x x
-     */
-    struct upperHessenberg_t : public dense_t {
-        constexpr operator MatrixAccessPolicy() const { return MatrixAccessPolicy::UpperHessenberg; }
-    };
-
-    /**
-     * @brief Lower Hessenberg access
-     * 
-     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i+1   in a m-by-n matrix.
-     * 
-     *      x x 0 0 0
-     *      x x x 0 0
-     *      x x x x 0
-     *      x x x x x
-     */
-    struct lowerHessenberg_t : public dense_t {
-        constexpr operator MatrixAccessPolicy() const { return MatrixAccessPolicy::LowerHessenberg; }
-    };
-
-    /**
-     * @brief Upper Triangle access
-     * 
-     * Pairs (i,j) such that 0 <= i <= j,   0 <= j <= n     in a m-by-n matrix.
-     * 
-     *      x x x x x
-     *      0 x x x x
-     *      0 0 x x x
-     *      0 0 0 x x
-     */
-    struct upperTriangle_t : public upperHessenberg_t {
-        constexpr operator Uplo() const { return Uplo::Upper; }
-        constexpr operator MatrixAccessPolicy() const { return MatrixAccessPolicy::UpperTriangle; }
-    };
-
-    /**
-     * @brief Lower Triangle access
-     * 
-     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i     in a m-by-n matrix.
-     * 
-     *      x 0 0 0 0
-     *      x x 0 0 0
-     *      x x x 0 0
-     *      x x x x 0
-     */
-    struct lowerTriangle_t : public lowerHessenberg_t {
-        constexpr operator Uplo() const { return Uplo::Lower; }
-        constexpr operator MatrixAccessPolicy() const { return MatrixAccessPolicy::LowerTriangle; }
-    };
-
-    /**
-     * @brief Strict Upper Triangle access
-     * 
-     * Pairs (i,j) such that 0 <= i <= j-1, 0 <= j <= n     in a m-by-n matrix.
-     * 
-     *      0 x x x x
-     *      0 0 x x x
-     *      0 0 0 x x
-     *      0 0 0 0 x
-     */
-    struct strictUpper_t : public upperTriangle_t {
-        constexpr operator MatrixAccessPolicy() const { return MatrixAccessPolicy::StrictUpper; }
-    };
-
-    /**
-     * @brief Strict Lower Triangle access
-     * 
-     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i-1   in a m-by-n matrix.
-     * 
-     *      0 0 0 0 0
-     *      x 0 0 0 0
-     *      x x 0 0 0
-     *      x x x 0 0
-     */
-    struct strictLower_t : public lowerTriangle_t {
-        constexpr operator MatrixAccessPolicy() const { return MatrixAccessPolicy::StrictLower; }
-    };
-
-    /**
-     * @brief Band access
-     * 
-     * Pairs (i,j) such that max(0,j-ku) <= i <= min(m,j+kl) in a m-by-n matrix,
-     * where kl is the lower_bandwidth and ku is the upper_bandwidth.
-     * 
-     *      x x x 0 0
-     *      x x x x 0
-     *      0 x x x x
-     *      0 0 x x x
-     */
-    struct band_t : dense_t {
-        std::size_t lower_bandwidth; ///< Number of subdiagonals.
-        std::size_t upper_bandwidth; ///< Number of superdiagonals.
-
-        constexpr band_t(std::size_t kl, std::size_t ku)
-        : lower_bandwidth(kl), upper_bandwidth(ku)
-        {}
-    };
-
-    // constant expressions
-    constexpr dense_t dense = { };
-    constexpr upperHessenberg_t upperHessenberg = { };
-    constexpr lowerHessenberg_t lowerHessenberg = { };
-    constexpr upperTriangle_t upperTriangle = { };
-    constexpr lowerTriangle_t lowerTriangle = { };
-    constexpr strictUpper_t strictUpper = { };
-    constexpr strictLower_t strictLower = { };
-
-    // -----------------------------------------------------------------------------
-    // Data traits
-    
-    namespace internal
+/**
+ * @brief Dense access.
+ *
+ * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= n     in a m-by-n matrix.
+ *
+ *      x x x x x
+ *      x x x x x
+ *      x x x x x
+ *      x x x x x
+ */
+struct dense_t {
+    constexpr operator Uplo() const { return Uplo::General; }
+    constexpr operator MatrixAccessPolicy() const
     {
-
-        /**
-         * @brief Trait to determine the layout of a given data structure.
-         * 
-         * This is used to verify if optimized routines can be used.
-         * 
-         * @tparam array_t Data structure.
-         * @tparam class If this is not an int, then the trait is not defined.
-         * 
-         * @ingroup abstract_matrix
-         */
-        template< class array_t, class = int >
-        struct LayoutImpl {
-            static constexpr Layout layout = Layout::Unspecified;
-        };
-
-        /**
-         * @brief Trait to determine the transpose of matrices from class matrix_t.
-         * 
-         * @tparam matrix_t Data structure.
-         * @tparam class If this is not an int, then the trait is not defined.
-         * 
-         * @ingroup abstract_matrix
-         */
-        template< class matrix_t, class = int >
-        struct TransposeTypeImpl;
-
-        /**
-         * @brief Trait to determine if a given list of data allows optimization
-         * using a optimized BLAS library.
-         * 
-         * @tparam Ts If the last class in this list is not an int, then the trait is not defined.
-         * 
-         * @ingroup abstract_matrix
-         */
-        template<class... Ts>
-        struct AllowOptBLASImpl {
-            static constexpr bool value = false;    ///< True if the list of types
-                                                    ///< allows optimized BLAS library.
-        };
-
-        /**
-         * @brief Functor for data creation
-         * 
-         * This is a boilerplate. It must be specialized for each class.
-         * 
-         * @ingroup abstract_matrix
-         */
-        template< class matrix_t, class = int > struct CreateImpl
-        {
-            static_assert(false && sizeof(matrix_t), "Must use correct specialization");
-
-            /**
-             * @brief Creates an object (matrix or vector)
-             * 
-             * @param[out] v
-             *      Vector that can be used to reference allocated memory.
-             * @param[in] m Number of rows
-             * @param[in] n Number of Columns
-             * 
-             * @return The new object
-             */
-            template< class T, class idx_t >
-            inline constexpr auto
-            operator()( std::vector<T>& v, idx_t m, idx_t n = 1 ) const {
-                return matrix_t();
-            }
-
-            /**
-             * @brief Creates a matrix
-             * 
-             * @param[in] W
-             *      Workspace that references to allocated memory.
-             * @param[in] m Number of rows
-             * @param[in] n Number of Columns
-             * @param[out] rW
-             *      On exit, receives the updated workspace, i.e., that references
-             *      remaining allocated memory.
-             * 
-             * @return The new object
-             */
-            template< class idx_t, class Workspace >
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n, Workspace& rW ) const {
-                return matrix_t();
-            }
-
-            /**
-             * @brief Creates a vector
-             * 
-             * @param[in] W
-             *      Workspace that references to allocated memory.
-             * @param[in] m Size of the vector
-             * @param[out] rW
-             *      On exit, receives the updated workspace, i.e., that references
-             *      remaining allocated memory.
-             * 
-             * @return The new object
-             */
-            template< class idx_t, class Workspace >
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, Workspace& rW ) const {
-                return matrix_t();
-            }
-
-            /**
-             * @brief Creates an object (matrix or vector)
-             * 
-             * @param[in] W
-             *      Vector that can be used to reference allocated memory.
-             * @param[in] m Number of rows
-             * @param[in] n Number of Columns
-             * 
-             * @return The new object
-             */
-            template< class idx_t, class Workspace >
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n = 1 ) const {
-                return matrix_t();
-            }
-        };
-        
-        // Matrix and vector type deduction:
-
-        /**
-         * @brief Matrix type deduction
-         * 
-         * The deduction for two types must be implemented elsewhere. For example,
-         * the plugins for LegacyArray, Eigen and mdspan all have their own
-         * implementation.
-         * 
-         * @tparam matrix_t List of matrix types. The last type must be an int.
-         * 
-         * @ingroup abstract_matrix
-         */
-        template< typename... matrix_t >
-        struct matrix_type_traits;
-
-        /// Matrix type deduction for one type
-        template< typename matrix_t >
-        struct matrix_type_traits< matrix_t, int >
-        {
-            using type = typename matrix_type_traits<matrix_t,matrix_t,int>::type;
-        };
-
-        /// Matrix type deduction for three or more types
-        template< typename matrixA_t, typename matrixB_t, typename... matrix_t >
-        struct matrix_type_traits< matrixA_t, matrixB_t, matrix_t... >
-        {
-            using type = typename matrix_type_traits< typename matrix_type_traits< matrixA_t, matrixB_t, int >::type, matrix_t... >::type;
-        };
-
-        /**
-         * @brief Vector type deduction
-         * 
-         * The deduction for two types must be implemented elsewhere. For example,
-         * the plugins for LegacyArray, Eigen and mdspan all have their own
-         * implementation.
-         * 
-         * @tparam vector_t List of vector types. The last type must be an int.
-         * 
-         * @ingroup abstract_matrix
-         */
-        template< typename... vector_t >
-        struct vector_type_traits;
-
-        /// Vector type deduction for one type
-        template< typename vector_t >
-        struct vector_type_traits< vector_t, int >
-        {
-            using type = typename matrix_type_traits<vector_t,vector_t,int>::type;
-        };
-
-        /// Vector type deduction for three or more types
-        template< typename vectorA_t, typename vectorB_t, typename... vector_t >
-        struct vector_type_traits< vectorA_t, vectorB_t, vector_t... >
-        {
-            using type = typename vector_type_traits< typename vector_type_traits< vectorA_t, vectorB_t, int >::type, vector_t... >::type;
-        };
+        return MatrixAccessPolicy::Dense;
     }
+};
 
-    /// @brief Alias for @c internal::LayoutImpl<,int>::layout.
-    /// @ingroup abstract_matrix
-    template< class array_t >
-    constexpr Layout layout = internal::LayoutImpl<array_t,int>::layout;
+/**
+ * @brief Upper Hessenberg access
+ *
+ * Pairs (i,j) such that 0 <= i <= j+1, 0 <= j <= n     in a m-by-n matrix.
+ *
+ *      x x x x x
+ *      x x x x x
+ *      0 x x x x
+ *      0 0 x x x
+ */
+struct upperHessenberg_t : public dense_t {
+    constexpr operator MatrixAccessPolicy() const
+    {
+        return MatrixAccessPolicy::UpperHessenberg;
+    }
+};
+
+/**
+ * @brief Lower Hessenberg access
+ *
+ * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i+1   in a m-by-n matrix.
+ *
+ *      x x 0 0 0
+ *      x x x 0 0
+ *      x x x x 0
+ *      x x x x x
+ */
+struct lowerHessenberg_t : public dense_t {
+    constexpr operator MatrixAccessPolicy() const
+    {
+        return MatrixAccessPolicy::LowerHessenberg;
+    }
+};
+
+/**
+ * @brief Upper Triangle access
+ *
+ * Pairs (i,j) such that 0 <= i <= j,   0 <= j <= n     in a m-by-n matrix.
+ *
+ *      x x x x x
+ *      0 x x x x
+ *      0 0 x x x
+ *      0 0 0 x x
+ */
+struct upperTriangle_t : public upperHessenberg_t {
+    constexpr operator Uplo() const { return Uplo::Upper; }
+    constexpr operator MatrixAccessPolicy() const
+    {
+        return MatrixAccessPolicy::UpperTriangle;
+    }
+};
+
+/**
+ * @brief Lower Triangle access
+ *
+ * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i     in a m-by-n matrix.
+ *
+ *      x 0 0 0 0
+ *      x x 0 0 0
+ *      x x x 0 0
+ *      x x x x 0
+ */
+struct lowerTriangle_t : public lowerHessenberg_t {
+    constexpr operator Uplo() const { return Uplo::Lower; }
+    constexpr operator MatrixAccessPolicy() const
+    {
+        return MatrixAccessPolicy::LowerTriangle;
+    }
+};
+
+/**
+ * @brief Strict Upper Triangle access
+ *
+ * Pairs (i,j) such that 0 <= i <= j-1, 0 <= j <= n     in a m-by-n matrix.
+ *
+ *      0 x x x x
+ *      0 0 x x x
+ *      0 0 0 x x
+ *      0 0 0 0 x
+ */
+struct strictUpper_t : public upperTriangle_t {
+    constexpr operator MatrixAccessPolicy() const
+    {
+        return MatrixAccessPolicy::StrictUpper;
+    }
+};
+
+/**
+ * @brief Strict Lower Triangle access
+ *
+ * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i-1   in a m-by-n matrix.
+ *
+ *      0 0 0 0 0
+ *      x 0 0 0 0
+ *      x x 0 0 0
+ *      x x x 0 0
+ */
+struct strictLower_t : public lowerTriangle_t {
+    constexpr operator MatrixAccessPolicy() const
+    {
+        return MatrixAccessPolicy::StrictLower;
+    }
+};
+
+/**
+ * @brief Band access
+ *
+ * Pairs (i,j) such that max(0,j-ku) <= i <= min(m,j+kl) in a m-by-n matrix,
+ * where kl is the lower_bandwidth and ku is the upper_bandwidth.
+ *
+ *      x x x 0 0
+ *      x x x x 0
+ *      0 x x x x
+ *      0 0 x x x
+ */
+struct band_t : dense_t {
+    std::size_t lower_bandwidth;  ///< Number of subdiagonals.
+    std::size_t upper_bandwidth;  ///< Number of superdiagonals.
+
+    constexpr band_t(std::size_t kl, std::size_t ku)
+        : lower_bandwidth(kl), upper_bandwidth(ku)
+    {}
+};
+
+// constant expressions
+constexpr dense_t dense = {};
+constexpr upperHessenberg_t upperHessenberg = {};
+constexpr lowerHessenberg_t lowerHessenberg = {};
+constexpr upperTriangle_t upperTriangle = {};
+constexpr lowerTriangle_t lowerTriangle = {};
+constexpr strictUpper_t strictUpper = {};
+constexpr strictLower_t strictLower = {};
+
+// -----------------------------------------------------------------------------
+// Data traits
+
+namespace internal {
 
     /**
-     * @brief Alias for @c internal::CreateImpl<,int>.
-     * 
-     * Usage:
-     * @code{.cpp}
-     * // matrix_t is a predefined type at this point
-     * 
-     * using T = tlapack::type_t<matrix_t>;
-     * using idx_t = tlapack::size_type<matrix_t>;
-     * 
-     * tlapack::Create<matrix_t> new_matrix; // Creates the functor
-     * 
-     * idx_t m = 11;
-     * idx_t n = 6;
-     * 
-     * std::vector<T> A_container; // Empty vector
-     * auto A = new_matrix(A_container, m, n); // Initialize A_container if needed
-     * 
-     * tlapack::vectorOfBytes B_container; // Empty vector
-     * auto B = new_matrix(
-     *  tlapack::alloc_workspace( B_container, m*n*sizeof(T) ),
-     *  m, n ); // B_container stores allocated memory
-     * 
-     * tlapack::vectorOfBytes C_container; // Empty vector
-     * Workspace W; // Empty workspace
-     * auto C = new_matrix(
-     *  tlapack::alloc_workspace( C_container, m*n*sizeof(T) ),
-     *  m, n, W ); // W receives the updated workspace, i.e., without the space taken by C
-     * @endcode
-     * 
+     * @brief Trait to determine the layout of a given data structure.
+     *
+     * This is used to verify if optimized routines can be used.
+     *
+     * @tparam array_t Data structure.
+     * @tparam class If this is not an int, then the trait is not defined.
+     *
      * @ingroup abstract_matrix
      */
-    template< class T > using Create = internal::CreateImpl<T,int>;
+    template <class array_t, class = int>
+    struct LayoutImpl {
+        static constexpr Layout layout = Layout::Unspecified;
+    };
 
-    /// Alias for @c internal::TransposeTypeImpl<,int>::type.
-    /// @ingroup abstract_matrix
-    template< class T >
-    using transpose_type = typename internal::TransposeTypeImpl<T,int>::type;
+    /**
+     * @brief Trait to determine the transpose of matrices from class matrix_t.
+     *
+     * @tparam matrix_t Data structure.
+     * @tparam class If this is not an int, then the trait is not defined.
+     *
+     * @ingroup abstract_matrix
+     */
+    template <class matrix_t, class = int>
+    struct TransposeTypeImpl;
 
-    /// Alias for @c internal::matrix_type<,int>::type.
-    /// @ingroup abstract_matrix
-    template< typename... matrix_t >
-    using matrix_type = typename internal::matrix_type_traits< matrix_t..., int >::type;
+    /**
+     * @brief Trait to determine if a given list of data allows optimization
+     * using a optimized BLAS library.
+     *
+     * @tparam Ts If the last class in this list is not an int, then the trait
+     * is not defined.
+     *
+     * @ingroup abstract_matrix
+     */
+    template <class... Ts>
+    struct AllowOptBLASImpl {
+        static constexpr bool value =
+            false;  ///< True if the list of types
+                    ///< allows optimized BLAS library.
+    };
 
-    /// Alias for @c internal::vector_type<,int>::type.
-    /// @ingroup abstract_matrix
-    template< typename... vector_t >
-    using vector_type = typename internal::vector_type_traits< vector_t..., int >::type;
+    /**
+     * @brief Functor for data creation
+     *
+     * This is a boilerplate. It must be specialized for each class.
+     *
+     * @ingroup abstract_matrix
+     */
+    template <class matrix_t, class = int>
+    struct CreateImpl {
+        static_assert(false && sizeof(matrix_t),
+                      "Must use correct specialization");
 
-    /// Alias for @c internal::AllowOptBLASImpl<,int>::value.
-    /// @ingroup abstract_matrix
-    template<class... Ts>
-    constexpr bool allow_optblas = internal::AllowOptBLASImpl< Ts..., int >::value;
+        /**
+         * @brief Creates an object (matrix or vector)
+         *
+         * @param[out] v
+         *      Vector that can be used to reference allocated memory.
+         * @param[in] m Number of rows
+         * @param[in] n Number of Columns
+         *
+         * @return The new object
+         */
+        template <class T, class idx_t>
+        inline constexpr auto operator()(std::vector<T>& v,
+                                         idx_t m,
+                                         idx_t n = 1) const
+        {
+            return matrix_t();
+        }
 
-}
+        /**
+         * @brief Creates a matrix
+         *
+         * @param[in] W
+         *      Workspace that references to allocated memory.
+         * @param[in] m Number of rows
+         * @param[in] n Number of Columns
+         * @param[out] rW
+         *      On exit, receives the updated workspace, i.e., that references
+         *      remaining allocated memory.
+         *
+         * @return The new object
+         */
+        template <class idx_t, class Workspace>
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n,
+                                         Workspace& rW) const
+        {
+            return matrix_t();
+        }
 
-#endif // TLAPACK_ARRAY_TRAITS
+        /**
+         * @brief Creates a vector
+         *
+         * @param[in] W
+         *      Workspace that references to allocated memory.
+         * @param[in] m Size of the vector
+         * @param[out] rW
+         *      On exit, receives the updated workspace, i.e., that references
+         *      remaining allocated memory.
+         *
+         * @return The new object
+         */
+        template <class idx_t, class Workspace>
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         Workspace& rW) const
+        {
+            return matrix_t();
+        }
+
+        /**
+         * @brief Creates an object (matrix or vector)
+         *
+         * @param[in] W
+         *      Vector that can be used to reference allocated memory.
+         * @param[in] m Number of rows
+         * @param[in] n Number of Columns
+         *
+         * @return The new object
+         */
+        template <class idx_t, class Workspace>
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n = 1) const
+        {
+            return matrix_t();
+        }
+    };
+
+    // Matrix and vector type deduction:
+
+    /**
+     * @brief Matrix type deduction
+     *
+     * The deduction for two types must be implemented elsewhere. For example,
+     * the plugins for LegacyArray, Eigen and mdspan all have their own
+     * implementation.
+     *
+     * @tparam matrix_t List of matrix types. The last type must be an int.
+     *
+     * @ingroup abstract_matrix
+     */
+    template <typename... matrix_t>
+    struct matrix_type_traits;
+
+    /// Matrix type deduction for one type
+    template <typename matrix_t>
+    struct matrix_type_traits<matrix_t, int> {
+        using type = typename matrix_type_traits<matrix_t, matrix_t, int>::type;
+    };
+
+    /// Matrix type deduction for three or more types
+    template <typename matrixA_t, typename matrixB_t, typename... matrix_t>
+    struct matrix_type_traits<matrixA_t, matrixB_t, matrix_t...> {
+        using type = typename matrix_type_traits<
+            typename matrix_type_traits<matrixA_t, matrixB_t, int>::type,
+            matrix_t...>::type;
+    };
+
+    /**
+     * @brief Vector type deduction
+     *
+     * The deduction for two types must be implemented elsewhere. For example,
+     * the plugins for LegacyArray, Eigen and mdspan all have their own
+     * implementation.
+     *
+     * @tparam vector_t List of vector types. The last type must be an int.
+     *
+     * @ingroup abstract_matrix
+     */
+    template <typename... vector_t>
+    struct vector_type_traits;
+
+    /// Vector type deduction for one type
+    template <typename vector_t>
+    struct vector_type_traits<vector_t, int> {
+        using type = typename matrix_type_traits<vector_t, vector_t, int>::type;
+    };
+
+    /// Vector type deduction for three or more types
+    template <typename vectorA_t, typename vectorB_t, typename... vector_t>
+    struct vector_type_traits<vectorA_t, vectorB_t, vector_t...> {
+        using type = typename vector_type_traits<
+            typename vector_type_traits<vectorA_t, vectorB_t, int>::type,
+            vector_t...>::type;
+    };
+}  // namespace internal
+
+/// @brief Alias for @c internal::LayoutImpl<,int>::layout.
+/// @ingroup abstract_matrix
+template <class array_t>
+constexpr Layout layout = internal::LayoutImpl<array_t, int>::layout;
+
+/**
+ * @brief Alias for @c internal::CreateImpl<,int>.
+ *
+ * Usage:
+ * @code{.cpp}
+ * // matrix_t is a predefined type at this point
+ *
+ * using T = tlapack::type_t<matrix_t>;
+ * using idx_t = tlapack::size_type<matrix_t>;
+ *
+ * tlapack::Create<matrix_t> new_matrix; // Creates the functor
+ *
+ * idx_t m = 11;
+ * idx_t n = 6;
+ *
+ * std::vector<T> A_container; // Empty vector
+ * auto A = new_matrix(A_container, m, n); // Initialize A_container if needed
+ *
+ * tlapack::vectorOfBytes B_container; // Empty vector
+ * auto B = new_matrix(
+ *  tlapack::alloc_workspace( B_container, m*n*sizeof(T) ),
+ *  m, n ); // B_container stores allocated memory
+ *
+ * tlapack::vectorOfBytes C_container; // Empty vector
+ * Workspace W; // Empty workspace
+ * auto C = new_matrix(
+ *  tlapack::alloc_workspace( C_container, m*n*sizeof(T) ),
+ *  m, n, W ); // W receives the updated workspace, i.e., without the space
+ * taken by C
+ * @endcode
+ *
+ * @ingroup abstract_matrix
+ */
+template <class T>
+using Create = internal::CreateImpl<T, int>;
+
+/// Alias for @c internal::TransposeTypeImpl<,int>::type.
+/// @ingroup abstract_matrix
+template <class T>
+using transpose_type = typename internal::TransposeTypeImpl<T, int>::type;
+
+/// Alias for @c internal::matrix_type<,int>::type.
+/// @ingroup abstract_matrix
+template <typename... matrix_t>
+using matrix_type =
+    typename internal::matrix_type_traits<matrix_t..., int>::type;
+
+/// Alias for @c internal::vector_type<,int>::type.
+/// @ingroup abstract_matrix
+template <typename... vector_t>
+using vector_type =
+    typename internal::vector_type_traits<vector_t..., int>::type;
+
+/// Alias for @c internal::AllowOptBLASImpl<,int>::value.
+/// @ingroup abstract_matrix
+template <class... Ts>
+constexpr bool allow_optblas = internal::AllowOptBLASImpl<Ts..., int>::value;
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_ARRAY_TRAITS

--- a/include/tlapack/base/constants.hpp
+++ b/include/tlapack/base/constants.hpp
@@ -10,8 +10,9 @@
 #ifndef TLAPACK_CONSTANTS_HH
 #define TLAPACK_CONSTANTS_HH
 
-#include <type_traits>
 #include <limits>
+#include <type_traits>
+
 #include "tlapack/base/utils.hpp"
 
 namespace tlapack {
@@ -29,13 +30,13 @@ namespace tlapack {
  *      b^{-(p-1)}
  * \]
  * where b is the machine base, and p is the number of digits in the mantissa.
- * 
+ *
  * @ingroup constants
  */
 template <typename real_t>
 inline constexpr real_t ulp()
 {
-    return std::numeric_limits< real_t >::epsilon();
+    return std::numeric_limits<real_t>::epsilon();
 }
 
 /** Unit roundoff
@@ -43,18 +44,18 @@ inline constexpr real_t ulp()
  *      b^{-(p-1)} * r
  * \]
  * where b is the machine base, p is the number of digits in the mantissa,
- * and r is the largest possible rounding error in ULPs (units in the last place)
- * as defined by ISO 10967, which can vary from 0.5 (rounding to the nearest digit)
- * to 1.0 (rounding to zero or to infinity).
- * 
+ * and r is the largest possible rounding error in ULPs (units in the last
+ * place) as defined by ISO 10967, which can vary from 0.5 (rounding to the
+ * nearest digit) to 1.0 (rounding to zero or to infinity).
+ *
  * @see https://people.eecs.berkeley.edu/~demmel/cs267/lecture21/lecture21.html
- * 
+ *
  * @ingroup constants
  */
 template <typename real_t>
 inline constexpr real_t uroundoff()
 {
-    return ulp<real_t>() * std::numeric_limits< real_t >::round_error();
+    return ulp<real_t>() * std::numeric_limits<real_t>::round_error();
 }
 
 /** Digits
@@ -63,7 +64,7 @@ inline constexpr real_t uroundoff()
 template <typename real_t>
 inline const int digits()
 {
-    return std::numeric_limits< real_t >::digits;
+    return std::numeric_limits<real_t>::digits;
 }
 
 /** Safe Minimum such that 1/safe_min() is representable
@@ -76,13 +77,13 @@ inline constexpr real_t safe_min()
     constexpr int expm = std::numeric_limits<real_t>::min_exponent;
     constexpr int expM = std::numeric_limits<real_t>::max_exponent;
 
-    return max( pow(fradix, real_t(expm-1)), pow(fradix, real_t(1-expM)) );
+    return max(pow(fradix, real_t(expm - 1)), pow(fradix, real_t(1 - expM)));
 }
 
-/** Safe Maximum such that 1/safe_max() is representable 
+/** Safe Maximum such that 1/safe_max() is representable
  *
  * safe_max() := 1/SAFMIN
- * 
+ *
  * @ingroup constants
  */
 template <typename real_t>
@@ -92,7 +93,7 @@ inline constexpr real_t safe_max()
     constexpr int expm = std::numeric_limits<real_t>::min_exponent;
     constexpr int expM = std::numeric_limits<real_t>::max_exponent;
 
-    return min( pow(fradix, real_t(1-expm)), pow(fradix, real_t(expM-1)) );
+    return min(pow(fradix, real_t(1 - expm)), pow(fradix, real_t(expM - 1)));
 }
 
 /** Safe Minimum such its square is representable
@@ -101,7 +102,7 @@ inline constexpr real_t safe_max()
 template <typename real_t>
 inline constexpr real_t root_min()
 {
-    return sqrt( safe_min<real_t>() / ulp<real_t>() );
+    return sqrt(safe_min<real_t>() / ulp<real_t>());
 }
 
 /** Safe Maximum such its square is representable
@@ -110,7 +111,7 @@ inline constexpr real_t root_min()
 template <typename real_t>
 inline constexpr real_t root_max()
 {
-    return sqrt( safe_max<real_t>() * ulp<real_t>() );
+    return sqrt(safe_max<real_t>() * ulp<real_t>());
 }
 
 /** Blue's min constant b for the sum of squares
@@ -120,11 +121,11 @@ inline constexpr real_t root_max()
 template <typename real_t>
 inline constexpr real_t blue_min()
 {
-    const real_t half( 0.5 );
+    const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;
-    constexpr int expm   = std::numeric_limits<real_t>::min_exponent;
+    constexpr int expm = std::numeric_limits<real_t>::min_exponent;
 
-    return pow( fradix, ceil( half*real_t(expm-1) ) );
+    return pow(fradix, ceil(half * real_t(expm - 1)));
 }
 
 /** Blue's max constant B for the sum of squares
@@ -134,30 +135,30 @@ inline constexpr real_t blue_min()
 template <typename real_t>
 inline constexpr real_t blue_max()
 {
-    const real_t half( 0.5 );
+    const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;
-    constexpr int expM   = std::numeric_limits<real_t>::max_exponent;
-    const int t          = digits<real_t>();
+    constexpr int expM = std::numeric_limits<real_t>::max_exponent;
+    const int t = digits<real_t>();
 
-    return pow( fradix, floor( half*real_t( expM - t + 1 ) ) );
+    return pow(fradix, floor(half * real_t(expM - t + 1)));
 }
 
 /** Blue's scaling constant for numbers smaller than b
- * 
+ *
  * @details Modification introduced in @see https://doi.org/10.1145/3061665
  *          to scale denormalized numbers correctly.
- * 
+ *
  * @ingroup constants
  */
 template <typename real_t>
 inline constexpr real_t blue_scalingMin()
 {
-    const real_t half( 0.5 );
+    const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;
-    constexpr int expm   = std::numeric_limits<real_t>::min_exponent;
-    const int t          = digits<real_t>();
+    constexpr int expm = std::numeric_limits<real_t>::min_exponent;
+    const int t = digits<real_t>();
 
-    return pow( fradix, -floor( half*real_t(expm-t) ) );
+    return pow(fradix, -floor(half * real_t(expm - t)));
 }
 
 /** Blue's scaling constant for numbers bigger than B
@@ -167,14 +168,14 @@ inline constexpr real_t blue_scalingMin()
 template <typename real_t>
 inline constexpr real_t blue_scalingMax()
 {
-    const real_t half( 0.5 );
+    const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;
-    constexpr int expM   = std::numeric_limits<real_t>::max_exponent;
-    const int t          = digits<real_t>();
+    constexpr int expM = std::numeric_limits<real_t>::max_exponent;
+    const int t = digits<real_t>();
 
-    return pow( fradix, -ceil( half*real_t( expM + t - 1 ) ) );
+    return pow(fradix, -ceil(half * real_t(expM + t - 1)));
 }
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_CONSTANTS_HH
+#endif  // TLAPACK_CONSTANTS_HH

--- a/include/tlapack/base/exceptionHandling.hpp
+++ b/include/tlapack/base/exceptionHandling.hpp
@@ -10,9 +10,9 @@
 #ifndef TLAPACK_EXCEPTION_HH
 #define TLAPACK_EXCEPTION_HH
 
+#include <iostream>
 #include <stdexcept>
 #include <string>
-#include <iostream>
 
 #ifndef TLAPACK_DEFAULT_INFCHECK
     #define TLAPACK_DEFAULT_INFCHECK true
@@ -24,55 +24,52 @@
 
 namespace tlapack {
 
-    using check_error = std::domain_error;
-    using internal_error = std::runtime_error;
+using check_error = std::domain_error;
+using internal_error = std::runtime_error;
 
-    namespace internal {
+namespace internal {
 
-        /**
-         * @brief Create a string with the error message.
-         * 
-         * @param info Error code.
-         * @param detailedInfo Details about the error.
-         * @return std::string Final error message.
-         * 
-         * @ingroup exception
-         */
-        inline
-        std::string error_msg( int info, const std::string& detailedInfo ) {
-            return std::string("[") + std::to_string(info) + "] " + detailedInfo;
-        }
+    /**
+     * @brief Create a string with the error message.
+     *
+     * @param info Error code.
+     * @param detailedInfo Details about the error.
+     * @return std::string Final error message.
+     *
+     * @ingroup exception
+     */
+    inline std::string error_msg(int info, const std::string& detailedInfo)
+    {
+        return std::string("[") + std::to_string(info) + "] " + detailedInfo;
     }
+}  // namespace internal
 
-    /**
-     * @brief Descriptor for Exception Handling
-     * @ingroup exception
-     */
-    struct ErrorCheck {
-        
-        bool inf  = TLAPACK_DEFAULT_INFCHECK; ///< Default behavior of inf check 
-        bool nan  = TLAPACK_DEFAULT_NANCHECK; ///< Default behavior of nan check
-        bool internal = true; ///< Used to enable / disable internal checks.
+/**
+ * @brief Descriptor for Exception Handling
+ * @ingroup exception
+ */
+struct ErrorCheck {
+    bool inf = TLAPACK_DEFAULT_INFCHECK;  ///< Default behavior of inf check
+    bool nan = TLAPACK_DEFAULT_NANCHECK;  ///< Default behavior of nan check
+    bool internal = true;  ///< Used to enable / disable internal checks.
+};
 
-    };
+/**
+ * @brief Options to disable error checking.
+ * @ingroup exception
+ */
+constexpr ErrorCheck noErrorCheck = {false, false, false};
 
-    /**
-     * @brief Options to disable error checking.
-     * @ingroup exception
-     */
-    constexpr ErrorCheck noErrorCheck = { false, false, false };
+/**
+ * @brief Options for error checking.
+ * @ingroup exception
+ */
+struct ec_opts_t {
+    ErrorCheck ec = {};
 
-    /**
-     * @brief Options for error checking.
-     * @ingroup exception
-     */
-    struct ec_opts_t {
-        ErrorCheck ec = {};
-        
-        inline constexpr
-        ec_opts_t( const ErrorCheck& ec_ = {} ) : ec(ec_) {}
-    };
-}
+    inline constexpr ec_opts_t(const ErrorCheck& ec_ = {}) : ec(ec_) {}
+};
+}  // namespace tlapack
 
 // -----------------------------------------------------------------------------
 // Macros to handle error in the input
@@ -81,42 +78,40 @@ namespace tlapack {
 
     /**
      * @brief Throw an error if cond is false.
-     * 
+     *
      * ex: lapack_check( 1 > 2 ); throws an error.
-     * 
+     *
      * @note Disable the check by defining TLAPACK_NDEBUG or
      *  undefining TLAPACK_CHECK_INPUT.
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_check( cond ) do { \
-        if( !static_cast<bool>(cond) ) \
-            throw tlapack::check_error( #cond ); \
-    } while(false)
+    #define tlapack_check(cond)                                              \
+        do {                                                                 \
+            if (!static_cast<bool>(cond)) throw tlapack::check_error(#cond); \
+        } while (false)
 
     /**
      * @brief Throw an error if cond is true.
-     * 
+     *
      * ex: tlapack_check_false( 1 < 2 ); throws an error.
-     * 
+     *
      * @note Disable the check by defining TLAPACK_NDEBUG or
      *  undefining TLAPACK_CHECK_INPUT.
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_check_false( cond ) do { \
-        if( static_cast<bool>(cond) ) \
-            throw tlapack::check_error( #cond ); \
-    } while(false)
+    #define tlapack_check_false(cond)                                       \
+        do {                                                                \
+            if (static_cast<bool>(cond)) throw tlapack::check_error(#cond); \
+        } while (false)
 
-#else // !defined(TLAPACK_CHECK_INPUT) || defined(TLAPACK_NDEBUG)
+#else  // !defined(TLAPACK_CHECK_INPUT) || defined(TLAPACK_NDEBUG)
 
     // <T>LAPACK does not check input parameters
 
-    #define tlapack_check_false( cond ) \
-        ((void)0)
-    #define tlapack_check( cond ) \
-        ((void)0)
+    #define tlapack_check_false(cond) ((void)0)
+    #define tlapack_check(cond) ((void)0)
 
 #endif
 
@@ -127,60 +122,57 @@ namespace tlapack {
 
     /**
      * @brief Error handler
-     * 
+     *
      * @param[in] info Code of the error.
      * @param[in] detailedInfo String with information about the error.
-     * 
+     *
      * @note Disable the handler by defining TLAPACK_NDEBUG.
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_error( info, detailedInfo ) \
-        throw tlapack::internal_error( \
-            tlapack::internal::error_msg(info, detailedInfo) )
+    #define tlapack_error(info, detailedInfo) \
+        throw tlapack::internal_error(        \
+            tlapack::internal::error_msg(info, detailedInfo))
 
     /**
      * @brief Warning handler
-     * 
+     *
      * @param[in] info Code of the warning.
      * @param[in] detailedInfo String with information about the warning.
-     * 
+     *
      * @note Disable the handler by defining TLAPACK_NDEBUG.
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_warning( info, detailedInfo ) \
-        std::cerr \
-            << tlapack::internal::error_msg(info, detailedInfo) \
-            << std::endl;
+    #define tlapack_warning(info, detailedInfo)                       \
+        std::cerr << tlapack::internal::error_msg(info, detailedInfo) \
+                  << std::endl;
 
     /**
      * @brief Error handler with conditional for internal checks
-     * 
+     *
      * @param[in] ec Exception handling configuration at runtime.
      *      Default options are defined in ErrorCheck.
      * @param[in] info Code of the error.
      * @param[in] detailedInfo String with information about the error.
-     * 
+     *
      * @note Disable the handler by defining TLAPACK_NDEBUG.
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_error_internal( ec, info, detailedInfo ) do { \
-        if( static_cast<bool>(ec.internal) ) \
-            tlapack_error( info, detailedInfo ); \
-    } while(false)
+    #define tlapack_error_internal(ec, info, detailedInfo) \
+        do {                                               \
+            if (static_cast<bool>(ec.internal))            \
+                tlapack_error(info, detailedInfo);         \
+        } while (false)
 
 #else
 
     // <T>LAPACK does not throw errors or display warnings
 
-    #define tlapack_error( info, detailedInfo ) \
-        ((void)0)
-    #define tlapack_warning( info, detailedInfo ) \
-        ((void)0)
-    #define tlapack_error_internal( ec, info, detailedInfo ) \
-        ((void)0)
+    #define tlapack_error(info, detailedInfo) ((void)0)
+    #define tlapack_warning(info, detailedInfo) ((void)0)
+    #define tlapack_error_internal(ec, info, detailedInfo) ((void)0)
 
 #endif
 
@@ -191,38 +183,39 @@ namespace tlapack {
 
     /**
      * @brief Run tlapack_warning if there is an inf in the matrix.
-     * 
+     *
      * @note Disable the warning by defining TLAPACK_NDEBUG
      *  or undefining TLAPACK_ENABLE_INFCHECK
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_warn_infs_in_matrix( ec, accessType, A, info, detailedInfo ) do { \
-        if( static_cast<bool>(ec.inf) && hasinf(accessType, A) ) \
-            tlapack_warning( info, detailedInfo ); \
-    } while(false)
+    #define tlapack_warn_infs_in_matrix(ec, accessType, A, info, detailedInfo) \
+        do {                                                                   \
+            if (static_cast<bool>(ec.inf) && hasinf(accessType, A))            \
+                tlapack_warning(info, detailedInfo);                           \
+        } while (false)
 
     /**
      * @brief Run tlapack_warning if there is an inf in the vector.
-     * 
+     *
      * @note Disable the warning by defining TLAPACK_NDEBUG
      *  or undefining TLAPACK_ENABLE_INFCHECK
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_warn_infs_in_vector( ec, x, info, detailedInfo ) do { \
-        if( static_cast<bool>(ec.inf) && hasinf(x) ) \
-            tlapack_warning( info, detailedInfo ); \
-    } while(false)
+    #define tlapack_warn_infs_in_vector(ec, x, info, detailedInfo) \
+        do {                                                       \
+            if (static_cast<bool>(ec.inf) && hasinf(x))            \
+                tlapack_warning(info, detailedInfo);               \
+        } while (false)
 
-#else // !defined(TLAPACK_ENABLE_INFCHECK) || defined(TLAPACK_NDEBUG)
+#else  // !defined(TLAPACK_ENABLE_INFCHECK) || defined(TLAPACK_NDEBUG)
 
     // <T>LAPACK does not check for infs
 
-    #define tlapack_warn_infs_in_matrix( ec, accessType, A, info, detailedInfo ) \
+    #define tlapack_warn_infs_in_matrix(ec, accessType, A, info, detailedInfo) \
         ((void)0)
-    #define tlapack_warn_infs_in_vector( ec, x, info, detailedInfo ) \
-        ((void)0)
+    #define tlapack_warn_infs_in_vector(ec, x, info, detailedInfo) ((void)0)
 
 #endif
 
@@ -233,39 +226,40 @@ namespace tlapack {
 
     /**
      * @brief Run tlapack_warning if there is a nan in the matrix.
-     * 
+     *
      * @note Disable the warning by defining TLAPACK_NDEBUG
      *  or undefining TLAPACK_ENABLE_NANCHECK
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_warn_nans_in_matrix( ec, accessType, A, info, detailedInfo ) do { \
-        if( static_cast<bool>(ec.nan) && hasnan(accessType, A) ) \
-            tlapack_warning( info, detailedInfo ); \
-    } while(false)
+    #define tlapack_warn_nans_in_matrix(ec, accessType, A, info, detailedInfo) \
+        do {                                                                   \
+            if (static_cast<bool>(ec.nan) && hasnan(accessType, A))            \
+                tlapack_warning(info, detailedInfo);                           \
+        } while (false)
 
     /**
      * @brief Run tlapack_warning if there is a nan in the vector.
-     * 
+     *
      * @note Disable the warning by defining TLAPACK_NDEBUG
      *  or undefining TLAPACK_ENABLE_NANCHECK
-     * 
+     *
      * @ingroup exception
      */
-    #define tlapack_warn_nans_in_vector( ec, x, info, detailedInfo ) do { \
-        if( static_cast<bool>(ec.nan) && hasnan(x) ) \
-            tlapack_warning( info, detailedInfo ); \
-    } while(false)
-    
-#else // !defined(TLAPACK_ENABLE_NANCHECK) || defined(TLAPACK_NDEBUG)
+    #define tlapack_warn_nans_in_vector(ec, x, info, detailedInfo) \
+        do {                                                       \
+            if (static_cast<bool>(ec.nan) && hasnan(x))            \
+                tlapack_warning(info, detailedInfo);               \
+        } while (false)
+
+#else  // !defined(TLAPACK_ENABLE_NANCHECK) || defined(TLAPACK_NDEBUG)
 
     // <T>LAPACK does not check for nans
 
-    #define tlapack_warn_nans_in_matrix( ec, accessType, A, info, detailedInfo ) \
+    #define tlapack_warn_nans_in_matrix(ec, accessType, A, info, detailedInfo) \
         ((void)0)
-    #define tlapack_warn_nans_in_vector( ec, x, info, detailedInfo ) \
-        ((void)0)
-        
+    #define tlapack_warn_nans_in_vector(ec, x, info, detailedInfo) ((void)0)
+
 #endif
 
-#endif // TLAPACK_EXCEPTION_HH
+#endif  // TLAPACK_EXCEPTION_HH

--- a/include/tlapack/base/legacyArray.hpp
+++ b/include/tlapack/base/legacyArray.hpp
@@ -12,141 +12,149 @@
 #define TLAPACK_LEGACY_ARRAY_HH
 
 #include <cassert>
-#include "tlapack/base/types.hpp"
+
 #include "tlapack/base/exceptionHandling.hpp"
+#include "tlapack/base/types.hpp"
 
 namespace tlapack {
 
-    /** Legacy matrix.
-     * 
-     * legacyMatrix::ldim is assumed to be positive.
-     * 
-     * @tparam T Floating-point type
-     * @tparam idx_t Index type
-     * @tparam L Either Layout::ColMajor or Layout::RowMajor
-     */
-    template< class T, class idx_t = std::size_t, Layout L = Layout::ColMajor,
-        std::enable_if_t< (L == Layout::RowMajor) || (L == Layout::ColMajor), int > = 0
-    >
-    struct legacyMatrix {
-        idx_t m, n;                 ///< Sizes
-        T* ptr;                     ///< Pointer to array in memory
-        idx_t ldim;                 ///< Leading dimension
+/** Legacy matrix.
+ *
+ * legacyMatrix::ldim is assumed to be positive.
+ *
+ * @tparam T Floating-point type
+ * @tparam idx_t Index type
+ * @tparam L Either Layout::ColMajor or Layout::RowMajor
+ */
+template <class T,
+          class idx_t = std::size_t,
+          Layout L = Layout::ColMajor,
+          std::enable_if_t<(L == Layout::RowMajor) || (L == Layout::ColMajor),
+                           int> = 0>
+struct legacyMatrix {
+    idx_t m, n;  ///< Sizes
+    T* ptr;      ///< Pointer to array in memory
+    idx_t ldim;  ///< Leading dimension
 
-        static constexpr Layout layout = L;
-        
-        inline constexpr T&
-        operator()( idx_t i, idx_t j ) const noexcept {
-            assert( i >= 0);
-            assert( i < m);
-            assert( j >= 0);
-            assert( j < n);
-            return (layout == Layout::ColMajor)
-                ? ptr[ i + j*ldim ]
-                : ptr[ i*ldim + j ];
-        }
-        
-        inline constexpr legacyMatrix( idx_t m, idx_t n, T* ptr, idx_t ldim )
+    static constexpr Layout layout = L;
+
+    inline constexpr T& operator()(idx_t i, idx_t j) const noexcept
+    {
+        assert(i >= 0);
+        assert(i < m);
+        assert(j >= 0);
+        assert(j < n);
+        return (layout == Layout::ColMajor) ? ptr[i + j * ldim]
+                                            : ptr[i * ldim + j];
+    }
+
+    inline constexpr legacyMatrix(idx_t m, idx_t n, T* ptr, idx_t ldim)
         : m(m), n(n), ptr(ptr), ldim(ldim)
-        {
-            tlapack_check( m >= 0 );
-            tlapack_check( n >= 0 );
-            tlapack_check( ldim >= ((layout == Layout::ColMajor) ? m : n) );
-        }
-        
-        inline constexpr legacyMatrix( idx_t m, idx_t n, T* ptr )
+    {
+        tlapack_check(m >= 0);
+        tlapack_check(n >= 0);
+        tlapack_check(ldim >= ((layout == Layout::ColMajor) ? m : n));
+    }
+
+    inline constexpr legacyMatrix(idx_t m, idx_t n, T* ptr)
         : m(m), n(n), ptr(ptr), ldim((layout == Layout::ColMajor) ? m : n)
-        {
-            tlapack_check( m >= 0 );
-            tlapack_check( n >= 0 );
-        }
-        
-        /**
-         * @brief Converts a legacyMatrix<T,idx_t,L> to legacyMatrix<byte>
+    {
+        tlapack_check(m >= 0);
+        tlapack_check(n >= 0);
+    }
 
-         * @return constexpr legacyMatrix<byte> Column-major matrix.
-         */
-        inline constexpr legacyMatrix<byte> in_bytes() const {
-            if( L == Layout::ColMajor )
-                return legacyMatrix<byte>( m * sizeof(T), n, (byte*) ptr, ldim * sizeof(T) );
-            else // if( L == Layout::RowMajor )
-                return legacyMatrix<byte>( n * sizeof(T), m, (byte*) ptr, ldim * sizeof(T) );
-        }
-    };
+    /**
+     * @brief Converts a legacyMatrix<T,idx_t,L> to legacyMatrix<byte>
 
-    /** Legacy vector.
-     * 
-     * @tparam T Floating-point type
-     * @tparam idx_t Index type
-     * @tparam D Either Direction::Forward or Direction::Backward
+     * @return constexpr legacyMatrix<byte> Column-major matrix.
      */
-    template< typename T, class idx_t = std::size_t, typename int_t = internal::StrongOne, Direction D = Direction::Forward >
-    struct legacyVector {
-        idx_t n;                    ///< Size
-        T* ptr;                     ///< Pointer to array in memory
-        int_t inc;                  ///< Memory increment
+    inline constexpr legacyMatrix<byte> in_bytes() const
+    {
+        if (L == Layout::ColMajor)
+            return legacyMatrix<byte>(m * sizeof(T), n, (byte*)ptr,
+                                      ldim * sizeof(T));
+        else  // if( L == Layout::RowMajor )
+            return legacyMatrix<byte>(n * sizeof(T), m, (byte*)ptr,
+                                      ldim * sizeof(T));
+    }
+};
 
-        static constexpr Direction direction = D;
-        
-        inline constexpr T&
-        operator[]( idx_t i ) const noexcept {
-            assert( i >= 0);
-            assert( i < n);
-            return (direction == Direction::Forward)
-                ? *(ptr + (i*inc))
-                : *(ptr + ((n-1)-i)*inc);
-        }
-        
-        inline constexpr legacyVector( idx_t n, T* ptr, int_t inc = 1 )
+/** Legacy vector.
+ *
+ * @tparam T Floating-point type
+ * @tparam idx_t Index type
+ * @tparam D Either Direction::Forward or Direction::Backward
+ */
+template <typename T,
+          class idx_t = std::size_t,
+          typename int_t = internal::StrongOne,
+          Direction D = Direction::Forward>
+struct legacyVector {
+    idx_t n;    ///< Size
+    T* ptr;     ///< Pointer to array in memory
+    int_t inc;  ///< Memory increment
+
+    static constexpr Direction direction = D;
+
+    inline constexpr T& operator[](idx_t i) const noexcept
+    {
+        assert(i >= 0);
+        assert(i < n);
+        return (direction == Direction::Forward) ? *(ptr + (i * inc))
+                                                 : *(ptr + ((n - 1) - i) * inc);
+    }
+
+    inline constexpr legacyVector(idx_t n, T* ptr, int_t inc = 1)
         : n(n), ptr(ptr), inc(inc)
-        {
-            tlapack_check_false( n < 0 );
-        }
-    };
+    {
+        tlapack_check_false(n < 0);
+    }
+};
 
-    /** Legacy banded matrix.
-     * 
-     * Mind that the access A(i,j) is valid if, and only if,
+/** Legacy banded matrix.
+ *
+ * Mind that the access A(i,j) is valid if, and only if,
+ *  max(0,j-ku) <= i <= min(m,j+kl)
+ * This class does not perform such a check,
+ * otherwise it would lack in performance.
+ *
+ * @tparam T Floating-point type
+ * @tparam idx_t Index type
+ */
+template <typename T, class idx_t = std::size_t>
+struct legacyBandedMatrix {
+    idx_t m, n, kl, ku;  ///< Sizes
+    T* ptr;              ///< Pointer to array in memory
+
+    /** Access A(i,j) = ptr[ (ku+(i-j)) + j*(ku+kl+1) ]
+     *
+     * Mind that this access is valid if, and only if,
      *  max(0,j-ku) <= i <= min(m,j+kl)
-     * This class does not perform such a check,
+     * This operator does not perform such a check,
      * otherwise it would lack in performance.
-     * 
-     * @tparam T Floating-point type
-     * @tparam idx_t Index type
+     *
      */
-    template< typename T, class idx_t = std::size_t >
-    struct legacyBandedMatrix {
-        idx_t m, n, kl, ku;         ///< Sizes
-        T* ptr;                     ///< Pointer to array in memory
-        
-        /** Access A(i,j) = ptr[ (ku+(i-j)) + j*(ku+kl+1) ]
-         * 
-         * Mind that this access is valid if, and only if,
-         *  max(0,j-ku) <= i <= min(m,j+kl)
-         * This operator does not perform such a check,
-         * otherwise it would lack in performance.
-         * 
-         */
-        inline constexpr T&
-        operator()( idx_t i, idx_t j ) const noexcept {
-            assert( i >= 0);
-            assert( i < m);
-            assert( j >= 0);
-            assert( j < n);
-            assert( j <= i + ku);
-            assert( i <= j + kl);
-            return ptr[ (ku+i) + j*(ku+kl) ];
-        }
-        
-        inline constexpr legacyBandedMatrix( idx_t m, idx_t n, idx_t kl, idx_t ku, T* ptr )
+    inline constexpr T& operator()(idx_t i, idx_t j) const noexcept
+    {
+        assert(i >= 0);
+        assert(i < m);
+        assert(j >= 0);
+        assert(j < n);
+        assert(j <= i + ku);
+        assert(i <= j + kl);
+        return ptr[(ku + i) + j * (ku + kl)];
+    }
+
+    inline constexpr legacyBandedMatrix(
+        idx_t m, idx_t n, idx_t kl, idx_t ku, T* ptr)
         : m(m), n(n), kl(kl), ku(ku), ptr(ptr)
-        {
-            tlapack_check_false( m < 0 );
-            tlapack_check_false( n < 0 );
-            tlapack_check_false( (kl + 1 > m && m > 0) || (ku + 1 > n && n > 0) );
-        }
-    };
+    {
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false((kl + 1 > m && m > 0) || (ku + 1 > n && n > 0));
+    }
+};
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_ARRAY_HH
+#endif  // TLAPACK_LEGACY_ARRAY_HH

--- a/include/tlapack/base/legacyBandedMatrix.hpp
+++ b/include/tlapack/base/legacyBandedMatrix.hpp
@@ -11,54 +11,56 @@
 #define TLAPACK_LEGACY_BANDED_HH
 
 #include <cassert>
-#include "tlapack/base/types.hpp"
+
 #include "tlapack/base/exceptionHandling.hpp"
+#include "tlapack/base/types.hpp"
 
 namespace tlapack {
 
-    /** Legacy banded matrix.
-     * 
-     * Mind that the access A(i,j) is valid if, and only if,
+/** Legacy banded matrix.
+ *
+ * Mind that the access A(i,j) is valid if, and only if,
+ *  max(0,j-ku) <= i <= min(m,j+kl)
+ * This class does not perform such a check,
+ * otherwise it would lack in performance.
+ *
+ * @tparam T Floating-point type
+ * @tparam idx_t Index type
+ */
+template <typename T, class idx_t = std::size_t>
+struct legacyBandedMatrix {
+    idx_t m, n, kl, ku;  ///< Sizes
+    T* ptr;              ///< Pointer to array in memory
+
+    /** Access A(i,j) = ptr[ (ku+(i-j)) + j*(ku+kl+1) ]
+     *
+     * Mind that this access is valid if, and only if,
      *  max(0,j-ku) <= i <= min(m,j+kl)
-     * This class does not perform such a check,
+     * This operator does not perform such a check,
      * otherwise it would lack in performance.
-     * 
-     * @tparam T Floating-point type
-     * @tparam idx_t Index type
+     *
      */
-    template< typename T, class idx_t = std::size_t >
-    struct legacyBandedMatrix {
-        idx_t m, n, kl, ku;         ///< Sizes
-        T* ptr;                     ///< Pointer to array in memory
-        
-        /** Access A(i,j) = ptr[ (ku+(i-j)) + j*(ku+kl+1) ]
-         * 
-         * Mind that this access is valid if, and only if,
-         *  max(0,j-ku) <= i <= min(m,j+kl)
-         * This operator does not perform such a check,
-         * otherwise it would lack in performance.
-         * 
-         */
-        inline constexpr T&
-        operator()( idx_t i, idx_t j ) const noexcept {
-            assert( i >= 0);
-            assert( i < m);
-            assert( j >= 0);
-            assert( j < n);
-            assert( j <= i + ku);
-            assert( i <= j + kl);
-            return ptr[ (ku+i) + j*(ku+kl) ];
-        }
-        
-        inline constexpr legacyBandedMatrix( idx_t m, idx_t n, idx_t kl, idx_t ku, T* ptr )
+    inline constexpr T& operator()(idx_t i, idx_t j) const noexcept
+    {
+        assert(i >= 0);
+        assert(i < m);
+        assert(j >= 0);
+        assert(j < n);
+        assert(j <= i + ku);
+        assert(i <= j + kl);
+        return ptr[(ku + i) + j * (ku + kl)];
+    }
+
+    inline constexpr legacyBandedMatrix(
+        idx_t m, idx_t n, idx_t kl, idx_t ku, T* ptr)
         : m(m), n(n), kl(kl), ku(ku), ptr(ptr)
-        {
-            tlapack_check( m >= 0 );
-            tlapack_check( n >= 0 );
-            tlapack_check( (kl + 1 <= m || m == 0) && (ku + 1 <= n || n == 0) );
-        }
-    };
+    {
+        tlapack_check(m >= 0);
+        tlapack_check(n >= 0);
+        tlapack_check((kl + 1 <= m || m == 0) && (ku + 1 <= n || n == 0));
+    }
+};
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_ARRAY_HH
+#endif  // TLAPACK_LEGACY_ARRAY_HH

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -11,275 +11,275 @@
 #ifndef TLAPACK_TYPES_HH
 #define TLAPACK_TYPES_HH
 
+#include <cassert>
 #include <complex>
 #include <type_traits>
 #include <vector>
-#include <cassert>
 
 // Helpers:
 
-#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES( EnumClass, A, B ) \
-    inline std::ostream& operator << ( std::ostream& out, const EnumClass v ) \
-    { \
-        if( v == EnumClass::A ) return out << #A; \
-        if( v == EnumClass::B ) return out << #B; \
-        return out << "<Invalid>"; \
+#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(EnumClass, A, B)       \
+    inline std::ostream& operator<<(std::ostream& out, const EnumClass v) \
+    {                                                                     \
+        if (v == EnumClass::A) return out << #A;                          \
+        if (v == EnumClass::B) return out << #B;                          \
+        return out << "<Invalid>";                                        \
     }
 
-#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_3_VALUES( EnumClass, A, B, C ) \
-    inline std::ostream& operator << ( std::ostream& out, const EnumClass v ) \
-    { \
-        if( v == EnumClass::A ) return out << #A; \
-        if( v == EnumClass::B ) return out << #B; \
-        if( v == EnumClass::C ) return out << #C; \
-        return out << "<Invalid>"; \
+#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_3_VALUES(EnumClass, A, B, C)    \
+    inline std::ostream& operator<<(std::ostream& out, const EnumClass v) \
+    {                                                                     \
+        if (v == EnumClass::A) return out << #A;                          \
+        if (v == EnumClass::B) return out << #B;                          \
+        if (v == EnumClass::C) return out << #C;                          \
+        return out << "<Invalid>";                                        \
     }
 
-#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES( EnumClass, A, B, C, D ) \
-    inline std::ostream& operator << ( std::ostream& out, const EnumClass v ) \
-    { \
-        if( v == EnumClass::A ) return out << #A; \
-        if( v == EnumClass::B ) return out << #B; \
-        if( v == EnumClass::C ) return out << #C; \
-        if( v == EnumClass::D ) return out << #D; \
-        return out << "<Invalid>"; \
+#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(EnumClass, A, B, C, D) \
+    inline std::ostream& operator<<(std::ostream& out, const EnumClass v) \
+    {                                                                     \
+        if (v == EnumClass::A) return out << #A;                          \
+        if (v == EnumClass::B) return out << #B;                          \
+        if (v == EnumClass::C) return out << #C;                          \
+        if (v == EnumClass::D) return out << #D;                          \
+        return out << "<Invalid>";                                        \
     }
 
-#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES( EnumClass, A, B, C, D, E ) \
-    inline std::ostream& operator << ( std::ostream& out, const EnumClass v ) \
-    { \
-        if( v == EnumClass::A ) return out << #A; \
-        if( v == EnumClass::B ) return out << #B; \
-        if( v == EnumClass::C ) return out << #C; \
-        if( v == EnumClass::D ) return out << #D; \
-        if( v == EnumClass::E ) return out << #E; \
-        return out << "<Invalid>"; \
+#define TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES(EnumClass, A, B, C, D, E) \
+    inline std::ostream& operator<<(std::ostream& out, const EnumClass v)    \
+    {                                                                        \
+        if (v == EnumClass::A) return out << #A;                             \
+        if (v == EnumClass::B) return out << #B;                             \
+        if (v == EnumClass::C) return out << #C;                             \
+        if (v == EnumClass::D) return out << #D;                             \
+        if (v == EnumClass::E) return out << #E;                             \
+        return out << "<Invalid>";                                           \
     }
 
 // Types:
 
 namespace tlapack {
 
-    namespace internal {
+namespace internal {
 
-        /// Auxiliary data type to vector increments.
-        struct StrongOne {
-            inline constexpr operator int() const { return 1; }
-            inline constexpr StrongOne( int i = 1 ) { assert( i == 1 ); }
-        };
-
-        /**
-         * @brief Auxiliary data type
-         * 
-         * Suppose x is of type T. Then:
-         * 
-         * 1. T(StrongZero()) is equivalent to T(0).
-         * 2. x *= StrongZero() is equivalent to x = T(0).
-         * 3. x += StrongZero() does not modify x.
-         * 
-         * This class satisfies:
-         * 
-         *      x * StrongZero() = StrongZero()
-         *      StrongZero() * x = StrongZero()
-         *      x + StrongZero() = x
-         *      StrongZero() + x = x 
-         * 
-         */
-        struct StrongZero {
-
-            template<typename T>
-            explicit constexpr
-            operator T() const { return T(0); }
-
-            template<typename T>
-            friend constexpr
-            T& operator*=( T& lhs, const StrongZero& )
-            {
-                lhs = T(0);
-                return lhs;
-            }
-
-            template<typename T>
-            friend constexpr
-            const StrongZero operator*( const StrongZero&, const T& ) { return StrongZero(); }
-
-            template<typename T>
-            friend constexpr
-            const StrongZero operator*( const T&, const StrongZero& ) { return StrongZero(); }
-
-            template<typename T>
-            friend constexpr
-            const T& operator+=( const T& lhs, const StrongZero& ) { return lhs; }
-
-            template<typename T>
-            friend constexpr
-            const T operator+( const StrongZero&, const T& rhs ) { return rhs; }
-
-            template<typename T>
-            friend constexpr
-            const T operator+( const T& lhs, const StrongZero& ) { return lhs; }
-
-        };
-    }
-
-    // -----------------------------------------------------------------------------
-    // Layouts
-
-    enum class Layout :char {
-        Unspecified = 0,
-        ColMajor = 'C',
-        RowMajor = 'R',
-        BandStorage = 'B'
-    };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(Layout, Unspecified, ColMajor, RowMajor, BandStorage)
-
-    // -----------------------------------------------------------------------------
-    // Upper or Lower access
-
-    enum class Uplo : char {
-        Upper    = 'U', 
-        Lower    = 'L', 
-        General  = 'G'
-    };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_3_VALUES( Uplo, Upper, Lower, General )
-
-    // -----------------------------------------------------------------------------
-    // Information about the main diagonal
-
-    enum class Diag : char {
-        NonUnit  = 'N',
-        Unit     = 'U'
-    };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES( Diag, NonUnit, Unit )
-
-    struct nonUnit_diagonal_t {
-        constexpr operator Diag() const { return Diag::NonUnit; }
-    };
-    struct unit_diagonal_t {
-        constexpr operator Diag() const { return Diag::Unit; }
+    /// Auxiliary data type to vector increments.
+    struct StrongOne {
+        inline constexpr operator int() const { return 1; }
+        inline constexpr StrongOne(int i = 1) { assert(i == 1); }
     };
 
-    // constants
-    constexpr nonUnit_diagonal_t nonUnit_diagonal = { };
-    constexpr unit_diagonal_t unit_diagonal = { };
+    /**
+     * @brief Auxiliary data type
+     *
+     * Suppose x is of type T. Then:
+     *
+     * 1. T(StrongZero()) is equivalent to T(0).
+     * 2. x *= StrongZero() is equivalent to x = T(0).
+     * 3. x += StrongZero() does not modify x.
+     *
+     * This class satisfies:
+     *
+     *      x * StrongZero() = StrongZero()
+     *      StrongZero() * x = StrongZero()
+     *      x + StrongZero() = x
+     *      StrongZero() + x = x
+     *
+     */
+    struct StrongZero {
+        template <typename T>
+        explicit constexpr operator T() const
+        {
+            return T(0);
+        }
 
-    // -----------------------------------------------------------------------------
-    // Operations over data
+        template <typename T>
+        friend constexpr T& operator*=(T& lhs, const StrongZero&)
+        {
+            lhs = T(0);
+            return lhs;
+        }
 
-    enum class Op : char {
-        NoTrans  = 'N',
-        Trans    = 'T',
-        ConjTrans = 'C',
-        Conj = 0            ///< non-transpose conjugate
+        template <typename T>
+        friend constexpr const StrongZero operator*(const StrongZero&, const T&)
+        {
+            return StrongZero();
+        }
+
+        template <typename T>
+        friend constexpr const StrongZero operator*(const T&, const StrongZero&)
+        {
+            return StrongZero();
+        }
+
+        template <typename T>
+        friend constexpr const T& operator+=(const T& lhs, const StrongZero&)
+        {
+            return lhs;
+        }
+
+        template <typename T>
+        friend constexpr const T operator+(const StrongZero&, const T& rhs)
+        {
+            return rhs;
+        }
+
+        template <typename T>
+        friend constexpr const T operator+(const T& lhs, const StrongZero&)
+        {
+            return lhs;
+        }
     };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES( Op, NoTrans, Trans, ConjTrans, Conj )
+}  // namespace internal
 
-    struct noTranspose_t {
-        constexpr operator Op() const { return Op::NoTrans; }
-    };
-    struct transpose_t {
-        constexpr operator Op() const { return Op::Trans; }
-    };
-    struct conjTranspose_t {
-        constexpr operator Op() const { return Op::ConjTrans; }
-    };
+// -----------------------------------------------------------------------------
+// Layouts
 
-    // Constants
-    constexpr noTranspose_t noTranspose = { };
-    constexpr transpose_t Transpose = { };
-    constexpr conjTranspose_t conjTranspose = { };
+enum class Layout : char {
+    Unspecified = 0,
+    ColMajor = 'C',
+    RowMajor = 'R',
+    BandStorage = 'B'
+};
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(
+    Layout, Unspecified, ColMajor, RowMajor, BandStorage)
 
-    // -----------------------------------------------------------------------------
-    // Sides
+// -----------------------------------------------------------------------------
+// Upper or Lower access
 
-    enum class Side : char {
-        Left     = 'L', 
-        Right    = 'R'
-    };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES( Side, Left, Right )
+enum class Uplo : char { Upper = 'U', Lower = 'L', General = 'G' };
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_3_VALUES(Uplo, Upper, Lower, General)
 
-    struct left_side_t {
-        constexpr operator Side() const { return Side::Left; }
-    };
-    struct right_side_t {
-        constexpr operator Side() const { return Side::Right; }
-    };
+// -----------------------------------------------------------------------------
+// Information about the main diagonal
 
-    // Constants
-    constexpr left_side_t left_side { };
-    constexpr right_side_t right_side { };
+enum class Diag : char { NonUnit = 'N', Unit = 'U' };
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Diag, NonUnit, Unit)
 
-    // -----------------------------------------------------------------------------
-    // Norm types
+struct nonUnit_diagonal_t {
+    constexpr operator Diag() const { return Diag::NonUnit; }
+};
+struct unit_diagonal_t {
+    constexpr operator Diag() const { return Diag::Unit; }
+};
 
-    enum class Norm : char {
-        One = '1',  // or 'O'
-        Two = '2',
-        Inf = 'I',
-        Fro = 'F',  // or 'E'
-        Max = 'M',
-    };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES( Norm, One, Two, Inf, Fro, Max )
+// constants
+constexpr nonUnit_diagonal_t nonUnit_diagonal = {};
+constexpr unit_diagonal_t unit_diagonal = {};
 
-    struct max_norm_t {
-        constexpr operator Norm() const { return Norm::Max; }
-    };
-    struct one_norm_t {
-        constexpr operator Norm() const { return Norm::One; }
-    };
-    struct inf_norm_t {
-        constexpr operator Norm() const { return Norm::Inf; }
-    };
-    struct frob_norm_t {
-        constexpr operator Norm() const { return Norm::Fro; }
-    };
+// -----------------------------------------------------------------------------
+// Operations over data
 
-    // Constants
-    constexpr max_norm_t max_norm = { };
-    constexpr one_norm_t one_norm = { };
-    constexpr inf_norm_t inf_norm = { };
-    constexpr frob_norm_t frob_norm = { };
+enum class Op : char {
+    NoTrans = 'N',
+    Trans = 'T',
+    ConjTrans = 'C',
+    Conj = 0  ///< non-transpose conjugate
+};
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(Op, NoTrans, Trans, ConjTrans, Conj)
 
-    // -----------------------------------------------------------------------------
-    // Directions
+struct noTranspose_t {
+    constexpr operator Op() const { return Op::NoTrans; }
+};
+struct transpose_t {
+    constexpr operator Op() const { return Op::Trans; }
+};
+struct conjTranspose_t {
+    constexpr operator Op() const { return Op::ConjTrans; }
+};
 
-    enum class Direction : char {
-        Forward     = 'F',
-        Backward    = 'B',
-    };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES( Direction, Forward, Backward )
+// Constants
+constexpr noTranspose_t noTranspose = {};
+constexpr transpose_t Transpose = {};
+constexpr conjTranspose_t conjTranspose = {};
 
-    struct forward_t {
-        constexpr operator Direction() const { return Direction::Forward; }
-    };
-    struct backward_t {
-        constexpr operator Direction() const { return Direction::Backward; }
-    };
+// -----------------------------------------------------------------------------
+// Sides
 
-    // Constants
-    constexpr forward_t forward { };
-    constexpr backward_t backward { };
+enum class Side : char { Left = 'L', Right = 'R' };
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Side, Left, Right)
 
-    // -----------------------------------------------------------------------------
-    // Storage types
+struct left_side_t {
+    constexpr operator Side() const { return Side::Left; }
+};
+struct right_side_t {
+    constexpr operator Side() const { return Side::Right; }
+};
 
-    enum class StoreV : char {
-        Columnwise  = 'C',
-        Rowwise     = 'R',
-    };
-    TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES( StoreV, Columnwise, Rowwise )
+// Constants
+constexpr left_side_t left_side{};
+constexpr right_side_t right_side{};
 
-    struct columnwise_storage_t {
-        constexpr operator StoreV() const { return StoreV::Columnwise; }
-    };
-    struct rowwise_storage_t {
-        constexpr operator StoreV() const { return StoreV::Rowwise; }
-    };
+// -----------------------------------------------------------------------------
+// Norm types
 
-    // Constants
-    constexpr columnwise_storage_t columnwise_storage { };
-    constexpr rowwise_storage_t rowwise_storage { };
-} // namespace tlapack
+enum class Norm : char {
+    One = '1',  // or 'O'
+    Two = '2',
+    Inf = 'I',
+    Fro = 'F',  // or 'E'
+    Max = 'M',
+};
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES(Norm, One, Two, Inf, Fro, Max)
+
+struct max_norm_t {
+    constexpr operator Norm() const { return Norm::Max; }
+};
+struct one_norm_t {
+    constexpr operator Norm() const { return Norm::One; }
+};
+struct inf_norm_t {
+    constexpr operator Norm() const { return Norm::Inf; }
+};
+struct frob_norm_t {
+    constexpr operator Norm() const { return Norm::Fro; }
+};
+
+// Constants
+constexpr max_norm_t max_norm = {};
+constexpr one_norm_t one_norm = {};
+constexpr inf_norm_t inf_norm = {};
+constexpr frob_norm_t frob_norm = {};
+
+// -----------------------------------------------------------------------------
+// Directions
+
+enum class Direction : char {
+    Forward = 'F',
+    Backward = 'B',
+};
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Direction, Forward, Backward)
+
+struct forward_t {
+    constexpr operator Direction() const { return Direction::Forward; }
+};
+struct backward_t {
+    constexpr operator Direction() const { return Direction::Backward; }
+};
+
+// Constants
+constexpr forward_t forward{};
+constexpr backward_t backward{};
+
+// -----------------------------------------------------------------------------
+// Storage types
+
+enum class StoreV : char {
+    Columnwise = 'C',
+    Rowwise = 'R',
+};
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(StoreV, Columnwise, Rowwise)
+
+struct columnwise_storage_t {
+    constexpr operator StoreV() const { return StoreV::Columnwise; }
+};
+struct rowwise_storage_t {
+    constexpr operator StoreV() const { return StoreV::Rowwise; }
+};
+
+// Constants
+constexpr columnwise_storage_t columnwise_storage{};
+constexpr rowwise_storage_t rowwise_storage{};
+}  // namespace tlapack
 
 #undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES
 #undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_3_VALUES
@@ -288,194 +288,183 @@ namespace tlapack {
 
 namespace tlapack {
 
-    // -----------------------------------------------------------------------------
-    // Based on C++14 std::common_type implementation from
-    // http://www.cplusplus.com/reference/type_traits/std::common_type/
-    // Adds promotion of complex types based on the common type of the associated
-    // real types. This fixes various cases:
-    //
-    // std::std::common_type_t< double, complex<float> > is complex<float>  (wrong)
-    //        scalar_type< double, complex<float> > is complex<double> (right)
-    //
-    // std::std::common_type_t< int, complex<long> > is not defined (compile error)
-    //        scalar_type< int, complex<long> > is complex<long> (right)
+// -----------------------------------------------------------------------------
+// Based on C++14 std::common_type implementation from
+// http://www.cplusplus.com/reference/type_traits/std::common_type/
+// Adds promotion of complex types based on the common type of the associated
+// real types. This fixes various cases:
+//
+// std::std::common_type_t< double, complex<float> > is complex<float>  (wrong)
+//        scalar_type< double, complex<float> > is complex<double> (right)
+//
+// std::std::common_type_t< int, complex<long> > is not defined (compile error)
+//        scalar_type< int, complex<long> > is complex<long> (right)
 
-    // for zero types
-    template< typename... Types >
-    struct scalar_type_traits;
+// for zero types
+template <typename... Types>
+struct scalar_type_traits;
 
-    /// define scalar_type<> type alias
-    template< typename... Types >
-    using scalar_type = typename scalar_type_traits< Types... >::type;
+/// define scalar_type<> type alias
+template <typename... Types>
+using scalar_type = typename scalar_type_traits<Types...>::type;
 
-    // for one type
-    template< typename T >
-    struct scalar_type_traits< T >
-    {
-        using type = typename std::decay<T>::type;
-    };
+// for one type
+template <typename T>
+struct scalar_type_traits<T> {
+    using type = typename std::decay<T>::type;
+};
 
-    // for two types
-    // relies on type of ?: operator being the common type of its two arguments
-    template< typename T1, typename T2 >
-    struct scalar_type_traits< T1, T2 >
-    {
-        using type = typename std::decay< decltype( true ? std::declval<T1>() : std::declval<T2>() ) >::type;
-    };
+// for two types
+// relies on type of ?: operator being the common type of its two arguments
+template <typename T1, typename T2>
+struct scalar_type_traits<T1, T2> {
+    using type = typename std::decay<decltype(true ? std::declval<T1>()
+                                                   : std::declval<T2>())>::type;
+};
 
-    // for either or both complex,
-    // find common type of associated real types, then add complex
-    template< typename T1, typename T2 >
-    struct scalar_type_traits< std::complex<T1>, T2 >
-    {
-        using type = std::complex< typename std::common_type< T1, T2 >::type >;
-    };
+// for either or both complex,
+// find common type of associated real types, then add complex
+template <typename T1, typename T2>
+struct scalar_type_traits<std::complex<T1>, T2> {
+    using type = std::complex<typename std::common_type<T1, T2>::type>;
+};
 
-    template< typename T1, typename T2 >
-    struct scalar_type_traits< T1, std::complex<T2> >
-    {
-        using type = std::complex< typename std::common_type< T1, T2 >::type >;
-    };
+template <typename T1, typename T2>
+struct scalar_type_traits<T1, std::complex<T2> > {
+    using type = std::complex<typename std::common_type<T1, T2>::type>;
+};
 
-    template< typename T1, typename T2 >
-    struct scalar_type_traits< std::complex<T1>, std::complex<T2> >
-    {
-        using type = std::complex< typename std::common_type< T1, T2 >::type >;
-    };
+template <typename T1, typename T2>
+struct scalar_type_traits<std::complex<T1>, std::complex<T2> > {
+    using type = std::complex<typename std::common_type<T1, T2>::type>;
+};
 
-    // for three or more types
-    template< typename T1, typename T2, typename... Types >
-    struct scalar_type_traits< T1, T2, Types... >
-    {
-        using type = scalar_type< scalar_type< T1, T2 >, Types... >;
-    };
+// for three or more types
+template <typename T1, typename T2, typename... Types>
+struct scalar_type_traits<T1, T2, Types...> {
+    using type = scalar_type<scalar_type<T1, T2>, Types...>;
+};
 
-    // -----------------------------------------------------------------------------
-    // for any combination of types, determine associated real, scalar,
-    // and complex types.
-    //
-    // real_type< float >                               is float
-    // real_type< float, double, complex<float> >       is double
-    //
-    // scalar_type< float >                             is float
-    // scalar_type< float, complex<float> >             is complex<float>
-    // scalar_type< float, double, complex<float> >     is complex<double>
-    //
-    // complex_type< float >                            is complex<float>
-    // complex_type< float, double >                    is complex<double>
-    // complex_type< float, double, complex<float> >    is complex<double>
+// -----------------------------------------------------------------------------
+// for any combination of types, determine associated real, scalar,
+// and complex types.
+//
+// real_type< float >                               is float
+// real_type< float, double, complex<float> >       is double
+//
+// scalar_type< float >                             is float
+// scalar_type< float, complex<float> >             is complex<float>
+// scalar_type< float, double, complex<float> >     is complex<double>
+//
+// complex_type< float >                            is complex<float>
+// complex_type< float, double >                    is complex<double>
+// complex_type< float, double, complex<float> >    is complex<double>
 
-    // for zero types
-    template< typename... Types >
-    struct real_type_traits;
+// for zero types
+template <typename... Types>
+struct real_type_traits;
 
-    /// define real_type<> type alias
-    template< typename... Types >
-    using real_type = typename real_type_traits< Types... >::type;
+/// define real_type<> type alias
+template <typename... Types>
+using real_type = typename real_type_traits<Types...>::type;
 
-    // for one type
-    template< typename T >
-    struct real_type_traits<T>
-    {
-        using type = T;
-    };
+// for one type
+template <typename T>
+struct real_type_traits<T> {
+    using type = T;
+};
 
-    // for one complex type, strip complex
-    template< typename T >
-    struct real_type_traits< std::complex<T> >
-    {
-        using type = T;
-    };
+// for one complex type, strip complex
+template <typename T>
+struct real_type_traits<std::complex<T> > {
+    using type = T;
+};
 
-    // for two or more types
-    template< typename T1, typename... Types >
-    struct real_type_traits< T1, Types... >
-    {
-        using type = scalar_type< real_type<T1>, real_type< Types... > >;
-    };
+// for two or more types
+template <typename T1, typename... Types>
+struct real_type_traits<T1, Types...> {
+    using type = scalar_type<real_type<T1>, real_type<Types...> >;
+};
 
-    // for zero types
-    template< typename... Types >
-    struct complex_type_traits;
+// for zero types
+template <typename... Types>
+struct complex_type_traits;
 
-    /// define complex_type<> type alias
-    template< typename... Types >
-    using complex_type = typename complex_type_traits< Types... >::type;
+/// define complex_type<> type alias
+template <typename... Types>
+using complex_type = typename complex_type_traits<Types...>::type;
 
-    // for one type
-    template< typename T >
-    struct complex_type_traits<T>
-    {
-        using type = std::complex<T>;
-    };
+// for one type
+template <typename T>
+struct complex_type_traits<T> {
+    using type = std::complex<T>;
+};
 
-    // for one complex type, strip complex
-    template< typename T >
-    struct complex_type_traits< std::complex<T> >
-    {
-        using type = std::complex<T>;
-    };
+// for one complex type, strip complex
+template <typename T>
+struct complex_type_traits<std::complex<T> > {
+    using type = std::complex<T>;
+};
 
-    // for two or more types
-    template< typename T1, typename... Types >
-    struct complex_type_traits< T1, Types... >
-    {
-        using type = scalar_type< complex_type<T1>, complex_type< Types... > >;
-    };
+// for two or more types
+template <typename T1, typename... Types>
+struct complex_type_traits<T1, Types...> {
+    using type = scalar_type<complex_type<T1>, complex_type<Types...> >;
+};
 
-} // namespace tlapack
+}  // namespace tlapack
 
 namespace tlapack {
 
-    namespace internal {
+namespace internal {
 
-        /**
-         * @brief Data type trait.
-         * 
-         * The data type is defined on @c type_trait<array_t>::type.
-         * 
-         * @tparam T A non-array class.
-         */
-        template< class T, typename = int >
-        struct type_trait {
-            using type = void;
-        };
+    /**
+     * @brief Data type trait.
+     *
+     * The data type is defined on @c type_trait<array_t>::type.
+     *
+     * @tparam T A non-array class.
+     */
+    template <class T, typename = int>
+    struct type_trait {
+        using type = void;
+    };
 
-        /**
-         * @brief Size type trait.
-         * 
-         * The size type is defined on @c sizet_trait<array_t>::type.
-         * 
-         * @tparam T A non-array class.
-         */
-        template< class T, typename = int >
-        struct sizet_trait {
-            using type = std::size_t;
-        };
+    /**
+     * @brief Size type trait.
+     *
+     * The size type is defined on @c sizet_trait<array_t>::type.
+     *
+     * @tparam T A non-array class.
+     */
+    template <class T, typename = int>
+    struct sizet_trait {
+        using type = std::size_t;
+    };
 
-    }
+}  // namespace internal
 
-    /// Alias for @c type_trait<>::type.
-    template< class array_t >
-    using type_t = typename internal::type_trait< array_t >::type;
+/// Alias for @c type_trait<>::type.
+template <class array_t>
+using type_t = typename internal::type_trait<array_t>::type;
 
-    /// Alias for @c sizet_trait<>::type.
-    template< class array_t >
-    using size_type = typename internal::sizet_trait< array_t >::type;
+/// Alias for @c sizet_trait<>::type.
+template <class array_t>
+using size_type = typename internal::sizet_trait<array_t>::type;
 
-} // namespace tlapack
+}  // namespace tlapack
 
 namespace tlapack {
-    
-    // Workspace
 
-    /// Byte type
-    using byte = unsigned char;
-    /// Byte allocator
-    using byteAlloc = std::allocator<byte>;
-    /// Vector of bytes. May use a specialized allocator in future
-    using vectorOfBytes = std::vector<byte,byteAlloc>;
+// Workspace
 
-} // namespace tlapack
+/// Byte type
+using byte = unsigned char;
+/// Byte allocator
+using byteAlloc = std::allocator<byte>;
+/// Vector of bytes. May use a specialized allocator in future
+using vectorOfBytes = std::vector<byte, byteAlloc>;
 
-#endif // TLAPACK_TYPES_HH
+}  // namespace tlapack
+
+#endif  // TLAPACK_TYPES_HH

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -141,19 +141,19 @@ enum class Layout : char {
     BandStorage = 'B'
 };
 TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(
-    Layout, Unspecified, ColMajor, RowMajor, BandStorage)
+    Layout, Unspecified, ColMajor, RowMajor, BandStorage);
 
 // -----------------------------------------------------------------------------
 // Upper or Lower access
 
 enum class Uplo : char { Upper = 'U', Lower = 'L', General = 'G' };
-TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_3_VALUES(Uplo, Upper, Lower, General)
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_3_VALUES(Uplo, Upper, Lower, General);
 
 // -----------------------------------------------------------------------------
 // Information about the main diagonal
 
 enum class Diag : char { NonUnit = 'N', Unit = 'U' };
-TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Diag, NonUnit, Unit)
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Diag, NonUnit, Unit);
 
 struct nonUnit_diagonal_t {
     constexpr operator Diag() const { return Diag::NonUnit; }
@@ -175,7 +175,7 @@ enum class Op : char {
     ConjTrans = 'C',
     Conj = 0  ///< non-transpose conjugate
 };
-TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(Op, NoTrans, Trans, ConjTrans, Conj)
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(Op, NoTrans, Trans, ConjTrans, Conj);
 
 struct noTranspose_t {
     constexpr operator Op() const { return Op::NoTrans; }
@@ -196,7 +196,7 @@ constexpr conjTranspose_t conjTranspose = {};
 // Sides
 
 enum class Side : char { Left = 'L', Right = 'R' };
-TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Side, Left, Right)
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Side, Left, Right);
 
 struct left_side_t {
     constexpr operator Side() const { return Side::Left; }
@@ -219,7 +219,7 @@ enum class Norm : char {
     Fro = 'F',  // or 'E'
     Max = 'M',
 };
-TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES(Norm, One, Two, Inf, Fro, Max)
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES(Norm, One, Two, Inf, Fro, Max);
 
 struct max_norm_t {
     constexpr operator Norm() const { return Norm::Max; }
@@ -247,7 +247,7 @@ enum class Direction : char {
     Forward = 'F',
     Backward = 'B',
 };
-TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Direction, Forward, Backward)
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Direction, Forward, Backward);
 
 struct forward_t {
     constexpr operator Direction() const { return Direction::Forward; }
@@ -267,7 +267,7 @@ enum class StoreV : char {
     Columnwise = 'C',
     Rowwise = 'R',
 };
-TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(StoreV, Columnwise, Rowwise)
+TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(StoreV, Columnwise, Rowwise);
 
 struct columnwise_storage_t {
     constexpr operator StoreV() const { return StoreV::Columnwise; }

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -11,80 +11,84 @@
 #ifndef TLAPACK_UTILS_HH
 #define TLAPACK_UTILS_HH
 
-#include <limits>
 #include <cmath>
-#include <utility>
+#include <limits>
 #include <type_traits>
+#include <utility>
 
-#include "tlapack/base/types.hpp"
 #include "tlapack/base/arrayTraits.hpp"
-#include "tlapack/base/workspace.hpp"
 #include "tlapack/base/exceptionHandling.hpp"
+#include "tlapack/base/types.hpp"
+#include "tlapack/base/workspace.hpp"
 
 #ifdef USE_LAPACKPP_WRAPPERS
-    #include "lapack.hh" // from LAPACK++
+    #include "lapack.hh"  // from LAPACK++
 #endif
 
 namespace tlapack {
 
 // -----------------------------------------------------------------------------
 // From std C++
+using std::atan;
+using std::ceil;
+using std::cos;
+using std::exp;
+using std::floor;
 using std::isinf;
 using std::isnan;
-using std::ceil;
-using std::floor;
-using std::sqrt;
-using std::sin;
-using std::cos;
-using std::atan;
-using std::exp;
-using std::pow;
 using std::pair;
+using std::pow;
+using std::sin;
+using std::sqrt;
 
-template<typename idx_t>
-using range = pair<idx_t,idx_t>;
+template <typename idx_t>
+using range = pair<idx_t, idx_t>;
 using std::enable_if_t;
 
 // -----------------------------------------------------------------------------
 // is_same_v is defined in C++17; here's a C++11 definition
 #if __cplusplus >= 201703L
-    using std::is_same_v;
+using std::is_same_v;
 #else
-    template< class T, class U >
-    constexpr bool is_same_v = std::is_same<T, U>::value;
+template <class T, class U>
+constexpr bool is_same_v = std::is_same<T, U>::value;
 #endif
 
 //------------------------------------------------------------------------------
 /// True if T is complex_type<T>
 template <typename T>
 struct is_complex {
-    static constexpr bool value = is_same_v< complex_type<T>, T >;
+    static constexpr bool value = is_same_v<complex_type<T>, T>;
 };
 
-template <typename T, enable_if_t<!is_complex<T>::value,int> = 0>
-inline constexpr
-real_type<T> real( const T& x ) { return x; }
+template <typename T, enable_if_t<!is_complex<T>::value, int> = 0>
+inline constexpr real_type<T> real(const T& x)
+{
+    return x;
+}
 
-template <typename T, enable_if_t<!is_complex<T>::value,int> = 0>
-inline constexpr
-real_type<T> imag( const T& x ) { return real_type<T>(0); }
+template <typename T, enable_if_t<!is_complex<T>::value, int> = 0>
+inline constexpr real_type<T> imag(const T& x)
+{
+    return real_type<T>(0);
+}
 
 /** Extend conj to real datatypes.
- * 
+ *
  * Usage:
- * 
+ *
  *     using tlapack::conj;
  *     scalar_t x = ...
  *     scalar_t y = conj( x );
- * 
+ *
  * @param[in] x Real number
  * @return x
- * 
- * @note C++11 to C++17 returns complex<real_t> instead of real_t. @see std::conj
+ *
+ * @note C++11 to C++17 returns complex<real_t> instead of real_t. @see
+ * std::conj
  */
-template< typename real_t, enable_if_t<!is_complex<real_t>::value,int> = 0 >
-inline constexpr
-real_t conj( const real_t& x )
+template <typename real_t, enable_if_t<!is_complex<real_t>::value, int> = 0>
+inline constexpr real_t conj(const real_t& x)
 {
     return x;
 }
@@ -94,23 +98,24 @@ real_t conj( const real_t& x )
 // and any number of arguments: max( a, b, c, d )
 
 // one argument
-template< typename T >
-inline T max( const T& x ) { return x; }
+template <typename T>
+inline T max(const T& x)
+{
+    return x;
+}
 
 // two arguments
-template< typename T1, typename T2 >
-inline scalar_type< T1, T2 >
-    max( const T1& x, const T2& y )
+template <typename T1, typename T2>
+inline scalar_type<T1, T2> max(const T1& x, const T2& y)
 {
     return (x >= y ? x : y);
 }
 
 // three or more arguments
-template< typename T1, typename... Types >
-inline scalar_type< T1, Types... >
-    max( const T1& first, const Types&... args )
+template <typename T1, typename... Types>
+inline scalar_type<T1, Types...> max(const T1& first, const Types&... args)
 {
-    return max( first, max( args... ) );
+    return max(first, max(args...));
 }
 
 // -----------------------------------------------------------------------------
@@ -118,23 +123,24 @@ inline scalar_type< T1, Types... >
 // and any number of arguments: min( a, b, c, d )
 
 // one argument
-template< typename T >
-inline T min( const T& x ) { return x; }
+template <typename T>
+inline T min(const T& x)
+{
+    return x;
+}
 
 // two arguments
-template< typename T1, typename T2 >
-inline scalar_type< T1, T2 >
-    min( const T1& x, const T2& y )
+template <typename T1, typename T2>
+inline scalar_type<T1, T2> min(const T1& x, const T2& y)
 {
     return (x <= y ? x : y);
 }
 
 // three or more arguments
-template< typename T1, typename... Types >
-inline scalar_type< T1, Types... >
-    min( const T1& first, const Types&... args )
+template <typename T1, typename... Types>
+inline scalar_type<T1, Types...> min(const T1& first, const Types&... args)
 {
-    return min( first, min( args... ) );
+    return min(first, min(args...));
 }
 
 // -----------------------------------------------------------------------------
@@ -144,22 +150,22 @@ inline scalar_type< T1, Types... >
 // For real scalar types.
 template <typename real_t>
 struct MakeScalarTraits {
-    static inline real_t make( const real_t& re, const real_t& im )
-        { return re; }
+    static inline real_t make(const real_t& re, const real_t& im) { return re; }
 };
 
 // For complex scalar types.
 template <typename real_t>
-struct MakeScalarTraits< std::complex<real_t> > {
-    static inline std::complex<real_t> make( const real_t& re, const real_t& im )
-        { return std::complex<real_t>( re, im ); }
+struct MakeScalarTraits<std::complex<real_t> > {
+    static inline std::complex<real_t> make(const real_t& re, const real_t& im)
+    {
+        return std::complex<real_t>(re, im);
+    }
 };
 
 template <typename scalar_t>
-inline scalar_t make_scalar( real_type<scalar_t> re,
-                             real_type<scalar_t> im=0 )
+inline scalar_t make_scalar(real_type<scalar_t> re, real_type<scalar_t> im = 0)
 {
-    return MakeScalarTraits<scalar_t>::make( re, im );
+    return MakeScalarTraits<scalar_t>::make(re, im);
 }
 
 // -----------------------------------------------------------------------------
@@ -167,116 +173,113 @@ inline scalar_t make_scalar( real_type<scalar_t> re,
 /// @see Source: https://stackoverflow.com/a/4609795/5253097
 ///
 template <typename real_t>
-inline int sgn( const real_t& val ) {
+inline int sgn(const real_t& val)
+{
     return (real_t(0) < val) - (val < real_t(0));
 }
 
 // -----------------------------------------------------------------------------
 /// isinf for complex numbers
-template< typename real_t >
-inline bool isinf( const std::complex<real_t>& x )
+template <typename real_t>
+inline bool isinf(const std::complex<real_t>& x)
 {
-    return isinf( real(x) ) || isinf( imag(x) );
+    return isinf(real(x)) || isinf(imag(x));
 }
 
 namespace internal {
 
-    template< class array_t, typename = int >
-    struct has_operator_parenthesis_with_2_indexes : std::false_type { };
+    template <class array_t, typename = int>
+    struct has_operator_parenthesis_with_2_indexes : std::false_type {};
 
-    template< class array_t >
+    template <class array_t>
     struct has_operator_parenthesis_with_2_indexes<
         array_t,
-        enable_if_t<
-            !is_same_v<
-                decltype( std::declval<array_t>()(0,0) )
-            , void >
-        , int >
-    > : std::true_type { };
+        enable_if_t<!is_same_v<decltype(std::declval<array_t>()(0, 0)), void>,
+                    int> > : std::true_type {};
 
-    template< class array_t, typename = int >
-    struct has_operator_brackets_with_1_index : std::false_type { };
+    template <class array_t, typename = int>
+    struct has_operator_brackets_with_1_index : std::false_type {};
 
-    template< class array_t >
+    template <class array_t>
     struct has_operator_brackets_with_1_index<
         array_t,
-        enable_if_t<
-            !is_same_v<
-                decltype( std::declval<array_t>()[0] )
-            , void >
-        , int >
-    > : std::true_type { };
-    
-}
+        enable_if_t<!is_same_v<decltype(std::declval<array_t>()[0]), void>,
+                    int> > : std::true_type {};
 
-template< class array_t >
+}  // namespace internal
+
+template <class array_t>
 constexpr bool is_matrix =
     internal::has_operator_parenthesis_with_2_indexes<array_t>::value;
 
-template< class array_t >
+template <class array_t>
 constexpr bool is_vector =
-    ( !is_matrix<array_t> ) &&
-    internal::has_operator_brackets_with_1_index<array_t>::value;
+    (!is_matrix<array_t>)&&internal::has_operator_brackets_with_1_index<
+        array_t>::value;
 
 namespace internal {
 
     /**
      * @brief Data type trait.
-     * 
+     *
      * The data type is defined on @c type_trait<array_t>::type.
-     * 
+     *
      * @tparam matrix_t Matrix class.
      */
-    template< class matrix_t >
-    struct type_trait< matrix_t, enable_if_t< is_matrix< matrix_t >, int > > {
-        using type = typename std::decay< decltype( std::declval<matrix_t>()(0,0) ) >::type;
+    template <class matrix_t>
+    struct type_trait<matrix_t, enable_if_t<is_matrix<matrix_t>, int> > {
+        using type =
+            typename std::decay<decltype(std::declval<matrix_t>()(0, 0))>::type;
     };
 
     /**
      * @brief Data type trait.
-     * 
+     *
      * The data type is defined on @c type_trait<array_t>::type.
-     * 
+     *
      * @tparam vector_t Vector class.
      */
-    template< class vector_t >
-    struct type_trait< vector_t, enable_if_t< is_vector< vector_t >, int > > {
-        using type = typename std::decay< decltype( std::declval<vector_t>()[0] ) >::type;
+    template <class vector_t>
+    struct type_trait<vector_t, enable_if_t<is_vector<vector_t>, int> > {
+        using type =
+            typename std::decay<decltype(std::declval<vector_t>()[0])>::type;
     };
 
     /**
      * @brief Size type trait.
-     * 
+     *
      * The size type is defined on @c sizet_trait<array_t>::type.
-     * 
+     *
      * @tparam matrix_t Matrix class.
      */
-    template< class matrix_t >
-    struct sizet_trait< matrix_t, enable_if_t< is_matrix< matrix_t >, int > > {
-        using type = typename std::decay< decltype( nrows(std::declval<matrix_t>()) ) >::type;
+    template <class matrix_t>
+    struct sizet_trait<matrix_t, enable_if_t<is_matrix<matrix_t>, int> > {
+        using type = typename std::decay<decltype(
+            nrows(std::declval<matrix_t>()))>::type;
     };
 
     /**
      * @brief Size type trait.
-     * 
+     *
      * The size type is defined on @c sizet_trait<array_t>::type.
-     * 
+     *
      * @tparam vector_t Vector class.
      */
-    template< class vector_t >
-    struct sizet_trait< vector_t, enable_if_t< is_vector< vector_t >, int > > {
-        using type = typename std::decay< decltype( size(std::declval<vector_t>()) ) >::type;
+    template <class vector_t>
+    struct sizet_trait<vector_t, enable_if_t<is_vector<vector_t>, int> > {
+        using type =
+            typename std::decay<decltype(size(std::declval<vector_t>()))>::type;
     };
 
-}
+}  // namespace internal
 
 /**
  * Returns true if and only if A has an infinite entry.
- * 
+ *
  * @tparam access_t Type of access inside the algorithm.
  *      Either MatrixAccessPolicy or any type that implements
  *          operator MatrixAccessPolicy().
- * 
+ *
  * @param[in] accessType Determines the entries of A that will be checked.
  *      The following access types are allowed:
  *          MatrixAccessPolicy::Dense,
@@ -286,89 +289,81 @@ namespace internal {
  *          MatrixAccessPolicy::LowerTriangle,
  *          MatrixAccessPolicy::StrictUpper,
  *          MatrixAccessPolicy::StrictLower.
- * 
+ *
  * @param[in] A matrix.
- * 
+ *
  * @return true if A has an infinite entry.
  * @return false if A has no infinite entry.
  */
-template< class access_t, class matrix_t >
-bool hasinf( access_t accessType, const matrix_t& A ) {
-
-    using idx_t  = size_type< matrix_t >;
+template <class access_t, class matrix_t>
+bool hasinf(access_t accessType, const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
-    if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::UpperHessenberg )
-    {
+    if ((MatrixAccessPolicy)accessType == MatrixAccessPolicy::UpperHessenberg) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < ((j < m) ? j+2 : m); ++i)
-                if( isinf( A(i,j) ) )
-                    return true;
+            for (idx_t i = 0; i < ((j < m) ? j + 2 : m); ++i)
+                if (isinf(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::UpperTriangle )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::UpperTriangle) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < ((j < m) ? j+1 : m); ++i)
-                if( isinf( A(i,j) ) )
-                    return true;
+            for (idx_t i = 0; i < ((j < m) ? j + 1 : m); ++i)
+                if (isinf(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::StrictUpper )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::StrictUpper) {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < ((j < m) ? j : m); ++i)
-                if( isinf( A(i,j) ) )
-                    return true;
+                if (isinf(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::LowerHessenberg )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::LowerHessenberg) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = ((j > 1) ? j-1 : 0); i < m; ++i)
-                if( isinf( A(i,j) ) )
-                    return true;
+            for (idx_t i = ((j > 1) ? j - 1 : 0); i < m; ++i)
+                if (isinf(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::LowerTriangle )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::LowerTriangle) {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = j; i < m; ++i)
-                if( isinf( A(i,j) ) )
-                    return true;
+                if (isinf(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::StrictLower )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::StrictLower) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = j+1; i < m; ++i)
-                if( isinf( A(i,j) ) )
-                    return true;
+            for (idx_t i = j + 1; i < m; ++i)
+                if (isinf(A(i, j))) return true;
         return false;
     }
-    else // if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::Dense )
+    else  // if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::Dense )
     {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < m; ++i)
-                if( isinf( A(i,j) ) )
-                    return true;
+                if (isinf(A(i, j))) return true;
         return false;
     }
 }
 
 /**
  * Returns true if and only if A has an infinite entry.
- * 
+ *
  * Specific implementation for band access types.
  * @see hasinf( access_t accessType, const matrix_t& A ).
  */
-template< class matrix_t >
-bool hasinf( band_t accessType, const matrix_t& A ) {
-
-    using idx_t  = size_type< matrix_t >;
+template <class matrix_t>
+bool hasinf(band_t accessType, const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -377,49 +372,47 @@ bool hasinf( band_t accessType, const matrix_t& A ) {
     const idx_t ku = accessType.upper_bandwidth;
 
     for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = ((j >= ku) ? (j-ku) : 0); i < min(m,j+kl+1); ++i)
-            if( isinf( A(i,j) ) )
-                return true;
+        for (idx_t i = ((j >= ku) ? (j - ku) : 0); i < min(m, j + kl + 1); ++i)
+            if (isinf(A(i, j))) return true;
     return false;
 }
 
 /**
  * Returns true if and only if x has an infinite entry.
- * 
+ *
  * @param[in] x vector.
- * 
+ *
  * @return true if x has an infinite entry.
  * @return false if x has no infinite entry.
  */
-template< class vector_t >
-bool hasinf( const vector_t& x ) {
-
-    using idx_t  = size_type< vector_t >;
+template <class vector_t>
+bool hasinf(const vector_t& x)
+{
+    using idx_t = size_type<vector_t>;
 
     // constants
     const idx_t n = size(x);
 
     for (idx_t i = 0; i < n; ++i)
-        if( isinf( x[i] ) )
-            return true;
+        if (isinf(x[i])) return true;
     return false;
 }
 
 // -----------------------------------------------------------------------------
 /// isnan for complex numbers
-template< typename real_t >
-inline bool isnan( const std::complex<real_t>& x )
+template <typename real_t>
+inline bool isnan(const std::complex<real_t>& x)
 {
-    return isnan( real(x) ) || isnan( imag(x) );
+    return isnan(real(x)) || isnan(imag(x));
 }
 
 /**
  * Returns true if and only if A has an NaN entry.
- * 
+ *
  * @tparam access_t Type of access inside the algorithm.
  *      Either MatrixAccessPolicy or any type that implements
  *          operator MatrixAccessPolicy().
- * 
+ *
  * @param[in] accessType Determines the entries of A that will be checked.
  *      The following access types are allowed:
  *          MatrixAccessPolicy::Dense,
@@ -429,89 +422,81 @@ inline bool isnan( const std::complex<real_t>& x )
  *          MatrixAccessPolicy::LowerTriangle,
  *          MatrixAccessPolicy::StrictUpper,
  *          MatrixAccessPolicy::StrictLower.
- * 
+ *
  * @param[in] A matrix.
- * 
+ *
  * @return true if A has an NaN entry.
  * @return false if A has no NaN entry.
  */
-template< class access_t, class matrix_t >
-bool hasnan( access_t accessType, const matrix_t& A ) {
-
-    using idx_t  = size_type< matrix_t >;
+template <class access_t, class matrix_t>
+bool hasnan(access_t accessType, const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
-    if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::UpperHessenberg )
-    {
+    if ((MatrixAccessPolicy)accessType == MatrixAccessPolicy::UpperHessenberg) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < ((j < m) ? j+2 : m); ++i)
-                if( isnan( A(i,j) ) )
-                    return true;
+            for (idx_t i = 0; i < ((j < m) ? j + 2 : m); ++i)
+                if (isnan(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::UpperTriangle )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::UpperTriangle) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < ((j < m) ? j+1 : m); ++i)
-                if( isnan( A(i,j) ) )
-                    return true;
+            for (idx_t i = 0; i < ((j < m) ? j + 1 : m); ++i)
+                if (isnan(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::StrictUpper )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::StrictUpper) {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < ((j < m) ? j : m); ++i)
-                if( isnan( A(i,j) ) )
-                    return true;
+                if (isnan(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::LowerHessenberg )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::LowerHessenberg) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = ((j > 1) ? j-1 : 0); i < m; ++i)
-                if( isnan( A(i,j) ) )
-                    return true;
+            for (idx_t i = ((j > 1) ? j - 1 : 0); i < m; ++i)
+                if (isnan(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::LowerTriangle )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::LowerTriangle) {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = j; i < m; ++i)
-                if( isnan( A(i,j) ) )
-                    return true;
+                if (isnan(A(i, j))) return true;
         return false;
     }
-    else if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::StrictLower )
-    {
+    else if ((MatrixAccessPolicy)accessType ==
+             MatrixAccessPolicy::StrictLower) {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = j+1; i < m; ++i)
-                if( isnan( A(i,j) ) )
-                    return true;
+            for (idx_t i = j + 1; i < m; ++i)
+                if (isnan(A(i, j))) return true;
         return false;
     }
-    else // if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::Dense )
+    else  // if ( (MatrixAccessPolicy) accessType == MatrixAccessPolicy::Dense )
     {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < m; ++i)
-                if( isnan( A(i,j) ) )
-                    return true;
+                if (isnan(A(i, j))) return true;
         return false;
     }
 }
 
 /**
  * Returns true if and only if A has an NaN entry.
- * 
+ *
  * Specific implementation for band access types.
  * @see hasnan( access_t accessType, const matrix_t& A ).
  */
-template< class matrix_t >
-bool hasnan( band_t accessType, const matrix_t& A ) {
-
-    using idx_t  = size_type< matrix_t >;
+template <class matrix_t>
+bool hasnan(band_t accessType, const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -520,31 +505,29 @@ bool hasnan( band_t accessType, const matrix_t& A ) {
     const idx_t ku = accessType.upper_bandwidth;
 
     for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = ((j >= ku) ? (j-ku) : 0); i < min(m,j+kl+1); ++i)
-            if( isnan( A(i,j) ) )
-                return true;
+        for (idx_t i = ((j >= ku) ? (j - ku) : 0); i < min(m, j + kl + 1); ++i)
+            if (isnan(A(i, j))) return true;
     return false;
 }
 
 /**
  * Returns true if and only if x has an NaN entry.
- * 
+ *
  * @param[in] x vector.
- * 
+ *
  * @return true if x has an NaN entry.
  * @return false if x has no NaN entry.
  */
-template< class vector_t >
-bool hasnan( const vector_t& x ) {
-
-    using idx_t  = size_type< vector_t >;
+template <class vector_t>
+bool hasnan(const vector_t& x)
+{
+    using idx_t = size_type<vector_t>;
 
     // constants
     const idx_t n = size(x);
 
     for (idx_t i = 0; i < n; ++i)
-        if( isnan( x[i] ) )
-            return true;
+        if (isnan(x[i])) return true;
     return false;
 }
 
@@ -556,142 +539,137 @@ bool hasnan( const vector_t& x ) {
 /// @see https://en.cppreference.com/w/cpp/numeric/complex/abs
 /// but it may not propagate NaNs.
 ///
-template< typename T > T abs ( const T& x );
+template <typename T>
+T abs(const T& x);
 
-inline float abs( float x ) { return std::fabs( x ); }
-inline double abs( double x ) { return std::fabs( x ); }
-inline long double abs( long double x ) { return std::fabs( x ); }
+inline float abs(float x) { return std::fabs(x); }
+inline double abs(double x) { return std::fabs(x); }
+inline long double abs(long double x) { return std::fabs(x); }
 
-template< typename T >
-inline T abs( const std::complex<T>& x ) {
-    return ( isnan(x) )
-        ? std::numeric_limits<T>::quiet_NaN()
-        : std::abs( x );
+template <typename T>
+inline T abs(const std::complex<T>& x)
+{
+    return (isnan(x)) ? std::numeric_limits<T>::quiet_NaN() : std::abs(x);
 }
 
 // -----------------------------------------------------------------------------
 /// 1-norm absolute value, |Re(x)| + |Im(x)|
-template< typename real_t >
-inline real_t abs1( const real_t& x ) { return abs( x ); }
-
-template< typename real_t >
-inline real_t abs1( const std::complex<real_t>& x )
+template <typename real_t>
+inline real_t abs1(const real_t& x)
 {
-    return abs( real(x) ) + abs( imag(x) );
+    return abs(x);
+}
+
+template <typename real_t>
+inline real_t abs1(const std::complex<real_t>& x)
+{
+    return abs(real(x)) + abs(imag(x));
 }
 
 // -----------------------------------------------------------------------------
 /// Optimized BLAS
 
-template< class C1, class C2, class... Cs >
-constexpr bool has_compatible_layout = 
-    has_compatible_layout<C1, C2> &&
-    has_compatible_layout<C1, Cs...> &&
-    has_compatible_layout<C2, Cs...>;
+template <class C1, class C2, class... Cs>
+constexpr bool has_compatible_layout = has_compatible_layout<C1, C2>&&
+    has_compatible_layout<C1, Cs...>&& has_compatible_layout<C2, Cs...>;
 
-template< class C1, class C2 >
-constexpr bool has_compatible_layout< C1, C2 > = (
-    ( layout<C1> == Layout::Unspecified ) ||
-    ( layout<C2> == Layout::Unspecified ) ||
-    ( layout<C1> == layout<C2> )
-);
+template <class C1, class C2>
+constexpr bool has_compatible_layout<C1, C2> =
+    ((layout<C1> == Layout::Unspecified) ||
+     (layout<C2> == Layout::Unspecified) || (layout<C1> == layout<C2>));
 
-template< class C1, class T1, class C2, class T2 >
-constexpr bool has_compatible_layout< pair<C1,T1>, pair<C2,T2> > =
-    has_compatible_layout< C1, C2 >;
+template <class C1, class T1, class C2, class T2>
+constexpr bool has_compatible_layout<pair<C1, T1>, pair<C2, T2> > =
+    has_compatible_layout<C1, C2>;
 
 namespace internal {
 
-    template< class C, class T >
-    struct AllowOptBLASImpl< pair<C,T>, int > {
-        static constexpr bool value = 
-            allow_optblas<T>
-            && (
-                (is_matrix<C> || is_vector<C>)
-                ? (
-                    allow_optblas<C> &&
-                    is_same_v< type_t<C>, typename std::decay<T>::type >
-                )
-                : std::is_convertible< C, T >::value
-            );
+    template <class C, class T>
+    struct AllowOptBLASImpl<pair<C, T>, int> {
+        static constexpr bool value =
+            allow_optblas<T> &&
+            ((is_matrix<C> || is_vector<C>)
+                 ? (allow_optblas<C> &&
+                    is_same_v<type_t<C>, typename std::decay<T>::type>)
+                 : std::is_convertible<C, T>::value);
     };
 
-    template< class C1, class T1, class C2, class T2, class... Ps >
-    struct AllowOptBLASImpl< pair<C1,T1>, pair<C2,T2>, Ps... > {
-        static constexpr bool value = 
-            AllowOptBLASImpl< pair<C1,T1>, int >::value &&
-            AllowOptBLASImpl< pair<C2,T2>, Ps... >::value &&
-            has_compatible_layout< C1, C2, Ps... >;
+    template <class C1, class T1, class C2, class T2, class... Ps>
+    struct AllowOptBLASImpl<pair<C1, T1>, pair<C2, T2>, Ps...> {
+        static constexpr bool value =
+            AllowOptBLASImpl<pair<C1, T1>, int>::value &&
+            AllowOptBLASImpl<pair<C2, T2>, Ps...>::value &&
+            has_compatible_layout<C1, C2, Ps...>;
     };
-}
+}  // namespace internal
 
-template<class T1, class... Ts>
-using enable_if_allow_optblas_t = enable_if_t<(
-    allow_optblas< T1, Ts... >
-), int >;
+template <class T1, class... Ts>
+using enable_if_allow_optblas_t = enable_if_t<(allow_optblas<T1, Ts...>), int>;
 
-template<class T1, class... Ts>
-using disable_if_allow_optblas_t = enable_if_t<(
-    ! allow_optblas< T1, Ts... >
-), int >;
+template <class T1, class... Ts>
+using disable_if_allow_optblas_t =
+    enable_if_t<(!allow_optblas<T1, Ts...>), int>;
 
-#define TLAPACK_OPT_TYPE( T ) \
-    namespace internal { \
-        template<> struct AllowOptBLASImpl< T, int > { \
+#define TLAPACK_OPT_TYPE(T)                     \
+    namespace internal {                        \
+        template <>                             \
+        struct AllowOptBLASImpl<T, int> {       \
             static constexpr bool value = true; \
-        }; \
-        template<> struct type_trait< T > { \
-            using type = T; \
-        }; \
+        };                                      \
+        template <>                             \
+        struct type_trait<T> {                  \
+            using type = T;                     \
+        };                                      \
     }
 
-    /// Optimized types
-    #ifdef USE_LAPACKPP_WRAPPERS
-        TLAPACK_OPT_TYPE(float)
-        TLAPACK_OPT_TYPE(double)
-        TLAPACK_OPT_TYPE(std::complex<float>)
-        TLAPACK_OPT_TYPE(std::complex<double>)
-    #endif
+/// Optimized types
+#ifdef USE_LAPACKPP_WRAPPERS
+TLAPACK_OPT_TYPE(float)
+TLAPACK_OPT_TYPE(double)
+TLAPACK_OPT_TYPE(std::complex<float>)
+TLAPACK_OPT_TYPE(std::complex<double>)
+#endif
 #undef TLAPACK_OPT_TYPE
 
 // -----------------------------------------------------------------------------
 // Workspace:
 
 /// @brief Output information in the workspace query
-struct workinfo_t
-{
-    size_t m = 0; ///< Number of rows needed in the Workspace
-    size_t n = 0; ///< Number of columns needed in the Workspace
+struct workinfo_t {
+    size_t m = 0;  ///< Number of rows needed in the Workspace
+    size_t n = 0;  ///< Number of columns needed in the Workspace
 
     /// Constructor using sizes
-    inline constexpr workinfo_t( size_t m = 0, size_t n = 0 ) noexcept
-    : m(m), n(n) {}
+    inline constexpr workinfo_t(size_t m = 0, size_t n = 0) noexcept
+        : m(m), n(n)
+    {}
 
     /// Size needed in the Workspace
-    inline constexpr size_t size() const noexcept { return m*n; }
+    inline constexpr size_t size() const noexcept { return m * n; }
 
     /**
      * @brief Set the current object to a state that
      *  fit its current sizes and the sizes of workinfo.
-     * 
-     * If sizes don't match, use simple solution: require contiguous space in memory.
-     * 
+     *
+     * If sizes don't match, use simple solution: require contiguous space in
+     * memory.
+     *
      * @param[in] workinfo Another specification of work sizes
      */
-    void minMax( const workinfo_t& workinfo ) noexcept
+    void minMax(const workinfo_t& workinfo) noexcept
     {
         // Check if the current sizes do not cover the sizes from workinfo
-        if( m < workinfo.size() && ((m < workinfo.m) || (n < workinfo.n)) )
-        {
+        if (m < workinfo.size() && ((m < workinfo.m) || (n < workinfo.n))) {
             // Check if the sizes from workinfo cover the current sizes
-            if( size() <= workinfo.m || ((m <= workinfo.m) && (n <= workinfo.n)) )
-            {
+            if (size() <= workinfo.m ||
+                ((m <= workinfo.m) && (n <= workinfo.n))) {
                 m = workinfo.m;
                 n = workinfo.n;
             }
-            else // Sizes do not match. Simple solution: contiguous space in memory
+            else  // Sizes do not match. Simple solution: contiguous space in
+                  // memory
             {
-                m = std::max( size(), workinfo.size() );
+                m = std::max(size(), workinfo.size());
                 n = 1;
             }
         }
@@ -699,26 +677,24 @@ struct workinfo_t
 
     /**
      * @brief Sum two object by matching sizes.
-     * 
-     * If sizes don't match, use simple solution: require contiguous space in memory.
-     * 
+     *
+     * If sizes don't match, use simple solution: require contiguous space in
+     * memory.
+     *
      * @param workinfo The object to be added to *this.
      * @return constexpr workinfo_t& The modified workinfo.
      */
-    constexpr
-    workinfo_t& operator +=( const workinfo_t& workinfo ) noexcept
+    constexpr workinfo_t& operator+=(const workinfo_t& workinfo) noexcept
     {
         // If first dimension matches, update second dimension
-        if( m == workinfo.m )
-        {
+        if (m == workinfo.m) {
             n += workinfo.n;
         }
         // Else, if second dimension matches, update first dimension
-        else if( n == workinfo.n )
-        {
+        else if (n == workinfo.n) {
             m += workinfo.m;
         }
-        else // Sizes do not match. Simple solution: contiguous space in memory
+        else  // Sizes do not match. Simple solution: contiguous space in memory
         {
             m = size() + workinfo.size();
             n = 1;
@@ -729,88 +705,88 @@ struct workinfo_t
 
 /**
  * @brief Allocates workspace
- * 
+ *
  * @param[out] v On exit, reference to allocated memory.
  * @param[in] lwork Number of bytes to allocate.
- * 
+ *
  * @return Workspace referencing the allocated memory.
  */
-inline Workspace
-alloc_workspace( vectorOfBytes& v, std::size_t lwork )
+inline Workspace alloc_workspace(vectorOfBytes& v, std::size_t lwork)
 {
-    v = vectorOfBytes( lwork ); // Allocates space in memory
-    return Workspace( v.data(), v.size() );
+    v = vectorOfBytes(lwork);  // Allocates space in memory
+    return Workspace(v.data(), v.size());
 }
 
 /**
  * @brief Allocates workspace
- * 
+ *
  * @param[out] v        On exit, reference to allocated memory if needed.
  * @param[in] workinfo  Information about the amount of workspace required.
  * @param[in] opts_w    Workspace previously allocated.
- * 
+ *
  * @return Workspace referencing either:
  *      1. new allocated memory, if opts_w.size() <= 0.
  *      2. previously allocated memory, if opts_w.size() >= lwork.
  */
-inline Workspace
-alloc_workspace( vectorOfBytes& v, const workinfo_t& workinfo, const Workspace& opts_w = {} )
+inline Workspace alloc_workspace(vectorOfBytes& v,
+                                 const workinfo_t& workinfo,
+                                 const Workspace& opts_w = {})
 {
-    if( opts_w.size() <= 0 )
-    {
-        return alloc_workspace( v, workinfo.size() );
+    if (opts_w.size() <= 0) {
+        return alloc_workspace(v, workinfo.size());
     }
-    else
-    {
+    else {
         tlapack_check(
             (opts_w.isContiguous() && (opts_w.size() >= workinfo.size())) ||
-            (opts_w.getM() >= workinfo.m && opts_w.getN() >= workinfo.n) );
-        
-        return Workspace( opts_w );
+            (opts_w.getM() >= workinfo.m && opts_w.getN() >= workinfo.n));
+
+        return Workspace(opts_w);
     }
 }
 
-/** Chooses between a preferrable type `work_type` and a default type `work_default`
- * 
+/** Chooses between a preferrable type `work_type` and a default type
+ * `work_default`
+ *
  * @c deduce_work<>::type = work_default only if deduce_work is void.
- * 
+ *
  * @tparam work_type    Preferrable workspace type
  * @tparam work_default Default workspace type
  */
-template< class work_type, class work_default >
-struct deduce_work { using type = work_type; };
-template< class work_default >
-struct deduce_work< void, work_default > { using type = work_default; };
+template <class work_type, class work_default>
+struct deduce_work {
+    using type = work_type;
+};
+template <class work_default>
+struct deduce_work<void, work_default> {
+    using type = work_default;
+};
 
 /// Alias for @c deduce_work<>::type
-template< class work_type, class work_default >
-using deduce_work_t = typename deduce_work<work_type,work_default>::type;
+template <class work_type, class work_default>
+using deduce_work_t = typename deduce_work<work_type, work_default>::type;
 
-    /**
-     * @brief Options structure with a Workspace attribute
-     * 
-     * @tparam work_t Give specialized data type to the workspaces.
-     *      Behavior defined by each implementation using this option.
-     */
-    template< class ... work_t >
-    struct workspace_opts_t
-    {
-        Workspace work; ///< Workspace object
+/**
+ * @brief Options structure with a Workspace attribute
+ *
+ * @tparam work_t Give specialized data type to the workspaces.
+ *      Behavior defined by each implementation using this option.
+ */
+template <class... work_t>
+struct workspace_opts_t {
+    Workspace work;  ///< Workspace object
 
-        // Constructors:
+    // Constructors:
 
-        inline constexpr
-        workspace_opts_t( Workspace&& w = {} ) : work(w) { }
+    inline constexpr workspace_opts_t(Workspace&& w = {}) : work(w) {}
 
-        inline constexpr
-        workspace_opts_t( const Workspace& w ) : work(w) { }
+    inline constexpr workspace_opts_t(const Workspace& w) : work(w) {}
 
-        template< class matrix_t >
-        inline constexpr
-        workspace_opts_t( const matrix_t& A )
-        : work( legacy_matrix(A).in_bytes() ) { }
-    };
+    template <class matrix_t>
+    inline constexpr workspace_opts_t(const matrix_t& A)
+        : work(legacy_matrix(A).in_bytes())
+    {}
+};
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_UTILS_HH
+#endif  // TLAPACK_UTILS_HH

--- a/include/tlapack/base/workspace.hpp
+++ b/include/tlapack/base/workspace.hpp
@@ -14,102 +14,101 @@
 
 namespace tlapack {
 
-    /**
-     * @brief Workspace
-     * 
-     * The objects of this class always maintain one of the states:
-     *      1. `(n > 1) && (m > 0)`.
-     *      2. `((n <= 1) || (m == 0)) && (ldim == m)`.
-     */
-    struct Workspace
-    {
-        using idx_t = std::size_t;
+/**
+ * @brief Workspace
+ *
+ * The objects of this class always maintain one of the states:
+ *      1. `(n > 1) && (m > 0)`.
+ *      2. `((n <= 1) || (m == 0)) && (ldim == m)`.
+ */
+struct Workspace {
+    using idx_t = std::size_t;
 
-        // Constructors:
-        
-        inline constexpr
-        Workspace( byte* ptr = nullptr, idx_t n = 0 ) noexcept
-        : m(n), n(1), ptr(ptr), ldim(n) { }
+    // Constructors:
 
-        inline constexpr
-        Workspace( const legacyMatrix<byte>& w ) noexcept
+    inline constexpr Workspace(byte* ptr = nullptr, idx_t n = 0) noexcept
+        : m(n), n(1), ptr(ptr), ldim(n)
+    {}
+
+    inline constexpr Workspace(const legacyMatrix<byte>& w) noexcept
         : m(w.m), n(w.n), ptr(w.ptr), ldim(w.ldim)
-        {
-            if( n <= 1 || m == 0 ) ldim = m;
+    {
+        if (n <= 1 || m == 0) ldim = m;
+    }
+
+    // Getters:
+    inline constexpr byte* data() const { return ptr; }
+    inline constexpr idx_t getM() const { return m; }
+    inline constexpr idx_t getN() const { return n; }
+    inline constexpr idx_t getLdim() const { return ldim; }
+    inline constexpr idx_t size() const { return m * n; }
+
+    /** Checks if a workspace is contiguous.
+     *
+     * @note This is one of the reasons to keep the attributes protected.
+     *  The objects of this class always maintain one of the states:
+     *      1. (n > 1) && (m > 0).
+     *      2. ((n <= 1) || (m == 0)) && (ldim == m).
+     */
+    inline constexpr bool isContiguous() const { return (ldim == m); }
+
+    /// Checks if a workspace contains the workspace of size m-by-n
+    inline constexpr bool contains(idx_t m, idx_t n) const
+    {
+        if (isContiguous())
+            return (size() >= (m * n));
+        else
+            return (this->m >= m && this->n >= n);
+    }
+
+    /** Returns a workspace that is obtained by removing m*n bytes from the
+     * current one.
+     *
+     * @note If the starting workspace is not contiguous, then we require:
+     *
+     *          this->m == m || this->n == n
+     *
+     * This is required to prevent bad partitioning by the algorithms using
+     * this functionality.
+     *
+     * @param m Number of rows to be extracted.
+     * @param n Number of columns to be extracted.
+     */
+    inline constexpr Workspace extract(idx_t m, idx_t n) const
+    {
+        if (isContiguous()) {
+            // contiguous space in memory
+            tlapack_check(size() >= (m * n));
+            return legacyMatrix<byte>(size() - (m * n), 1, ptr + (m * n));
         }
+        else {
+            // Only allows for the extraction of full set of rows or full set of
+            // columns
+            tlapack_check((this->m >= m && this->n >= n) &&
+                          (this->m == m || this->n == n));
 
-        // Getters:
-        inline constexpr byte* data() const { return ptr; }
-        inline constexpr idx_t getM() const { return m; }
-        inline constexpr idx_t getN() const { return n; }
-        inline constexpr idx_t getLdim() const { return ldim; }
-        inline constexpr idx_t size() const { return m*n; }
-
-        /** Checks if a workspace is contiguous.
-         * 
-         * @note This is one of the reasons to keep the attributes protected.
-         *  The objects of this class always maintain one of the states:
-         *      1. (n > 1) && (m > 0).
-         *      2. ((n <= 1) || (m == 0)) && (ldim == m).
-         */
-        inline constexpr bool isContiguous() const{ return (ldim == m); }
-
-        /// Checks if a workspace contains the workspace of size m-by-n
-        inline constexpr bool
-        contains( idx_t m, idx_t n ) const 
-        {    
-            if( isContiguous() )
-                return ( size() >= (m*n) );
-            else
-                return ( this->m >= m && this->n >= n );
-        }
-
-        /** Returns a workspace that is obtained by removing m*n bytes from the current one.
-         * 
-         * @note If the starting workspace is not contiguous, then we require:
-         * 
-         *          this->m == m || this->n == n
-         * 
-         * This is required to prevent bad partitioning by the algorithms using
-         * this functionality.
-         * 
-         * @param m Number of rows to be extracted.
-         * @param n Number of columns to be extracted.
-         */
-        inline constexpr Workspace
-        extract( idx_t m, idx_t n ) const
-        {    
-            if( isContiguous() )
-            {
-                // contiguous space in memory
-                tlapack_check( size() >= (m*n) );
-                return legacyMatrix<byte>( size()-(m*n), 1, ptr + (m*n) );
+            if (this->m == m) {
+                return (this->n <= n + 1)
+                           ? legacyMatrix<byte>(
+                                 this->m, this->n - n,
+                                 ptr + n * ldim)  // contiguous space in memory
+                           : legacyMatrix<byte>(
+                                 this->m, this->n - n, ptr + n * ldim,
+                                 ldim);  // non-contiguous space in memory
             }
-            else
+            else  // if ( this->n == n )
             {
-                // Only allows for the extraction of full set of rows or full set of columns 
-                tlapack_check(  (this->m >= m && this->n >= n) &&
-                                (this->m == m || this->n == n) );
-
-                if( this->m == m )
-                {
-                    return ( this->n <= n+1 )
-                        ? legacyMatrix<byte>( this->m, this->n-n, ptr + n*ldim ) // contiguous space in memory
-                        : legacyMatrix<byte>( this->m, this->n-n, ptr + n*ldim, ldim ); // non-contiguous space in memory
-                }
-                else // if ( this->n == n )
-                {
-                    // non-contiguous space in memory
-                    return legacyMatrix<byte>( this->m-m, this->n, ptr + m, ldim );
-                }
+                // non-contiguous space in memory
+                return legacyMatrix<byte>(this->m - m, this->n, ptr + m, ldim);
             }
         }
+    }
 
-    private:
-        idx_t m, n; ///< Sizes
-        byte* ptr;  ///< Pointer to array in memory
-        idx_t ldim; ///< Leading dimension
-    };
-}
+   private:
+    idx_t m, n;  ///< Sizes
+    byte* ptr;   ///< Pointer to array in memory
+    idx_t ldim;  ///< Leading dimension
+};
+}  // namespace tlapack
 
-#endif // TLAPACK_WORKSPACE_HH
+#endif  // TLAPACK_WORKSPACE_HH

--- a/include/tlapack/blas/asum.hpp
+++ b/include/tlapack/blas/asum.hpp
@@ -15,47 +15,42 @@
 
 namespace tlapack {
 
-/** 
+/**
  * Vector 1-norm:
  *      $\sum_{i=0}^{n-1} |Re(x_i)| + |Im(x_i)|$.
- * 
+ *
  * @param[in] x     A n-element vector.
  *
  * @ingroup blas1
  */
-template< class vector_t,
-    disable_if_allow_optblas_t< vector_t > = 0
->
-auto asum( vector_t const& x )
+template <class vector_t, disable_if_allow_optblas_t<vector_t> = 0>
+auto asum(vector_t const& x)
 {
-    using T      = type_t< vector_t >;
-    using idx_t  = size_type< vector_t >;
-    using real_t = real_type< T >;
+    using T = type_t<vector_t>;
+    using idx_t = size_type<vector_t>;
+    using real_t = real_type<T>;
 
     // constants
     const idx_t n = size(x);
 
     real_t result = 0;
     for (idx_t i = 0; i < n; ++i)
-        result += abs1( x[i] );
+        result += abs1(x[i]);
 
     return result;
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vector_t,
-        enable_if_allow_optblas_t< vector_t > = 0
-    >
-    inline
-    auto asum( vector_t const& x )
-    {
-        auto x_ = legacy_vector(x);
-        return ::blas::asum( x_.n, x_.ptr, x_.inc );
-    }
+template <class vector_t, enable_if_allow_optblas_t<vector_t> = 0>
+inline auto asum(vector_t const& x)
+{
+    auto x_ = legacy_vector(x);
+    return ::blas::asum(x_.n, x_.ptr, x_.inc);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_ASUM_HH
+#endif  //  #ifndef TLAPACK_BLAS_ASUM_HH

--- a/include/tlapack/blas/axpy.hpp
+++ b/include/tlapack/blas/axpy.hpp
@@ -24,25 +24,22 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< class vectorX_t, class vectorY_t, class alpha_t,
-    class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void axpy(
-    const alpha_t& alpha,
-    const vectorX_t& x, vectorY_t& y )
+template <class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+void axpy(const alpha_t& alpha, const vectorX_t& x, vectorY_t& y)
 {
-    using idx_t = size_type< vectorX_t >;
+    using idx_t = size_type<vectorX_t>;
 
     // constants
     const idx_t n = size(x);
 
     // check arguments
-    tlapack_check_false( (idx_t) size(y) < n );
+    tlapack_check_false((idx_t)size(y) < n);
 
     for (idx_t i = 0; i < n; ++i)
         y[i] += alpha * x[i];
@@ -50,38 +47,37 @@ void axpy(
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vectorX_t, class vectorY_t, class alpha_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void axpy(
-        const alpha_t alpha,
-        const vectorX_t& x, vectorY_t& y )
-    {
-        using idx_t = size_type< vectorX_t >;
+template <class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void axpy(const alpha_t alpha, const vectorX_t& x, vectorY_t& y)
+{
+    using idx_t = size_type<vectorX_t>;
 
-        // Legacy objects
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = x_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = x_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -1, "Infs and NaNs in x will not propagate to y on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(-1,
+                        "Infs and NaNs in x will not propagate to y on output");
 
-        return ::blas::axpy( n, alpha, x_.ptr, incx, y_.ptr, incy );
-    }
+    return ::blas::axpy(n, alpha, x_.ptr, incx, y_.ptr, incy);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_AXPY_HH
+#endif  //  #ifndef TLAPACK_BLAS_AXPY_HH

--- a/include/tlapack/blas/copy.hpp
+++ b/include/tlapack/blas/copy.hpp
@@ -23,22 +23,20 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< class vectorX_t, class vectorY_t,
+template <
+    class vectorX_t,
+    class vectorY_t,
     class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void copy( const vectorX_t& x, vectorY_t& y )
+    disable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+void copy(const vectorX_t& x, vectorY_t& y)
 {
-    using idx_t = size_type< vectorX_t >;
+    using idx_t = size_type<vectorX_t>;
 
     // constants
     const idx_t n = size(x);
 
     // check arguments
-    tlapack_check_false( (idx_t) size(y) < n );
+    tlapack_check_false((idx_t)size(y) < n);
 
     for (idx_t i = 0; i < n; ++i)
         y[i] = x[i];
@@ -46,32 +44,31 @@ void copy( const vectorX_t& x, vectorY_t& y )
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vectorX_t, class vectorY_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void copy( const vectorX_t& x, vectorY_t& y )
-    {
-        using idx_t = size_type< vectorX_t >;
+template <
+    class vectorX_t,
+    class vectorY_t,
+    class T = type_t<vectorY_t>,
+    enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+inline void copy(const vectorX_t& x, vectorY_t& y)
+{
+    using idx_t = size_type<vectorX_t>;
 
-        // Legacy objects
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = x_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = x_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::copy( n, x_.ptr, incx, y_.ptr, incy );
-    }
+    return ::blas::copy(n, x_.ptr, incx, y_.ptr, incy);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_COPY_HH
+#endif  //  #ifndef TLAPACK_BLAS_COPY_HH

--- a/include/tlapack/blas/dot.hpp
+++ b/include/tlapack/blas/dot.hpp
@@ -24,28 +24,23 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< class vectorX_t, class vectorY_t,
+template <
+    class vectorX_t,
+    class vectorY_t,
     class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-auto dot( const vectorX_t& x, const vectorY_t& y )
+    disable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+auto dot(const vectorX_t& x, const vectorY_t& y)
 {
-    using return_t = scalar_type<
-        type_t< vectorX_t >,
-        type_t< vectorY_t >
-    >;
-    using idx_t = size_type< vectorX_t >;
+    using return_t = scalar_type<type_t<vectorX_t>, type_t<vectorY_t> >;
+    using idx_t = size_type<vectorX_t>;
 
     // constants
     const idx_t n = size(x);
 
     // check arguments
-    tlapack_check_false( size(y) != n );
+    tlapack_check_false(size(y) != n);
 
-    return_t result( 0 );
+    return_t result(0);
     for (idx_t i = 0; i < n; ++i)
         result += conj(x[i]) * y[i];
 
@@ -54,32 +49,31 @@ auto dot( const vectorX_t& x, const vectorY_t& y )
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vectorX_t, class vectorY_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    auto dot( const vectorX_t& x, const vectorY_t& y )
-    {
-        using idx_t = size_type< vectorX_t >;
+template <
+    class vectorX_t,
+    class vectorY_t,
+    class T = type_t<vectorY_t>,
+    enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+inline auto dot(const vectorX_t& x, const vectorY_t& y)
+{
+    using idx_t = size_type<vectorX_t>;
 
-        // Legacy objects
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = x_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = x_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::dot( n, x_.ptr, incx, y_.ptr, incy );
-    }
+    return ::blas::dot(n, x_.ptr, incx, y_.ptr, incy);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_DOT_HH
+#endif  //  #ifndef TLAPACK_BLAS_DOT_HH

--- a/include/tlapack/blas/dotu.hpp
+++ b/include/tlapack/blas/dotu.hpp
@@ -24,28 +24,23 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< class vectorX_t, class vectorY_t,
+template <
+    class vectorX_t,
+    class vectorY_t,
     class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-auto dotu( const vectorX_t& x, const vectorY_t& y )
+    disable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+auto dotu(const vectorX_t& x, const vectorY_t& y)
 {
-    using return_t = scalar_type<
-        type_t< vectorX_t >,
-        type_t< vectorY_t >
-    >;
-    using idx_t = size_type< vectorX_t >;
+    using return_t = scalar_type<type_t<vectorX_t>, type_t<vectorY_t> >;
+    using idx_t = size_type<vectorX_t>;
 
     // constants
     const idx_t n = size(x);
 
     // check arguments
-    tlapack_check_false( size(y) != n );
+    tlapack_check_false(size(y) != n);
 
-    return_t result( 0 );
+    return_t result(0);
     for (idx_t i = 0; i < n; ++i)
         result += x[i] * y[i];
 
@@ -54,32 +49,31 @@ auto dotu( const vectorX_t& x, const vectorY_t& y )
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vectorX_t, class vectorY_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    auto dotu( const vectorX_t& x, const vectorY_t& y )
-    {
-        using idx_t = size_type< vectorX_t >;
+template <
+    class vectorX_t,
+    class vectorY_t,
+    class T = type_t<vectorY_t>,
+    enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+inline auto dotu(const vectorX_t& x, const vectorY_t& y)
+{
+    using idx_t = size_type<vectorX_t>;
 
-        // Legacy objects
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = x_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = x_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::dotu( n, x_.ptr, incx, y_.ptr, incy );
-    }
+    return ::blas::dotu(n, x_.ptr, incx, y_.ptr, incy);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_DOTU_HH
+#endif  //  #ifndef TLAPACK_BLAS_DOTU_HH

--- a/include/tlapack/blas/gemm.hpp
+++ b/include/tlapack/blas/gemm.hpp
@@ -44,37 +44,32 @@ namespace tlapack {
  * @param[in] B $op(B)$ is an k-by-n matrix.
  * @param[in] beta Scalar.
  * @param[in,out] C A m-by-n matrix.
- * 
+ *
  * @ingroup blas3
  */
-template<
-    class matrixA_t,
-    class matrixB_t,
-    class matrixC_t,
-    class alpha_t,
-    class beta_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >,
-        pair< beta_t,    T >
-    > = 0
->
-void gemm(
-    Op transA,
-    Op transB,
-    const alpha_t& alpha,
-    const matrixA_t& A,
-    const matrixB_t& B,
-    const beta_t& beta,
-    matrixC_t& C )
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T>,
+                                     pair<beta_t, T> > = 0>
+void gemm(Op transA,
+          Op transB,
+          const alpha_t& alpha,
+          const matrixA_t& A,
+          const matrixB_t& B,
+          const beta_t& beta,
+          matrixC_t& C)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TB    = type_t< matrixB_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TB = type_t<matrixB_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t m = (transA == Op::NoTrans) ? nrows(A) : ncols(A);
@@ -82,121 +77,117 @@ void gemm(
     const idx_t k = (transA == Op::NoTrans) ? ncols(A) : nrows(A);
 
     // check arguments
-    tlapack_check_false( transA != Op::NoTrans &&
-                   transA != Op::Trans &&
-                   transA != Op::ConjTrans );
-    tlapack_check_false( transB != Op::NoTrans &&
-                   transB != Op::Trans &&
-                   transB != Op::ConjTrans );
-    tlapack_check_false( (idx_t) nrows(C) != m );
-    tlapack_check_false( (idx_t) ncols(C) != n );
-    tlapack_check_false( (idx_t) ((transB == Op::NoTrans) ? nrows(B) : ncols(B)) != k );
-
+    tlapack_check_false(transA != Op::NoTrans && transA != Op::Trans &&
+                        transA != Op::ConjTrans);
+    tlapack_check_false(transB != Op::NoTrans && transB != Op::Trans &&
+                        transB != Op::ConjTrans);
+    tlapack_check_false((idx_t)nrows(C) != m);
+    tlapack_check_false((idx_t)ncols(C) != n);
+    tlapack_check_false(
+        (idx_t)((transB == Op::NoTrans) ? nrows(B) : ncols(B)) != k);
 
     if (transA == Op::NoTrans) {
-
-        using scalar_t = scalar_type<alpha_t,TB>;
+        using scalar_t = scalar_type<alpha_t, TB>;
 
         if (transB == Op::NoTrans) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i)
-                    C(i,j) *= beta;
-                for(idx_t l = 0; l < k; ++l) {
-                    const scalar_t alphaTimesblj = alpha*B(l,j);
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) += A(i,l)*alphaTimesblj;
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i)
+                    C(i, j) *= beta;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_t alphaTimesblj = alpha * B(l, j);
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) += A(i, l) * alphaTimesblj;
                 }
             }
         }
         else if (transB == Op::Trans) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i)
-                    C(i,j) *= beta;
-                for(idx_t l = 0; l < k; ++l) {
-                    const scalar_t alphaTimesbjl = alpha*B(j,l);
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) += A(i,l)*alphaTimesbjl;
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i)
+                    C(i, j) *= beta;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_t alphaTimesbjl = alpha * B(j, l);
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) += A(i, l) * alphaTimesbjl;
                 }
             }
         }
-        else { // transB == Op::ConjTrans
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i)
-                    C(i,j) *= beta;
-                for(idx_t l = 0; l < k; ++l) {
-                    const scalar_t alphaTimesbjl = alpha*conj(B(j,l));
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) += A(i,l)*alphaTimesbjl;
+        else {  // transB == Op::ConjTrans
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i)
+                    C(i, j) *= beta;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_t alphaTimesbjl = alpha * conj(B(j, l));
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) += A(i, l) * alphaTimesbjl;
                 }
             }
         }
     }
     else if (transA == Op::Trans) {
-
-        using scalar_t = scalar_type<TA,TB>;
+        using scalar_t = scalar_type<TA, TB>;
 
         if (transB == Op::NoTrans) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i) {
-                    scalar_t sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum += A(l,i)*B(l,j);
-                    C(i,j) = alpha*sum + beta*C(i,j);
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i) {
+                    scalar_t sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += A(l, i) * B(l, j);
+                    C(i, j) = alpha * sum + beta * C(i, j);
                 }
             }
         }
         else if (transB == Op::Trans) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i) {
-                    scalar_t sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum += A(l,i)*B(j,l);
-                    C(i,j) = alpha*sum + beta*C(i,j);
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i) {
+                    scalar_t sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += A(l, i) * B(j, l);
+                    C(i, j) = alpha * sum + beta * C(i, j);
                 }
             }
         }
-        else { // transB == Op::ConjTrans
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i) {
-                    scalar_t sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum += A(l,i)*conj(B(j,l));
-                    C(i,j) = alpha*sum + beta*C(i,j);
+        else {  // transB == Op::ConjTrans
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i) {
+                    scalar_t sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += A(l, i) * conj(B(j, l));
+                    C(i, j) = alpha * sum + beta * C(i, j);
                 }
             }
         }
     }
-    else { // transA == Op::ConjTrans
+    else {  // transA == Op::ConjTrans
 
-        using scalar_t = scalar_type<TA,TB>;
-        
+        using scalar_t = scalar_type<TA, TB>;
+
         if (transB == Op::NoTrans) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i) {
-                    scalar_t sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum += conj(A(l,i))*B(l,j);
-                    C(i,j) = alpha*sum + beta*C(i,j);
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i) {
+                    scalar_t sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += conj(A(l, i)) * B(l, j);
+                    C(i, j) = alpha * sum + beta * C(i, j);
                 }
             }
         }
         else if (transB == Op::Trans) {
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i) {
-                    scalar_t sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum += conj(A(l,i))*B(j,l);
-                    C(i,j) = alpha*sum + beta*C(i,j);
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i) {
+                    scalar_t sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += conj(A(l, i)) * B(j, l);
+                    C(i, j) = alpha * sum + beta * C(i, j);
                 }
             }
         }
-        else { // transB == Op::ConjTrans
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i) {
-                    scalar_t sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum += A(l,i)*B(j,l); // little improvement here
-                    C(i,j) = alpha*conj(sum) + beta*C(i,j);
+        else {  // transB == Op::ConjTrans
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i) {
+                    scalar_t sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += A(l, i) * B(j, l);  // little improvement here
+                    C(i, j) = alpha * conj(sum) + beta * C(i, j);
                 }
             }
         }
@@ -231,166 +222,140 @@ void gemm(
  * @param[in] A $op(A)$ is an m-by-k matrix.
  * @param[in] B $op(B)$ is an k-by-n matrix.
  * @param[out] C A m-by-n matrix.
- * 
+ *
  * @ingroup blas3
  */
-template<
-    class matrixA_t,
-    class matrixB_t,
-    class matrixC_t,
-    class alpha_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >
-    > = 0
->
-inline
-void gemm(
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T> > = 0>
+inline void gemm(Op transA,
+                 Op transB,
+                 const alpha_t& alpha,
+                 const matrixA_t& A,
+                 const matrixB_t& B,
+                 matrixC_t& C)
+{
+    return gemm(transA, transB, alpha, A, B, internal::StrongZero(), C);
+}
+
+#ifdef USE_LAPACKPP_WRAPPERS
+
+/**
+ * General matrix-matrix multiply.
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see gemm(
+    Op transA,
+    Op transB,
+    const alpha_t& alpha,
+    const matrixA_t& A,
+    const matrixB_t& B,
+    const beta_t& beta,
+    matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T>,
+                                    pair<beta_t, T> > = 0>
+inline void gemm(Op transA,
+                 Op transB,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const matrixB_t& B,
+                 const beta_t beta,
+                 matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& m = C_.m;
+    const auto& n = C_.n;
+    const auto& k = (transA == Op::NoTrans) ? A_.n : A_.m;
+
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -6,
+            "Infs and NaNs in C on input will not propagate to C on output");
+
+    return ::blas::gemm((::blas::Layout)A_.layout, (::blas::Op)transA,
+                        (::blas::Op)transB, m, n, k, alpha, A_.ptr, A_.ldim,
+                        B_.ptr, B_.ldim, beta, C_.ptr, C_.ldim);
+}
+
+/**
+ * General matrix-matrix multiply.
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see gemm(
     Op transA,
     Op transB,
     const alpha_t& alpha,
     const matrixA_t& A,
     const matrixB_t& B,
     matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T> > = 0>
+inline void gemm(Op transA,
+                 Op transB,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const matrixB_t& B,
+                 matrixC_t& C)
 {
-    return gemm( transA, transB, alpha, A, B, internal::StrongZero(), C );
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
+
+    // Constants to forward
+    const auto& m = C_.m;
+    const auto& n = C_.n;
+    const auto& k = (transA == Op::NoTrans) ? A_.n : A_.m;
+
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
+
+    return ::blas::gemm((::blas::Layout)A_.layout, (::blas::Op)transA,
+                        (::blas::Op)transB, m, n, k, alpha, A_.ptr, A_.ldim,
+                        B_.ptr, B_.ldim, T(0), C_.ptr, C_.ldim);
 }
-
-#ifdef USE_LAPACKPP_WRAPPERS
-
-    /**
-     * General matrix-matrix multiply.
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see gemm(
-        Op transA,
-        Op transB,
-        const alpha_t& alpha,
-        const matrixA_t& A,
-        const matrixB_t& B,
-        const beta_t& beta,
-        matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t,
-        class matrixB_t, 
-        class matrixC_t, 
-        class alpha_t, 
-        class beta_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >,
-            pair< beta_t,    T >
-        > = 0
-    >
-    inline
-    void gemm(
-        Op transA,
-        Op transB,
-        const alpha_t alpha,
-        const matrixA_t& A,
-        const matrixB_t& B,
-        const beta_t beta,
-        matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
-
-        // Constants to forward
-        const auto& m = C_.m;
-        const auto& n = C_.n;
-        const auto& k = (transA == Op::NoTrans) ? A_.n : A_.m;
-
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
-
-        return ::blas::gemm(
-            (::blas::Layout) A_.layout,
-            (::blas::Op) transA, (::blas::Op) transB, 
-            m, n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            beta,
-            C_.ptr, C_.ldim );
-    }
-
-    /**
-     * General matrix-matrix multiply.
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see gemm(
-        Op transA,
-        Op transB,
-        const alpha_t& alpha,
-        const matrixA_t& A,
-        const matrixB_t& B,
-        matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t,
-        class matrixB_t,
-        class matrixC_t,
-        class alpha_t,
-        class T = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >
-        > = 0
-    >
-    inline
-    void gemm(
-        Op transA,
-        Op transB,
-        const alpha_t alpha,
-        const matrixA_t& A,
-        const matrixB_t& B,
-        matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
-
-        // Constants to forward
-        const auto& m = C_.m;
-        const auto& n = C_.n;
-        const auto& k = (transA == Op::NoTrans) ? A_.n : A_.m;
-
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
-
-        return ::blas::gemm(
-            (::blas::Layout) A_.layout,
-            (::blas::Op) transA, (::blas::Op) transB, 
-            m, n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            T(0),
-            C_.ptr, C_.ldim );
-    }
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_GEMM_HH
+#endif  //  #ifndef TLAPACK_BLAS_GEMM_HH

--- a/include/tlapack/blas/gemv.hpp
+++ b/include/tlapack/blas/gemv.hpp
@@ -39,61 +39,55 @@ namespace tlapack {
  * @param[in] x A n-element vector.
  * @param[in] beta Scalar.
  * @param[in,out] y A m-element vector.
- * 
+ *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t, 
-    class alpha_t, class beta_t,
-    class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t,    T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >,
-        pair< beta_t,    T >
-    > = 0
->
-void gemv(
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    const beta_t& beta, vectorY_t& y )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<vectorY_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T>,
+                                     pair<beta_t, T> > = 0>
+void gemv(Op trans,
+          const alpha_t& alpha,
+          const matrixA_t& A,
+          const vectorX_t& x,
+          const beta_t& beta,
+          vectorY_t& y)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TX    = type_t< vectorX_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TX = type_t<vectorX_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
-    const idx_t m = (trans == Op::NoTrans || trans == Op::Conj)
-                    ? nrows(A)
-                    : ncols(A);
-    const idx_t n = (trans == Op::NoTrans || trans == Op::Conj)
-                    ? ncols(A)
-                    : nrows(A);
+    const idx_t m =
+        (trans == Op::NoTrans || trans == Op::Conj) ? nrows(A) : ncols(A);
+    const idx_t n =
+        (trans == Op::NoTrans || trans == Op::Conj) ? ncols(A) : nrows(A);
 
     // check arguments
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans &&
-                   trans != Op::Conj );
-    tlapack_check_false( (idx_t) size(x) != n );
-    tlapack_check_false( (idx_t) size(y) != m );
-
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans && trans != Op::Conj);
+    tlapack_check_false((idx_t)size(x) != n);
+    tlapack_check_false((idx_t)size(y) != m);
 
     // quick return
-    if (m == 0 || n == 0)
-        return;
+    if (m == 0 || n == 0) return;
 
     // form y := beta*y
     for (idx_t i = 0; i < m; ++i)
         y[i] *= beta;
 
-    if (trans == Op::NoTrans ) {
+    if (trans == Op::NoTrans) {
         // form y += alpha * A * x
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TX> tmp = alpha*x[j];
+            const scalar_type<alpha_t, TX> tmp = alpha * x[j];
             for (idx_t i = 0; i < m; ++i) {
                 y[i] += tmp * A(i, j);
             }
@@ -102,7 +96,7 @@ void gemv(
     else if (trans == Op::Conj) {
         // form y += alpha * conj( A ) * x
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TX> tmp = alpha*x[j];
+            const scalar_type<alpha_t, TX> tmp = alpha * x[j];
             for (idx_t i = 0; i < m; ++i) {
                 y[i] += tmp * conj(A(i, j));
             }
@@ -111,21 +105,21 @@ void gemv(
     else if (trans == Op::Trans) {
         // form y += alpha * A^T * x
         for (idx_t i = 0; i < m; ++i) {
-            scalar_type<TA,TX> tmp( 0 );
+            scalar_type<TA, TX> tmp(0);
             for (idx_t j = 0; j < n; ++j) {
                 tmp += A(j, i) * x[j];
             }
-            y[i] += alpha*tmp;
+            y[i] += alpha * tmp;
         }
     }
     else {
         // form y += alpha * A^H * x
         for (idx_t i = 0; i < m; ++i) {
-            scalar_type<TA,TX> tmp( 0 );
+            scalar_type<TA, TX> tmp(0);
             for (idx_t j = 0; j < n; ++j) {
                 tmp += conj(A(j, i)) * x[j];
             }
-            y[i] += alpha*tmp;
+            y[i] += alpha * tmp;
         }
     }
 }
@@ -153,151 +147,140 @@ void gemv(
  * @param[in] A $op(A)$ is an m-by-n matrix.
  * @param[in] x A n-element vector.
  * @param[in,out] y A m-element vector.
- * 
+ *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t, 
-    class alpha_t,
-    class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t,    T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-inline
-void gemv(
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    vectorY_t& y )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+inline void gemv(Op trans,
+                 const alpha_t& alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 vectorY_t& y)
 {
-    return gemv( trans, alpha, A, x, internal::StrongZero(), y );
+    return gemv(trans, alpha, A, x, internal::StrongZero(), y);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    /**
-     * General matrix-vector multiply.
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see gemv(
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-        const beta_t& beta, vectorY_t& y )
-    * 
-    * @ingroup blas2
-    */
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t, 
-        class alpha_t, class beta_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >,
-            pair< beta_t,    T >
-        > = 0
-    >
-    inline
-    void gemv(
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
-        const beta_t beta, vectorY_t& y )
-    {
-        using idx_t = size_type< matrixA_t >;
+/**
+ * General matrix-vector multiply.
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see gemv(
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
+    const beta_t& beta, vectorY_t& y )
+*
+* @ingroup blas2
+*/
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<vectorY_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T>,
+                                    pair<beta_t, T> > = 0>
+inline void gemv(Op trans,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 const beta_t beta,
+                 vectorY_t& y)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& m = A_.m;
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& m = A_.m;
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -2, "Infs and NaNs in A or x will not propagate to y on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -5, "Infs and NaNs in y on input will not propagate to y on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -2, "Infs and NaNs in A or x will not propagate to y on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -5,
+            "Infs and NaNs in y on input will not propagate to y on output");
 
-        return ::blas::gemv(
-            (::blas::Layout) A_.layout,
-            (::blas::Op) trans,
-            m, n,
-            alpha,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx,
-            beta,
-            y_.ptr, incy );
-    }
+    return ::blas::gemv((::blas::Layout)A_.layout, (::blas::Op)trans, m, n,
+                        alpha, A_.ptr, A_.ldim, x_.ptr, incx, beta, y_.ptr,
+                        incy);
+}
 
-    /**
-     * General matrix-vector multiply.
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see gemv(
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-        vectorY_t& y )
-    * 
-    * @ingroup blas2
-    */
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t, 
-        class alpha_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void gemv(
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
-        vectorY_t& y )
-    {
-        using idx_t = size_type< matrixA_t >;
+/**
+ * General matrix-vector multiply.
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see gemv(
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
+    vectorY_t& y )
+*
+* @ingroup blas2
+*/
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void gemv(Op trans,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 vectorY_t& y)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& m = A_.m;
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& m = A_.m;
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -2, "Infs and NaNs in A or x will not propagate to y on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -2, "Infs and NaNs in A or x will not propagate to y on output");
 
-        return ::blas::gemv(
-            (::blas::Layout) A_.layout,
-            (::blas::Op) trans,
-            m, n,
-            alpha,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx,
-            T(0),
-            y_.ptr, incy );
-    }
+    return ::blas::gemv((::blas::Layout)A_.layout, (::blas::Op)trans, m, n,
+                        alpha, A_.ptr, A_.ldim, x_.ptr, incx, T(0), y_.ptr,
+                        incy);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_GEMV_HH
+#endif  //  #ifndef TLAPACK_BLAS_GEMV_HH

--- a/include/tlapack/blas/ger.hpp
+++ b/include/tlapack/blas/ger.hpp
@@ -22,7 +22,7 @@ namespace tlapack {
  * \]
  * where alpha is a scalar, x and y are vectors,
  * and A is an m-by-n matrix.
- * 
+ *
  * @param[in] alpha Scalar.
  * @param[in] x A m-element vector.
  * @param[in] y A n-element vector.
@@ -30,86 +30,76 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t,
-    class alpha_t,
-    class T = type_t<matrixA_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void ger(
-    const alpha_t& alpha,
-    const vectorX_t& x, const vectorY_t& y,
-    matrixA_t& A )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+void ger(const alpha_t& alpha,
+         const vectorX_t& x,
+         const vectorY_t& y,
+         matrixA_t& A)
 {
     // data traits
-    using idx_t = size_type< matrixA_t >;
-    using scalar_t = scalar_type< alpha_t, type_t<vectorY_t> >;
+    using idx_t = size_type<matrixA_t>;
+    using scalar_t = scalar_type<alpha_t, type_t<vectorY_t> >;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false( size(x) != m );
-    tlapack_check_false( size(y) != n );
+    tlapack_check_false(size(x) != m);
+    tlapack_check_false(size(y) != n);
 
     for (idx_t j = 0; j < n; ++j) {
-        const scalar_t tmp = alpha * conj( y[j] );
+        const scalar_t tmp = alpha * conj(y[j]);
         for (idx_t i = 0; i < m; ++i)
-            A(i,j) += x[i] * tmp;
+            A(i, j) += x[i] * tmp;
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t,
-        class alpha_t,
-        class T = type_t<matrixA_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void ger(
-        const alpha_t alpha,
-        const vectorX_t& x, const vectorY_t& y,
-        matrixA_t& A )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void ger(const alpha_t alpha,
+                const vectorX_t& x,
+                const vectorY_t& y,
+                matrixA_t& A)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& m = A_.m;
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& m = A_.m;
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::ger(
-            (::blas::Layout) A_.layout,
-            m, n,
-            alpha,
-            x_.ptr, incx,
-            y_.ptr, incy,
-            A_.ptr, A_.ldim );
-    }
+    return ::blas::ger((::blas::Layout)A_.layout, m, n, alpha, x_.ptr, incx,
+                       y_.ptr, incy, A_.ptr, A_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_GER_HH
+#endif  //  #ifndef TLAPACK_BLAS_GER_HH

--- a/include/tlapack/blas/geru.hpp
+++ b/include/tlapack/blas/geru.hpp
@@ -23,94 +23,84 @@ namespace tlapack {
  * \]
  * where alpha is a scalar, x and y are vectors,
  * and A is an m-by-n matrix.
- * 
+ *
  * @param[in] alpha Scalar.
  * @param[in] x A m-element vector.
  * @param[in] y A n-element vector.
  * @param[in] A A m-by-n matrix.
- * 
+ *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t,
-    class alpha_t,
-    class T = type_t<matrixA_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void geru(
-    const alpha_t& alpha,
-    const vectorX_t& x, const vectorY_t& y,
-    matrixA_t& A )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+void geru(const alpha_t& alpha,
+          const vectorX_t& x,
+          const vectorY_t& y,
+          matrixA_t& A)
 {
     // data traits
-    using idx_t = size_type< matrixA_t >;
-    using scalar_t = scalar_type< alpha_t, type_t<vectorY_t> >;
+    using idx_t = size_type<matrixA_t>;
+    using scalar_t = scalar_type<alpha_t, type_t<vectorY_t> >;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false( size(x) != m );
-    tlapack_check_false( size(y) != n );
+    tlapack_check_false(size(x) != m);
+    tlapack_check_false(size(y) != n);
 
     for (idx_t j = 0; j < n; ++j) {
         const scalar_t tmp = alpha * y[j];
         for (idx_t i = 0; i < m; ++i)
-            A(i,j) += x[i] * tmp;
+            A(i, j) += x[i] * tmp;
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t,
-        class alpha_t,
-        class T = type_t<matrixA_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void geru(
-        const alpha_t alpha,
-        const vectorX_t& x, const vectorY_t& y,
-        matrixA_t& A )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void geru(const alpha_t alpha,
+                 const vectorX_t& x,
+                 const vectorY_t& y,
+                 matrixA_t& A)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& m = A_.m;
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& m = A_.m;
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::geru(
-            (::blas::Layout) A_.layout,
-            m, n,
-            alpha,
-            x_.ptr, incx,
-            y_.ptr, incy,
-            A_.ptr, A_.ldim );
-    }
+    return ::blas::geru((::blas::Layout)A_.layout, m, n, alpha, x_.ptr, incx,
+                        y_.ptr, incy, A_.ptr, A_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_GER_HH
+#endif  //  #ifndef TLAPACK_BLAS_GER_HH

--- a/include/tlapack/blas/hemm.hpp
+++ b/include/tlapack/blas/hemm.hpp
@@ -49,133 +49,124 @@ namespace tlapack {
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t,
-    class matrixB_t,
-    class matrixC_t, 
-    class alpha_t,
-    class beta_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >,
-        pair< beta_t,    T >
-    > = 0
->
-void hemm(
-    Side side,
-    Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-    const beta_t& beta, matrixC_t& C )
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T>,
+                                     pair<beta_t, T> > = 0>
+void hemm(Side side,
+          Uplo uplo,
+          const alpha_t& alpha,
+          const matrixA_t& A,
+          const matrixB_t& B,
+          const beta_t& beta,
+          matrixC_t& C)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TB    = type_t< matrixB_t >;
-    using idx_t = size_type< matrixB_t >;
-            
+    using TA = type_t<matrixA_t>;
+    using TB = type_t<matrixB_t>;
+    using idx_t = size_type<matrixB_t>;
+
     // constants
     const idx_t m = nrows(B);
     const idx_t n = ncols(B);
 
     // check arguments
-    tlapack_check_false( side != Side::Left &&
-                   side != Side::Right );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( nrows(A) != ncols(A) );
-    tlapack_check_false( nrows(A) != ((side == Side::Left) ? m : n) );
-    tlapack_check_false( nrows(C) != m );
-    tlapack_check_false( ncols(C) != n );
-
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(nrows(A) != ncols(A));
+    tlapack_check_false(nrows(A) != ((side == Side::Left) ? m : n));
+    tlapack_check_false(nrows(C) != m);
+    tlapack_check_false(ncols(C) != n);
 
     if (side == Side::Left) {
         if (uplo != Uplo::Lower) {
             // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i < m; ++i) {
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < m; ++i) {
+                    const scalar_type<alpha_t, TB> alphaTimesBij =
+                        alpha * B(i, j);
+                    scalar_type<TA, TB> sum(0);
 
-                    const scalar_type<alpha_t,TB> alphaTimesBij = alpha*B(i,j);
-                    scalar_type<TA,TB> sum( 0 );
-
-                    for(idx_t k = 0; k < i; ++k) {
-                        C(k,j) += A(k,i) * alphaTimesBij;
-                        sum += conj( A(k,i) ) * B(k,j);
+                    for (idx_t k = 0; k < i; ++k) {
+                        C(k, j) += A(k, i) * alphaTimesBij;
+                        sum += conj(A(k, i)) * B(k, j);
                     }
-                    C(i,j) =
-                        beta * C(i,j)
-                        + real( A(i,i) ) * alphaTimesBij
-                        + alpha * sum;
+                    C(i, j) = beta * C(i, j) + real(A(i, i)) * alphaTimesBij +
+                              alpha * sum;
                 }
             }
         }
         else {
             // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = m-1; i != idx_t(-1); --i) {
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = m - 1; i != idx_t(-1); --i) {
+                    const scalar_type<alpha_t, TB> alphaTimesBij =
+                        alpha * B(i, j);
+                    scalar_type<TA, TB> sum(0);
 
-                    const scalar_type<alpha_t,TB> alphaTimesBij = alpha*B(i,j);
-                    scalar_type<TA,TB> sum( 0 );
-
-                    for(idx_t k = i+1; k < m; ++k) {
-                        C(k,j) += A(k,i) * alphaTimesBij;
-                        sum += conj( A(k,i) ) * B(k,j);
+                    for (idx_t k = i + 1; k < m; ++k) {
+                        C(k, j) += A(k, i) * alphaTimesBij;
+                        sum += conj(A(k, i)) * B(k, j);
                     }
-                    C(i,j) =
-                        beta * C(i,j)
-                        + real( A(i,i) ) * alphaTimesBij
-                        + alpha * sum;
+                    C(i, j) = beta * C(i, j) + real(A(i, i)) * alphaTimesBij +
+                              alpha * sum;
                 }
             }
         }
     }
-    else { // side == Side::Right
+    else {  // side == Side::Right
 
-        using scalar_t = scalar_type<alpha_t,TA>;
-        
+        using scalar_t = scalar_type<alpha_t, TA>;
+
         if (uplo != Uplo::Lower) {
             // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
+            for (idx_t j = 0; j < n; ++j) {
                 {
-                    const scalar_t alphaTimesAjj = alpha * real( A(j,j) );
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) = beta * C(i,j) + B(i,j) * alphaTimesAjj;
+                    const scalar_t alphaTimesAjj = alpha * real(A(j, j));
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) = beta * C(i, j) + B(i, j) * alphaTimesAjj;
                 }
 
-                for(idx_t k = 0; k < j; ++k) {
-                    const scalar_t alphaTimesAkj = alpha*A(k,j);
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) += B(i,k) * alphaTimesAkj;
+                for (idx_t k = 0; k < j; ++k) {
+                    const scalar_t alphaTimesAkj = alpha * A(k, j);
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) += B(i, k) * alphaTimesAkj;
                 }
 
-                for(idx_t k = j+1; k < n; ++k) {
-                    const scalar_t alphaTimesAjk = alpha * conj( A(j,k) );
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) += B(i,k) * alphaTimesAjk;
+                for (idx_t k = j + 1; k < n; ++k) {
+                    const scalar_t alphaTimesAjk = alpha * conj(A(j, k));
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) += B(i, k) * alphaTimesAjk;
                 }
             }
         }
         else {
             // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
+            for (idx_t j = 0; j < n; ++j) {
                 {
-                    const scalar_t alphaTimesAjj = alpha * real( A(j,j) );
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) = beta * C(i,j) + B(i,j) * alphaTimesAjj;
+                    const scalar_t alphaTimesAjj = alpha * real(A(j, j));
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) = beta * C(i, j) + B(i, j) * alphaTimesAjj;
                 }
 
-                for(idx_t k = 0; k < j; ++k) {
-                    const scalar_t alphaTimesAjk = alpha * conj( A(j,k) );
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) += B(i,k) * alphaTimesAjk;
+                for (idx_t k = 0; k < j; ++k) {
+                    const scalar_t alphaTimesAjk = alpha * conj(A(j, k));
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) += B(i, k) * alphaTimesAjk;
                 }
 
-                for(idx_t k = j+1; k < n; ++k) {
-                    const scalar_t alphaTimesAkj = alpha*A(k,j);
-                    for(idx_t i = 0; i < m; ++i)
-                        C(i,j) += B(i,k) * alphaTimesAkj;
+                for (idx_t k = j + 1; k < n; ++k) {
+                    const scalar_t alphaTimesAkj = alpha * A(k, j);
+                    for (idx_t i = 0; i < m; ++i)
+                        C(i, j) += B(i, k) * alphaTimesAkj;
                 }
             }
         }
@@ -215,149 +206,130 @@ void hemm(
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t,
-    class matrixB_t,
-    class matrixC_t, 
-    class alpha_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >
-    > = 0
->
-inline
-void hemm(
-    Side side,
-    Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-    matrixC_t& C )
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T> > = 0>
+inline void hemm(Side side,
+                 Uplo uplo,
+                 const alpha_t& alpha,
+                 const matrixA_t& A,
+                 const matrixB_t& B,
+                 matrixC_t& C)
 {
-    return hemm( side, uplo, alpha, A, B, internal::StrongZero(), C );
+    return hemm(side, uplo, alpha, A, B, internal::StrongZero(), C);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    /**
-     * Hermitian matrix-matrix multiply.
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see hemm(
-        Side side,
-        Uplo uplo,
-        const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-        const beta_t& beta, matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t,
-        class matrixB_t, 
-        class matrixC_t, 
-        class alpha_t, 
-        class beta_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >,
-            pair< beta_t,    T >
-        > = 0
-    >
-    inline
-    void hemm(
-        Side side,
-        Uplo uplo,
-        const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
-        const beta_t beta, matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
+/**
+ * Hermitian matrix-matrix multiply.
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see hemm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t& beta, matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T>,
+                                    pair<beta_t, T> > = 0>
+inline void hemm(Side side,
+                 Uplo uplo,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const matrixB_t& B,
+                 const beta_t beta,
+                 matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& m = C_.m;
-        const auto& n = C_.n;
+    // Constants to forward
+    const auto& m = C_.m;
+    const auto& n = C_.n;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -6,
+            "Infs and NaNs in C on input will not propagate to C on output");
 
-        return ::blas::hemm(
-            (::blas::Layout) A_.layout,
-            (::blas::Side) side, (::blas::Uplo) uplo, 
-            m, n,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            beta,
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::hemm((::blas::Layout)A_.layout, (::blas::Side)side,
+                        (::blas::Uplo)uplo, m, n, alpha, A_.ptr, A_.ldim,
+                        B_.ptr, B_.ldim, beta, C_.ptr, C_.ldim);
+}
 
-    /**
-     * Hermitian matrix-matrix multiply.
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see hemm(
-        Side side,
-        Uplo uplo,
-        const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-        matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t,
-        class matrixB_t, 
-        class matrixC_t, 
-        class alpha_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >
-        > = 0
-    >
-    inline
-    void hemm(
-        Side side,
-        Uplo uplo,
-        const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
-        matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
+/**
+ * Hermitian matrix-matrix multiply.
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see hemm(
+    Side side,
+    Uplo uplo,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T> > = 0>
+inline void hemm(Side side,
+                 Uplo uplo,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const matrixB_t& B,
+                 matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& m = C_.m;
-        const auto& n = C_.n;
+    // Constants to forward
+    const auto& m = C_.m;
+    const auto& n = C_.n;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
 
-        return ::blas::hemm(
-            (::blas::Layout) A_.layout,
-            (::blas::Side) side, (::blas::Uplo) uplo, 
-            m, n,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            T(0),
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::hemm((::blas::Layout)A_.layout, (::blas::Side)side,
+                        (::blas::Uplo)uplo, m, n, alpha, A_.ptr, A_.ldim,
+                        B_.ptr, B_.ldim, T(0), C_.ptr, C_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_HEMM_HH
+#endif  //  #ifndef TLAPACK_BLAS_HEMM_HH

--- a/include/tlapack/blas/hemv.hpp
+++ b/include/tlapack/blas/hemv.hpp
@@ -39,39 +39,37 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t, 
-    class alpha_t, class beta_t,
-    class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t,   T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >,
-        pair< beta_t,    T >
-    > = 0
->
-void hemv(
-    Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    const beta_t& beta, vectorY_t& y )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<vectorY_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T>,
+                                     pair<beta_t, T> > = 0>
+void hemv(Uplo uplo,
+          const alpha_t& alpha,
+          const matrixA_t& A,
+          const vectorX_t& x,
+          const beta_t& beta,
+          vectorY_t& y)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TX    = type_t< vectorX_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TX = type_t<vectorX_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( ncols(A) != n );
-    tlapack_check_false( size(x)  != n );
-    tlapack_check_false( size(y)  != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(ncols(A) != n);
+    tlapack_check_false(size(x) != n);
+    tlapack_check_false(size(y) != n);
 
     // form y = beta*y
     for (idx_t i = 0; i < n; ++i)
@@ -81,26 +79,26 @@ void hemv(
         // A is stored in upper triangle
         // form y += alpha * A * x
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TX> tmp1 = alpha*x[j];
-            scalar_type<TA,TX> sum(0);
+            const scalar_type<alpha_t, TX> tmp1 = alpha * x[j];
+            scalar_type<TA, TX> sum(0);
             for (idx_t i = 0; i < j; ++i) {
-                y[i] += tmp1 * A(i,j);
-                sum += conj( A(i,j) ) * x[i];
+                y[i] += tmp1 * A(i, j);
+                sum += conj(A(i, j)) * x[i];
             }
-            y[j] += tmp1 * real( A(j,j) ) + alpha * sum;
+            y[j] += tmp1 * real(A(j, j)) + alpha * sum;
         }
     }
     else {
         // A is stored in lower triangle
         // form y += alpha * A * x
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TX> tmp1 = alpha*x[j];
-            scalar_type<TA,TX> sum(0);
-            for (idx_t i = j+1; i < n; ++i) {
-                y[i] += tmp1 * A(i,j);
-                sum += conj( A(i,j) ) * x[i];
+            const scalar_type<alpha_t, TX> tmp1 = alpha * x[j];
+            scalar_type<TA, TX> sum(0);
+            for (idx_t i = j + 1; i < n; ++i) {
+                y[i] += tmp1 * A(i, j);
+                sum += conj(A(i, j)) * x[i];
             }
-            y[j] += tmp1 * real( A(j,j) ) + alpha * sum;
+            y[j] += tmp1 * real(A(j, j)) + alpha * sum;
         }
     }
 }
@@ -128,122 +126,109 @@ void hemv(
  *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t, 
-    class alpha_t,
-    class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t,   T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-inline
-void hemv(
-    Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    vectorY_t& y )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+inline void hemv(Uplo uplo,
+                 const alpha_t& alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 vectorY_t& y)
 {
-    return hemv( uplo, alpha, A, x, internal::StrongZero(), y );
+    return hemv(uplo, alpha, A, x, internal::StrongZero(), y);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t, 
-        class alpha_t, class beta_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >,
-            pair< beta_t,    T >
-        > = 0
-    >
-    inline
-    void hemv(
-        Uplo uplo,
-        const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
-        const beta_t beta, vectorY_t& y )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<vectorY_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T>,
+                                    pair<beta_t, T> > = 0>
+inline void hemv(Uplo uplo,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 const beta_t beta,
+                 vectorY_t& y)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -2, "Infs and NaNs in A or x will not propagate to y on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -5, "Infs and NaNs in y on input will not propagate to y on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -2, "Infs and NaNs in A or x will not propagate to y on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -5,
+            "Infs and NaNs in y on input will not propagate to y on output");
 
-        return ::blas::hemv(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx,
-            beta,
-            y_.ptr, incy );
-    }
+    return ::blas::hemv((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                        A_.ptr, A_.ldim, x_.ptr, incx, beta, y_.ptr, incy);
+}
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t, 
-        class alpha_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void hemv(
-        Uplo uplo,
-        const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
-        vectorY_t& y )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void hemv(Uplo uplo,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 vectorY_t& y)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -2, "Infs and NaNs in A or x will not propagate to y on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -2, "Infs and NaNs in A or x will not propagate to y on output");
 
-        return ::blas::hemv(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx,
-            T(0),
-            y_.ptr, incy );
-    }
+    return ::blas::hemv((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                        A_.ptr, A_.ldim, x_.ptr, incx, T(0), y_.ptr, incy);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_HEMV_HH
+#endif  //  #ifndef TLAPACK_BLAS_HEMV_HH

--- a/include/tlapack/blas/her.hpp
+++ b/include/tlapack/blas/her.hpp
@@ -22,7 +22,7 @@ namespace tlapack {
  * \]
  * where alpha is a real scalar, x is a vector,
  * and A is an n-by-n Hermitian matrix.
- * 
+ *
  * Mind that if alpha is complex, the output matrix is no longer Hermitian.
  *
  * @param[in] uplo
@@ -39,99 +39,82 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template< class matrixA_t, class vectorX_t, class alpha_t,
-    enable_if_t<(
-    /* Requires: */
-        ! is_complex<alpha_t>::value
-    ), int > = 0,
-    class T = type_t<matrixA_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, real_type<T> >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >
-    > = 0
->
-void her(
-    Uplo uplo,
-    const alpha_t& alpha,
-    const vectorX_t& x,
-    matrixA_t& A )
+template <class matrixA_t,
+          class vectorX_t,
+          class alpha_t,
+          enable_if_t<(
+                          /* Requires: */
+                          !is_complex<alpha_t>::value),
+                      int> = 0,
+          class T = type_t<matrixA_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, real_type<T> >,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T> > = 0>
+void her(Uplo uplo, const alpha_t& alpha, const vectorX_t& x, matrixA_t& A)
 {
     // data traits
-    using idx_t = size_type< matrixA_t >;
-    using scalar_t = scalar_type< alpha_t, type_t<vectorX_t> >;
+    using idx_t = size_type<matrixA_t>;
+    using scalar_t = scalar_type<alpha_t, type_t<vectorX_t> >;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( size(x)  != n );
-    tlapack_check_false( ncols(A) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(size(x) != n);
+    tlapack_check_false(ncols(A) != n);
 
     if (uplo == Uplo::Upper) {
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_t tmp = alpha * conj( x[j] );
+            const scalar_t tmp = alpha * conj(x[j]);
             for (idx_t i = 0; i < j; ++i)
-                A(i,j) += x[i] * tmp;
-            A(j,j) = real( A(j,j) ) + real(x[j])*real(tmp)
-                                    - imag(x[j])*imag(tmp);
+                A(i, j) += x[i] * tmp;
+            A(j, j) =
+                real(A(j, j)) + real(x[j]) * real(tmp) - imag(x[j]) * imag(tmp);
         }
     }
     else {
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_t tmp = alpha * conj( x[j] );
-            A(j,j) = real( A(j,j) ) + real(x[j])*real(tmp)
-                                    - imag(x[j])*imag(tmp);
-            for (idx_t i = j+1; i < n; ++i)
-                A(i,j) += x[i] * tmp;
+            const scalar_t tmp = alpha * conj(x[j]);
+            A(j, j) =
+                real(A(j, j)) + real(x[j]) * real(tmp) - imag(x[j]) * imag(tmp);
+            for (idx_t i = j + 1; i < n; ++i)
+                A(i, j) += x[i] * tmp;
         }
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t,
-        class alpha_t,
-        class T = type_t<matrixA_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, real_type<T> >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >
-        > = 0
-    >
-    inline
-    void her(
-        Uplo  uplo,
-        const alpha_t alpha,
-        const vectorX_t& x,
-        matrixA_t& A )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, real_type<T> >,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T> > = 0>
+inline void her(Uplo uplo,
+                const alpha_t alpha,
+                const vectorX_t& x,
+                matrixA_t& A)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        
-        return ::blas::her(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            x_.ptr, incx,
-            A_.ptr, A_.ldim );
-    }
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+
+    return ::blas::her((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                       x_.ptr, incx, A_.ptr, A_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_HER_HH
+#endif  //  #ifndef TLAPACK_BLAS_HER_HH

--- a/include/tlapack/blas/her2.hpp
+++ b/include/tlapack/blas/her2.hpp
@@ -28,7 +28,7 @@ namespace tlapack {
  *     the opposite triangle being assumed from symmetry.
  *     - Uplo::Lower: only the lower triangular part of A is referenced.
  *     - Uplo::Upper: only the upper triangular part of A is referenced.
- * 
+ *
  * @param[in] alpha Scalar.
  * @param[in] x A n-element vector.
  * @param[in] y A n-element vector.
@@ -38,111 +38,96 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t,
-    class alpha_t,
-    class T = type_t<matrixA_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void her2(
-    Uplo  uplo,
-    const alpha_t& alpha,
-    const vectorX_t& x, const vectorY_t& y,
-    matrixA_t& A )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+void her2(Uplo uplo,
+          const alpha_t& alpha,
+          const vectorX_t& x,
+          const vectorY_t& y,
+          matrixA_t& A)
 {
     // data traits
-    using idx_t = size_type< matrixA_t >;
-    using TX = type_t< vectorX_t >;
-    using TY = type_t< vectorY_t >;
+    using idx_t = size_type<matrixA_t>;
+    using TX = type_t<vectorX_t>;
+    using TY = type_t<vectorY_t>;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( size(x)  != n );
-    tlapack_check_false( size(y)  != n );
-    tlapack_check_false( ncols(A) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(size(x) != n);
+    tlapack_check_false(size(y) != n);
+    tlapack_check_false(ncols(A) != n);
 
     if (uplo == Uplo::Upper) {
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TY> tmp1 = alpha * conj( y[j] );
-            const scalar_type<alpha_t,TX> tmp2 = conj( alpha * x[j] );
+            const scalar_type<alpha_t, TY> tmp1 = alpha * conj(y[j]);
+            const scalar_type<alpha_t, TX> tmp2 = conj(alpha * x[j]);
             for (idx_t i = 0; i < j; ++i)
-                A(i,j) += x[i]*tmp1 + y[i]*tmp2;
-            A(j,j) = real( A(j,j) ) + real(x[j])*real(tmp1)
-                                    - imag(x[j])*imag(tmp1)
-                                    + real(y[j])*real(tmp2)
-                                    - imag(y[j])*imag(tmp2);
+                A(i, j) += x[i] * tmp1 + y[i] * tmp2;
+            A(j, j) = real(A(j, j)) + real(x[j]) * real(tmp1) -
+                      imag(x[j]) * imag(tmp1) + real(y[j]) * real(tmp2) -
+                      imag(y[j]) * imag(tmp2);
         }
     }
     else {
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TY> tmp1 = alpha * conj( y[j] );
-            const scalar_type<alpha_t,TX> tmp2 = conj( alpha * x[j] );
-            A(j,j) = real( A(j,j) ) + real(x[j])*real(tmp1)
-                                    - imag(x[j])*imag(tmp1)
-                                    + real(y[j])*real(tmp2)
-                                    - imag(y[j])*imag(tmp2);
-            for (idx_t i = j+1; i < n; ++i)
-                A(i,j) += x[i]*tmp1 + y[i]*tmp2;
+            const scalar_type<alpha_t, TY> tmp1 = alpha * conj(y[j]);
+            const scalar_type<alpha_t, TX> tmp2 = conj(alpha * x[j]);
+            A(j, j) = real(A(j, j)) + real(x[j]) * real(tmp1) -
+                      imag(x[j]) * imag(tmp1) + real(y[j]) * real(tmp2) -
+                      imag(y[j]) * imag(tmp2);
+            for (idx_t i = j + 1; i < n; ++i)
+                A(i, j) += x[i] * tmp1 + y[i] * tmp2;
         }
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t,
-        class alpha_t,
-        class T = type_t<matrixA_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void her2(
-        Uplo  uplo,
-        const alpha_t alpha,
-        const vectorX_t& x, const vectorY_t& y,
-        matrixA_t& A )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void her2(Uplo uplo,
+                 const alpha_t alpha,
+                 const vectorX_t& x,
+                 const vectorY_t& y,
+                 matrixA_t& A)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::her2(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            x_.ptr, incx,
-            y_.ptr, incy,
-            A_.ptr, A_.ldim );
-    }
+    return ::blas::her2((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                        x_.ptr, incx, y_.ptr, incy, A_.ptr, A_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_HER2_HH
+#endif  //  #ifndef TLAPACK_BLAS_HER2_HH

--- a/include/tlapack/blas/her2k.hpp
+++ b/include/tlapack/blas/her2k.hpp
@@ -54,143 +54,140 @@ namespace tlapack {
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t, class matrixB_t, class matrixC_t, 
-    class alpha_t, class beta_t,
-    enable_if_t<(
-    /* Requires: */
-        ! is_complex<beta_t>::value
-    ), int > = 0,
-    class T  = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >,
-        pair< beta_t,    real_type<T> >
-    > = 0
->
-void her2k(
-    Uplo uplo,
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-    const beta_t& beta, matrixC_t& C )
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          enable_if_t<(
+                          /* Requires: */
+                          !is_complex<beta_t>::value),
+                      int> = 0,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T>,
+                                     pair<beta_t, real_type<T> > > = 0>
+void her2k(Uplo uplo,
+           Op trans,
+           const alpha_t& alpha,
+           const matrixA_t& A,
+           const matrixB_t& B,
+           const beta_t& beta,
+           matrixC_t& C)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TB    = type_t< matrixB_t >;
-    using TC    = type_t< matrixC_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TB = type_t<matrixB_t>;
+    using TC = type_t<matrixC_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t n = (trans == Op::NoTrans) ? nrows(A) : ncols(A);
     const idx_t k = (trans == Op::NoTrans) ? ncols(A) : nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( nrows(B) != nrows(A) ||
-                   ncols(B) != ncols(A) );
-    tlapack_check_false( nrows(C) != ncols(C) );
-    tlapack_check_false( nrows(C) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::ConjTrans);
+    tlapack_check_false(nrows(B) != nrows(A) || ncols(B) != ncols(A));
+    tlapack_check_false(nrows(C) != ncols(C));
+    tlapack_check_false(nrows(C) != n);
 
     if (trans == Op::NoTrans) {
         if (uplo != Uplo::Lower) {
-        // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
+            // uplo == Uplo::Upper or uplo == Uplo::General
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i < j; ++i)
+                    C(i, j) *= beta;
+                C(j, j) = TC(beta * real(C(j, j)));
 
-                for(idx_t i = 0; i < j; ++i)
-                    C(i,j) *= beta;
-                C(j,j) = TC( beta * real(C(j,j)) );
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_type<alpha_t, TB> alphaConjBjl =
+                        alpha * conj(B(j, l));
+                    const scalar_type<alpha_t, TA> conjAlphaAjl =
+                        conj(alpha * A(j, l));
 
-                for(idx_t l = 0; l < k; ++l) {
-
-                    const scalar_type<alpha_t,TB> alphaConjBjl = alpha*conj( B(j,l) );
-                    const scalar_type<alpha_t,TA> conjAlphaAjl = conj( alpha*A(j,l) );
-
-                    for(idx_t i = 0; i < j; ++i)
-                        C(i,j) += A(i,l)*alphaConjBjl + B(i,l)*conjAlphaAjl;
-                    C(j,j) += 2 * (real(A(j,l)) * real(alphaConjBjl)
-                                    - imag(A(j,l)) * imag(alphaConjBjl));
+                    for (idx_t i = 0; i < j; ++i)
+                        C(i, j) +=
+                            A(i, l) * alphaConjBjl + B(i, l) * conjAlphaAjl;
+                    C(j, j) += 2 * (real(A(j, l)) * real(alphaConjBjl) -
+                                    imag(A(j, l)) * imag(alphaConjBjl));
                 }
             }
         }
-        else { // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
+        else {  // uplo == Uplo::Lower
+            for (idx_t j = 0; j < n; ++j) {
+                C(j, j) = TC(beta * real(C(j, j)));
+                for (idx_t i = j + 1; i < n; ++i)
+                    C(i, j) *= beta;
 
-                C(j,j) = TC( beta * real(C(j,j)) );
-                for(idx_t i = j+1; i < n; ++i)
-                    C(i,j) *= beta;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_type<alpha_t, TB> alphaConjBjl =
+                        alpha * conj(B(j, l));
+                    const scalar_type<alpha_t, TA> conjAlphaAjl =
+                        conj(alpha * A(j, l));
 
-                for(idx_t l = 0; l < k; ++l) {
-
-                    const scalar_type<alpha_t,TB> alphaConjBjl = alpha*conj( B(j,l) );
-                    const scalar_type<alpha_t,TA> conjAlphaAjl = conj( alpha*A(j,l) );
-
-                    C(j,j) += 2 * (real(A(j,l)) * real(alphaConjBjl)
-                                    - imag(A(j,l)) * imag(alphaConjBjl));
-                    for(idx_t i = j+1; i < n; ++i)
-                        C(i,j) += A(i,l) * alphaConjBjl + B(i,l) * conjAlphaAjl;
+                    C(j, j) += 2 * (real(A(j, l)) * real(alphaConjBjl) -
+                                    imag(A(j, l)) * imag(alphaConjBjl));
+                    for (idx_t i = j + 1; i < n; ++i)
+                        C(i, j) +=
+                            A(i, l) * alphaConjBjl + B(i, l) * conjAlphaAjl;
                 }
             }
         }
     }
-    else { // trans == Op::ConjTrans
-        using scalar_t = scalar_type<TA,TB>;
+    else {  // trans == Op::ConjTrans
+        using scalar_t = scalar_type<TA, TB>;
 
         if (uplo != Uplo::Lower) {
-        // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i <= j; ++i) {
-
-                    scalar_t sum1( 0 );
-                    scalar_t sum2( 0 );
-                    for(idx_t l = 0; l < k; ++l) {
-                        sum1 += conj( A(l,i) ) * B(l,j);
-                        sum2 += conj( B(l,i) ) * A(l,j);
+            // uplo == Uplo::Upper or uplo == Uplo::General
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i <= j; ++i) {
+                    scalar_t sum1(0);
+                    scalar_t sum2(0);
+                    for (idx_t l = 0; l < k; ++l) {
+                        sum1 += conj(A(l, i)) * B(l, j);
+                        sum2 += conj(B(l, i)) * A(l, j);
                     }
 
-                    C(i,j) = (i < j)
-                        ? alpha*sum1 + conj(alpha)*sum2 + beta*C(i,j)
-                        : real(alpha)*real(sum1)
-                            - imag(alpha)*imag(sum1)
-                            + real(alpha)*real(sum2)
-                            + imag(alpha)*imag(sum2)
-                            + beta*real( C(i,j) );
+                    C(i, j) = (i < j) ? alpha * sum1 + conj(alpha) * sum2 +
+                                            beta * C(i, j)
+                                      : real(alpha) * real(sum1) -
+                                            imag(alpha) * imag(sum1) +
+                                            real(alpha) * real(sum2) +
+                                            imag(alpha) * imag(sum2) +
+                                            beta * real(C(i, j));
                 }
             }
         }
-        else { // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = j; i < n; ++i) {
-
-                    scalar_t sum1( 0 );
-                    scalar_t sum2( 0 );
-                    for(idx_t l = 0; l < k; ++l) {
-                        sum1 += conj( A(l,i) ) * B(l,j);
-                        sum2 += conj( B(l,i) ) * A(l,j);
+        else {  // uplo == Uplo::Lower
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = j; i < n; ++i) {
+                    scalar_t sum1(0);
+                    scalar_t sum2(0);
+                    for (idx_t l = 0; l < k; ++l) {
+                        sum1 += conj(A(l, i)) * B(l, j);
+                        sum2 += conj(B(l, i)) * A(l, j);
                     }
 
-                    C(i,j) = (i > j)
-                        ? alpha*sum1 + conj(alpha)*sum2 + beta*C(i,j)
-                        : real(alpha)*real(sum1)
-                            - imag(alpha)*imag(sum1)
-                            + real(alpha)*real(sum2)
-                            + imag(alpha)*imag(sum2)
-                            + beta*real( C(i,j) );
+                    C(i, j) = (i > j) ? alpha * sum1 + conj(alpha) * sum2 +
+                                            beta * C(i, j)
+                                      : real(alpha) * real(sum1) -
+                                            imag(alpha) * imag(sum1) +
+                                            real(alpha) * real(sum2) +
+                                            imag(alpha) * imag(sum2) +
+                                            beta * real(C(i, j));
                 }
             }
         }
     }
 
     if (uplo == Uplo::General) {
-        for(idx_t j = 0; j < n; ++j) {
-            for(idx_t i = j+1; i < n; ++i)
-                C(i,j) = conj( C(j,i) );
+        for (idx_t j = 0; j < n; ++j) {
+            for (idx_t i = j + 1; i < n; ++i)
+                C(i, j) = conj(C(j, i));
         }
     }
 }
@@ -231,148 +228,134 @@ void her2k(
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t, class matrixB_t, class matrixC_t, 
-    class alpha_t,
-    class T  = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >
-    > = 0
->
-inline
-void her2k(
-    Uplo uplo,
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-    matrixC_t& C )
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T> > = 0>
+inline void her2k(Uplo uplo,
+                  Op trans,
+                  const alpha_t& alpha,
+                  const matrixA_t& A,
+                  const matrixB_t& B,
+                  matrixC_t& C)
 {
-    return her2k( uplo, trans, alpha, A, B, internal::StrongZero(), C );
+    return her2k(uplo, trans, alpha, A, B, internal::StrongZero(), C);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    /**
-     * Hermitian rank-k update
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see her2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-        const beta_t& beta, matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t, class matrixB_t, class matrixC_t, 
-        class alpha_t, class beta_t,
-        enable_if_t<(
-        /* Requires: */
-            ! is_complex<beta_t>::value
-        ), int > = 0,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >,
-            pair< beta_t,    real_type<T> >
-        > = 0
-    >
-    inline
-    void her2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
-        const beta_t beta, matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
+/**
+ * Hermitian rank-k update
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see her2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t& beta, matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          enable_if_t<(
+                          /* Requires: */
+                          !is_complex<beta_t>::value),
+                      int> = 0,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T>,
+                                    pair<beta_t, real_type<T> > > = 0>
+inline void her2k(Uplo uplo,
+                  Op trans,
+                  const alpha_t alpha,
+                  const matrixA_t& A,
+                  const matrixB_t& B,
+                  const beta_t beta,
+                  matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& n = C_.n;
-        const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -6,
+            "Infs and NaNs in C on input will not propagate to C on output");
 
-        return ::blas::her2k(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans, 
-            n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            beta,
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::her2k((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                         (::blas::Op)trans, n, k, alpha, A_.ptr, A_.ldim,
+                         B_.ptr, B_.ldim, beta, C_.ptr, C_.ldim);
+}
 
-    /**
-     * Hermitian rank-k update
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see her2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-        matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t, class matrixB_t, class matrixC_t, 
-        class alpha_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >
-        > = 0
-    >
-    inline
-    void her2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
-        matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
+/**
+ * Hermitian rank-k update
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see her2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T> > = 0>
+inline void her2k(Uplo uplo,
+                  Op trans,
+                  const alpha_t alpha,
+                  const matrixA_t& A,
+                  const matrixB_t& B,
+                  matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& n = C_.n;
-        const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
 
-        return ::blas::her2k(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans, 
-            n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            real_type<T>(0),
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::her2k((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                         (::blas::Op)trans, n, k, alpha, A_.ptr, A_.ldim,
+                         B_.ptr, B_.ldim, real_type<T>(0), C_.ptr, C_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_HER2K_HH
+#endif  //  #ifndef TLAPACK_BLAS_HER2K_HH

--- a/include/tlapack/blas/iamax.hpp
+++ b/include/tlapack/blas/iamax.hpp
@@ -11,19 +11,20 @@
 #ifndef TLAPACK_BLAS_IAMAX_HH
 #define TLAPACK_BLAS_IAMAX_HH
 
-#include "tlapack/base/utils.hpp"
 #include "tlapack/base/constants.hpp"
+#include "tlapack/base/utils.hpp"
 
 namespace tlapack {
 
 /**
  * @brief Return $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$
- * 
+ *
  * Version with NaN checks.
- * @see iamax_nc( const vector_t& x ) for the version that does not check for NaNs.
- * 
+ * @see iamax_nc( const vector_t& x ) for the version that does not check for
+ * NaNs.
+ *
  * @param[in] x The n-element vector x.
- * 
+ *
  * @return In priority order:
  * 1. 0 if n <= 0,
  * 2. the index of the first `NAN` in $x$ if it exists,
@@ -33,36 +34,34 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< class vector_t >
-size_type<vector_t>
-iamax_ec( const vector_t& x )
+template <class vector_t>
+size_type<vector_t> iamax_ec(const vector_t& x)
 {
     // data traits
-    using idx_t  = size_type< vector_t >;
-    using T      = type_t<vector_t>;
-    using real_t = real_type< T >;
+    using idx_t = size_type<vector_t>;
+    using T = type_t<vector_t>;
+    using real_t = real_type<T>;
 
     // constants
-    const real_t oneFourth( 0.25 );
+    const real_t oneFourth(0.25);
     const idx_t n = size(x);
 
     // quick return
-    if( n <= 0 ) return 0;
+    if (n <= 0) return 0;
 
-    bool scaledsmax = false; // indicates whether |Re(x_i)| + |Im(x_i)| = Inf
-    real_t smax( -1 );
+    bool scaledsmax = false;  // indicates whether |Re(x_i)| + |Im(x_i)| = Inf
+    real_t smax(-1);
     idx_t index = -1;
     idx_t i = 0;
     for (; i < n; ++i) {
-        if ( isnan(x[i]) ) {
+        if (isnan(x[i])) {
             // return when first NaN found
             return i;
         }
-        else if ( isinf(x[i]) ) {
-            
+        else if (isinf(x[i])) {
             // keep looking for first NaN
-            for (idx_t k = i+1; k < n; ++k) {
-                if ( isnan(x[k]) ) {
+            for (idx_t k = i + 1; k < n; ++k) {
+                if (isnan(x[k])) {
                     // return when first NaN found
                     return k;
                 }
@@ -71,29 +70,29 @@ iamax_ec( const vector_t& x )
             // return the position of the first Inf
             return i;
         }
-        else { // still no Inf found yet
-            if ( ! is_complex<T>::value ) {
+        else {  // still no Inf found yet
+            if (!is_complex<T>::value) {
                 real_t a = abs1(x[i]);
-                if ( a > smax ) {
+                if (a > smax) {
                     smax = a;
                     index = i;
                 }
             }
-            else if ( !scaledsmax ) { // no |Re(x_i)| + |Im(x_i)| = Inf  yet
+            else if (!scaledsmax) {  // no |Re(x_i)| + |Im(x_i)| = Inf  yet
                 real_t a = abs1(x[i]);
-                if ( isinf(a) ) {
+                if (isinf(a)) {
                     scaledsmax = true;
-                    smax = abs1( oneFourth*x[i] );
+                    smax = abs1(oneFourth * x[i]);
                     index = i;
                 }
-                else if ( a > smax ) {
+                else if (a > smax) {
                     smax = a;
                     index = i;
                 }
             }
-            else { // scaledsmax = true
-                real_t a = abs1( oneFourth*x[i] );
-                if ( a > smax ) {
+            else {  // scaledsmax = true
+                real_t a = abs1(oneFourth * x[i]);
+                if (a > smax) {
                     smax = a;
                     index = i;
                 }
@@ -106,12 +105,12 @@ iamax_ec( const vector_t& x )
 
 /**
  * @brief Return $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$
- * 
+ *
  * Version with no NaN checks.
  * @see iamax_ec( const vector_t& x ) for the version that check for NaNs.
- * 
+ *
  * @param[in] x The n-element vector x.
- * 
+ *
  * @return In priority order:
  * 1. 0 if n <= 0,
  * 2. the index of the first `Infinity` in $x$ if it exists,
@@ -120,54 +119,53 @@ iamax_ec( const vector_t& x )
  *
  * @ingroup blas1
  */
-template< class vector_t >
-size_type<vector_t>
-iamax_nc( const vector_t& x )
+template <class vector_t>
+size_type<vector_t> iamax_nc(const vector_t& x)
 {
     // data traits
-    using idx_t  = size_type< vector_t >;
-    using T      = type_t<vector_t>;
-    using real_t = real_type< T >;
+    using idx_t = size_type<vector_t>;
+    using T = type_t<vector_t>;
+    using real_t = real_type<T>;
 
     // constants
-    const real_t oneFourth( 0.25 );
+    const real_t oneFourth(0.25);
     const idx_t n = size(x);
 
     // quick return
-    if( n <= 0 ) return 0;
+    if (n <= 0) return 0;
 
-    bool scaledsmax = false; // indicates whether |Re(x_i)| + |Im(x_i)| = Inf
-    real_t smax( -1 );
+    bool scaledsmax = false;  // indicates whether |Re(x_i)| + |Im(x_i)| = Inf
+    real_t smax(-1);
     idx_t index = -1;
     idx_t i = 0;
     for (; i < n; ++i) {
-        if ( isinf(x[i]) ) {
+        if (isinf(x[i])) {
             // return the position of the first Inf
             return i;
         }
-        else { // still no Inf found yet
-            if ( ! is_complex<T>::value ) {
+        else {  // still no Inf found yet
+            if (!is_complex<T>::value) {
                 real_t a = abs1(x[i]);
-                if ( a > smax ) {
+                if (a > smax) {
                     smax = a;
                     index = i;
                 }
             }
-            else if ( !scaledsmax ) { // no |Re(x_i)| + |Im(x_i)| = Inf  yet
+            else if (!scaledsmax) {  // no |Re(x_i)| + |Im(x_i)| = Inf  yet
                 real_t a = abs1(x[i]);
-                if ( isinf(a) ) {
+                if (isinf(a)) {
                     scaledsmax = true;
-                    smax = abs1( oneFourth*x[i] );
+                    smax = abs1(oneFourth * x[i]);
                     index = i;
                 }
-                else if ( a > smax ) {
+                else if (a > smax) {
                     smax = a;
                     index = i;
                 }
             }
-            else { // scaledsmax = true
-                real_t a = abs1( oneFourth*x[i] );
-                if ( a > smax ) {
+            else {  // scaledsmax = true
+                real_t a = abs1(oneFourth * x[i]);
+                if (a > smax) {
                     smax = a;
                     index = i;
                 }
@@ -180,14 +178,15 @@ iamax_nc( const vector_t& x )
 
 /**
  * @brief Return $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$
- * 
- * @see iamax_nc( const vector_t& x ) for the version that does not check for NaNs.
+ *
+ * @see iamax_nc( const vector_t& x ) for the version that does not check for
+ * NaNs.
  * @see iamax_ec( const vector_t& x ) for the version that check for NaNs.
- * 
+ *
  * @param[in] x The n-element vector x.
  * @param[in] opts Options.
  *      Define the behavior of checks for NaNs.
- * 
+ *
  * @return In priority order:
  * 1. 0 if n <= 0,
  * 2. the index of the first `NAN` in $x$ if it exists and if `ec.nan == true`,
@@ -197,31 +196,23 @@ iamax_nc( const vector_t& x )
  *
  * @ingroup blas1
  */
-template< class vector_t, 
-    disable_if_allow_optblas_t< vector_t > = 0
->
-inline
-size_type<vector_t>
-iamax( const vector_t& x, const ec_opts_t& opts = {} )
+template <class vector_t, disable_if_allow_optblas_t<vector_t> = 0>
+inline size_type<vector_t> iamax(const vector_t& x, const ec_opts_t& opts = {})
 {
-    return ( opts.ec.nan == true ) ? iamax_ec(x) : iamax_nc(x);
+    return (opts.ec.nan == true) ? iamax_ec(x) : iamax_nc(x);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vector_t,
-        enable_if_allow_optblas_t< vector_t > = 0
-    >
-    inline
-    size_type<vector_t>
-    iamax( vector_t const& x )
-    {
-        auto x_ = legacy_vector(x);
-        return ::blas::iamax( x_.n, x_.ptr, x_.inc );
-    }
+template <class vector_t, enable_if_allow_optblas_t<vector_t> = 0>
+inline size_type<vector_t> iamax(vector_t const& x)
+{
+    auto x_ = legacy_vector(x);
+    return ::blas::iamax(x_.n, x_.ptr, x_.inc);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_IAMAX_HH
+#endif  //  #ifndef TLAPACK_BLAS_IAMAX_HH

--- a/include/tlapack/blas/nrm2.hpp
+++ b/include/tlapack/blas/nrm2.hpp
@@ -16,8 +16,8 @@
 #ifndef TLAPACK_BLAS_NRM2_HH
 #define TLAPACK_BLAS_NRM2_HH
 
-#include "tlapack/base/utils.hpp"
 #include "tlapack/base/constants.hpp"
+#include "tlapack/base/utils.hpp"
 
 namespace tlapack {
 
@@ -29,20 +29,18 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< class vector_t,
-    disable_if_allow_optblas_t< vector_t > = 0
->
-auto nrm2( const vector_t& x )
+template <class vector_t, disable_if_allow_optblas_t<vector_t> = 0>
+auto nrm2(const vector_t& x)
 {
-    using real_t = real_type< type_t<vector_t> >;
-    using idx_t  = size_type< vector_t >;
+    using real_t = real_type<type_t<vector_t> >;
+    using idx_t = size_type<vector_t>;
 
     // constants
     const idx_t n = size(x);
 
     // constants
-    const real_t zero( 0 );
-    const real_t one( 1 );
+    const real_t zero(0);
+    const real_t one(1);
     const real_t tsml = blue_min<real_t>();
     const real_t tbig = blue_max<real_t>();
     const real_t ssml = blue_scalingMin<real_t>();
@@ -53,7 +51,7 @@ auto nrm2( const vector_t& x )
     real_t sumsq = zero;
 
     // quick return
-    if( n <= 0 ) return zero;
+    if (n <= 0) return zero;
 
     // Compute the sum of squares in 3 accumulators:
     //    abig -- sums of squares scaled down to avoid overflow
@@ -66,45 +64,44 @@ auto nrm2( const vector_t& x )
     real_t amed = zero;
     real_t abig = zero;
 
-    for (idx_t i = 0; i < n; ++i)
-    {
-        real_t ax = tlapack::abs( x[i] );
-        if( ax > tbig )
-            abig += (ax*sbig) * (ax*sbig);
-        else if( ax < tsml ) {
-            if( abig == zero ) asml += (ax*ssml) * (ax*ssml);
-        } else
+    for (idx_t i = 0; i < n; ++i) {
+        real_t ax = tlapack::abs(x[i]);
+        if (ax > tbig)
+            abig += (ax * sbig) * (ax * sbig);
+        else if (ax < tsml) {
+            if (abig == zero) asml += (ax * ssml) * (ax * ssml);
+        }
+        else
             amed += ax * ax;
     }
 
     // Combine abig and amed or amed and asml if
     // more than one accumulator was used.
 
-    if( abig > zero ) {
+    if (abig > zero) {
         // Combine abig and amed if abig > 0
-        if( amed > zero || isnan(amed) )
-            abig += (amed*sbig)*sbig;
+        if (amed > zero || isnan(amed)) abig += (amed * sbig) * sbig;
         scl = one / sbig;
         sumsq = abig;
     }
-    else if( asml > zero ) {
+    else if (asml > zero) {
         // Combine amed and asml if asml > 0
-        if( amed > zero || isnan(amed) ) {
-            
+        if (amed > zero || isnan(amed)) {
             amed = sqrt(amed);
             asml = sqrt(asml) / ssml;
-            
+
             real_t ymin, ymax;
-            if( asml > amed ) {
+            if (asml > amed) {
                 ymin = amed;
                 ymax = asml;
-            } else {
+            }
+            else {
                 ymin = asml;
                 ymax = amed;
             }
 
             scl = one;
-            sumsq = (ymax * ymax) * ( one + (ymin/ymax) * (ymin/ymax) );
+            sumsq = (ymax * ymax) * (one + (ymin / ymax) * (ymin / ymax));
         }
         else {
             scl = one / ssml;
@@ -117,23 +114,20 @@ auto nrm2( const vector_t& x )
         sumsq = amed;
     }
 
-    return real_t( scl * sqrt(sumsq) );
+    return real_t(scl * sqrt(sumsq));
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vector_t,
-        enable_if_allow_optblas_t< vector_t > = 0
-    >
-    inline
-    auto nrm2( vector_t const& x )
-    {
-        auto x_ = legacy_vector(x);
-        return ::blas::nrm2( x_.n, x_.ptr, x_.inc );
-    }
+template <class vector_t, enable_if_allow_optblas_t<vector_t> = 0>
+inline auto nrm2(vector_t const& x)
+{
+    auto x_ = legacy_vector(x);
+    return ::blas::nrm2(x_.n, x_.ptr, x_.inc);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        // #ifndef TLAPACK_BLAS_NRM2_HH
+#endif  // #ifndef TLAPACK_BLAS_NRM2_HH

--- a/include/tlapack/blas/rot.hpp
+++ b/include/tlapack/blas/rot.hpp
@@ -32,75 +32,68 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template<
-    class vectorX_t, class vectorY_t,
-    class c_type, class s_type,
-    class T = type_t<vectorX_t>,
-    disable_if_allow_optblas_t<
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >,
-        pair< c_type, real_type<T> >,
-        pair< s_type, real_type<T> >
-    > = 0
->
-void rot(
-    vectorX_t& x, vectorY_t& y,
-    const c_type& c, const s_type& s )
+template <class vectorX_t,
+          class vectorY_t,
+          class c_type,
+          class s_type,
+          class T = type_t<vectorX_t>,
+          disable_if_allow_optblas_t<pair<vectorX_t, T>,
+                                     pair<vectorY_t, T>,
+                                     pair<c_type, real_type<T> >,
+                                     pair<s_type, real_type<T> > > = 0>
+void rot(vectorX_t& x, vectorY_t& y, const c_type& c, const s_type& s)
 {
-    using idx_t = size_type< vectorX_t >;
-    using scalar_t = scalar_type< c_type, s_type, type_t<vectorX_t>, type_t<vectorY_t> >;
+    using idx_t = size_type<vectorX_t>;
+    using scalar_t =
+        scalar_type<c_type, s_type, type_t<vectorX_t>, type_t<vectorY_t> >;
 
     // constants
     const idx_t n = size(x);
 
     // check arguments
-    tlapack_check_false( size(y) != n );
+    tlapack_check_false(size(y) != n);
 
     // quick return
-    if ( n == 0 || (c == c_type(1) && s == s_type(0)) )
-        return;
+    if (n == 0 || (c == c_type(1) && s == s_type(0))) return;
 
     for (idx_t i = 0; i < n; ++i) {
-        const scalar_t stmp = c*x[i] + s*y[i];
-        y[i] = c*y[i] - conj(s)*x[i];
+        const scalar_t stmp = c * x[i] + s * y[i];
+        y[i] = c * y[i] - conj(s) * x[i];
         x[i] = stmp;
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class vectorX_t, class vectorY_t,
-        class c_type, class s_type,
-        class T = type_t<vectorX_t>,
-        enable_if_allow_optblas_t<
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >,
-            pair< c_type, real_type<T> >,
-            pair< s_type, real_type<T> >
-        > = 0
-    >
-    inline
-    void rot(
-        vectorX_t& x, vectorY_t& y,
-        const c_type c, const s_type s )
-    {
-        using idx_t = size_type< vectorX_t >;
+template <class vectorX_t,
+          class vectorY_t,
+          class c_type,
+          class s_type,
+          class T = type_t<vectorX_t>,
+          enable_if_allow_optblas_t<pair<vectorX_t, T>,
+                                    pair<vectorY_t, T>,
+                                    pair<c_type, real_type<T> >,
+                                    pair<s_type, real_type<T> > > = 0>
+inline void rot(vectorX_t& x, vectorY_t& y, const c_type c, const s_type s)
+{
+    using idx_t = size_type<vectorX_t>;
 
-        // Legacy objects
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = x_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = x_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::rot( n, x_.ptr, incx, y_.ptr, incy, c, s );
-    }
+    return ::blas::rot(n, x_.ptr, incx, y_.ptr, incy, c, s);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_ROT_HH
+#endif  //  #ifndef TLAPACK_BLAS_ROT_HH

--- a/include/tlapack/blas/rotg.hpp
+++ b/include/tlapack/blas/rotg.hpp
@@ -33,16 +33,13 @@ namespace tlapack {
  * @ingroup blas1
  */
 template <typename T,
-    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
-    disable_if_allow_optblas_t< T > = 0
->
-void rotg(
-    T& a, T& b,
-    T& c, T& s )
+          enable_if_t<is_same_v<T, real_type<T> >, int> = 0,
+          disable_if_allow_optblas_t<T> = 0>
+void rotg(T& a, T& b, T& c, T& s)
 {
     // Constants
-    const T one( 1 );
-    const T zero( 0 );
+    const T one(1);
+    const T zero(0);
 
     // Scaling constants
     const T safmin = safe_min<T>();
@@ -53,27 +50,27 @@ void rotg(
     const T bnorm = tlapack::abs(b);
 
     // quick return
-    if ( bnorm == zero ) {
+    if (bnorm == zero) {
         c = one;
         s = zero;
         b = zero;
     }
-    else if ( anorm == zero ) {
+    else if (anorm == zero) {
         c = zero;
         s = one;
         a = b;
         b = one;
     }
     else {
-        T scl = min( safmax, max(safmin, anorm, bnorm) );
-        T sigma( (anorm > bnorm) ? sgn(a) : sgn(b) );
-        T r = sigma * scl * sqrt( (a/scl) * (a/scl) + (b/scl) * (b/scl) );
+        T scl = min(safmax, max(safmin, anorm, bnorm));
+        T sigma((anorm > bnorm) ? sgn(a) : sgn(b));
+        T r = sigma * scl * sqrt((a / scl) * (a / scl) + (b / scl) * (b / scl));
         c = a / r;
         s = b / r;
         a = r;
-        if ( anorm > bnorm )
+        if (anorm > bnorm)
             b = s;
-        else if ( c != zero )
+        else if (c != zero)
             b = one / c;
         else
             b = one;
@@ -103,13 +100,9 @@ void rotg(
  * @ingroup blas1
  */
 template <typename T,
-    enable_if_t< !is_same_v< T, real_type<T> >, int > = 0,
-    disable_if_allow_optblas_t< T > = 0
->
-void rotg(
-    T& a, const T& b,
-    real_type<T>& c,
-    T& s )
+          enable_if_t<!is_same_v<T, real_type<T> >, int> = 0,
+          disable_if_allow_optblas_t<T> = 0>
+void rotg(T& a, const T& b, real_type<T>& c, T& s)
 {
     typedef real_type<T> real_t;
     typedef T scalar_t;
@@ -121,131 +114,124 @@ void rotg(
     // Scaling constants
     const real_t safmin = safe_min<real_t>();
     const real_t safmax = safe_max<real_t>();
-    const real_t rtmin  = root_min<real_t>();
-    const real_t rtmax  = root_max<real_t>();
+    const real_t rtmin = root_min<real_t>();
+    const real_t rtmax = root_max<real_t>();
 
     // quick return
-    if ( b == zero ) {
+    if (b == zero) {
         c = one;
         s = zero;
         return;
     }
 
-    if ( a == zero ) {
+    if (a == zero) {
         c = zero;
-        real_t g1 = max( tlapack::abs(real(b)), tlapack::abs(imag(b)) );
-        if ( g1 > rtmin && g1 < rtmax ) {
+        real_t g1 = max(tlapack::abs(real(b)), tlapack::abs(imag(b)));
+        if (g1 > rtmin && g1 < rtmax) {
             // Use unscaled algorithm
-            real_t g2 = real(b)*real(b) + imag(b)*imag(b);
-            real_t d = sqrt( g2 );
-            s = conj( b ) / d;
+            real_t g2 = real(b) * real(b) + imag(b) * imag(b);
+            real_t d = sqrt(g2);
+            s = conj(b) / d;
             a = d;
         }
         else {
             // Use scaled algorithm
-            real_t u = min( safmax, max( safmin, g1 ) );
+            real_t u = min(safmax, max(safmin, g1));
             real_t uu = one / u;
-            scalar_t gs = b*uu;
-            real_t g2 = real(gs)*real(gs) + imag(gs)*imag(gs);
-            real_t d = sqrt( g2 );
-            s = conj( gs ) / d;
-            a = d*u;
+            scalar_t gs = b * uu;
+            real_t g2 = real(gs) * real(gs) + imag(gs) * imag(gs);
+            real_t d = sqrt(g2);
+            s = conj(gs) / d;
+            a = d * u;
         }
     }
     else {
-        real_t f1 = max( tlapack::abs(real(a)), tlapack::abs(imag(a)) );
-        real_t g1 = max( tlapack::abs(real(b)), tlapack::abs(imag(b)) );
-        if ( f1 > rtmin && f1 < rtmax &&
-            g1 > rtmin && g1 < rtmax ) {
+        real_t f1 = max(tlapack::abs(real(a)), tlapack::abs(imag(a)));
+        real_t g1 = max(tlapack::abs(real(b)), tlapack::abs(imag(b)));
+        if (f1 > rtmin && f1 < rtmax && g1 > rtmin && g1 < rtmax) {
             // Use unscaled algorithm
-            real_t f2 = real(a)*real(a) + imag(a)*imag(a);
-            real_t g2 = real(b)*real(b) + imag(b)*imag(b);
+            real_t f2 = real(a) * real(a) + imag(a) * imag(a);
+            real_t g2 = real(b) * real(b) + imag(b) * imag(b);
             real_t h2 = f2 + g2;
-            real_t d = ( f2 > rtmin && h2 < rtmax )
-                       ? sqrt( f2*h2 )
-                       : sqrt( f2 )*sqrt( h2 );
+            real_t d = (f2 > rtmin && h2 < rtmax) ? sqrt(f2 * h2)
+                                                  : sqrt(f2) * sqrt(h2);
             real_t p = one / d;
-            c  = f2*p;
-            s  = conj( b )*( a*p );
-            a *= h2*p ;
+            c = f2 * p;
+            s = conj(b) * (a * p);
+            a *= h2 * p;
         }
         else {
             // Use scaled algorithm
-            real_t u = min( safmax, max( safmin, f1, g1 ) );
+            real_t u = min(safmax, max(safmin, f1, g1));
             real_t uu = one / u;
-            scalar_t gs = b*uu;
-            real_t g2 = real(gs)*real(gs) + imag(gs)*imag(gs);
+            scalar_t gs = b * uu;
+            real_t g2 = real(gs) * real(gs) + imag(gs) * imag(gs);
             real_t f2, h2, w;
             scalar_t fs;
-            if ( f1*uu < rtmin ) {
+            if (f1 * uu < rtmin) {
                 // a is not well-scaled when scaled by g1.
-                real_t v = min( safmax, max( safmin, f1 ) );
+                real_t v = min(safmax, max(safmin, f1));
                 real_t vv = one / v;
                 w = v * uu;
-                fs = a*vv;
-                f2 = real(fs)*real(fs) + imag(fs)*imag(fs);
-                h2 = f2*w*w + g2;
+                fs = a * vv;
+                f2 = real(fs) * real(fs) + imag(fs) * imag(fs);
+                h2 = f2 * w * w + g2;
             }
             else {
                 // Otherwise use the same scaling for a and b.
                 w = one;
-                fs = a*uu;
-                f2 = real(fs)*real(fs) + imag(fs)*imag(fs);
+                fs = a * uu;
+                f2 = real(fs) * real(fs) + imag(fs) * imag(fs);
                 h2 = f2 + g2;
             }
-            real_t d = ( f2 > rtmin && h2 < rtmax )
-                       ? sqrt( f2*h2 )
-                       : sqrt( f2 )*sqrt( h2 );
+            real_t d = (f2 > rtmin && h2 < rtmax) ? sqrt(f2 * h2)
+                                                  : sqrt(f2) * sqrt(h2);
             real_t p = one / d;
-            c = ( f2*p )*w;
-            s = conj( gs )*( fs*p );
-            a = ( fs*( h2*p ) )*u;
+            c = (f2 * p) * w;
+            s = conj(gs) * (fs * p);
+            a = (fs * (h2 * p)) * u;
         }
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template <typename T,
-        enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
-        enable_if_allow_optblas_t< T > = 0
-    >
-    inline
-    void rotg( T& a, T& b, T& c, T& s )
-    {
-        // Constants
-        const T zero = 0;
-        const T one  = 1;
-        const T anorm = tlapack::abs(a);
-        const T bnorm = tlapack::abs(b);
+template <typename T,
+          enable_if_t<is_same_v<T, real_type<T> >, int> = 0,
+          enable_if_allow_optblas_t<T> = 0>
+inline void rotg(T& a, T& b, T& c, T& s)
+{
+    // Constants
+    const T zero = 0;
+    const T one = 1;
+    const T anorm = tlapack::abs(a);
+    const T bnorm = tlapack::abs(b);
 
-        T r;
-        ::lapack::lartg( a, b, &c, &s, &r );
-        
-        // Return information on a and b:
-        a = r;
-        if( s == zero || c == zero || (anorm > bnorm) )
-            b = s;
-        else if ( c != zero )
-            b = one / c;
-        else
-            b = one;
-    }
+    T r;
+    ::lapack::lartg(a, b, &c, &s, &r);
 
-    template <typename T,
-        enable_if_t< !is_same_v< T, real_type<T> >, int > = 0,
-        enable_if_allow_optblas_t< T > = 0
-    >
-    inline
-    void rotg( T& a, const T& b, real_type<T>& c, T& s )
-    {
-        T r;
-        ::lapack::lartg( a, b, &c, &s, &r );
-        a = r;
-    }
+    // Return information on a and b:
+    a = r;
+    if (s == zero || c == zero || (anorm > bnorm))
+        b = s;
+    else if (c != zero)
+        b = one / c;
+    else
+        b = one;
+}
+
+template <typename T,
+          enable_if_t<!is_same_v<T, real_type<T> >, int> = 0,
+          enable_if_allow_optblas_t<T> = 0>
+inline void rotg(T& a, const T& b, real_type<T>& c, T& s)
+{
+    T r;
+    ::lapack::lartg(a, b, &c, &s, &r);
+    a = r;
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_ROTG_HH
+#endif  //  #ifndef TLAPACK_BLAS_ROTG_HH

--- a/include/tlapack/blas/rotm.hpp
+++ b/include/tlapack/blas/rotm.hpp
@@ -24,7 +24,7 @@ namespace tlapack {
  * \]
  *
  * @see rotmg to generate the rotation, and for fuller description.
- * 
+ *
  * @tparam flag Defines the format of H.
  * - For flag = -1,
  *     \[
@@ -64,46 +64,43 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template<
+template <
     int flag,
-    class vectorX_t, class vectorY_t,
-    enable_if_t<((-2 <= flag) && (flag <= 1)), int > = 0,
+    class vectorX_t,
+    class vectorY_t,
+    enable_if_t<((-2 <= flag) && (flag <= 1)), int> = 0,
     class T = type_t<vectorX_t>,
-    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
-    disable_if_allow_optblas_t<
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void rotm( vectorX_t& x, vectorY_t& y, const T h[4] )
+    enable_if_t<is_same_v<T, real_type<T> >, int> = 0,
+    disable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+void rotm(vectorX_t& x, vectorY_t& y, const T h[4])
 {
-    using idx_t = size_type< vectorX_t >;
-    using scalar_t = scalar_type< T, type_t<vectorX_t>, type_t<vectorY_t> >;
+    using idx_t = size_type<vectorX_t>;
+    using scalar_t = scalar_type<T, type_t<vectorX_t>, type_t<vectorY_t> >;
 
     // constants
     const idx_t n = size(x);
 
     // check arguments
-    tlapack_check_false( size(y) != n );
+    tlapack_check_false(size(y) != n);
 
-    if ( flag == -1 ) {
+    if (flag == -1) {
         for (idx_t i = 0; i < n; ++i) {
-            const scalar_t stmp = h[0]*x[i] + h[2]*y[i];
-            y[i] = h[3]*y[i] + h[1]*x[i];
+            const scalar_t stmp = h[0] * x[i] + h[2] * y[i];
+            y[i] = h[3] * y[i] + h[1] * x[i];
             x[i] = stmp;
         }
     }
-    else if ( flag == 0 ) {
+    else if (flag == 0) {
         for (idx_t i = 0; i < n; ++i) {
-            const scalar_t stmp = x[i] + h[2]*y[i];
-            y[i] = y[i] + h[1]*x[i];
+            const scalar_t stmp = x[i] + h[2] * y[i];
+            y[i] = y[i] + h[1] * x[i];
             x[i] = stmp;
         }
     }
-    else if ( flag == 1 ) {
+    else if (flag == 1) {
         for (idx_t i = 0; i < n; ++i) {
-            const scalar_t stmp = h[0]*x[i] + y[i];
-            y[i] = h[3]*y[i] - x[i];
+            const scalar_t stmp = h[0] * x[i] + y[i];
+            y[i] = h[3] * y[i] - x[i];
             x[i] = stmp;
         }
     }
@@ -111,37 +108,35 @@ void rotm( vectorX_t& x, vectorY_t& y, const T h[4] )
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        int flag,
-        class vectorX_t, class vectorY_t,
-        enable_if_t<((-2 <= flag) && (flag <= 1)), int > = 0,
-        class T = type_t<vectorX_t>,
-        enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
-        enable_if_allow_optblas_t<
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void rotm( vectorX_t& x, vectorY_t& y, const T h[4] )
-    {
-        using idx_t = size_type< vectorX_t >;
+template <
+    int flag,
+    class vectorX_t,
+    class vectorY_t,
+    enable_if_t<((-2 <= flag) && (flag <= 1)), int> = 0,
+    class T = type_t<vectorX_t>,
+    enable_if_t<is_same_v<T, real_type<T> >, int> = 0,
+    enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+inline void rotm(vectorX_t& x, vectorY_t& y, const T h[4])
+{
+    using idx_t = size_type<vectorX_t>;
 
-        // Legacy objects
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = x_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
-        const T h_[] = { (T) flag, h[0], h[1], h[2], h[3] };
+    // Constants to forward
+    const idx_t& n = x_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    const T h_[] = {(T)flag, h[0], h[1], h[2], h[3]};
 
-        return ::blas::rotm( n, x_.ptr, incx, y_.ptr, incy, h_ );
-    }
+    return ::blas::rotm(n, x_.ptr, incx, y_.ptr, incy, h_);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_ROTM_HH
+#endif  //  #ifndef TLAPACK_BLAS_ROTM_HH

--- a/include/tlapack/blas/rotmg.hpp
+++ b/include/tlapack/blas/rotmg.hpp
@@ -89,21 +89,20 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< typename T,
-    enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
-    disable_if_allow_optblas_t< T > = 0
->
-int rotmg( T& d1, T& d2, T& a, const T& b, T h[4] )
+template <typename T,
+          enable_if_t<is_same_v<T, real_type<T> >, int> = 0,
+          disable_if_allow_optblas_t<T> = 0>
+int rotmg(T& d1, T& d2, T& a, const T& b, T h[4])
 {
     // check arguments
-    tlapack_check_false( d1 <= 0 );
+    tlapack_check_false(d1 <= 0);
 
     // Constants
-    const T zero( 0 );
-    const T one( 1 );
-    const T gam( 4096 );
-    const T gamsq = gam*gam;
-    const T rgamsq = one/gamsq;
+    const T zero(0);
+    const T one(1);
+    const T gam(4096);
+    const T gamsq = gam * gam;
+    const T rgamsq = one / gamsq;
 
     int flag;
     h[0] = zero;
@@ -111,34 +110,34 @@ int rotmg( T& d1, T& d2, T& a, const T& b, T h[4] )
     h[2] = zero;
     h[3] = zero;
 
-    if(d1 < zero) {
+    if (d1 < zero) {
         flag = -1;
         d1 = zero;
         d2 = zero;
         a = zero;
     }
     else {
-        const T p2 = d2*b;
-        if(p2 == zero) {
+        const T p2 = d2 * b;
+        if (p2 == zero) {
             flag = -2;
         }
         else {
-            const T p1 = d1*a;
-            const T q2 = p2*b;
-            const T q1 = p1*a;
+            const T p1 = d1 * a;
+            const T q2 = p2 * b;
+            const T q1 = p1 * a;
 
-            if( tlapack::abs(q1) > tlapack::abs(q2) ) {
+            if (tlapack::abs(q1) > tlapack::abs(q2)) {
                 flag = zero;
-                h[1] = -b/a;
-                h[2] = p2/p1;
-                const T u = one - h[2]*h[1];
-                if( u > zero ) {
+                h[1] = -b / a;
+                h[2] = p2 / p1;
+                const T u = one - h[2] * h[1];
+                if (u > zero) {
                     d1 /= u;
                     d2 /= u;
                     a *= u;
                 }
             }
-            else if(q2 < zero) {
+            else if (q2 < zero) {
                 flag = -1;
                 d1 = zero;
                 d2 = zero;
@@ -146,18 +145,18 @@ int rotmg( T& d1, T& d2, T& a, const T& b, T h[4] )
             }
             else {
                 flag = 1;
-                h[0] = p1/p2;
-                h[3] = a/b;
-                const T u = one + h[0]*h[3];
-                const T stemp = d2/u;
-                d2 = d1/u;
+                h[0] = p1 / p2;
+                h[3] = a / b;
+                const T u = one + h[0] * h[3];
+                const T stemp = d2 / u;
+                d2 = d1 / u;
                 d1 = stemp;
-                a = b*u;
+                a = b * u;
             }
 
-            if(d1 != zero) {
-                while( (d1 <= rgamsq) || (d1 >= gamsq) ) {
-                    if(flag == 0) {
+            if (d1 != zero) {
+                while ((d1 <= rgamsq) || (d1 >= gamsq)) {
+                    if (flag == 0) {
                         h[0] = one;
                         h[3] = one;
                         flag = -1;
@@ -167,40 +166,41 @@ int rotmg( T& d1, T& d2, T& a, const T& b, T h[4] )
                         h[2] = one;
                         flag = -1;
                     }
-                    if(d1 <= rgamsq) {
-                        d1  *= gam*gam;
-                        a  /= gam;
+                    if (d1 <= rgamsq) {
+                        d1 *= gam * gam;
+                        a /= gam;
                         h[0] /= gam;
                         h[2] /= gam;
                     }
                     else {
-                        d1 /= gam*gam;
-                        a  *= gam;
+                        d1 /= gam * gam;
+                        a *= gam;
                         h[0] *= gam;
                         h[2] *= gam;
                     }
                 }
             }
 
-            if(d2 != zero) {
-                while( (tlapack::abs(d2) <= rgamsq) || (tlapack::abs(d2) >= gamsq) ) {
-                    if(flag == 0) {
-                        h[0]=one;
-                        h[3]=one;
-                        flag=-1;
+            if (d2 != zero) {
+                while ((tlapack::abs(d2) <= rgamsq) ||
+                       (tlapack::abs(d2) >= gamsq)) {
+                    if (flag == 0) {
+                        h[0] = one;
+                        h[3] = one;
+                        flag = -1;
                     }
                     else {
-                        h[1]=-one;
-                        h[2]=one;
-                        flag=-1;
+                        h[1] = -one;
+                        h[2] = one;
+                        flag = -1;
                     }
-                    if(tlapack::abs(d2) <= rgamsq) {
-                        d2  *= gam*gam;
+                    if (tlapack::abs(d2) <= rgamsq) {
+                        d2 *= gam * gam;
                         h[1] /= gam;
                         h[3] /= gam;
                     }
                     else {
-                        d2 /= gam*gam;
+                        d2 /= gam * gam;
                         h[1] *= gam;
                         h[3] *= gam;
                     }
@@ -214,26 +214,24 @@ int rotmg( T& d1, T& d2, T& a, const T& b, T h[4] )
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< typename T,
-        enable_if_t< is_same_v< T, real_type<T> >, int > = 0,
-        enable_if_allow_optblas_t< T > = 0
-    >
-    inline
-    int rotmg( T& d1, T& d2, T& a, const T b, T h[4] )
-    {
-        T param[5];
-        ::blas::rotmg( &d1, &d2, &a, b, param );
-        
-        h[0] = param[1];
-        h[1] = param[2];
-        h[2] = param[3];
-        h[3] = param[4];
-        
-        return param[0];
-    }
+template <typename T,
+          enable_if_t<is_same_v<T, real_type<T> >, int> = 0,
+          enable_if_allow_optblas_t<T> = 0>
+inline int rotmg(T& d1, T& d2, T& a, const T b, T h[4])
+{
+    T param[5];
+    ::blas::rotmg(&d1, &d2, &a, b, param);
+
+    h[0] = param[1];
+    h[1] = param[2];
+    h[2] = param[3];
+    h[3] = param[4];
+
+    return param[0];
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_ROTMG_HH
+#endif  //  #ifndef TLAPACK_BLAS_ROTMG_HH

--- a/include/tlapack/blas/scal.hpp
+++ b/include/tlapack/blas/scal.hpp
@@ -23,16 +23,13 @@ namespace tlapack {
  *
  * @ingroup blas1
  */
-template< class vector_t, class alpha_t,
-    class T = type_t<vector_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, T >,
-        pair< vector_t, T >
-    > = 0
->
-void scal( const alpha_t& alpha, vector_t& x )
+template <class vector_t,
+          class alpha_t,
+          class T = type_t<vector_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>, pair<vector_t, T> > = 0>
+void scal(const alpha_t& alpha, vector_t& x)
 {
-    using idx_t = size_type< vector_t >;
+    using idx_t = size_type<vector_t>;
 
     // constants
     const idx_t n = size(x);
@@ -43,22 +40,18 @@ void scal( const alpha_t& alpha, vector_t& x )
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vector_t, class alpha_t,
-        class T = type_t<vector_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< vector_t, T >
-        > = 0
-    >
-    inline
-    void scal( const alpha_t alpha, vector_t& x )
-    {
-        auto x_ = legacy_vector(x);
-        return ::blas::scal( x_.n, alpha, x_.ptr, x_.inc );
-    }
+template <class vector_t,
+          class alpha_t,
+          class T = type_t<vector_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>, pair<vector_t, T> > = 0>
+inline void scal(const alpha_t alpha, vector_t& x)
+{
+    auto x_ = legacy_vector(x);
+    return ::blas::scal(x_.n, alpha, x_.ptr, x_.inc);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_SCAL_HH
+#endif  //  #ifndef TLAPACK_BLAS_SCAL_HH

--- a/include/tlapack/blas/swap.hpp
+++ b/include/tlapack/blas/swap.hpp
@@ -17,29 +17,27 @@ namespace tlapack {
 
 /**
  * Swap vectors, $x <=> y$.
- * 
+ *
  * @param[in,out] x A n-element vector.
  * @param[in,out] y A n-element vector.
  *
  * @ingroup blas1
  */
-template< class vectorX_t, class vectorY_t,
+template <
+    class vectorX_t,
+    class vectorY_t,
     class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void swap( vectorX_t& x, vectorY_t& y )
+    disable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+void swap(vectorX_t& x, vectorY_t& y)
 {
-    using idx_t = size_type< vectorY_t >;
+    using idx_t = size_type<vectorY_t>;
     using TX = type_t<vectorX_t>;
 
     // constants
     const idx_t n = size(x);
 
     // check arguments
-    tlapack_check_false( size(y) != n );
+    tlapack_check_false(size(y) != n);
 
     for (idx_t i = 0; i < n; ++i) {
         const TX aux = x[i];
@@ -50,46 +48,48 @@ void swap( vectorX_t& x, vectorY_t& y )
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class vectorX_t, class vectorY_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void swap( vectorX_t& x, vectorY_t& y )
-    {
-        using idx_t = size_type< vectorX_t >;
+template <
+    class vectorX_t,
+    class vectorY_t,
+    class T = type_t<vectorY_t>,
+    enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
+inline void swap(vectorX_t& x, vectorY_t& y)
+{
+    using idx_t = size_type<vectorX_t>;
 
-        // Legacy objects
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = x_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = x_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::swap( n, x_.ptr, incx, y_.ptr, incy );
-    }
+    return ::blas::swap(n, x_.ptr, incx, y_.ptr, incy);
+}
 
 #endif
 
-/** 
+/**
  * Swap vectors, $x <=> y$.
- * 
+ *
  * @see swap( vectorX_t& x, vectorY_t& y )
- * 
+ *
  * @note This overload avoids unexpected behavior as follows.
  *      Without it, the unspecialized call `swap( x, y )` using arrays with
  *      `std::complex` entries would call `std::swap`, while `swap( x, y )`
  *      using arrays with float or double entries would call `tlapack::swap`.
  *      Use @c tlapack::swap(x,y) instead of @c swap(x,y) .
  */
-template< class vector_t >
-inline void swap( vector_t& x, vector_t& y ) { return swap<vector_t,vector_t>(x,y); }
+template <class vector_t>
+inline void swap(vector_t& x, vector_t& y)
+{
+    return swap<vector_t, vector_t>(x, y);
+}
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_SWAP_HH
+#endif  //  #ifndef TLAPACK_BLAS_SWAP_HH

--- a/include/tlapack/blas/symv.hpp
+++ b/include/tlapack/blas/symv.hpp
@@ -37,38 +37,36 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t, 
-    class alpha_t, class beta_t,
-    class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >,
-        pair< beta_t,    T >
-    > = 0
->
-void symv(
-    Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    const beta_t& beta, vectorY_t& y )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<vectorY_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T>,
+                                     pair<beta_t, T> > = 0>
+void symv(Uplo uplo,
+          const alpha_t& alpha,
+          const matrixA_t& A,
+          const vectorX_t& x,
+          const beta_t& beta,
+          vectorY_t& y)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TX    = type_t< vectorX_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TX = type_t<vectorX_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( ncols(A) != n );
-    tlapack_check_false( size(x)  != n );
-    tlapack_check_false( size(y)  != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(ncols(A) != n);
+    tlapack_check_false(size(x) != n);
+    tlapack_check_false(size(y) != n);
 
     // form y = beta*y
     for (idx_t i = 0; i < n; ++i)
@@ -78,26 +76,26 @@ void symv(
         // A is stored in upper triangle
         // form y += alpha * A * x
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TX> tmp1 = alpha*x[j];
-            scalar_type<TA,TX> sum(0);
+            const scalar_type<alpha_t, TX> tmp1 = alpha * x[j];
+            scalar_type<TA, TX> sum(0);
             for (idx_t i = 0; i < j; ++i) {
-                y[i] += tmp1 * A(i,j);
-                sum += A(i,j) * x[i];
+                y[i] += tmp1 * A(i, j);
+                sum += A(i, j) * x[i];
             }
-            y[j] += tmp1 * A(j,j) + alpha * sum;
+            y[j] += tmp1 * A(j, j) + alpha * sum;
         }
     }
     else {
         // A is stored in lower triangle
         // form y += alpha * A * x
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TX> tmp1 = alpha*x[j];
-            scalar_type<TA,TX> sum(0);
-            for (idx_t i = j+1; i < n; ++i) {
-                y[i] += tmp1 * A(i,j);
-                sum += A(i,j) * x[i];
+            const scalar_type<alpha_t, TX> tmp1 = alpha * x[j];
+            scalar_type<TA, TX> sum(0);
+            for (idx_t i = j + 1; i < n; ++i) {
+                y[i] += tmp1 * A(i, j);
+                sum += A(i, j) * x[i];
             }
-            y[j] += tmp1 * A(j,j) + alpha * sum;
+            y[j] += tmp1 * A(j, j) + alpha * sum;
         }
     }
 }
@@ -123,119 +121,106 @@ void symv(
  *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t, 
-    class alpha_t,
-    class T = type_t<vectorY_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-inline
-void symv(
-    Uplo uplo,
-    const alpha_t& alpha, const matrixA_t& A, const vectorX_t& x,
-    vectorY_t& y )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+inline void symv(Uplo uplo,
+                 const alpha_t& alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 vectorY_t& y)
 {
-    return symv( uplo, alpha, A, x, internal::StrongZero(), y );
+    return symv(uplo, alpha, A, x, internal::StrongZero(), y);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t, 
-        class alpha_t, class beta_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >,
-            pair< beta_t,    T >
-        > = 0
-    >
-    inline
-    void symv(
-        Uplo uplo,
-        const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
-        const beta_t beta, vectorY_t& y )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<vectorY_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T>,
+                                    pair<beta_t, T> > = 0>
+inline void symv(Uplo uplo,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 const beta_t beta,
+                 vectorY_t& y)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -2, "Infs and NaNs in A or x will not propagate to y on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -5, "Infs and NaNs in y on input will not propagate to y on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -2, "Infs and NaNs in A or x will not propagate to y on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -5,
+            "Infs and NaNs in y on input will not propagate to y on output");
 
-        return ::blas::symv(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx,
-            beta,
-            y_.ptr, incy );
-    }
+    return ::blas::symv((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                        A_.ptr, A_.ldim, x_.ptr, incx, beta, y_.ptr, incy);
+}
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t, 
-        class alpha_t,
-        class T = type_t<vectorY_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void symv(
-        Uplo uplo,
-        const alpha_t alpha, const matrixA_t& A, const vectorX_t& x,
-        vectorY_t& y )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<vectorY_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void symv(Uplo uplo,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const vectorX_t& x,
+                 vectorY_t& y)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -2, "Infs and NaNs in A or x will not propagate to y on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -2, "Infs and NaNs in A or x will not propagate to y on output");
 
-        return ::blas::symv(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx,
-            T(0),
-            y_.ptr, incy );
-    }
+    return ::blas::symv((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                        A_.ptr, A_.ldim, x_.ptr, incx, T(0), y_.ptr, incy);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_SYMV_HH
+#endif  //  #ifndef TLAPACK_BLAS_SYMV_HH

--- a/include/tlapack/blas/syr.hpp
+++ b/include/tlapack/blas/syr.hpp
@@ -35,91 +35,74 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template< class matrixA_t, class vectorX_t, class alpha_t,
-    class T = type_t<matrixA_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >
-    > = 0
->
-void syr(
-    Uplo uplo,
-    const alpha_t& alpha,
-    const vectorX_t& x,
-    matrixA_t& A )
+template <class matrixA_t,
+          class vectorX_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T> > = 0>
+void syr(Uplo uplo, const alpha_t& alpha, const vectorX_t& x, matrixA_t& A)
 {
     // data traits
-    using idx_t = size_type< matrixA_t >;
-    using scalar_t = scalar_type< alpha_t, type_t<vectorX_t> >;
+    using idx_t = size_type<matrixA_t>;
+    using scalar_t = scalar_type<alpha_t, type_t<vectorX_t> >;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( size(x)  != n );
-    tlapack_check_false( ncols(A) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(size(x) != n);
+    tlapack_check_false(ncols(A) != n);
 
     if (uplo == Uplo::Upper) {
         for (idx_t j = 0; j < n; ++j) {
             const scalar_t tmp = alpha * x[j];
             for (idx_t i = 0; i <= j; ++i)
-                A(i,j) += x[i] * tmp;
+                A(i, j) += x[i] * tmp;
         }
     }
     else {
         for (idx_t j = 0; j < n; ++j) {
             const scalar_t tmp = alpha * x[j];
             for (idx_t i = j; i < n; ++i)
-                A(i,j) += x[i] * tmp;
+                A(i, j) += x[i] * tmp;
         }
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t,
-        class alpha_t,
-        class T = type_t<matrixA_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >
-        > = 0
-    >
-    inline
-    void syr(
-        Uplo  uplo,
-        const alpha_t alpha,
-        const vectorX_t& x,
-        matrixA_t& A )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T> > = 0>
+inline void syr(Uplo uplo,
+                const alpha_t alpha,
+                const vectorX_t& x,
+                matrixA_t& A)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        
-        return ::blas::syr(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            x_.ptr, incx,
-            A_.ptr, A_.ldim );
-    }
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+
+    return ::blas::syr((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                       x_.ptr, incx, A_.ptr, A_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_SYR_HH
+#endif  //  #ifndef TLAPACK_BLAS_SYR_HH

--- a/include/tlapack/blas/syr2.hpp
+++ b/include/tlapack/blas/syr2.hpp
@@ -28,7 +28,7 @@ namespace tlapack {
  *     the opposite triangle being assumed from symmetry.
  *     - Uplo::Lower: only the lower triangular part of A is referenced.
  *     - Uplo::Upper: only the upper triangular part of A is referenced.
- * 
+ *
  * @param[in] alpha Scalar.
  * @param[in] x A n-element vector.
  * @param[in] y A n-element vector.
@@ -36,103 +36,90 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template<
-    class matrixA_t,
-    class vectorX_t, class vectorY_t,
-    class alpha_t,
-    class T = type_t<matrixA_t>,
-    disable_if_allow_optblas_t<
-        pair< alpha_t, T >,
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >,
-        pair< vectorY_t, T >
-    > = 0
->
-void syr2(
-    Uplo  uplo,
-    const alpha_t& alpha,
-    const vectorX_t& x, const vectorY_t& y,
-    matrixA_t& A )
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          disable_if_allow_optblas_t<pair<alpha_t, T>,
+                                     pair<matrixA_t, T>,
+                                     pair<vectorX_t, T>,
+                                     pair<vectorY_t, T> > = 0>
+void syr2(Uplo uplo,
+          const alpha_t& alpha,
+          const vectorX_t& x,
+          const vectorY_t& y,
+          matrixA_t& A)
 {
     // data traits
-    using idx_t = size_type< matrixA_t >;
-    using TX = type_t< vectorX_t >;
-    using TY = type_t< vectorY_t >;
+    using idx_t = size_type<matrixA_t>;
+    using TX = type_t<vectorX_t>;
+    using TY = type_t<vectorY_t>;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( size(x)  != n );
-    tlapack_check_false( size(y)  != n );
-    tlapack_check_false( ncols(A) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(size(x) != n);
+    tlapack_check_false(size(y) != n);
+    tlapack_check_false(ncols(A) != n);
 
     if (uplo == Uplo::Upper) {
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TY> tmp1 = alpha * y[j];
-            const scalar_type<alpha_t,TX> tmp2 = alpha * x[j];
+            const scalar_type<alpha_t, TY> tmp1 = alpha * y[j];
+            const scalar_type<alpha_t, TX> tmp2 = alpha * x[j];
             for (idx_t i = 0; i <= j; ++i)
-                A(i,j) += x[i]*tmp1 + y[i]*tmp2;
+                A(i, j) += x[i] * tmp1 + y[i] * tmp2;
         }
     }
     else {
         for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t,TY> tmp1 = alpha * y[j];
-            const scalar_type<alpha_t,TX> tmp2 = alpha * x[j];
+            const scalar_type<alpha_t, TY> tmp1 = alpha * y[j];
+            const scalar_type<alpha_t, TX> tmp2 = alpha * x[j];
             for (idx_t i = j; i < n; ++i)
-                A(i,j) += x[i]*tmp1 + y[i]*tmp2;
+                A(i, j) += x[i] * tmp1 + y[i] * tmp2;
         }
     }
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template<
-        class matrixA_t,
-        class vectorX_t, class vectorY_t,
-        class alpha_t,
-        class T = type_t<matrixA_t>,
-        enable_if_allow_optblas_t<
-            pair< alpha_t, T >,
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >,
-            pair< vectorY_t, T >
-        > = 0
-    >
-    inline
-    void syr2(
-        Uplo  uplo,
-        const alpha_t alpha,
-        const vectorX_t& x, const vectorY_t& y,
-        matrixA_t& A )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <class matrixA_t,
+          class vectorX_t,
+          class vectorY_t,
+          class alpha_t,
+          class T = type_t<matrixA_t>,
+          enable_if_allow_optblas_t<pair<alpha_t, T>,
+                                    pair<matrixA_t, T>,
+                                    pair<vectorX_t, T>,
+                                    pair<vectorY_t, T> > = 0>
+inline void syr2(Uplo uplo,
+                 const alpha_t alpha,
+                 const vectorX_t& x,
+                 const vectorY_t& y,
+                 matrixA_t& A)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
-        auto y_ = legacy_vector(y);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
+    auto y_ = legacy_vector(y);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        const idx_t incy = (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+    const idx_t incy =
+        (y_.direction == Direction::Forward) ? idx_t(y_.inc) : idx_t(-y_.inc);
 
-        return ::blas::syr2(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            n,
-            alpha,
-            x_.ptr, incx,
-            y_.ptr, incy,
-            A_.ptr, A_.ldim );
-    }
+    return ::blas::syr2((::blas::Layout)A_.layout, (::blas::Uplo)uplo, n, alpha,
+                        x_.ptr, incx, y_.ptr, incy, A_.ptr, A_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_SYR2_HH
+#endif  //  #ifndef TLAPACK_BLAS_SYR2_HH

--- a/include/tlapack/blas/syr2k.hpp
+++ b/include/tlapack/blas/syr2k.hpp
@@ -50,114 +50,107 @@ namespace tlapack {
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t, class matrixB_t, class matrixC_t, 
-    class alpha_t, class beta_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >,
-        pair< beta_t,    T >
-    > = 0
->
-void syr2k(
-    Uplo uplo,
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-    const beta_t& beta, matrixC_t& C )
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T>,
+                                     pair<beta_t, T> > = 0>
+void syr2k(Uplo uplo,
+           Op trans,
+           const alpha_t& alpha,
+           const matrixA_t& A,
+           const matrixB_t& B,
+           const beta_t& beta,
+           matrixC_t& C)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TB    = type_t< matrixB_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TB = type_t<matrixB_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t n = (trans == Op::NoTrans) ? nrows(A) : ncols(A);
     const idx_t k = (trans == Op::NoTrans) ? ncols(A) : nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans );
-    tlapack_check_false( nrows(B) != nrows(A) ||
-                   ncols(B) != ncols(A) );
-    tlapack_check_false( nrows(C) != ncols(C) );
-    tlapack_check_false( nrows(C) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans);
+    tlapack_check_false(nrows(B) != nrows(A) || ncols(B) != ncols(A));
+    tlapack_check_false(nrows(C) != ncols(C));
+    tlapack_check_false(nrows(C) != n);
 
     if (trans == Op::NoTrans) {
         if (uplo != Uplo::Lower) {
-        // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
+            // uplo == Uplo::Upper or uplo == Uplo::General
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i <= j; ++i)
+                    C(i, j) *= beta;
 
-                for(idx_t i = 0; i <= j; ++i)
-                    C(i,j) *= beta;
-
-                for(idx_t l = 0; l < k; ++l) {
-                    const scalar_type<alpha_t,TB> alphaBjl = alpha*B(j,l);
-                    const scalar_type<alpha_t,TA> alphaAjl = alpha*A(j,l);
-                    for(idx_t i = 0; i <= j; ++i)
-                        C(i,j) += A(i,l)*alphaBjl + B(i,l)*alphaAjl;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_type<alpha_t, TB> alphaBjl = alpha * B(j, l);
+                    const scalar_type<alpha_t, TA> alphaAjl = alpha * A(j, l);
+                    for (idx_t i = 0; i <= j; ++i)
+                        C(i, j) += A(i, l) * alphaBjl + B(i, l) * alphaAjl;
                 }
             }
         }
-        else { // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
+        else {  // uplo == Uplo::Lower
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = j; i < n; ++i)
+                    C(i, j) *= beta;
 
-                for(idx_t i = j; i < n; ++i)
-                    C(i,j) *= beta;
-
-                for(idx_t l = 0; l < k; ++l) {
-                    const scalar_type<alpha_t,TB> alphaBjl = alpha*B(j,l);
-                    const scalar_type<alpha_t,TA> alphaAjl = alpha*A(j,l);
-                    for(idx_t i = j; i < n; ++i)
-                        C(i,j) += A(i,l)*alphaBjl + B(i,l)*alphaAjl;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_type<alpha_t, TB> alphaBjl = alpha * B(j, l);
+                    const scalar_type<alpha_t, TA> alphaAjl = alpha * A(j, l);
+                    for (idx_t i = j; i < n; ++i)
+                        C(i, j) += A(i, l) * alphaBjl + B(i, l) * alphaAjl;
                 }
             }
         }
     }
-    else { // trans == Op::Trans
-        using scalar_t = scalar_type<TA,TB>;
+    else {  // trans == Op::Trans
+        using scalar_t = scalar_type<TA, TB>;
 
         if (uplo != Uplo::Lower) {
-        // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i <= j; ++i) {
-
-                    scalar_t sum1( 0 );
-                    scalar_t sum2( 0 );
-                    for(idx_t l = 0; l < k; ++l) {
-                        sum1 += A(l,i) * B(l,j);
-                        sum2 += B(l,i) * A(l,j);
+            // uplo == Uplo::Upper or uplo == Uplo::General
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i <= j; ++i) {
+                    scalar_t sum1(0);
+                    scalar_t sum2(0);
+                    for (idx_t l = 0; l < k; ++l) {
+                        sum1 += A(l, i) * B(l, j);
+                        sum2 += B(l, i) * A(l, j);
                     }
-                    C(i,j) = alpha*sum1 + alpha*sum2 + beta*C(i,j);
+                    C(i, j) = alpha * sum1 + alpha * sum2 + beta * C(i, j);
                 }
             }
         }
-        else { // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = j; i < n; ++i) {
-
-                    scalar_t sum1( 0 );
-                    scalar_t sum2( 0 );
-                    for(idx_t l = 0; l < k; ++l) {
-                        sum1 +=  A(l,i) * B(l,j);
-                        sum2 +=  B(l,i) * A(l,j);
+        else {  // uplo == Uplo::Lower
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = j; i < n; ++i) {
+                    scalar_t sum1(0);
+                    scalar_t sum2(0);
+                    for (idx_t l = 0; l < k; ++l) {
+                        sum1 += A(l, i) * B(l, j);
+                        sum2 += B(l, i) * A(l, j);
                     }
-                    C(i,j) = alpha*sum1 + alpha*sum2 + beta*C(i,j);
+                    C(i, j) = alpha * sum1 + alpha * sum2 + beta * C(i, j);
                 }
             }
         }
     }
 
     if (uplo == Uplo::General) {
-        for(idx_t j = 0; j < n; ++j) {
-            for(idx_t i = j+1; i < n; ++i)
-                C(i,j) = C(j,i);
+        for (idx_t j = 0; j < n; ++j) {
+            for (idx_t i = j + 1; i < n; ++i)
+                C(i, j) = C(j, i);
         }
     }
 }
@@ -196,144 +189,130 @@ void syr2k(
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t, class matrixB_t, class matrixC_t, 
-    class alpha_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixB_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >
-    > = 0
->
-inline
-void syr2k(
-    Uplo uplo,
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-    matrixC_t& C )
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixB_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T> > = 0>
+inline void syr2k(Uplo uplo,
+                  Op trans,
+                  const alpha_t& alpha,
+                  const matrixA_t& A,
+                  const matrixB_t& B,
+                  matrixC_t& C)
 {
-    return syr2k( uplo, trans, alpha, A, B, internal::StrongZero(), C );
+    return syr2k(uplo, trans, alpha, A, B, internal::StrongZero(), C);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    /**
-     * Symmetric rank-k update
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see syr2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-        const beta_t& beta, matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t, class matrixB_t, class matrixC_t, 
-        class alpha_t, class beta_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >,
-            pair< beta_t,    T >
-        > = 0
-    >
-    inline
-    void syr2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
-        const beta_t beta, matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
+/**
+ * Symmetric rank-k update
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see syr2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    const beta_t& beta, matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T>,
+                                    pair<beta_t, T> > = 0>
+inline void syr2k(Uplo uplo,
+                  Op trans,
+                  const alpha_t alpha,
+                  const matrixA_t& A,
+                  const matrixB_t& B,
+                  const beta_t beta,
+                  matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& n = C_.n;
-        const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -6, "Infs and NaNs in C on input will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -6,
+            "Infs and NaNs in C on input will not propagate to C on output");
 
-        return ::blas::syr2k(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans, 
-            n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            beta,
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::syr2k((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                         (::blas::Op)trans, n, k, alpha, A_.ptr, A_.ldim,
+                         B_.ptr, B_.ldim, beta, C_.ptr, C_.ldim);
+}
 
-    /**
-     * Symmetric rank-k update
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see syr2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
-        matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t, class matrixB_t, class matrixC_t, 
-        class alpha_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixB_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >
-        > = 0
-    >
-    inline
-    void syr2k(
-        Uplo uplo,
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A, const matrixB_t& B,
-        matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto B_ = legacy_matrix(B);
-        auto C_ = legacy_matrix(C);
+/**
+ * Symmetric rank-k update
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see syr2k(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A, const matrixB_t& B,
+    matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixB_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixB_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T> > = 0>
+inline void syr2k(Uplo uplo,
+                  Op trans,
+                  const alpha_t alpha,
+                  const matrixA_t& A,
+                  const matrixB_t& B,
+                  matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto B_ = legacy_matrix(B);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& n = C_.n;
-        const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
 
-        return ::blas::syr2k(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans, 
-            n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            B_.ptr, B_.ldim,
-            T(0),
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::syr2k((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                         (::blas::Op)trans, n, k, alpha, A_.ptr, A_.ldim,
+                         B_.ptr, B_.ldim, T(0), C_.ptr, C_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_SYR2K_HH
+#endif  //  #ifndef TLAPACK_BLAS_SYR2K_HH

--- a/include/tlapack/blas/syrk.hpp
+++ b/include/tlapack/blas/syrk.hpp
@@ -47,98 +47,92 @@ namespace tlapack {
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t, class matrixC_t, 
-    class alpha_t, class beta_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >,
-        pair< beta_t,    T >
-    > = 0
->
-void syrk(
-    Uplo uplo,
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A,
-    const beta_t& beta, matrixC_t& C )
+template <class matrixA_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T>,
+                                     pair<beta_t, T> > = 0>
+void syrk(Uplo uplo,
+          Op trans,
+          const alpha_t& alpha,
+          const matrixA_t& A,
+          const beta_t& beta,
+          matrixC_t& C)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t n = (trans == Op::NoTrans) ? nrows(A) : ncols(A);
     const idx_t k = (trans == Op::NoTrans) ? ncols(A) : nrows(A);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans );
-    tlapack_check_false( nrows(C) != ncols(C) );
-    tlapack_check_false( nrows(C) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans);
+    tlapack_check_false(nrows(C) != ncols(C));
+    tlapack_check_false(nrows(C) != n);
 
     if (trans == Op::NoTrans) {
         if (uplo != Uplo::Lower) {
-        // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
+            // uplo == Uplo::Upper or uplo == Uplo::General
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i <= j; ++i)
+                    C(i, j) *= beta;
 
-                for(idx_t i = 0; i <= j; ++i)
-                    C(i,j) *= beta;
-
-                for(idx_t l = 0; l < k; ++l) {
-                    const scalar_type<alpha_t,TA> alphaAjl = alpha*A(j,l);
-                    for(idx_t i = 0; i <= j; ++i)
-                        C(i,j) += A(i,l)*alphaAjl;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_type<alpha_t, TA> alphaAjl = alpha * A(j, l);
+                    for (idx_t i = 0; i <= j; ++i)
+                        C(i, j) += A(i, l) * alphaAjl;
                 }
             }
         }
-        else { // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
+        else {  // uplo == Uplo::Lower
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = j; i < n; ++i)
+                    C(i, j) *= beta;
 
-                for(idx_t i = j; i < n; ++i)
-                    C(i,j) *= beta;
-
-                for(idx_t l = 0; l < k; ++l) {
-                    const scalar_type<alpha_t,TA> alphaAjl = alpha * A(j,l);
-                    for(idx_t i = j; i < n; ++i)
-                        C(i,j) += A(i,l) * alphaAjl;
+                for (idx_t l = 0; l < k; ++l) {
+                    const scalar_type<alpha_t, TA> alphaAjl = alpha * A(j, l);
+                    for (idx_t i = j; i < n; ++i)
+                        C(i, j) += A(i, l) * alphaAjl;
                 }
             }
         }
     }
-    else { // trans == Op::Trans
+    else {  // trans == Op::Trans
         if (uplo != Uplo::Lower) {
-        // uplo == Uplo::Upper or uplo == Uplo::General
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = 0; i <= j; ++i) {
-                    TA sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum += A(l,i) * A(l,j);
-                    C(i,j) = alpha*sum + beta*C(i,j);
+            // uplo == Uplo::Upper or uplo == Uplo::General
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = 0; i <= j; ++i) {
+                    TA sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += A(l, i) * A(l, j);
+                    C(i, j) = alpha * sum + beta * C(i, j);
                 }
             }
         }
-        else { // uplo == Uplo::Lower
-            for(idx_t j = 0; j < n; ++j) {
-                for(idx_t i = j; i < n; ++i) {
-                    TA sum( 0 );
-                    for(idx_t l = 0; l < k; ++l)
-                        sum +=  A(l,i) * A(l,j);
-                    C(i,j) = alpha*sum + beta*C(i,j);
+        else {  // uplo == Uplo::Lower
+            for (idx_t j = 0; j < n; ++j) {
+                for (idx_t i = j; i < n; ++i) {
+                    TA sum(0);
+                    for (idx_t l = 0; l < k; ++l)
+                        sum += A(l, i) * A(l, j);
+                    C(i, j) = alpha * sum + beta * C(i, j);
                 }
             }
         }
     }
 
     if (uplo == Uplo::General) {
-        for(idx_t j = 0; j < n; ++j) {
-            for(idx_t i = j+1; i < n; ++i)
-                C(i,j) = C(j,i);
+        for (idx_t j = 0; j < n; ++j) {
+            for (idx_t i = j + 1; i < n; ++i)
+                C(i, j) = C(j, i);
         }
     }
 }
@@ -174,137 +168,113 @@ void syrk(
  *
  * @ingroup blas3
  */
-template<
-    class matrixA_t, class matrixC_t, 
-    class alpha_t,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< matrixC_t, T >,
-        pair< alpha_t,   T >
-    > = 0
->
-inline
-void syrk(
-    Uplo uplo,
-    Op trans,
-    const alpha_t& alpha, const matrixA_t& A,
-    matrixC_t& C )
+template <class matrixA_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, T> > = 0>
+inline void syrk(
+    Uplo uplo, Op trans, const alpha_t& alpha, const matrixA_t& A, matrixC_t& C)
 {
-    return syrk( uplo, trans, alpha, A, internal::StrongZero(), C );
+    return syrk(uplo, trans, alpha, A, internal::StrongZero(), C);
 }
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    /**
-     * Symmetric rank-k update
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see syrk(
-        Uplo uplo,
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A,
-        const beta_t& beta, matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t, class matrixC_t, 
-        class alpha_t, class beta_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >,
-            pair< beta_t,    T >
-        > = 0
-    >
-    inline
-    void syrk(
-        Uplo uplo,
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A,
-        const beta_t beta, matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto C_ = legacy_matrix(C);
+/**
+ * Symmetric rank-k update
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see syrk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A,
+    const beta_t& beta, matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T>,
+                                    pair<beta_t, T> > = 0>
+inline void syrk(Uplo uplo,
+                 Op trans,
+                 const alpha_t alpha,
+                 const matrixA_t& A,
+                 const beta_t beta,
+                 matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& n = C_.n;
-        const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A will not propagate to C on output" );
-        if( beta == beta_t(0) )
-            tlapack_warning( -5, "Infs and NaNs in C on input will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(-3,
+                        "Infs and NaNs in A will not propagate to C on output");
+    if (beta == beta_t(0))
+        tlapack_warning(
+            -5,
+            "Infs and NaNs in C on input will not propagate to C on output");
 
-        return ::blas::syrk(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans, 
-            n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            beta,
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::syrk((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                        (::blas::Op)trans, n, k, alpha, A_.ptr, A_.ldim, beta,
+                        C_.ptr, C_.ldim);
+}
 
-    /**
-     * Symmetric rank-k update
-     * 
-     * Wrapper to optimized BLAS.
-     * 
-     * @see syrk(
-        Uplo uplo,
-        Op trans,
-        const alpha_t& alpha, const matrixA_t& A,
-        matrixC_t& C )
-    * 
-    * @ingroup blas3
-    */
-    template<
-        class matrixA_t, class matrixC_t, 
-        class alpha_t,
-        class T  = type_t<matrixC_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< matrixC_t, T >,
-            pair< alpha_t,   T >
-        > = 0
-    >
-    inline
-    void syrk(
-        Uplo uplo,
-        Op trans,
-        const alpha_t alpha, const matrixA_t& A,
-        matrixC_t& C )
-    {
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto C_ = legacy_matrix(C);
+/**
+ * Symmetric rank-k update
+ *
+ * Wrapper to optimized BLAS.
+ *
+ * @see syrk(
+    Uplo uplo,
+    Op trans,
+    const alpha_t& alpha, const matrixA_t& A,
+    matrixC_t& C )
+*
+* @ingroup blas3
+*/
+template <class matrixA_t,
+          class matrixC_t,
+          class alpha_t,
+          class T = type_t<matrixC_t>,
+          enable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                    pair<matrixC_t, T>,
+                                    pair<alpha_t, T> > = 0>
+inline void syrk(
+    Uplo uplo, Op trans, const alpha_t alpha, const matrixA_t& A, matrixC_t& C)
+{
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto C_ = legacy_matrix(C);
 
-        // Constants to forward
-        const auto& n = C_.n;
-        const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
+    // Constants to forward
+    const auto& n = C_.n;
+    const auto& k = (trans == Op::NoTrans) ? A_.n : A_.m;
 
-        if( alpha == alpha_t(0) )
-            tlapack_warning( -3, "Infs and NaNs in A or B will not propagate to C on output" );
+    if (alpha == alpha_t(0))
+        tlapack_warning(
+            -3, "Infs and NaNs in A or B will not propagate to C on output");
 
-        return ::blas::syrk(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans, 
-            n, k,
-            alpha,
-            A_.ptr, A_.ldim,
-            T(0),
-            C_.ptr, C_.ldim );
-    }
+    return ::blas::syrk((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                        (::blas::Op)trans, n, k, alpha, A_.ptr, A_.ldim, T(0),
+                        C_.ptr, C_.ldim);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_SYRK_HH
+#endif  //  #ifndef TLAPACK_BLAS_SYRK_HH

--- a/include/tlapack/blas/trmv.hpp
+++ b/include/tlapack/blas/trmv.hpp
@@ -51,62 +51,49 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template< class matrixA_t, class vectorX_t,
+template <
+    class matrixA_t,
+    class vectorX_t,
     class T = type_t<vectorX_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >
-    > = 0
->
-void trmv(
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    const matrixA_t& A,
-    vectorX_t& x )
+    disable_if_allow_optblas_t<pair<matrixA_t, T>, pair<vectorX_t, T> > = 0>
+void trmv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TX    = type_t< vectorX_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TX = type_t<vectorX_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t n = nrows(A);
     const bool nonunit = (diag == Diag::NonUnit);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans &&
-                   trans != Op::Conj );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                   diag != Diag::Unit );
-    tlapack_check_false( nrows(A) != ncols(A) );
-    tlapack_check_false( (idx_t) size(x) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans && trans != Op::Conj);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+    tlapack_check_false(nrows(A) != ncols(A));
+    tlapack_check_false((idx_t)size(x) != n);
 
     if (trans == Op::NoTrans) {
         // Form x := A*x
         if (uplo == Uplo::Upper) {
             // upper
             for (idx_t j = 0; j < n; ++j) {
-                // note: NOT skipping if x[j] is zero, for consistent NAN handling
+                // note: NOT skipping if x[j] is zero, for consistent NAN
+                // handling
                 for (idx_t i = 0; i < j; ++i)
-                    x[i] += x[j] * A(i,j);
-                if (nonunit)
-                    x[j] *= A(j,j);
+                    x[i] += x[j] * A(i, j);
+                if (nonunit) x[j] *= A(j, j);
             }
         }
         else {
             // lower
-            for (idx_t j = n-1; j != idx_t(-1); --j) {
+            for (idx_t j = n - 1; j != idx_t(-1); --j) {
                 // note: NOT skipping if x[j] is zero ...
-                for (idx_t i = n-1; i >= j+1; --i)
-                    x[i] += x[j] * A(i,j);
-                if (nonunit)
-                    x[j] *= A(j,j);
+                for (idx_t i = n - 1; i >= j + 1; --i)
+                    x[i] += x[j] * A(i, j);
+                if (nonunit) x[j] *= A(j, j);
             }
         }
     }
@@ -115,37 +102,35 @@ void trmv(
         if (uplo == Uplo::Upper) {
             // upper
             for (idx_t j = 0; j < n; ++j) {
-                // note: NOT skipping if x[j] is zero, for consistent NAN handling
+                // note: NOT skipping if x[j] is zero, for consistent NAN
+                // handling
                 for (idx_t i = 0; i < j; ++i)
-                    x[i] += x[j] * conj( A(i,j) );
-                if (nonunit)
-                    x[j] *= conj( A(j,j) );
+                    x[i] += x[j] * conj(A(i, j));
+                if (nonunit) x[j] *= conj(A(j, j));
             }
         }
         else {
             // lower
-            for (idx_t j = n-1; j != idx_t(-1); --j) {
+            for (idx_t j = n - 1; j != idx_t(-1); --j) {
                 // note: NOT skipping if x[j] is zero ...
-                for (idx_t i = n-1; i >= j+1; --i)
-                    x[i] += x[j] * conj( A(i,j) );
-                if (nonunit)
-                    x[j] *= conj( A(j,j) );
+                for (idx_t i = n - 1; i >= j + 1; --i)
+                    x[i] += x[j] * conj(A(i, j));
+                if (nonunit) x[j] *= conj(A(j, j));
             }
         }
     }
     else if (trans == Op::Trans) {
         // Form  x := A^T * x
-        
-        using scalar_t = scalar_type<TA,TX>;
+
+        using scalar_t = scalar_type<TA, TX>;
 
         if (uplo == Uplo::Upper) {
             // upper
-            for (idx_t j = n-1; j != idx_t(-1); --j) {
+            for (idx_t j = n - 1; j != idx_t(-1); --j) {
                 scalar_t tmp = x[j];
-                if (nonunit)
-                    tmp *= A(j,j);
+                if (nonunit) tmp *= A(j, j);
                 for (idx_t i = j - 1; i != idx_t(-1); --i)
-                    tmp += A(i,j) * x[i];
+                    tmp += A(i, j) * x[i];
                 x[j] = tmp;
             }
         }
@@ -153,10 +138,9 @@ void trmv(
             // lower
             for (idx_t j = 0; j < n; ++j) {
                 scalar_t tmp = x[j];
-                if (nonunit)
-                    tmp *= A(j,j);
+                if (nonunit) tmp *= A(j, j);
                 for (idx_t i = j + 1; i < n; ++i)
-                    tmp += A(i,j) * x[i];
+                    tmp += A(i, j) * x[i];
                 x[j] = tmp;
             }
         }
@@ -164,17 +148,16 @@ void trmv(
     else {
         // Form x := A^H * x
         // same code as above A^T * x case, except add conj()
-        
-        using scalar_t = scalar_type<TA,TX>;
-        
+
+        using scalar_t = scalar_type<TA, TX>;
+
         if (uplo == Uplo::Upper) {
             // upper
-            for (idx_t j = n-1; j != idx_t(-1); --j) {
+            for (idx_t j = n - 1; j != idx_t(-1); --j) {
                 scalar_t tmp = x[j];
-                if (nonunit)
-                    tmp *= conj( A(j,j) );
+                if (nonunit) tmp *= conj(A(j, j));
                 for (idx_t i = j - 1; i != idx_t(-1); --i)
-                    tmp += conj( A(i,j) ) * x[i];
+                    tmp += conj(A(i, j)) * x[i];
                 x[j] = tmp;
             }
         }
@@ -182,10 +165,9 @@ void trmv(
             // lower
             for (idx_t j = 0; j < n; ++j) {
                 scalar_t tmp = x[j];
-                if (nonunit)
-                    tmp *= conj( A(j,j) );
+                if (nonunit) tmp *= conj(A(j, j));
                 for (idx_t i = j + 1; i < n; ++i)
-                    tmp += conj( A(i,j) ) * x[i];
+                    tmp += conj(A(i, j)) * x[i];
                 x[j] = tmp;
             }
         }
@@ -194,43 +176,32 @@ void trmv(
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class matrixA_t, class vectorX_t,
-        class T = type_t<vectorX_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >
-        > = 0
-    >
-    inline
-    void trmv(
-        Uplo uplo,
-        Op trans,
-        Diag diag,
-        const matrixA_t& A,
-        vectorX_t& x )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <
+    class matrixA_t,
+    class vectorX_t,
+    class T = type_t<vectorX_t>,
+    enable_if_allow_optblas_t<pair<matrixA_t, T>, pair<vectorX_t, T> > = 0>
+inline void trmv(
+    Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        
-        return ::blas::trmv(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans,
-            (::blas::Diag) diag,
-            n,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx );
-    }
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+
+    return ::blas::trmv((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                        (::blas::Op)trans, (::blas::Diag)diag, n, A_.ptr,
+                        A_.ldim, x_.ptr, incx);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_TRMV_HH
+#endif  //  #ifndef TLAPACK_BLAS_TRMV_HH

--- a/include/tlapack/blas/trsv.hpp
+++ b/include/tlapack/blas/trsv.hpp
@@ -55,53 +55,42 @@ namespace tlapack {
  *
  * @ingroup blas2
  */
-template< class matrixA_t, class vectorX_t,
+template <
+    class matrixA_t,
+    class vectorX_t,
     class T = type_t<vectorX_t>,
-    disable_if_allow_optblas_t<
-        pair< matrixA_t, T >,
-        pair< vectorX_t, T >
-    > = 0
->
-void trsv(
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    const matrixA_t& A,
-    vectorX_t& x )
+    disable_if_allow_optblas_t<pair<matrixA_t, T>, pair<vectorX_t, T> > = 0>
+void trsv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
 {
     // data traits
-    using TA    = type_t< matrixA_t >;
-    using TX    = type_t< vectorX_t >;
-    using idx_t = size_type< matrixA_t >;
+    using TA = type_t<matrixA_t>;
+    using TX = type_t<vectorX_t>;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t n = nrows(A);
     const bool nonunit = (diag == Diag::NonUnit);
 
     // check arguments
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans &&
-                   trans != Op::Conj );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                   diag != Diag::Unit );
-    tlapack_check_false( nrows(A) != ncols(A) );
-    tlapack_check_false( size(x) != n );
-
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans && trans != Op::Conj);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+    tlapack_check_false(nrows(A) != ncols(A));
+    tlapack_check_false(size(x) != n);
 
     if (trans == Op::NoTrans) {
         // Form x := A^{-1} * x
         if (uplo == Uplo::Upper) {
             // upper
             for (idx_t j = n - 1; j != idx_t(-1); --j) {
-                // note: NOT skipping if x[j] is zero, for consistent NAN handling
+                // note: NOT skipping if x[j] is zero, for consistent NAN
+                // handling
                 if (nonunit) {
-                    x[j] /= A(j,j);
+                    x[j] /= A(j, j);
                 }
                 for (idx_t i = j - 1; i != idx_t(-1); --i) {
-                    x[i] -= x[j] * A(i,j);
+                    x[i] -= x[j] * A(i, j);
                 }
             }
         }
@@ -110,10 +99,10 @@ void trsv(
             for (idx_t j = 0; j < n; ++j) {
                 // note: NOT skipping if x[j] is zero ...
                 if (nonunit) {
-                    x[j] /= A(j,j);
+                    x[j] /= A(j, j);
                 }
                 for (idx_t i = j + 1; i < n; ++i) {
-                    x[i] -= x[j] * A(i,j);
+                    x[i] -= x[j] * A(i, j);
                 }
             }
         }
@@ -123,12 +112,13 @@ void trsv(
         if (uplo == Uplo::Upper) {
             // upper
             for (idx_t j = n - 1; j != idx_t(-1); --j) {
-                // note: NOT skipping if x[j] is zero, for consistent NAN handling
+                // note: NOT skipping if x[j] is zero, for consistent NAN
+                // handling
                 if (nonunit) {
-                    x[j] /= conj( A(j,j) );
+                    x[j] /= conj(A(j, j));
                 }
                 for (idx_t i = j - 1; i != idx_t(-1); --i) {
-                    x[i] -= x[j] * conj( A(i,j) );
+                    x[i] -= x[j] * conj(A(i, j));
                 }
             }
         }
@@ -137,28 +127,28 @@ void trsv(
             for (idx_t j = 0; j < n; ++j) {
                 // note: NOT skipping if x[j] is zero ...
                 if (nonunit) {
-                    x[j] /= conj( A(j,j) );
+                    x[j] /= conj(A(j, j));
                 }
                 for (idx_t i = j + 1; i < n; ++i) {
-                    x[i] -= x[j] * conj( A(i,j) );
+                    x[i] -= x[j] * conj(A(i, j));
                 }
             }
         }
     }
     else if (trans == Op::Trans) {
         // Form  x := A^{-T} * x
-        
-        using scalar_t = scalar_type<TA,TX>;
-        
+
+        using scalar_t = scalar_type<TA, TX>;
+
         if (uplo == Uplo::Upper) {
             // upper
             for (idx_t j = 0; j < n; ++j) {
                 scalar_t tmp = x[j];
                 for (idx_t i = 0; i < j; ++i) {
-                    tmp -= A(i,j) * x[i];
+                    tmp -= A(i, j) * x[i];
                 }
                 if (nonunit) {
-                    tmp /= A(j,j);
+                    tmp /= A(j, j);
                 }
                 x[j] = tmp;
             }
@@ -168,10 +158,10 @@ void trsv(
             for (idx_t j = n - 1; j != idx_t(-1); --j) {
                 scalar_t tmp = x[j];
                 for (idx_t i = j + 1; i < n; ++i) {
-                    tmp -= A(i,j) * x[i];
+                    tmp -= A(i, j) * x[i];
                 }
                 if (nonunit) {
-                    tmp /= A(j,j);
+                    tmp /= A(j, j);
                 }
                 x[j] = tmp;
             }
@@ -180,18 +170,18 @@ void trsv(
     else {
         // Form x := A^{-H} * x
         // same code as above A^{-T} * x case, except add conj()
-        
-        using scalar_t = scalar_type<TA,TX>;
-        
+
+        using scalar_t = scalar_type<TA, TX>;
+
         if (uplo == Uplo::Upper) {
             // upper
             for (idx_t j = 0; j < n; ++j) {
                 scalar_t tmp = x[j];
                 for (idx_t i = 0; i < j; ++i) {
-                    tmp -= conj( A(i,j) ) * x[i];
+                    tmp -= conj(A(i, j)) * x[i];
                 }
                 if (nonunit) {
-                    tmp /= conj( A(j,j) );
+                    tmp /= conj(A(j, j));
                 }
                 x[j] = tmp;
             }
@@ -201,10 +191,10 @@ void trsv(
             for (idx_t j = n - 1; j != idx_t(-1); --j) {
                 scalar_t tmp = x[j];
                 for (idx_t i = j + 1; i < n; ++i) {
-                    tmp -= conj( A(i,j) ) * x[i];
+                    tmp -= conj(A(i, j)) * x[i];
                 }
                 if (nonunit) {
-                    tmp /= conj( A(j,j) );
+                    tmp /= conj(A(j, j));
                 }
                 x[j] = tmp;
             }
@@ -214,43 +204,32 @@ void trsv(
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-    template< class matrixA_t, class vectorX_t,
-        class T = type_t<vectorX_t>,
-        enable_if_allow_optblas_t<
-            pair< matrixA_t, T >,
-            pair< vectorX_t, T >
-        > = 0
-    >
-    inline
-    void trsv(
-        Uplo uplo,
-        Op trans,
-        Diag diag,
-        const matrixA_t& A,
-        vectorX_t& x )
-    {
-        using idx_t = size_type< matrixA_t >;
+template <
+    class matrixA_t,
+    class vectorX_t,
+    class T = type_t<vectorX_t>,
+    enable_if_allow_optblas_t<pair<matrixA_t, T>, pair<vectorX_t, T> > = 0>
+inline void trsv(
+    Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
+{
+    using idx_t = size_type<matrixA_t>;
 
-        // Legacy objects
-        auto A_ = legacy_matrix(A);
-        auto x_ = legacy_vector(x);
+    // Legacy objects
+    auto A_ = legacy_matrix(A);
+    auto x_ = legacy_vector(x);
 
-        // Constants to forward
-        const idx_t& n = A_.n;
-        const idx_t incx = (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
-        
-        return ::blas::trsv(
-            (::blas::Layout) A_.layout,
-            (::blas::Uplo) uplo,
-            (::blas::Op) trans,
-            (::blas::Diag) diag,
-            n,
-            A_.ptr, A_.ldim,
-            x_.ptr, incx );
-    }
+    // Constants to forward
+    const idx_t& n = A_.n;
+    const idx_t incx =
+        (x_.direction == Direction::Forward) ? idx_t(x_.inc) : idx_t(-x_.inc);
+
+    return ::blas::trsv((::blas::Layout)A_.layout, (::blas::Uplo)uplo,
+                        (::blas::Op)trans, (::blas::Diag)diag, n, A_.ptr,
+                        A_.ldim, x_.ptr, incx);
+}
 
 #endif
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_BLAS_TRSV_HH
+#endif  //  #ifndef TLAPACK_BLAS_TRSV_HH

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -11,626 +11,583 @@
 #define TLAPACK_AED_HH
 
 #include "tlapack/base/utils.hpp"
-
 #include "tlapack/blas/gemm.hpp"
-#include "tlapack/lapack/laset.hpp"
-#include "tlapack/lapack/larfg.hpp"
-#include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/gehd2.hpp"
 #include "tlapack/lapack/lahqr.hpp"
 #include "tlapack/lapack/lahqr_eig22.hpp"
-#include "tlapack/lapack/gehd2.hpp"
-#include "tlapack/lapack/unghr.hpp"
+#include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/larfg.hpp"
+#include "tlapack/lapack/laset.hpp"
 #include "tlapack/lapack/multishift_qr.hpp"
 #include "tlapack/lapack/schur_move.hpp"
 #include "tlapack/lapack/schur_swap.hpp"
+#include "tlapack/lapack/unghr.hpp"
 #include "tlapack/lapack/unmhr.hpp"
 
-namespace tlapack
+namespace tlapack {
+// Forward declaration
+template <class idx_t>
+struct francis_opts_t;
+
+/** Worspace query of agressive_early_deflation().
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ *
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ *
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ *
+ * @param[in] ihi    integer.
+ *      ilo and ihi determine an isolated block in A.
+ *
+ * @param[in] nw    integer.
+ *      Desired window size to perform agressive early deflation on.
+ *      If the matrix is not large enough to provide the scratch space
+ *      or if the isolated block is small, a smaller value may be used.
+ *
+ * @param[in] A  n by n matrix.
+ *       Hessenberg matrix on which AED will be performed
+ *
+ * @param s  Not referenced.
+ *
+ * @param[in] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors.
+ *
+ * @param ns    Not referenced.
+ *
+ * @param nd    Not referenced.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t> >::value, int> = 0>
+void agressive_early_deflation_worksize(
+    bool want_t,
+    bool want_z,
+    size_type<matrix_t> ilo,
+    size_type<matrix_t> ihi,
+    size_type<matrix_t> nw,
+    const matrix_t& A,
+    const vector_t& s,
+    const matrix_t& Z,
+    const size_type<matrix_t>& ns,
+    const size_type<matrix_t>& nd,
+    workinfo_t& workinfo,
+    const francis_opts_t<size_type<matrix_t> >& opts = {})
 {
-    // Forward declaration
-    template < class idx_t > struct francis_opts_t;
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
 
-    /** Worspace query of agressive_early_deflation().
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     *
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     *
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     *
-     * @param[in] ihi    integer.
-     *      ilo and ihi determine an isolated block in A.
-     *
-     * @param[in] nw    integer.
-     *      Desired window size to perform agressive early deflation on.
-     *      If the matrix is not large enough to provide the scratch space
-     *      or if the isolated block is small, a smaller value may be used.
-     *
-     * @param[in] A  n by n matrix.
-     *       Hessenberg matrix on which AED will be performed
-     *
-     * @param s  Not referenced.
-     *
-     * @param[in] Z  n by n matrix.
-     *      On entry, the previously calculated Schur factors.
-     *
-     * @param ns    Not referenced.
-     *
-     * @param nd    Not referenced.
-     *
-     * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<
-            is_complex< type_t<vector_t> >::value
-        , int > = 0
-    >
-    void agressive_early_deflation_worksize(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        size_type<matrix_t> nw, 
-        const matrix_t &A, 
-        const vector_t &s, 
-        const matrix_t &Z, 
-        const size_type<matrix_t> &ns,
-        const size_type<matrix_t> &nd,
-        workinfo_t& workinfo,
-        const francis_opts_t< size_type<matrix_t> > &opts = {} )
-    {
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
-        
-        const idx_t n = ncols(A);
-        const idx_t nw_max = (n - 3) / 3;
-        const idx_t jw = min( min(nw, ihi - ilo), nw_max );
+    const idx_t n = ncols(A);
+    const idx_t nw_max = (n - 3) / 3;
+    const idx_t jw = min(min(nw, ihi - ilo), nw_max);
 
-        auto TW = slice(A, pair{0,jw}, pair{0,jw});
+    auto TW = slice(A, pair{0, jw}, pair{0, jw});
 
-        // quick return
-        if( n < 9 || nw <= 1 || ihi <= 1+ilo )
-            return;
+    // quick return
+    if (n < 9 || nw <= 1 || ihi <= 1 + ilo) return;
 
-        if( jw >= opts.nmin )
-        {
-            auto s_window = slice(s, pair{0,jw});
-            auto V = slice(A, pair{0,jw}, pair{0,jw});
-            
-            multishift_qr_worksize(true, true, 0, jw, TW, s_window, V, workinfo, opts);
+    if (jw >= opts.nmin) {
+        auto s_window = slice(s, pair{0, jw});
+        auto V = slice(A, pair{0, jw}, pair{0, jw});
+
+        multishift_qr_worksize(true, true, 0, jw, TW, s_window, V, workinfo,
+                               opts);
+    }
+
+    if (jw != ihi - ilo) {
+        // Hessenberg reduction
+        auto tau = slice(A, pair{0, jw}, 0);
+        gehrd_worksize(0, jw, TW, tau, workinfo);
+    }
+}
+
+/** agressive_early_deflation accepts as input an upper Hessenberg matrix
+ *  H and performs an orthogonal similarity transformation
+ *  designed to detect and deflate fully converged eigenvalues from
+ *  a trailing principal submatrix.  On output H has been over-
+ *  written by a new Hessenberg matrix that is a perturbation of
+ *  an orthogonal similarity transformation of H.  It is to be
+ *  hoped that the final version of H has many zero subdiagonal
+ *  entries.
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ *
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ *
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ *
+ * @param[in] ihi    integer.
+ *      ilo and ihi determine an isolated block in A.
+ *
+ * @param[in] nw    integer.
+ *      Desired window size to perform agressive early deflation on.
+ *      If the matrix is not large enough to provide the scratch space
+ *      or if the isolated block is small, a smaller value may be used.
+ *
+ * @param[in,out] A  n by n matrix.
+ *       Hessenberg matrix on which AED will be performed
+ *
+ * @param[out] s  size n vector.
+ *      On exit, the entries s[ihi-nd-ns:ihi-nd] contain the unconverged
+ *      eigenvalues that can be used a shifts. The entries s[ihi-nd:ihi]
+ *      contain the converged eigenvalues. Entries outside the range
+ *      s[ihi-nw:ihi] are not changed. The converged shifts are stored
+ *      in the same positions as their correspinding diagonal elements
+ *      in A.
+ *
+ * @param[in,out] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors
+ *      On exit, the orthogonal updates applied to A accumulated
+ *      into Z.
+ *
+ * @param[out] ns    integer.
+ *      Number of eigenvalues available as shifts in s.
+ *
+ * @param[out] nd    integer.
+ *      Number of converged eigenvalues available as shifts in s.
+ *
+ * @param[in,out] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *      - Output parameters
+ *          @c opts.n_aed,
+ *          @c opts.n_sweep and
+ *          @c opts.n_shifts_total
+ *        are updated by the internal call to multishift_qr.
+ *
+ * @ingroup computational
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t> >::value, int> = 0>
+void agressive_early_deflation(bool want_t,
+                               bool want_z,
+                               size_type<matrix_t> ilo,
+                               size_type<matrix_t> ihi,
+                               size_type<matrix_t> nw,
+                               matrix_t& A,
+                               vector_t& s,
+                               matrix_t& Z,
+                               size_type<matrix_t>& ns,
+                               size_type<matrix_t>& nd,
+                               francis_opts_t<size_type<matrix_t> >& opts)
+{
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
+    using std::max;
+    using std::min;
+
+    // Constants
+    const real_t one(1);
+    const real_t zero(0);
+    const idx_t n = ncols(A);
+    // Because we will use the lower triangular part of A as workspace,
+    // We have a maximum window size
+    const idx_t nw_max = (n - 3) / 3;
+    const real_t eps = ulp<real_t>();
+    const real_t small_num = safe_min<real_t>() * ((real_t)n / ulp<real_t>());
+    // Size of the deflation window
+    const idx_t jw = min(min(nw, ihi - ilo), nw_max);
+    // First row index in the deflation window
+    const idx_t kwtop = ihi - jw;
+
+    // Assertions
+    assert(nrows(A) == n);
+    if (want_z) {
+        assert(ncols(Z) == n);
+        assert(nrows(Z) == n);
+    }
+    assert((idx_t)size(s) == n);
+
+    // s is the value just outside the window. It determines the spike
+    // together with the orthogonal schur factors.
+    T s_spike;
+    if (kwtop == ilo)
+        s_spike = zero;
+    else
+        s_spike = A(kwtop, kwtop - 1);
+
+    if (kwtop + 1 == ihi) {
+        // 1x1 deflation window, not much to do
+        s[kwtop] = A(kwtop, kwtop);
+        ns = 1;
+        nd = 0;
+        if (abs1(s_spike) <= max(small_num, eps * abs1(A(kwtop, kwtop)))) {
+            ns = 0;
+            nd = 1;
+            if (kwtop > ilo) A(kwtop, kwtop - 1) = zero;
         }
+        return;
+    }
 
-        if( jw != ihi-ilo )
-        {
-            // Hessenberg reduction
-            auto tau = slice(A, pair{0,jw}, 0);
-            gehrd_worksize(0, jw, TW, tau, workinfo);
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    Workspace work = [&]() {
+        workinfo_t workinfo;
+        agressive_early_deflation_worksize(want_t, want_z, ilo, ihi, nw, A, s,
+                                           Z, ns, nd, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+
+    // Options to forward
+    opts.work = work;
+    auto&& gehrdOpts = gehrd_opts_t<idx_t>{work};
+
+    // Define workspace matrices
+    // We use the lower triangular part of A as workspace
+    // TW and WH overlap, but WH is only used after we no longer need
+    // TW so it is ok.
+    auto V = slice(A, pair{n - jw, n}, pair{0, jw});
+    auto TW = slice(A, pair{n - jw, n}, pair{jw, 2 * jw});
+    auto WH = slice(A, pair{n - jw, n}, pair{jw, n - jw - 3});
+    auto WV = slice(A, pair{jw + 3, n - jw}, pair{0, jw});
+
+    // Convert the window to spike-triangular form. i.e. calculate the
+    // Schur form of the deflation window.
+    // If the QR algorithm fails to convergence, it can still be
+    // partially in Schur form. In that case we continue on a smaller
+    // window (note the use of infqr later in the code).
+    auto A_window = slice(A, pair{kwtop, ihi}, pair{kwtop, ihi});
+    auto s_window = slice(s, pair{kwtop, ihi});
+    laset(Uplo::Lower, zero, zero, TW);
+    for (idx_t j = 0; j < jw; ++j)
+        for (idx_t i = 0; i < std::min(j + 2, jw); ++i)
+            TW(i, j) = A_window(i, j);
+    laset(Uplo::General, zero, one, V);
+    int infqr;
+    if (jw < opts.nmin)
+        infqr = lahqr(true, true, 0, jw, TW, s_window, V);
+    else {
+        infqr = multishift_qr(true, true, 0, jw, TW, s_window, V, opts);
+        for (idx_t j = 0; j < jw; ++j)
+            for (idx_t i = j + 2; i < jw; ++i)
+                TW(i, j) = zero;
+    }
+
+    // Deflation detection loop
+    // one eigenvalue block at a time, we will check if it is deflatable
+    // by checking the bottom spike element. If it is not deflatable,
+    // we move the block up. This moves other blocks down to check.
+    ns = jw;
+    idx_t ilst = infqr;
+    while (ilst < ns) {
+        bool bulge = false;
+        if (!is_complex<T>::value)
+            if (ns > 1)
+                if (TW(ns - 1, ns - 2) != zero) bulge = true;
+
+        if (!bulge) {
+            // 1x1 eigenvalue block
+            real_t foo = abs1(TW(ns - 1, ns - 1));
+            if (foo == zero) foo = abs1(s_spike);
+            if (abs1(s_spike) * abs1(V(0, ns - 1)) <=
+                max(small_num, eps * foo)) {
+                // Eigenvalue is deflatable
+                ns = ns - 1;
+            }
+            else {
+                // Eigenvalue is not deflatable.
+                // Move it up out of the way.
+                idx_t ifst = ns - 1;
+                schur_move(true, TW, V, ifst, ilst);
+                ilst = ilst + 1;
+            }
+        }
+        else {
+            // 2x2 eigenvalue block
+            real_t foo = tlapack::abs(TW(ns - 1, ns - 1)) +
+                         sqrt(tlapack::abs(TW(ns - 1, ns - 2))) *
+                             sqrt(tlapack::abs(TW(ns - 2, ns - 1)));
+            if (foo == zero) foo = tlapack::abs(s_spike);
+            if (max(tlapack::abs(s_spike * V(0, ns - 1)),
+                    tlapack::abs(s_spike * V(0, ns - 2))) <=
+                max<real_t>(small_num, eps * foo)) {
+                // Eigenvalue pair is deflatable
+                ns = ns - 2;
+            }
+            else {
+                // Eigenvalue pair is not deflatable.
+                // Move it up out of the way.
+                idx_t ifst = ns - 2;
+                schur_move(true, TW, V, ifst, ilst);
+                ilst = ilst + 2;
+            }
         }
     }
 
-    /** agressive_early_deflation accepts as input an upper Hessenberg matrix
-     *  H and performs an orthogonal similarity transformation
-     *  designed to detect and deflate fully converged eigenvalues from
-     *  a trailing principal submatrix.  On output H has been over-
-     *  written by a new Hessenberg matrix that is a perturbation of
-     *  an orthogonal similarity transformation of H.  It is to be
-     *  hoped that the final version of H has many zero subdiagonal
-     *  entries.
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     *
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     *
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     *
-     * @param[in] ihi    integer.
-     *      ilo and ihi determine an isolated block in A.
-     *
-     * @param[in] nw    integer.
-     *      Desired window size to perform agressive early deflation on.
-     *      If the matrix is not large enough to provide the scratch space
-     *      or if the isolated block is small, a smaller value may be used.
-     *
-     * @param[in,out] A  n by n matrix.
-     *       Hessenberg matrix on which AED will be performed
-     *
-     * @param[out] s  size n vector.
-     *      On exit, the entries s[ihi-nd-ns:ihi-nd] contain the unconverged
-     *      eigenvalues that can be used a shifts. The entries s[ihi-nd:ihi]
-     *      contain the converged eigenvalues. Entries outside the range
-     *      s[ihi-nw:ihi] are not changed. The converged shifts are stored
-     *      in the same positions as their correspinding diagonal elements
-     *      in A.
-     *
-     * @param[in,out] Z  n by n matrix.
-     *      On entry, the previously calculated Schur factors
-     *      On exit, the orthogonal updates applied to A accumulated
-     *      into Z.
-     *
-     * @param[out] ns    integer.
-     *      Number of eigenvalues available as shifts in s.
-     *
-     * @param[out] nd    integer.
-     *      Number of converged eigenvalues available as shifts in s.
-     *
-     * @param[in,out] opts Options.
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        The sufficient size can be obtained through a workspace query.
-     *      - Output parameters
-     *          @c opts.n_aed,
-     *          @c opts.n_sweep and
-     *          @c opts.n_shifts_total
-     *        are updated by the internal call to multishift_qr.
-     *
-     * @ingroup computational
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<
-            is_complex< type_t<vector_t> >::value
-        , int > = 0
-    >
-    void agressive_early_deflation(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        size_type<matrix_t> nw, 
-        matrix_t &A, 
-        vector_t &s, 
-        matrix_t &Z, 
-        size_type<matrix_t> &ns, 
-        size_type<matrix_t> &nd, 
-        francis_opts_t< size_type<matrix_t> > &opts )
-    {
+    if (ns == 0) s_spike = zero;
 
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
-        using std::max;
-        using std::min;
-
-        // Constants
-        const real_t one(1);
-        const real_t zero(0);
-        const idx_t n = ncols(A);
-        // Because we will use the lower triangular part of A as workspace,
-        // We have a maximum window size
-        const idx_t nw_max = (n - 3) / 3;
-        const real_t eps = ulp<real_t>();
-        const real_t small_num = safe_min<real_t>() * ((real_t)n / ulp<real_t>());
-        // Size of the deflation window
-        const idx_t jw = min(min(nw, ihi - ilo), nw_max);
-        // First row index in the deflation window
-        const idx_t kwtop = ihi - jw;
-
-        // Assertions
-        assert(nrows(A) == n);
-        if(want_z) {
-            assert(ncols(Z) == n);
-            assert(nrows(Z) == n);
-        }
-        assert((idx_t) size(s) == n);
-
-        // s is the value just outside the window. It determines the spike
-        // together with the orthogonal schur factors.
-        T s_spike;
-        if (kwtop == ilo)
-            s_spike = zero;
-        else
-            s_spike = A(kwtop, kwtop - 1);
-
-        if (kwtop + 1 == ihi)
-        {
-            // 1x1 deflation window, not much to do
-            s[kwtop] = A(kwtop, kwtop);
-            ns = 1;
-            nd = 0;
-            if (abs1(s_spike) <= max(small_num, eps * abs1(A(kwtop, kwtop))))
-            {
-                ns = 0;
-                nd = 1;
-                if (kwtop > ilo)
-                    A(kwtop, kwtop - 1) = zero;
-            }
-            return;
-        }
-
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            agressive_early_deflation_worksize( want_t, want_z, ilo, ihi, nw, A, s, Z, ns, nd, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-        
-        // Options to forward
-        opts.work = work;
-        auto&& gehrdOpts = gehrd_opts_t<idx_t>{ work };
-
-        // Define workspace matrices
-        // We use the lower triangular part of A as workspace
-        // TW and WH overlap, but WH is only used after we no longer need
-        // TW so it is ok.
-        auto V = slice(A, pair{n - jw, n}, pair{0, jw});
-        auto TW = slice(A, pair{n - jw, n}, pair{jw, 2 * jw});
-        auto WH = slice(A, pair{n - jw, n}, pair{jw, n - jw - 3});
-        auto WV = slice(A, pair{jw + 3, n - jw}, pair{0, jw});
-
-        // Convert the window to spike-triangular form. i.e. calculate the
-        // Schur form of the deflation window.
-        // If the QR algorithm fails to convergence, it can still be
-        // partially in Schur form. In that case we continue on a smaller
-        // window (note the use of infqr later in the code).
-        auto A_window = slice(A, pair{kwtop, ihi}, pair{kwtop, ihi});
-        auto s_window = slice(s, pair{kwtop, ihi});
-        laset(Uplo::Lower, zero, zero, TW);
-        for (idx_t j = 0; j < jw; ++j)
-            for (idx_t i = 0; i < std::min(j + 2, jw); ++i)
-                TW(i, j) = A_window(i, j);
-        laset(Uplo::General, zero, one, V);
-        int infqr;
-        if( jw < opts.nmin )
-            infqr = lahqr(true, true, 0, jw, TW, s_window, V);
-        else{
-            infqr = multishift_qr(true, true, 0, jw, TW, s_window, V, opts);
-            for (idx_t j = 0; j < jw; ++j)
-                for (idx_t i = j+2; i < jw; ++i)
-                    TW(i, j) = zero;
-        }
-
-        // Deflation detection loop
-        // one eigenvalue block at a time, we will check if it is deflatable
-        // by checking the bottom spike element. If it is not deflatable,
-        // we move the block up. This moves other blocks down to check.
-        ns = jw;
-        idx_t ilst = infqr;
-        while (ilst < ns)
-        {
-            bool bulge = false;
-            if (!is_complex<T>::value)
-                if (ns > 1)
-                    if (TW(ns - 1, ns - 2) != zero)
-                        bulge = true;
-
-            if (!bulge)
-            {
-                // 1x1 eigenvalue block
-                real_t foo = abs1(TW(ns - 1, ns - 1));
-                if (foo == zero)
-                    foo = abs1(s_spike);
-                if (abs1(s_spike) * abs1(V(0, ns - 1)) <= max(small_num, eps * foo))
-                {
-                    // Eigenvalue is deflatable
-                    ns = ns - 1;
-                }
-                else
-                {
-                    // Eigenvalue is not deflatable.
-                    // Move it up out of the way.
-                    idx_t ifst = ns - 1;
-                    schur_move(true, TW, V, ifst, ilst);
-                    ilst = ilst + 1;
-                }
-            }
-            else
-            {
-                // 2x2 eigenvalue block
-                real_t foo = tlapack::abs(TW(ns - 1, ns - 1)) + sqrt(tlapack::abs(TW(ns - 1, ns - 2))) * sqrt(tlapack::abs(TW(ns - 2, ns - 1)));
-                if (foo == zero)
-                    foo = tlapack::abs(s_spike);
-                if (max(tlapack::abs(s_spike * V(0, ns - 1)), tlapack::abs(s_spike * V(0, ns - 2))) <= max<real_t>(small_num, eps * foo))
-                {
-                    // Eigenvalue pair is deflatable
-                    ns = ns - 2;
-                }
-                else
-                {
-                    // Eigenvalue pair is not deflatable.
-                    // Move it up out of the way.
-                    idx_t ifst = ns - 2;
-                    schur_move(true, TW, V, ifst, ilst);
-                    ilst = ilst + 2;
-                }
-            }
-        }
-
-        if (ns == 0)
-            s_spike = zero;
-
-
-        if (ns == jw)
-        {
-            // Agressive early deflation didn't deflate any eigenvalues
-            // We don't need to apply the update to the rest of the matrix
-            nd = jw - ns;
-            ns = ns - infqr;
-            return;
-        }
-
-        // sorting diagonal blocks of T improves accuracy for graded matrices.
-        // Bubble sort deals well with exchange failures.
-        bool sorted = false;
-        // Window to be checked (other eigenvalue are sorted)
-        idx_t sorting_window_size = jw;
-        while (!sorted)
-        {
-            sorted = true;
-
-            // Index of last eigenvalue that was swapped
-            idx_t ilst = 0;
-
-            // Index of the first block
-            idx_t i1 = ns;
-
-            while (i1 + 1 < sorting_window_size)
-            {
-
-                // Size of the first block
-                idx_t n1 = 1;
-                if (!is_complex<T>::value)
-                    if (TW(i1 + 1, i1) != zero)
-                        n1 = 2;
-
-                // Check if there is a next block
-                if (i1 + n1 == jw)
-                {
-                    ilst = ilst - n1;
-                    break;
-                }
-
-                // Index of the second block
-                idx_t i2 = i1 + n1;
-
-                // Size of the second block
-                idx_t n2 = 1;
-                if (!is_complex<T>::value)
-                    if (i2 + 1 < jw)
-                        if (TW(i2 + 1, i2) != zero)
-                            n2 = 2;
-
-                real_t ev1, ev2;
-                if (n1 == 1)
-                    ev1 = abs1(TW(i1, i1));
-                else
-                    ev1 = tlapack::abs(TW(i1, i1)) + sqrt(tlapack::abs(TW(i1 + 1, i1))) * sqrt(tlapack::abs(TW(i1, i1 + 1)));
-                if (n2 == 1)
-                    ev2 = abs1(TW(i2, i2));
-                else
-                    ev2 = tlapack::abs(TW(i2, i2)) + sqrt(tlapack::abs(TW(i2 + 1, i2))) * sqrt(tlapack::abs(TW(i2, i2 + 1)));
-
-                if (ev1 > ev2)
-                {
-                    i1 = i2;
-                }
-                else
-                {
-                    sorted = false;
-                    int ierr = schur_swap(true, TW, V, i1, n1, n2);
-                    if (ierr == 0)
-                        i1 = i1 + n2;
-                    else
-                        i1 = i2;
-                    ilst = i1;
-                }
-            }
-            sorting_window_size = ilst;
-        }
-
-        // Recalculate the eigenvalues
-        idx_t i = 0;
-        while (i < jw)
-        {
-            idx_t n1 = 1;
-            if (!is_complex<T>::value)
-                if (i + 1 < jw)
-                    if (TW(i + 1, i) != zero)
-                        n1 = 2;
-
-            if (n1 == 1)
-                s[kwtop + i] = TW(i, i);
-            else
-                lahqr_eig22(TW(i, i), TW(i, i + 1), TW(i + 1, i), TW(i + 1, i + 1), s[kwtop + i], s[kwtop + i + 1]);
-            i = i + n1;
-        }
-
-        // Reduce A back to Hessenberg form (if neccesary)
-        if (s_spike != zero)
-        {
-
-            // Reflect spike back
-            {
-                T tau;
-                auto v = slice(WV, pair{0, ns}, 0);
-                for (idx_t i = 0; i < ns; ++i)
-                {
-                    v[i] = conj(V(0, i));
-                }
-                larfg(v, tau);
-                
-                auto Wv_aux = slice(WV, pair{0, jw}, 1);
-                workspace_opts_t<> work2(Wv_aux);
-                
-                auto TW_slice = slice(TW, pair{0, ns}, pair{0, jw});
-                larf(Side::Left, forward, v, conj(tau), TW_slice, work2);
-                
-                auto TW_slice2 = slice(TW, pair{0, jw}, pair{0, ns});
-                larf(Side::Right, forward, v, tau, TW_slice2, work2);
-                
-                auto V_slice = slice(V, pair{0, jw}, pair{0, ns});
-                larf(Side::Right, forward, v, tau, V_slice, work2);
-            }
-
-            // Hessenberg reduction
-            {
-                auto tau = slice(WV, pair{0, jw}, 0);
-                gehrd(0, ns, TW, tau, gehrdOpts);
-
-                workspace_opts_t<> work2(slice(WV, pair{0, jw}, 1));
-                unmhr(Side::Right, Op::NoTrans, 0, ns, TW, tau, V, work2);
-            }
-        }
-
-        // Copy the deflation window back into place
-        if (kwtop > 0)
-            A(kwtop, kwtop - 1) = s_spike * conj(V(0, 0));
-        for (idx_t j = 0; j < jw; ++j)
-            for (idx_t i = 0; i < std::min(j + 2, jw); ++i)
-                A(kwtop + i, kwtop + j) = TW(i, j);
-
-        // Store number of deflated eigenvalues
+    if (ns == jw) {
+        // Agressive early deflation didn't deflate any eigenvalues
+        // We don't need to apply the update to the rest of the matrix
         nd = jw - ns;
         ns = ns - infqr;
+        return;
+    }
 
-        //
-        // Update rest of the matrix using matrix matrix multiplication
-        //
-        idx_t istart_m, istop_m;
-        if (want_t)
-        {
-            istart_m = 0;
-            istop_m = n;
+    // sorting diagonal blocks of T improves accuracy for graded matrices.
+    // Bubble sort deals well with exchange failures.
+    bool sorted = false;
+    // Window to be checked (other eigenvalue are sorted)
+    idx_t sorting_window_size = jw;
+    while (!sorted) {
+        sorted = true;
+
+        // Index of last eigenvalue that was swapped
+        idx_t ilst = 0;
+
+        // Index of the first block
+        idx_t i1 = ns;
+
+        while (i1 + 1 < sorting_window_size) {
+            // Size of the first block
+            idx_t n1 = 1;
+            if (!is_complex<T>::value)
+                if (TW(i1 + 1, i1) != zero) n1 = 2;
+
+            // Check if there is a next block
+            if (i1 + n1 == jw) {
+                ilst = ilst - n1;
+                break;
+            }
+
+            // Index of the second block
+            idx_t i2 = i1 + n1;
+
+            // Size of the second block
+            idx_t n2 = 1;
+            if (!is_complex<T>::value)
+                if (i2 + 1 < jw)
+                    if (TW(i2 + 1, i2) != zero) n2 = 2;
+
+            real_t ev1, ev2;
+            if (n1 == 1)
+                ev1 = abs1(TW(i1, i1));
+            else
+                ev1 = tlapack::abs(TW(i1, i1)) +
+                      sqrt(tlapack::abs(TW(i1 + 1, i1))) *
+                          sqrt(tlapack::abs(TW(i1, i1 + 1)));
+            if (n2 == 1)
+                ev2 = abs1(TW(i2, i2));
+            else
+                ev2 = tlapack::abs(TW(i2, i2)) +
+                      sqrt(tlapack::abs(TW(i2 + 1, i2))) *
+                          sqrt(tlapack::abs(TW(i2, i2 + 1)));
+
+            if (ev1 > ev2) {
+                i1 = i2;
+            }
+            else {
+                sorted = false;
+                int ierr = schur_swap(true, TW, V, i1, n1, n2);
+                if (ierr == 0)
+                    i1 = i1 + n2;
+                else
+                    i1 = i2;
+                ilst = i1;
+            }
         }
+        sorting_window_size = ilst;
+    }
+
+    // Recalculate the eigenvalues
+    idx_t i = 0;
+    while (i < jw) {
+        idx_t n1 = 1;
+        if (!is_complex<T>::value)
+            if (i + 1 < jw)
+                if (TW(i + 1, i) != zero) n1 = 2;
+
+        if (n1 == 1)
+            s[kwtop + i] = TW(i, i);
         else
+            lahqr_eig22(TW(i, i), TW(i, i + 1), TW(i + 1, i), TW(i + 1, i + 1),
+                        s[kwtop + i], s[kwtop + i + 1]);
+        i = i + n1;
+    }
+
+    // Reduce A back to Hessenberg form (if neccesary)
+    if (s_spike != zero) {
+        // Reflect spike back
         {
-            istart_m = ilo;
-            istop_m = ihi;
-        }
-        // Horizontal multiply
-        if (ihi < istop_m)
-        {
-            idx_t i = ihi;
-            while (i < istop_m)
-            {
-                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
-                auto A_slice = slice(A, pair{kwtop, ihi}, pair{i, i + iblock});
-                auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                gemm(Op::ConjTrans, Op::NoTrans, one, V, A_slice, WH_slice);
-                lacpy(Uplo::General, WH_slice, A_slice);
-                i = i + iblock;
+            T tau;
+            auto v = slice(WV, pair{0, ns}, 0);
+            for (idx_t i = 0; i < ns; ++i) {
+                v[i] = conj(V(0, i));
             }
+            larfg(v, tau);
+
+            auto Wv_aux = slice(WV, pair{0, jw}, 1);
+            workspace_opts_t<> work2(Wv_aux);
+
+            auto TW_slice = slice(TW, pair{0, ns}, pair{0, jw});
+            larf(Side::Left, forward, v, conj(tau), TW_slice, work2);
+
+            auto TW_slice2 = slice(TW, pair{0, jw}, pair{0, ns});
+            larf(Side::Right, forward, v, tau, TW_slice2, work2);
+
+            auto V_slice = slice(V, pair{0, jw}, pair{0, ns});
+            larf(Side::Right, forward, v, tau, V_slice, work2);
         }
-        // Vertical multiply
-        if (istart_m < kwtop)
+
+        // Hessenberg reduction
         {
-            idx_t i = istart_m;
-            while (i < kwtop)
-            {
-                idx_t iblock = std::min<idx_t>(kwtop - i, nrows(WV));
-                auto A_slice = slice(A, pair{i, i + iblock}, pair{kwtop, ihi});
-                auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, V, WV_slice);
-                lacpy(Uplo::General, WV_slice, A_slice);
-                i = i + iblock;
-            }
-        }
-        // Update Z (also a vertical multiplication)
-        if (want_z)
-        {
-            idx_t i = 0;
-            while (i < n)
-            {
-                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
-                auto Z_slice = slice(Z, pair{i, i + iblock}, pair{kwtop, ihi});
-                auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, V, WV_slice);
-                lacpy(Uplo::General, WV_slice, Z_slice);
-                i = i + iblock;
-            }
+            auto tau = slice(WV, pair{0, jw}, 0);
+            gehrd(0, ns, TW, tau, gehrdOpts);
+
+            workspace_opts_t<> work2(slice(WV, pair{0, jw}, 1));
+            unmhr(Side::Right, Op::NoTrans, 0, ns, TW, tau, V, work2);
         }
     }
 
-    /** agressive_early_deflation accepts as input an upper Hessenberg matrix
-     *  H and performs an orthogonal similarity transformation
-     *  designed to detect and deflate fully converged eigenvalues from
-     *  a trailing principal submatrix.  On output H has been over-
-     *  written by a new Hessenberg matrix that is a perturbation of
-     *  an orthogonal similarity transformation of H.  It is to be
-     *  hoped that the final version of H has many zero subdiagonal
-     *  entries.
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     *
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     *
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     *
-     * @param[in] ihi    integer.
-     *      ilo and ihi determine an isolated block in A.
-     *
-     * @param[in] nw    integer.
-     *      Desired window size to perform agressive early deflation on.
-     *      If the matrix is not large enough to provide the scratch space
-     *      or if the isolated block is small, a smaller value may be used.
-     *
-     * @param[in,out] A  n by n matrix.
-     *       Hessenberg matrix on which AED will be performed
-     *
-     * @param[out] s  size n vector.
-     *      On exit, the entries s[ihi-nd-ns:ihi-nd] contain the unconverged
-     *      eigenvalues that can be used a shifts. The entries s[ihi-nd:ihi]
-     *      contain the converged eigenvalues. Entries outside the range
-     *      s[ihi-nw:ihi] are not changed. The converged shifts are stored
-     *      in the same positions as their correspinding diagonal elements
-     *      in A.
-     *
-     * @param[in,out] Z  n by n matrix.
-     *      On entry, the previously calculated Schur factors
-     *      On exit, the orthogonal updates applied to A accumulated
-     *      into Z.
-     *
-     * @param[out] ns    integer.
-     *      Number of eigenvalues available as shifts in s.
-     *
-     * @param[out] nd    integer.
-     *      Number of converged eigenvalues available as shifts in s.
-     *
-     * @ingroup computational
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<
-            is_complex< type_t<vector_t> >::value
-        , int > = 0
-    >
-    inline
-    void agressive_early_deflation(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        size_type<matrix_t> nw, 
-        matrix_t &A, 
-        vector_t &s, 
-        matrix_t &Z, 
-        size_type<matrix_t> &ns, 
-        size_type<matrix_t> &nd )
-    {
-        francis_opts_t< size_type<matrix_t> > opts = {};
-        agressive_early_deflation( want_t, want_z, ilo, ihi, nw, A, s, Z, ns, nd, opts );
+    // Copy the deflation window back into place
+    if (kwtop > 0) A(kwtop, kwtop - 1) = s_spike * conj(V(0, 0));
+    for (idx_t j = 0; j < jw; ++j)
+        for (idx_t i = 0; i < std::min(j + 2, jw); ++i)
+            A(kwtop + i, kwtop + j) = TW(i, j);
+
+    // Store number of deflated eigenvalues
+    nd = jw - ns;
+    ns = ns - infqr;
+
+    //
+    // Update rest of the matrix using matrix matrix multiplication
+    //
+    idx_t istart_m, istop_m;
+    if (want_t) {
+        istart_m = 0;
+        istop_m = n;
     }
+    else {
+        istart_m = ilo;
+        istop_m = ihi;
+    }
+    // Horizontal multiply
+    if (ihi < istop_m) {
+        idx_t i = ihi;
+        while (i < istop_m) {
+            idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+            auto A_slice = slice(A, pair{kwtop, ihi}, pair{i, i + iblock});
+            auto WH_slice =
+                slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+            gemm(Op::ConjTrans, Op::NoTrans, one, V, A_slice, WH_slice);
+            lacpy(Uplo::General, WH_slice, A_slice);
+            i = i + iblock;
+        }
+    }
+    // Vertical multiply
+    if (istart_m < kwtop) {
+        idx_t i = istart_m;
+        while (i < kwtop) {
+            idx_t iblock = std::min<idx_t>(kwtop - i, nrows(WV));
+            auto A_slice = slice(A, pair{i, i + iblock}, pair{kwtop, ihi});
+            auto WV_slice =
+                slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+            gemm(Op::NoTrans, Op::NoTrans, one, A_slice, V, WV_slice);
+            lacpy(Uplo::General, WV_slice, A_slice);
+            i = i + iblock;
+        }
+    }
+    // Update Z (also a vertical multiplication)
+    if (want_z) {
+        idx_t i = 0;
+        while (i < n) {
+            idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+            auto Z_slice = slice(Z, pair{i, i + iblock}, pair{kwtop, ihi});
+            auto WV_slice =
+                slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
+            gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, V, WV_slice);
+            lacpy(Uplo::General, WV_slice, Z_slice);
+            i = i + iblock;
+        }
+    }
+}
 
-} // lapack
+/** agressive_early_deflation accepts as input an upper Hessenberg matrix
+ *  H and performs an orthogonal similarity transformation
+ *  designed to detect and deflate fully converged eigenvalues from
+ *  a trailing principal submatrix.  On output H has been over-
+ *  written by a new Hessenberg matrix that is a perturbation of
+ *  an orthogonal similarity transformation of H.  It is to be
+ *  hoped that the final version of H has many zero subdiagonal
+ *  entries.
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ *
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ *
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ *
+ * @param[in] ihi    integer.
+ *      ilo and ihi determine an isolated block in A.
+ *
+ * @param[in] nw    integer.
+ *      Desired window size to perform agressive early deflation on.
+ *      If the matrix is not large enough to provide the scratch space
+ *      or if the isolated block is small, a smaller value may be used.
+ *
+ * @param[in,out] A  n by n matrix.
+ *       Hessenberg matrix on which AED will be performed
+ *
+ * @param[out] s  size n vector.
+ *      On exit, the entries s[ihi-nd-ns:ihi-nd] contain the unconverged
+ *      eigenvalues that can be used a shifts. The entries s[ihi-nd:ihi]
+ *      contain the converged eigenvalues. Entries outside the range
+ *      s[ihi-nw:ihi] are not changed. The converged shifts are stored
+ *      in the same positions as their correspinding diagonal elements
+ *      in A.
+ *
+ * @param[in,out] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors
+ *      On exit, the orthogonal updates applied to A accumulated
+ *      into Z.
+ *
+ * @param[out] ns    integer.
+ *      Number of eigenvalues available as shifts in s.
+ *
+ * @param[out] nd    integer.
+ *      Number of converged eigenvalues available as shifts in s.
+ *
+ * @ingroup computational
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t> >::value, int> = 0>
+inline void agressive_early_deflation(bool want_t,
+                                      bool want_z,
+                                      size_type<matrix_t> ilo,
+                                      size_type<matrix_t> ihi,
+                                      size_type<matrix_t> nw,
+                                      matrix_t& A,
+                                      vector_t& s,
+                                      matrix_t& Z,
+                                      size_type<matrix_t>& ns,
+                                      size_type<matrix_t>& nd)
+{
+    francis_opts_t<size_type<matrix_t> > opts = {};
+    agressive_early_deflation(want_t, want_z, ilo, ihi, nw, A, s, Z, ns, nd,
+                              opts);
+}
 
-#endif // TLAPACK_AED_HH
+}  // namespace tlapack
+
+#endif  // TLAPACK_AED_HH

--- a/include/tlapack/lapack/gebd2.hpp
+++ b/include/tlapack/lapack/gebd2.hpp
@@ -1,6 +1,7 @@
 /// @file gebd2.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgebd2.f
+/// @note Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgebd2.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -12,176 +13,172 @@
 #define TLAPACK_GEBD2_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/larfg.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+struct gebd2_opts_t : public workspace_opts_t<> {
+    inline constexpr gebd2_opts_t(const workspace_opts_t<>& opts = {})
+        : workspace_opts_t<>(opts){};
+};
+
+/** Worspace query of gebd2().
+ *
+ * @param[in] A m-by-n matrix.
+ *      On entry, the m by n general matrix to be reduced.
+ *
+ * @param tauv Not referenced.
+ *
+ * @param tauw Not referenced.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <typename matrix_t, class vector_t>
+inline constexpr void gebd2_worksize(const matrix_t& A,
+                                     const vector_t& tauv,
+                                     const vector_t& tauw,
+                                     workinfo_t& workinfo,
+                                     const gebd2_opts_t& opts = {})
 {
+    using idx_t = size_type<matrix_t>;
 
-    struct gebd2_opts_t : public workspace_opts_t<>
-    {
-        inline constexpr gebd2_opts_t( const workspace_opts_t<>& opts = {} )
-        : workspace_opts_t<>( opts ) {};
-    };
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
 
-    /** Worspace query of gebd2().
-     *
-     * @param[in] A m-by-n matrix.
-     *      On entry, the m by n general matrix to be reduced.
-     *
-     * @param tauv Not referenced.
-     *
-     * @param tauw Not referenced.
-     *
-     * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template <typename matrix_t, class vector_t>
-    inline constexpr 
-    void gebd2_worksize(const matrix_t &A, const vector_t &tauv, const vector_t &tauw, workinfo_t& workinfo, const gebd2_opts_t& opts = {})
-    {
-        using idx_t = size_type< matrix_t >;
+    if (n > 1) {
+        auto A11 = cols(A, range<idx_t>{1, n});
+        larf_worksize(left_side, forward, col(A, 0), tauv[0], A11, workinfo,
+                      opts);
 
-        // constants
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-        
-        if( n > 1 )
-        {
-            auto A11 = cols( A, range<idx_t>{1,n} );
-            larf_worksize( left_side, forward, col(A,0), tauv[0], A11, workinfo, opts );
-            
-            if( m > 1 )
-            {
-                auto B11 = rows( A11, range<idx_t>{1,m} );
-                auto row0 = slice(A,0,range<idx_t>{1,n});
-                
-                larf_worksize( right_side, forward, row0, tauw[0], B11, workinfo, opts );
-            }
+        if (m > 1) {
+            auto B11 = rows(A11, range<idx_t>{1, m});
+            auto row0 = slice(A, 0, range<idx_t>{1, n});
+
+            larf_worksize(right_side, forward, row0, tauw[0], B11, workinfo,
+                          opts);
         }
-    }
-
-    /** Reduces a complex general m by n matrix A to an upper
-     *  real bidiagonal form B by a unitary transformation:
-     * \[
-     *          Q**H * A * Z = B,
-     * \]
-     *  where m >= n.
-     *
-     * The matrices Q and Z are represented as products of elementary
-     * reflectors:
-     *
-     * If m >= n,
-     * \[
-     *          Q = H(1) H(2) . . . H(n)  and  Z = G(1) G(2) . . . G(n-1)
-     * \]
-     * Each H(i) and G(i) has the form:
-     * \[
-     *          H(j) = I - tauv * v * v**H  and G(j) = I - tauw * w * w**H
-     * \]
-     * where tauv and tauw are complex scalars, and v and w are complex
-     * vectors; v(1:j-1) = 0, v(j) = 1, and v(j+1:m) is stored on exit in
-     * A(j+1:m,j); w(1:j) = 0, w(j+1) = 1, and w(j+2:n) is stored on exit in
-     * A(j,i+2:n); tauv is stored in tauv(j) and tauw in tauw(j).
-     *
-     * @return  0 if success
-     *
-     * @param[in,out] A m-by-n matrix.
-     *      On entry, the m by n general matrix to be reduced.
-     *      On exit, if m >= n, the diagonal and the first superdiagonal
-     *      are overwritten with the upper bidiagonal matrix B; the
-     *      elements below the diagonal, with the array tauv, represent
-     *      the unitary matrix Q as a product of elementary reflectors,
-     *      and the elements above the first superdiagonal, with the array
-     *      tauw, represent the unitary matrix Z as a product of elementary
-     *      reflectors.
-     *
-     * @param[out] tauv Real vector of length min(m,n).
-     *      The scalar factors of the elementary reflectors which
-     *      represent the unitary matrix Q.
-     *
-     * @param[out] tauw Real vector of length min(m,n).
-     *      The scalar factors of the elementary reflectors which
-     *      represent the unitary matrix Z.
-     *
-     * @param[in] opts Options.
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        The sufficient size can be obtained through a workspace query.
-     *
-     * @ingroup computational
-     */
-    template <typename matrix_t, class vector_t>
-    int gebd2(matrix_t &A, vector_t &tauv, vector_t &tauw, const gebd2_opts_t& opts = {})
-    {
-
-        using idx_t = size_type<matrix_t>;
-        using range = std::pair<idx_t, idx_t>;
-
-        // constants
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-
-        // check arguments
-        tlapack_check_false((idx_t)size(tauv) < std::min<idx_t>(m, n));
-        tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
-        tlapack_check(m >= n); // Only m >= n matrices are supported (yet).
-
-        // quick return
-        if (n <= 0)
-            return 0;
-
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            gebd2_worksize( A, tauv, tauw, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-        
-        // Options to forward
-        auto&& larfOpts = workspace_opts_t<>{ work };
-
-        for (idx_t j = 0; j < n; ++j)
-        {
-
-            // Generate elementary reflector H(j) to annihilate A(j+1:m,j)
-            auto v = slice(A, range(j, m), j);
-            larfg(v, tauv[j]);
-
-            // Apply H(j)**H to A(j:m,j+1:n) from the left
-            if (j < n - 1)
-            {
-                auto A11 = slice(A, range(j, m), range(j + 1, n));
-                larf(Side::Left, forward, v, conj(tauv[j]), A11, larfOpts);
-            }
-
-            if (j < n - 1)
-            {
-                // Generate elementary reflector G(j) to annihilate A(j,j+2:n)
-                auto w = slice(A, j, range(j + 1, n));
-                for (idx_t i = 0; i < n - j - 1; ++i)
-                    w[i] = conj(w[i]);
-                larfg(w, tauw[j]);
-
-                // Apply G(j) to A(j+1:m,j+1:n) from the right
-                if (j < m - 1)
-                {
-                    auto B11 = slice(A, range(j + 1, m), range(j + 1, n));
-                    larf(Side::Right, forward, w, tauw[j], B11, larfOpts);
-                }
-                for (idx_t i = 0; i < n-j-1; ++i) 
-                    w[i] = conj(w[i]);
-            }
-        }
-
-        return 0;
     }
 }
 
-#endif // TLAPACK_GEBD2_HH
+/** Reduces a complex general m by n matrix A to an upper
+ *  real bidiagonal form B by a unitary transformation:
+ * \[
+ *          Q**H * A * Z = B,
+ * \]
+ *  where m >= n.
+ *
+ * The matrices Q and Z are represented as products of elementary
+ * reflectors:
+ *
+ * If m >= n,
+ * \[
+ *          Q = H(1) H(2) . . . H(n)  and  Z = G(1) G(2) . . . G(n-1)
+ * \]
+ * Each H(i) and G(i) has the form:
+ * \[
+ *          H(j) = I - tauv * v * v**H  and G(j) = I - tauw * w * w**H
+ * \]
+ * where tauv and tauw are complex scalars, and v and w are complex
+ * vectors; v(1:j-1) = 0, v(j) = 1, and v(j+1:m) is stored on exit in
+ * A(j+1:m,j); w(1:j) = 0, w(j+1) = 1, and w(j+2:n) is stored on exit in
+ * A(j,i+2:n); tauv is stored in tauv(j) and tauw in tauw(j).
+ *
+ * @return  0 if success
+ *
+ * @param[in,out] A m-by-n matrix.
+ *      On entry, the m by n general matrix to be reduced.
+ *      On exit, if m >= n, the diagonal and the first superdiagonal
+ *      are overwritten with the upper bidiagonal matrix B; the
+ *      elements below the diagonal, with the array tauv, represent
+ *      the unitary matrix Q as a product of elementary reflectors,
+ *      and the elements above the first superdiagonal, with the array
+ *      tauw, represent the unitary matrix Z as a product of elementary
+ *      reflectors.
+ *
+ * @param[out] tauv Real vector of length min(m,n).
+ *      The scalar factors of the elementary reflectors which
+ *      represent the unitary matrix Q.
+ *
+ * @param[out] tauw Real vector of length min(m,n).
+ *      The scalar factors of the elementary reflectors which
+ *      represent the unitary matrix Z.
+ *
+ * @param[in] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup computational
+ */
+template <typename matrix_t, class vector_t>
+int gebd2(matrix_t& A,
+          vector_t& tauv,
+          vector_t& tauw,
+          const gebd2_opts_t& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using range = std::pair<idx_t, idx_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+
+    // check arguments
+    tlapack_check_false((idx_t)size(tauv) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
+    tlapack_check(m >= n);  // Only m >= n matrices are supported (yet).
+
+    // quick return
+    if (n <= 0) return 0;
+
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    Workspace work = [&]() {
+        workinfo_t workinfo;
+        gebd2_worksize(A, tauv, tauw, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+
+    // Options to forward
+    auto&& larfOpts = workspace_opts_t<>{work};
+
+    for (idx_t j = 0; j < n; ++j) {
+        // Generate elementary reflector H(j) to annihilate A(j+1:m,j)
+        auto v = slice(A, range(j, m), j);
+        larfg(v, tauv[j]);
+
+        // Apply H(j)**H to A(j:m,j+1:n) from the left
+        if (j < n - 1) {
+            auto A11 = slice(A, range(j, m), range(j + 1, n));
+            larf(Side::Left, forward, v, conj(tauv[j]), A11, larfOpts);
+        }
+
+        if (j < n - 1) {
+            // Generate elementary reflector G(j) to annihilate A(j,j+2:n)
+            auto w = slice(A, j, range(j + 1, n));
+            for (idx_t i = 0; i < n - j - 1; ++i)
+                w[i] = conj(w[i]);
+            larfg(w, tauw[j]);
+
+            // Apply G(j) to A(j+1:m,j+1:n) from the right
+            if (j < m - 1) {
+                auto B11 = slice(A, range(j + 1, m), range(j + 1, n));
+                larf(Side::Right, forward, w, tauw[j], B11, larfOpts);
+            }
+            for (idx_t i = 0; i < n - j - 1; ++i)
+                w[i] = conj(w[i]);
+        }
+    }
+
+    return 0;
+}
+}  // namespace tlapack
+
+#endif  // TLAPACK_GEBD2_HH

--- a/include/tlapack/lapack/gehd2.hpp
+++ b/include/tlapack/lapack/gehd2.hpp
@@ -1,6 +1,7 @@
 /// @file gehd2.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dgehd2.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dgehd2.f
 //
 // This file is part of <T>LAPACK.
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
@@ -10,13 +11,13 @@
 #define TLAPACK_GEHD2_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/larfg.hpp"
 
 namespace tlapack {
 
 /** Worspace query of gehd2()
- * 
+ *
  * @param[in] ilo integer
  * @param[in] ihi integer
  *      It is assumed that A is already upper Hessenberg in columns
@@ -28,39 +29,40 @@ namespace tlapack {
  * @param tau Not referenced.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< class matrix_t, class vector_t >
-inline constexpr
-void gehd2_worksize(
-    size_type< matrix_t > ilo, size_type< matrix_t > ihi, const matrix_t& A,
-    const vector_t &tau, workinfo_t& workinfo,
-    const workspace_opts_t<>& opts = {} )
+template <class matrix_t, class vector_t>
+inline constexpr void gehd2_worksize(size_type<matrix_t> ilo,
+                                     size_type<matrix_t> ihi,
+                                     const matrix_t& A,
+                                     const vector_t& tau,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts = {})
 {
-    using idx_t = size_type< matrix_t >;
-    using pair  = pair<idx_t,idx_t>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
 
     // constants
     const idx_t n = ncols(A);
 
-    if( ilo+1 < ihi ) {
-        const auto v = slice( A, pair{ilo+1,ihi}, ilo );
-        
-        auto C0 = slice( A, pair{0,ihi}, pair{ilo+1,ihi} );
-        larf_worksize( right_side, forward, v, tau[0], C0, workinfo, opts );
-        
-        auto C1 = slice( A, pair{ilo+1,ihi}, pair{ilo+1,n} );
-        larf_worksize( left_side, forward, v, tau[0], C1, workinfo, opts );
+    if (ilo + 1 < ihi) {
+        const auto v = slice(A, pair{ilo + 1, ihi}, ilo);
+
+        auto C0 = slice(A, pair{0, ihi}, pair{ilo + 1, ihi});
+        larf_worksize(right_side, forward, v, tau[0], C0, workinfo, opts);
+
+        auto C1 = slice(A, pair{ilo + 1, ihi}, pair{ilo + 1, n});
+        larf_worksize(left_side, forward, v, tau[0], C1, workinfo, opts);
     }
 }
 
 /** Reduces a general square matrix to upper Hessenberg form
- * 
+ *
  * The matrix Q is represented as a product of elementary reflectors
  * \[
  *          Q = H_ilo H_ilo+1 ... H_ihi,
@@ -75,9 +77,9 @@ void gehd2_worksize(
  * \]
  * with v[i+2] through v[ihi] stored on exit below the diagonal
  * in the ith column of A, and tau in tau[i].
- * 
+ *
  * @return  0 if success
- * 
+ *
  * @param[in] ilo integer
  * @param[in] ihi integer
  *      It is assumed that A is already upper Hessenberg in columns
@@ -97,57 +99,59 @@ void gehd2_worksize(
  * @param[in] opts Options.
  *      - @c opts.work is used if whenever it has sufficient size.
  *        The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup computational
  */
-template< class matrix_t, class vector_t >
-int gehd2( size_type< matrix_t > ilo, size_type< matrix_t > ihi, matrix_t& A, vector_t &tau, const workspace_opts_t<>& opts = {} )
+template <class matrix_t, class vector_t>
+int gehd2(size_type<matrix_t> ilo,
+          size_type<matrix_t> ihi,
+          matrix_t& A,
+          vector_t& tau,
+          const workspace_opts_t<>& opts = {})
 {
-    using idx_t = size_type< matrix_t >;
-    using pair  = pair<idx_t,idx_t>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
 
     // constants
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false( ncols(A) != nrows(A) );
-    tlapack_check_false( (idx_t) size(tau)  < n-1 );
+    tlapack_check_false(ncols(A) != nrows(A));
+    tlapack_check_false((idx_t)size(tau) < n - 1);
 
     // quick return
     if (n <= 0) return 0;
 
     // Allocates workspace
     vectorOfBytes localworkdata;
-    Workspace work = [&]()
-    {
+    Workspace work = [&]() {
         workinfo_t workinfo;
-        gehd2_worksize( ilo, ihi, A, tau, workinfo, opts );
-        return alloc_workspace( localworkdata, workinfo, opts.work );
+        gehd2_worksize(ilo, ihi, A, tau, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
     }();
-    
+
     // Options to forward
-    auto&& larfOpts = workspace_opts_t<>{ work };
+    auto&& larfOpts = workspace_opts_t<>{work};
 
-    for(idx_t i = ilo; i < ihi-1; ++i) {
-
+    for (idx_t i = ilo; i < ihi - 1; ++i) {
         // Define x := A[i+1:ihi,i]
-        auto v = slice(A, pair{i+1,ihi}, i);
+        auto v = slice(A, pair{i + 1, ihi}, i);
 
         // Generate the (i+1)-th elementary Householder reflection on x
-        larfg( v, tau[i] );
+        larfg(v, tau[i]);
 
         // Apply Householder reflection from the right to A[0:ihi,i+1:ihi]
-        auto C0 = slice( A, pair{0,ihi}, pair{i+1,ihi} );
-        larf( right_side, forward, v, tau[i], C0, larfOpts );
+        auto C0 = slice(A, pair{0, ihi}, pair{i + 1, ihi});
+        larf(right_side, forward, v, tau[i], C0, larfOpts);
 
         // Apply Householder reflection from the left to A[i+1:ihi,i+1:n-1]
-        auto C1 = slice( A, pair{i+1,ihi}, pair{i+1,n} );
-        larf( left_side, forward, v, conj(tau[i]), C1, larfOpts );
-	}
+        auto C1 = slice(A, pair{i + 1, ihi}, pair{i + 1, n});
+        larf(left_side, forward, v, conj(tau[i]), C1, larfOpts);
+    }
 
     return 0;
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_GEHD2_HH
+#endif  // TLAPACK_GEHD2_HH

--- a/include/tlapack/lapack/gehrd.hpp
+++ b/include/tlapack/lapack/gehrd.hpp
@@ -1,6 +1,7 @@
 /// @file gehrd.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dgehrd.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dgehrd.f
 //
 // This file is part of <T>LAPACK.
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
@@ -10,212 +11,205 @@
 #define TLAPACK_GEHRD_HH
 
 #include "tlapack/base/utils.hpp"
-
 #include "tlapack/blas/gemm.hpp"
+#include "tlapack/lapack/gehd2.hpp"
 #include "tlapack/lapack/lahr2.hpp"
 #include "tlapack/lapack/larfb.hpp"
-#include "tlapack/lapack/gehd2.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/**
+ * Options struct for gehrd
+ */
+template <class idx_t = size_t>
+struct gehrd_opts_t : public workspace_opts_t<> {
+    inline constexpr gehrd_opts_t(const workspace_opts_t<>& opts = {})
+        : workspace_opts_t<>(opts){};
+
+    idx_t nb = 32;          ///< Block size used in the blocked reduction
+    idx_t nx_switch = 128;  ///< If only nx_switch columns are left, the
+                            ///< algorithm will use unblocked code
+};
+
+/** Worspace query of gehrd()
+ *
+ * @param[in] ilo integer
+ * @param[in] ihi integer
+ *      It is assumed that A is already upper Hessenberg in columns
+ *      0:ilo and rows ihi:n and is already upper triangular in
+ *      columns ihi+1:n and rows 0:ilo.
+ *      0 <= ilo <= ihi <= max(1,n).
+ * @param[in] A n-by-n matrix.
+ *      On entry, the n by n general matrix to be reduced.
+ * @param tau Not referenced.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t, class vector_t>
+void gehrd_worksize(size_type<matrix_t> ilo,
+                    size_type<matrix_t> ihi,
+                    const matrix_t& A,
+                    const vector_t& tau,
+                    workinfo_t& workinfo,
+                    const gehrd_opts_t<size_type<matrix_t> >& opts = {})
 {
+    using idx_t = size_type<matrix_t>;
+    using work_t = matrix_type<matrix_t, vector_t>;
+    using T = type_t<work_t>;
 
-    /**
-     * Options struct for gehrd
-     */
-    template< class idx_t = size_t >
-    struct gehrd_opts_t : public workspace_opts_t<>
-    {
-        inline constexpr gehrd_opts_t( const workspace_opts_t<>& opts = {} )
-        : workspace_opts_t<>( opts ) {};
+    const idx_t n = ncols(A);
+    const idx_t nb = std::min(opts.nb, ihi - ilo - 1);
 
-        idx_t nb = 32; ///< Block size used in the blocked reduction
-        idx_t nx_switch = 128; ///< If only nx_switch columns are left, the algorithm will use unblocked code
-    };
+    const workinfo_t myWorkinfo(sizeof(T) * (n + nb), nb);
+    workinfo.minMax(myWorkinfo);
+}
 
-    /** Worspace query of gehrd()
-     * 
-     * @param[in] ilo integer
-     * @param[in] ihi integer
-     *      It is assumed that A is already upper Hessenberg in columns
-     *      0:ilo and rows ihi:n and is already upper triangular in
-     *      columns ihi+1:n and rows 0:ilo.
-     *      0 <= ilo <= ihi <= max(1,n).
-     * @param[in] A n-by-n matrix.
-     *      On entry, the n by n general matrix to be reduced.
-     * @param tau Not referenced.
-     *
-     * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template < class matrix_t, class vector_t >
-    void gehrd_worksize(
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        const matrix_t &A, 
-        const vector_t &tau,
-        workinfo_t& workinfo, 
-        const gehrd_opts_t< size_type<matrix_t> > &opts = {} )
-    {
-        using idx_t = size_type<matrix_t>;
-        using work_t    = matrix_type<matrix_t,vector_t>;
-        using T         = type_t< work_t >;
+/** Reduces a general square matrix to upper Hessenberg form
+ *
+ * The matrix Q is represented as a product of elementary reflectors
+ * \[
+ *          Q = H_ilo H_ilo+1 ... H_ihi,
+ * \]
+ * Each H_i has the form
+ * \[
+ *          H_i = I - tau * v * v',
+ * \]
+ * where tau is a scalar, and v is a vector with
+ * \[
+ *          v[0] = v[1] = ... = v[i] = 0; v[i+1] = 1,
+ * \]
+ * with v[i+2] through v[ihi] stored on exit below the diagonal
+ * in the ith column of A, and tau in tau[i].
+ *
+ * @return  0 if success
+ *
+ * @param[in] ilo integer
+ * @param[in] ihi integer
+ *      It is assumed that A is already upper Hessenberg in columns
+ *      0:ilo and rows ihi:n and is already upper triangular in
+ *      columns ihi+1:n and rows 0:ilo.
+ *      0 <= ilo <= ihi <= max(1,n).
+ * @param[in,out] A n-by-n matrix.
+ *      On entry, the n by n general matrix to be reduced.
+ *      On exit, the upper triangle and the first subdiagonal of A
+ *      are overwritten with the upper Hessenberg matrix H, and the
+ *      elements below the first subdiagonal, with the array TAU,
+ *      represent the orthogonal matrix Q as a product of elementary
+ *      reflectors. See Further Details.
+ * @param[out] tau Real vector of length n-1.
+ *      The scalar factors of the elementary reflectors.
+ *
+ * @param[in] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup computational
+ */
+template <class matrix_t, class vector_t>
+int gehrd(size_type<matrix_t> ilo,
+          size_type<matrix_t> ihi,
+          matrix_t& A,
+          vector_t& tau,
+          const gehrd_opts_t<size_type<matrix_t> >& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using work_t = matrix_type<matrix_t, vector_t>;
+    using pair = pair<idx_t, idx_t>;
+    using TA = type_t<matrix_t>;
+    using real_t = real_type<TA>;
 
-        const idx_t n = ncols(A);
-        const idx_t nb = std::min( opts.nb, ihi-ilo-1 );
+    // Functor
+    Create<work_t> new_matrix;
 
-        const workinfo_t myWorkinfo( sizeof(T)*(n+nb), nb );
-        workinfo.minMax( myWorkinfo );
-    }
+    // constants
+    const real_t one(1);
+    const type_t<work_t> zero(0);
+    const idx_t n = ncols(A);
 
-    /** Reduces a general square matrix to upper Hessenberg form
-     *
-     * The matrix Q is represented as a product of elementary reflectors
-     * \[
-     *          Q = H_ilo H_ilo+1 ... H_ihi,
-     * \]
-     * Each H_i has the form
-     * \[
-     *          H_i = I - tau * v * v',
-     * \]
-     * where tau is a scalar, and v is a vector with
-     * \[
-     *          v[0] = v[1] = ... = v[i] = 0; v[i+1] = 1,
-     * \]
-     * with v[i+2] through v[ihi] stored on exit below the diagonal
-     * in the ith column of A, and tau in tau[i].
-     *
-     * @return  0 if success
-     *
-     * @param[in] ilo integer
-     * @param[in] ihi integer
-     *      It is assumed that A is already upper Hessenberg in columns
-     *      0:ilo and rows ihi:n and is already upper triangular in
-     *      columns ihi+1:n and rows 0:ilo.
-     *      0 <= ilo <= ihi <= max(1,n).
-     * @param[in,out] A n-by-n matrix.
-     *      On entry, the n by n general matrix to be reduced.
-     *      On exit, the upper triangle and the first subdiagonal of A
-     *      are overwritten with the upper Hessenberg matrix H, and the
-     *      elements below the first subdiagonal, with the array TAU,
-     *      represent the orthogonal matrix Q as a product of elementary
-     *      reflectors. See Further Details.
-     * @param[out] tau Real vector of length n-1.
-     *      The scalar factors of the elementary reflectors.
-     *
-     * @param[in] opts Options.
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        The sufficient size can be obtained through a workspace query.
-     *
-     * @ingroup computational
-     */
-    template < class matrix_t, class vector_t >
-    int gehrd(
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        matrix_t &A, 
-        vector_t &tau,
-        const gehrd_opts_t< size_type<matrix_t> > &opts = {} )
-    {
-        using idx_t     = size_type<matrix_t>;
-        using work_t    = matrix_type<matrix_t,vector_t>;
-        using pair = pair<idx_t, idx_t>;
-        using TA   = type_t< matrix_t >;
-        using real_t = real_type< TA >;
+    // Blocksize
+    idx_t nb = std::min(opts.nb, ihi - ilo - 1);
+    // Size of the last block which be handled with unblocked code
+    idx_t nx_switch = opts.nx_switch;
+    idx_t nx = std::max(nb, nx_switch);
 
-        // Functor
-        Create<work_t> new_matrix;
+    // check arguments
+    tlapack_check_false((ilo < 0) or (ilo >= n));
+    tlapack_check_false((ihi < 0) or (ihi > n));
+    tlapack_check_false(ncols(A) != nrows(A));
+    tlapack_check_false((idx_t)size(tau) < n - 1);
 
-        // constants
-        const real_t one(1);
-        const type_t<work_t> zero(0);
-        const idx_t n = ncols(A);
+    // quick return
+    if (n <= 0) return 0;
 
-        // Blocksize
-        idx_t nb = std::min( opts.nb, ihi-ilo-1 );
-        // Size of the last block which be handled with unblocked code
-        idx_t nx_switch = opts.nx_switch;
-        idx_t nx = std::max( nb, nx_switch );
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    Workspace work = [&]() {
+        workinfo_t workinfo;
+        gehrd_worksize(ilo, ihi, A, tau, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
 
-        // check arguments
-        tlapack_check_false((ilo < 0) or (ilo >= n) );
-        tlapack_check_false((ihi < 0) or (ihi > n) );
-        tlapack_check_false(ncols(A) != nrows(A) );
-        tlapack_check_false((idx_t)size(tau) < n - 1 );
+    // Options to forward
+    auto&& larfbOpts = workspace_opts_t<transpose_type<work_t> >{work};
+    auto&& gehd2Opts = workspace_opts_t<>{work};
 
-        // quick return
-        if (n <= 0)
-            return 0;
+    // Matrix Y
+    Workspace workMatrixT;
+    auto Y = new_matrix(work, n, nb, workMatrixT);
+    laset(dense, zero, zero, Y);
 
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            gehrd_worksize( ilo, ihi, A, tau, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-    
-        // Options to forward
-        auto&& larfbOpts = workspace_opts_t< transpose_type<work_t> >{ work };
-        auto&& gehd2Opts = workspace_opts_t<>{ work };
+    // Matrix T
+    auto matrixT = new_matrix(workMatrixT, nb, nb);
 
-        // Matrix Y
-        Workspace workMatrixT;
-        auto Y = new_matrix( work, n, nb, workMatrixT );
-        laset( dense, zero, zero, Y );
+    idx_t i = ilo;
+    for (; i + nx < ihi - 1; i = i + nb) {
+        const idx_t nb2 = std::min(nb, ihi - i - 1);
 
-        // Matrix T
-        auto matrixT = new_matrix( workMatrixT, nb, nb );
+        auto V = slice(A, pair{i + 1, ihi}, pair{i, i + nb2});
+        auto A2 = slice(A, pair{0, ihi}, pair{i, ihi});
+        auto tau2 = slice(tau, pair{i, ihi});
+        auto T_s = slice(matrixT, pair{0, nb2}, pair{0, nb2});
+        auto Y_s = slice(Y, pair{0, n}, pair{0, nb2});
+        lahr2(i, nb2, A2, tau2, T_s, Y_s);
+        if (i + nb2 < ihi) {
+            // Note, this V2 contains the last row of the triangular part
+            auto V2 = slice(V, pair{nb2 - 1, ihi - i - 1}, pair{0, nb2});
 
-        idx_t i = ilo;
-        for (; i+nx < ihi-1; i = i + nb)
-        {
-            const idx_t nb2 = std::min(nb, ihi - i - 1);
-
-            auto V = slice(A, pair{i + 1, ihi}, pair{i, i + nb2});
-            auto A2 = slice(A, pair{0, ihi}, pair{i, ihi});
-            auto tau2 = slice(tau, pair{i, ihi});
-            auto T_s = slice(matrixT, pair{0, nb2}, pair{0, nb2});
-            auto Y_s = slice(Y, pair{0, n}, pair{0, nb2});
-            lahr2(i, nb2, A2, tau2, T_s, Y_s);
-            if( i + nb2 < ihi ){
-                // Note, this V2 contains the last row of the triangular part
-                auto V2 = slice(V, pair{nb2-1, ihi-i-1}, pair{0, nb2});
-
-                // Apply the block reflector H to A(0:ihi,i+nb:ihi) from the right, computing
-                // A := A - Y * V**T. The multiplication requires V(nb2-1,nb2-1) to be set to 1.
-                const TA ei = V(nb2-1, nb2-1);
-                V(nb2-1, nb2-1) = one;
-                auto A3 = slice(A, pair{0, ihi}, pair{i + nb2, ihi});
-                auto Y_2 = slice(Y, pair{0, ihi}, pair{0, nb2});
-                gemm(Op::NoTrans, Op::ConjTrans, -one, Y_2, V2, one, A3);
-                V(nb2-1, nb2-1) = ei;
-            }
-            // Apply the block reflector H to A(0:i+1,i+1:i+ib) from the right
-            auto V1 = slice(A, pair{i + 1, i + nb2 + 1}, pair{i, i + nb2});
-            trmm(Side::Right, Uplo::Lower, Op::ConjTrans, Diag::Unit, one, V1, Y_s);
-            for (idx_t j = 0; j < nb2 - 1; ++j)
-            {
-                auto A4 = slice(A, pair{0, i+1}, i + j + 1);
-                axpy(-one, slice(Y, pair{0, i+1}, j), A4);
-            }
-
-            // Apply the block reflector H to A(i+1:ihi,i+nb:n) from the left
-            auto A5 = slice(A, pair{i + 1, ihi}, pair{i + nb2, n});
-            larfb( Side::Left, Op::ConjTrans, Direction::Forward,
-                   StoreV::Columnwise, V, T_s, A5, larfbOpts );
+            // Apply the block reflector H to A(0:ihi,i+nb:ihi) from the right,
+            // computing A := A - Y * V**T. The multiplication requires
+            // V(nb2-1,nb2-1) to be set to 1.
+            const TA ei = V(nb2 - 1, nb2 - 1);
+            V(nb2 - 1, nb2 - 1) = one;
+            auto A3 = slice(A, pair{0, ihi}, pair{i + nb2, ihi});
+            auto Y_2 = slice(Y, pair{0, ihi}, pair{0, nb2});
+            gemm(Op::NoTrans, Op::ConjTrans, -one, Y_2, V2, one, A3);
+            V(nb2 - 1, nb2 - 1) = ei;
+        }
+        // Apply the block reflector H to A(0:i+1,i+1:i+ib) from the right
+        auto V1 = slice(A, pair{i + 1, i + nb2 + 1}, pair{i, i + nb2});
+        trmm(Side::Right, Uplo::Lower, Op::ConjTrans, Diag::Unit, one, V1, Y_s);
+        for (idx_t j = 0; j < nb2 - 1; ++j) {
+            auto A4 = slice(A, pair{0, i + 1}, i + j + 1);
+            axpy(-one, slice(Y, pair{0, i + 1}, j), A4);
         }
 
-        gehd2( i, ihi, A, tau, gehd2Opts );
-
-        return 0;
+        // Apply the block reflector H to A(i+1:ihi,i+nb:n) from the left
+        auto A5 = slice(A, pair{i + 1, ihi}, pair{i + nb2, n});
+        larfb(Side::Left, Op::ConjTrans, Direction::Forward, StoreV::Columnwise,
+              V, T_s, A5, larfbOpts);
     }
 
-} // lapack
+    gehd2(i, ihi, A, tau, gehd2Opts);
 
-#endif // TLAPACK_GEHRD_HH
+    return 0;
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_GEHRD_HH

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -1,6 +1,7 @@
 /// @file gelq2.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelq2.f
+/// @note Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelq2.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -12,130 +13,127 @@
 #define TLAPACK_GELQ2_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/larfg.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** Worspace query of gelq2()
+ *
+ * @param[in] A m-by-n matrix.
+ *
+ * @param tauw Not referenced.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t, class vector_t>
+inline constexpr void gelq2_worksize(const matrix_t& A,
+                                     const vector_t& tauw,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts = {})
 {
+    using idx_t = size_type<matrix_t>;
 
-    /** Worspace query of gelq2()
-     *
-     * @param[in] A m-by-n matrix.
-     *
-     * @param tauw Not referenced.
-     *
-     * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template< class matrix_t, class vector_t >
-    inline constexpr
-    void gelq2_worksize(
-        const matrix_t& A, const vector_t &tauw, workinfo_t& workinfo,
-        const workspace_opts_t<>& opts = {} )
-    {
-        using idx_t = size_type< matrix_t >;
+    // constants
+    const idx_t m = nrows(A);
 
-        // constants
-        const idx_t m = nrows(A);
-
-        if( m > 1 ) {
-            auto C = rows( A, range<idx_t>{1,m} );
-            larf_worksize( right_side, forward, row(A,0), tauw[0], C, workinfo, opts );
-        }
-    }
-    
-    /** Computes an LQ factorization of a complex m-by-n matrix A using
-     *  an unblocked algorithm.
-     *
-     * The matrix Q is represented as a product of elementary reflectors.
-     * \[
-     *          Q = H(k)**H ... H(2)**H H(1)**H,
-     * \]
-     * where k = min(m,n). Each H(j) has the form
-     * \[
-     *          H(j) = I - tauw * w * w**H
-     * \]
-     * where tauw is a complex scalar, and w is a complex vector with
-     * \[
-     *          w[0] = w[1] = ... = w[j-1] = 0; w[j] = 1,
-     * \]
-     * with w[j+1]**H through w[n]**H is stored on exit
-     * in the jth row of A, and tauw in tauw[j].
-     * 
-     * 
-     *
-     * @return  0 if success
-     *
-     * @param[in,out] A m-by-n matrix.
-     *      On exit, the elements on and below the diagonal of the array
-     *      contain the m by min(m,n) lower trapezoidal matrix L (L is
-     *      lower triangular if m <= n); the elements above the diagonal,
-     *      with the array tauw, represent the unitary matrix Q as a
-     *      product of elementary reflectors.
-     *
-     * @param[out] tauw Complex vector of length min(m,n).
-     *      The scalar factors of the elementary reflectors.
-     *
-     * @param[in] opts Options.
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        The sufficient size can be obtained through a workspace query.
-     *
-     * @ingroup computational
-     */
-    template <typename matrix_t, class vector_t>
-    int gelq2(matrix_t &A, vector_t &tauw, const workspace_opts_t<>& opts = {})
-    {
-        using idx_t = size_type<matrix_t>;
-        using range = std::pair<idx_t, idx_t>;
-
-        // constants
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-        const idx_t k = min(m, n);
-
-        // check arguments
-        tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n) );
-
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            gelq2_worksize( A, tauw, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-        
-        // Options to forward
-        auto&& larfOpts = workspace_opts_t<>{ work };
-
-        for (idx_t j = 0; j < k; ++j)
-        {
-            // Define w := A(j,j:n)
-            auto w = slice(A, j, range(j, n));
-
-            // Generate elementary reflector H(j) to annihilate A(j,j+1:n)
-            for (idx_t i = 0; i < n - j; ++i)
-                w[i] = conj(w[i]); 
-            larfg(w, tauw[j]);
-
-            // If either condition is satisfied, Q11 will not be empty
-            if (j < k - 1 || k < m)
-            {
-                // Apply H(j) to A(j+1:m,j:n) from the right
-                auto Q11 = slice(A, range(j + 1, m), range(j, n));
-                larf(Side::Right, forward, w, tauw[j], Q11, larfOpts);
-            }
-            for (idx_t i = 0; i < n - j; ++i)
-                w[i] = conj(w[i]); 
-        }
-
-        return 0;
+    if (m > 1) {
+        auto C = rows(A, range<idx_t>{1, m});
+        larf_worksize(right_side, forward, row(A, 0), tauw[0], C, workinfo,
+                      opts);
     }
 }
 
-#endif // TLAPACK_GELQ2_HH
+/** Computes an LQ factorization of a complex m-by-n matrix A using
+ *  an unblocked algorithm.
+ *
+ * The matrix Q is represented as a product of elementary reflectors.
+ * \[
+ *          Q = H(k)**H ... H(2)**H H(1)**H,
+ * \]
+ * where k = min(m,n). Each H(j) has the form
+ * \[
+ *          H(j) = I - tauw * w * w**H
+ * \]
+ * where tauw is a complex scalar, and w is a complex vector with
+ * \[
+ *          w[0] = w[1] = ... = w[j-1] = 0; w[j] = 1,
+ * \]
+ * with w[j+1]**H through w[n]**H is stored on exit
+ * in the jth row of A, and tauw in tauw[j].
+ *
+ *
+ *
+ * @return  0 if success
+ *
+ * @param[in,out] A m-by-n matrix.
+ *      On exit, the elements on and below the diagonal of the array
+ *      contain the m by min(m,n) lower trapezoidal matrix L (L is
+ *      lower triangular if m <= n); the elements above the diagonal,
+ *      with the array tauw, represent the unitary matrix Q as a
+ *      product of elementary reflectors.
+ *
+ * @param[out] tauw Complex vector of length min(m,n).
+ *      The scalar factors of the elementary reflectors.
+ *
+ * @param[in] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup computational
+ */
+template <typename matrix_t, class vector_t>
+int gelq2(matrix_t& A, vector_t& tauw, const workspace_opts_t<>& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using range = std::pair<idx_t, idx_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t k = min(m, n);
+
+    // check arguments
+    tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
+
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    Workspace work = [&]() {
+        workinfo_t workinfo;
+        gelq2_worksize(A, tauw, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+
+    // Options to forward
+    auto&& larfOpts = workspace_opts_t<>{work};
+
+    for (idx_t j = 0; j < k; ++j) {
+        // Define w := A(j,j:n)
+        auto w = slice(A, j, range(j, n));
+
+        // Generate elementary reflector H(j) to annihilate A(j,j+1:n)
+        for (idx_t i = 0; i < n - j; ++i)
+            w[i] = conj(w[i]);
+        larfg(w, tauw[j]);
+
+        // If either condition is satisfied, Q11 will not be empty
+        if (j < k - 1 || k < m) {
+            // Apply H(j) to A(j+1:m,j:n) from the right
+            auto Q11 = slice(A, range(j + 1, m), range(j, n));
+            larf(Side::Right, forward, w, tauw[j], Q11, larfOpts);
+        }
+        for (idx_t i = 0; i < n - j; ++i)
+            w[i] = conj(w[i]);
+    }
+
+    return 0;
+}
+}  // namespace tlapack
+
+#endif  // TLAPACK_GELQ2_HH

--- a/include/tlapack/lapack/gelqf.hpp
+++ b/include/tlapack/lapack/gelqf.hpp
@@ -1,6 +1,7 @@
 /// @file gelqf.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelqf.f
+/// @note Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelqf.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -12,167 +13,161 @@
 #define TLAPACK_GELQF_HH
 
 #include "tlapack/base/utils.hpp"
-
-#include "tlapack/lapack/larft.hpp"
-#include "tlapack/lapack/larfb.hpp"
 #include "tlapack/lapack/gelq2.hpp"
+#include "tlapack/lapack/larfb.hpp"
+#include "tlapack/lapack/larft.hpp"
 
-namespace tlapack
+namespace tlapack {
+/**
+ * Options struct for gelqf
+ */
+template <class idx_t = size_t>
+struct gelqf_opts_t : public workspace_opts_t<> {
+    inline constexpr gelqf_opts_t(const workspace_opts_t<>& opts = {})
+        : workspace_opts_t<>(opts){};
+
+    idx_t nb = 32;  ///< Block size
+};
+
+/** Worspace query of gelqf()
+ *
+ * @param[in] A m-by-n matrix.
+ *
+ * @param TT Not referenced.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <typename matrix_t>
+inline constexpr void gelqf_worksize(
+    const matrix_t& A,
+    const matrix_t& TT,
+    workinfo_t& workinfo,
+    const gelqf_opts_t<size_type<matrix_t> >& opts = {})
 {
-    /**
-     * Options struct for gelqf
-     */
-    template< class idx_t = size_t >
-    struct gelqf_opts_t : public workspace_opts_t<>
-    {
-        inline constexpr gelqf_opts_t( const workspace_opts_t<>& opts = {} )
-        : workspace_opts_t<>( opts ) {};
+    using idx_t = size_type<matrix_t>;
 
-        idx_t nb = 32; ///< Block size
-    };
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t k = min(m, n);
+    const idx_t nb = opts.nb;
+    const idx_t ib = std::min<idx_t>(nb, k);
 
-    /** Worspace query of gelqf()
-     *
-     * @param[in] A m-by-n matrix.
-     *
-     * @param TT Not referenced.
-     *
-     * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template< typename matrix_t >
-    inline constexpr
-    void gelqf_worksize(
-        const matrix_t &A, const matrix_t &TT, workinfo_t& workinfo,
-        const gelqf_opts_t< size_type<matrix_t> > &opts = {} )
-    {
-        using idx_t = size_type<matrix_t>;
+    auto TT1 = slice(TT, range<idx_t>(0, ib), range<idx_t>(0, ib));
+    auto A11 = rows(A, range<idx_t>(0, ib));
+    auto tauw1 = diag(TT1);
 
-        // constants
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-        const idx_t k = min(m, n);
-        const idx_t nb = opts.nb;
-        const idx_t ib = std::min<idx_t>(nb, k);
+    gelq2_worksize(A11, tauw1, workinfo, opts);
+}
 
-        auto TT1 = slice(TT, range<idx_t>(0, ib), range<idx_t>(0, ib));
-        auto A11 = rows(A, range<idx_t>(0, ib));
+/** Computes an LQ factorization of a complex m-by-n matrix A using
+ *  a blocked algorithm.
+ *
+ * The matrix Q is represented as a product of elementary reflectors.
+ * \[
+ *          Q = H(k)**H ... H(2)**H H(1)**H,
+ * \]
+ * where k = min(m,n). Each H(j) has the form
+ * \[
+ *          H(j) = I - tauw * w * w**H
+ * \]
+ * where tauw is a complex scalar, and w is a complex vector with
+ * \[
+ *          w[0] = w[1] = ... = w[j-1] = 0; w[j] = 1,
+ * \]
+ * with w[j+1]**H through w[n]**H is stored on exit in the jth row of A.
+ * tauw is stored in TT(j,i), where 0 <= i < nb and i = j (mod nb).
+ *
+ * @return  0 if success
+ *
+ * @param[in,out] A m-by-n matrix.
+ *      On exit, the elements on and below the diagonal of the array
+ *      contain the m by min(m,n) lower trapezoidal matrix L (L is
+ *      lower triangular if m <= n); the elements above the diagonal,
+ *      with the array tauw, represent the unitary matrix Q as a
+ *      product of elementary reflectors.
+ *
+ * @param[out] TT m-by-nb matrix.
+ *      In the representation of the block reflector.
+ *      tauw[j] is stored in TT(j,i), where 0 <= i < nb and i = j (mod nb).
+ *      On exit, TT( 0:k, 0:nb ) contains blocks used to build Q :
+ *      \[
+ *          Q^H
+ *          =
+ *          [ I - W(0:nb,0:k)^T * TT(0:nb,0:nb) * conj(W(0:nb,0:k)) ]
+ *          *
+ *          [ I - W(nb:2nb,0:k)^T * TT(nb:2nb,0:nb) * conj(W(nb:2nb,0:k)) ]
+ *          *
+ *          ...
+ *      \]
+ *
+ * @param[in] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup computational
+ */
+template <typename matrix_t>
+int gelqf(matrix_t& A,
+          matrix_t& TT,
+          const gelqf_opts_t<size_type<matrix_t> >& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using range = std::pair<idx_t, idx_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t k = min(m, n);
+    const idx_t nb = opts.nb;
+
+    // check arguments
+    tlapack_check_false(nrows(TT) < m || ncols(TT) < nb);
+
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    Workspace work = [&]() {
+        workinfo_t workinfo;
+        gelqf_worksize(A, TT, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+
+    // Options to forward
+    auto&& gelq2Opts = workspace_opts_t<>{work};
+
+    for (idx_t j = 0; j < k; j += nb) {
+        // Use blocked code initially
+        idx_t ib = std::min<idx_t>(nb, k - j);
+
+        // Compute the LQ factorization of the current block A(j:j+ib-1,j:n)
+        auto TT1 = slice(TT, range(j, j + ib), range(0, ib));
+        auto A11 = slice(A, range(j, j + ib), range(j, n));
         auto tauw1 = diag(TT1);
 
-        gelq2_worksize(A11, tauw1, workinfo, opts);
-    }
+        gelq2(A11, tauw1, gelq2Opts);
 
-    /** Computes an LQ factorization of a complex m-by-n matrix A using
-     *  a blocked algorithm.
-     *
-     * The matrix Q is represented as a product of elementary reflectors.
-     * \[
-     *          Q = H(k)**H ... H(2)**H H(1)**H,
-     * \]
-     * where k = min(m,n). Each H(j) has the form
-     * \[
-     *          H(j) = I - tauw * w * w**H
-     * \]
-     * where tauw is a complex scalar, and w is a complex vector with
-     * \[
-     *          w[0] = w[1] = ... = w[j-1] = 0; w[j] = 1,
-     * \]
-     * with w[j+1]**H through w[n]**H is stored on exit in the jth row of A.
-     * tauw is stored in TT(j,i), where 0 <= i < nb and i = j (mod nb).
-     *
-     * @return  0 if success
-     *
-     * @param[in,out] A m-by-n matrix.
-     *      On exit, the elements on and below the diagonal of the array
-     *      contain the m by min(m,n) lower trapezoidal matrix L (L is
-     *      lower triangular if m <= n); the elements above the diagonal,
-     *      with the array tauw, represent the unitary matrix Q as a
-     *      product of elementary reflectors.
-     * 
-     * @param[out] TT m-by-nb matrix.
-     *      In the representation of the block reflector.
-     *      tauw[j] is stored in TT(j,i), where 0 <= i < nb and i = j (mod nb).
-     *      On exit, TT( 0:k, 0:nb ) contains blocks used to build Q :
-     *      \[
-     *          Q^H
-     *          =
-     *          [ I - W(0:nb,0:k)^T * TT(0:nb,0:nb) * conj(W(0:nb,0:k)) ]
-     *          *
-     *          [ I - W(nb:2nb,0:k)^T * TT(nb:2nb,0:nb) * conj(W(nb:2nb,0:k)) ]
-     *          *
-     *          ...
-     *      \]
-     * 
-     * @param[in] opts Options.
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        The sufficient size can be obtained through a workspace query.
-     *
-     * @ingroup computational
-     */
-    template< typename matrix_t >
-    int gelqf(matrix_t &A, matrix_t &TT, const gelqf_opts_t< size_type<matrix_t> > &opts = {})
-    {
-        using idx_t = size_type<matrix_t>;
-        using range = std::pair<idx_t, idx_t>;
+        if (j + ib < k) {
+            // Form the triangular factor of the block reflector H = H(j) H(j+1)
+            // . . . H(j+ib-1)
+            larft(Direction::Forward, StoreV::Rowwise, A11, tauw1, TT1);
 
-        // constants
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-        const idx_t k = min(m, n);
-        const idx_t nb = opts.nb;
+            // Apply H to A(j+ib:m,j:n) from the right
+            auto A12 = slice(A, range(j + ib, m), range(j, n));
 
-        // check arguments
-        tlapack_check_false( nrows(TT) < m || ncols(TT) < nb );
-
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            gelqf_worksize( A, TT, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-        
-        // Options to forward
-        auto&& gelq2Opts = workspace_opts_t<>{ work };
-
-        for (idx_t j = 0; j < k; j += nb)
-        {
-            // Use blocked code initially
-            idx_t ib = std::min<idx_t>(nb, k - j);
-
-            // Compute the LQ factorization of the current block A(j:j+ib-1,j:n)
-            auto TT1 = slice(TT, range(j, j + ib), range(0, ib));
-            auto A11 = slice(A, range(j, j + ib), range(j, n));
-            auto tauw1 = diag(TT1);
-
-            gelq2(A11, tauw1, gelq2Opts);
-
-            if (j + ib < k)
-            {
-                // Form the triangular factor of the block reflector H = H(j) H(j+1) . . . H(j+ib-1)
-                larft(Direction::Forward, StoreV::Rowwise, A11, tauw1, TT1);
-
-                // Apply H to A(j+ib:m,j:n) from the right
-                auto A12 = slice(A, range(j + ib, m), range(j, n));
-                
-                workspace_opts_t<void> work1(
-                                slice(TT, range(j + ib, m), range(0, ib)) );
-                larfb(
-                    Side::Right,
-                    Op::NoTrans,
-                    Direction::Forward,
-                    StoreV::Rowwise,
-                    A11, TT1, A12, work1);
-            }
+            workspace_opts_t<void> work1(
+                slice(TT, range(j + ib, m), range(0, ib)));
+            larfb(Side::Right, Op::NoTrans, Direction::Forward, StoreV::Rowwise,
+                  A11, TT1, A12, work1);
         }
-
-        return 0;
     }
+
+    return 0;
 }
-#endif // TLAPACK_GELQF_HH
+}  // namespace tlapack
+#endif  // TLAPACK_GELQF_HH

--- a/include/tlapack/lapack/geqr2.hpp
+++ b/include/tlapack/lapack/geqr2.hpp
@@ -1,6 +1,7 @@
 /// @file geqr2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/geqr2.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/geqr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/getrf.hpp
+++ b/include/tlapack/lapack/getrf.hpp
@@ -12,67 +12,62 @@
 #define TLAPACK_GETRF_HH
 
 #include "tlapack/base/utils.hpp"
-
 #include "tlapack/lapack/getrf_level0.hpp"
 #include "tlapack/lapack/getrf_recursive.hpp"
 
 namespace tlapack {
 
-    enum class GetrfVariant : char {
-        Level0 = '0',
-        Recursive = 'R'
-    };
+enum class GetrfVariant : char { Level0 = '0', Recursive = 'R' };
 
-    struct getrf_opts_t
-    {
-        GetrfVariant variant = GetrfVariant::Recursive;
-    };
+struct getrf_opts_t {
+    GetrfVariant variant = GetrfVariant::Recursive;
+};
 
-    /** getrf computes an LU factorization of a general m-by-n matrix A.
-     *
-     *  The factorization has the form
-     * \[
-     *   P A = L U
-     * \]
-     *  where P is a permutation matrix constructed from our Piv vector, L is lower triangular with unit
-     *  diagonal elements (lower trapezoidal if m > n), and U is upper
-     *  triangular (upper trapezoidal if m < n).
-     *
-     * @return  0 if success
-     * @return  i+1 if failed to compute the LU on iteration i
-     *
-     * @param[in,out] A m-by-n matrix.
-     *      On exit, the factors L and U from the factorization A=PLU;
-     *      the unit diagonal elements of L are not stored.
-     *      
-     * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
-     * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the algorithm,
-     * the j-th row needs to be swapped with i
-     * 
-     * @param[in] opts Options.
-     *      - variant:
-     *          - Recursive = 'R',
-     *          - Level0 = '0'
-     * 
-     * @note To construct L and U, one proceeds as in the following steps
-     *      1. Set matrices L m-by-k, and U k-by-n be to matrices with all zeros, where k=min(m,n)
-     *      2. Set elements on the diagonal of L to 1
-     *      3. below the diagonal of A will be copied to L
-     *      4. On and above the diagonal of A will be copied to U
-     *
-     * @ingroup computational
-     */
-    template< class matrix_t , class vector_t >
-    inline
-    int getrf( matrix_t& A, vector_t &Piv, const getrf_opts_t& opts = {} )
-    {
-        // Call variant
-        if( opts.variant == GetrfVariant::Recursive )
-            return getrf_recursive( A, Piv );
-        else
-            return getrf_level0( A, Piv );
-    }
+/** getrf computes an LU factorization of a general m-by-n matrix A.
+ *
+ *  The factorization has the form
+ * \[
+ *   P A = L U
+ * \]
+ *  where P is a permutation matrix constructed from our Piv vector, L is lower
+ * triangular with unit diagonal elements (lower trapezoidal if m > n), and U is
+ * upper triangular (upper trapezoidal if m < n).
+ *
+ * @return  0 if success
+ * @return  i+1 if failed to compute the LU on iteration i
+ *
+ * @param[in,out] A m-by-n matrix.
+ *      On exit, the factors L and U from the factorization A=PLU;
+ *      the unit diagonal elements of L are not stored.
+ *
+ * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
+ * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
+ * algorithm, the j-th row needs to be swapped with i
+ *
+ * @param[in] opts Options.
+ *      - variant:
+ *          - Recursive = 'R',
+ *          - Level0 = '0'
+ *
+ * @note To construct L and U, one proceeds as in the following steps
+ *      1. Set matrices L m-by-k, and U k-by-n be to matrices with all zeros,
+ * where k=min(m,n)
+ *      2. Set elements on the diagonal of L to 1
+ *      3. below the diagonal of A will be copied to L
+ *      4. On and above the diagonal of A will be copied to U
+ *
+ * @ingroup computational
+ */
+template <class matrix_t, class vector_t>
+inline int getrf(matrix_t& A, vector_t& Piv, const getrf_opts_t& opts = {})
+{
+    // Call variant
+    if (opts.variant == GetrfVariant::Recursive)
+        return getrf_recursive(A, Piv);
+    else
+        return getrf_level0(A, Piv);
+}
 
-} // tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_GETRF_HH
+#endif  // TLAPACK_GETRF_HH

--- a/include/tlapack/lapack/getrf_level0.hpp
+++ b/include/tlapack/lapack/getrf_level0.hpp
@@ -15,95 +15,95 @@
 
 namespace tlapack {
 
-    /** getrf computes an LU factorization of a general m-by-n matrix A
-     *  using partial pivoting with row interchanges.
-     *
-     *  The factorization has the form
-     * \[
-     *   P A = L U
-     * \]
-     *  where P is a permutation matrix constructed from our Piv vector, L is lower triangular with unit
-     *  diagonal elements (lower trapezoidal if m > n), and U is upper
-     *  triangular (upper trapezoidal if m < n).
-     * 
-     *  This is a Level 0 version of the algorithm.
-     *  We currently still rely on iamax because of the control on
-     *  inf and nan propagation.
-     *
-     * @return  0 if success
-     * @return  i+1 if failed to compute the LU on iteration i
-     *
-     * @param[in,out] A m-by-n matrix.
-     *      On exit, the factors L and U from the factorization A=PLU;
-     *      the unit diagonal elements of L are not stored.
-     *      
-     * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
-     * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the algorithm,
-     * the j-th row needs to be swapped with i
-     * 
-     * @note To construct L and U, one proceeds as in the following steps
-     *      1. Set matrices L m-by-k, and U k-by-n be to matrices with all zeros, where k=min(m,n)
-     *      2. Set elements on the diagonal of L to 1
-     *      3. below the diagonal of A will be copied to L
-     *      4. On and above the diagonal of A will be copied to U
-     *
-     * @ingroup computational
-     */
-    template< class matrix_t , class vector_t >
-    int getrf_level0( matrix_t& A, vector_t &Piv)
-    {
-        using idx_t = size_type< matrix_t >;
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
+/** getrf computes an LU factorization of a general m-by-n matrix A
+ *  using partial pivoting with row interchanges.
+ *
+ *  The factorization has the form
+ * \[
+ *   P A = L U
+ * \]
+ *  where P is a permutation matrix constructed from our Piv vector, L is lower
+ * triangular with unit diagonal elements (lower trapezoidal if m > n), and U is
+ * upper triangular (upper trapezoidal if m < n).
+ *
+ *  This is a Level 0 version of the algorithm.
+ *  We currently still rely on iamax because of the control on
+ *  inf and nan propagation.
+ *
+ * @return  0 if success
+ * @return  i+1 if failed to compute the LU on iteration i
+ *
+ * @param[in,out] A m-by-n matrix.
+ *      On exit, the factors L and U from the factorization A=PLU;
+ *      the unit diagonal elements of L are not stored.
+ *
+ * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
+ * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
+ * algorithm, the j-th row needs to be swapped with i
+ *
+ * @note To construct L and U, one proceeds as in the following steps
+ *      1. Set matrices L m-by-k, and U k-by-n be to matrices with all zeros,
+ * where k=min(m,n)
+ *      2. Set elements on the diagonal of L to 1
+ *      3. below the diagonal of A will be copied to L
+ *      4. On and above the diagonal of A will be copied to U
+ *
+ * @ingroup computational
+ */
+template <class matrix_t, class vector_t>
+int getrf_level0(matrix_t& A, vector_t& Piv)
+{
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
 
-        // constants
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-        const idx_t end = std::min<idx_t>( m, n );
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t end = std::min<idx_t>(m, n);
 
-        // check arguments
-        tlapack_check( (idx_t) size(Piv)>= end);
-        
-        // quick return
-        if (m<=0 || n <= 0) return 0;
+    // check arguments
+    tlapack_check((idx_t)size(Piv) >= end);
 
-        for(idx_t j=0;j<end;j++){
-            
-            // find pivot and swap the row with pivot row
-            Piv[j] = j+iamax(tlapack::slice(A,tlapack::range<idx_t>(j,m),j));
-            
-            // if nonzero pivot does not exist, return 
-            if (A(Piv[j],j)==real_t(0)){
-                return j+1;
-            }
-            
-            // if the pivot happens to be a Piv[j]>j(Piv[j] not equal to j), then swap j-th row and Piv[j] row of A
-            if (Piv[j]!=j) {
-                for(idx_t i=0; i<n; i++)
-                {
-                    T tmp = A(j,i);
-                    A(j,i)= A(Piv[j],i);
-                    A(Piv[j],i)= tmp;
-                }
-            }
-            
-            // divide below diagonal part of j-th column by the element on the diagonal(A(j,j))
-            for(idx_t i=j+1;i<m;i++){
-                A(i,j)/=A(j,j);
-            }
-            
-            // update the submatrix A(j+1:m-1,j+1:n-1)
-            for(idx_t row=j+1;row<m;row++){
-                for(idx_t col=j+1;col<n;col++){
-                    A(row,col)-=A(row,j)*A(j,col);
-                }   
-            } 
+    // quick return
+    if (m <= 0 || n <= 0) return 0;
 
+    for (idx_t j = 0; j < end; j++) {
+        // find pivot and swap the row with pivot row
+        Piv[j] = j + iamax(tlapack::slice(A, tlapack::range<idx_t>(j, m), j));
+
+        // if nonzero pivot does not exist, return
+        if (A(Piv[j], j) == real_t(0)) {
+            return j + 1;
         }
-        
-        return 0;
+
+        // if the pivot happens to be a Piv[j]>j(Piv[j] not equal to j), then
+        // swap j-th row and Piv[j] row of A
+        if (Piv[j] != j) {
+            for (idx_t i = 0; i < n; i++) {
+                T tmp = A(j, i);
+                A(j, i) = A(Piv[j], i);
+                A(Piv[j], i) = tmp;
+            }
+        }
+
+        // divide below diagonal part of j-th column by the element on the
+        // diagonal(A(j,j))
+        for (idx_t i = j + 1; i < m; i++) {
+            A(i, j) /= A(j, j);
+        }
+
+        // update the submatrix A(j+1:m-1,j+1:n-1)
+        for (idx_t row = j + 1; row < m; row++) {
+            for (idx_t col = j + 1; col < n; col++) {
+                A(row, col) -= A(row, j) * A(j, col);
+            }
+        }
     }
 
-} // tlapack
+    return 0;
+}
 
-#endif // TLAPACK_GETRF_LV0_HH
+}  // namespace tlapack
+
+#endif  // TLAPACK_GETRF_LV0_HH

--- a/include/tlapack/lapack/getrf_recursive.hpp
+++ b/include/tlapack/lapack/getrf_recursive.hpp
@@ -11,189 +11,190 @@
 #define TLAPACK_GETRF_RECURSIVE_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/blas/iamax.hpp"
-#include "tlapack/blas/trsm.hpp"
 #include "tlapack/blas/gemm.hpp"
-#include "tlapack/blas/swap.hpp"
+#include "tlapack/blas/iamax.hpp"
 #include "tlapack/blas/scal.hpp"
+#include "tlapack/blas/swap.hpp"
+#include "tlapack/blas/trsm.hpp"
 
-namespace tlapack{
+namespace tlapack {
 
-    /** getrf_recursive computes an LU factorization of a general m-by-n matrix A
-     *  using partial pivoting with row interchanges.
-     *
-     *  The factorization has the form
-     * \[
-     *   P A = L U
-     * \]
-     *  where P is a permutation matrix constructed from our Piv vector, L is lower triangular with unit
-     *  diagonal elements (lower trapezoidal if m > n), and U is upper
-     *  triangular (upper trapezoidal if m < n).
-     * 
-     *  This is a recursive version of the algorithm.
-     *
-     * @return  0 if success
-     * @return  i+1 if failed to compute the LU on iteration i
-     *
-     * @param[in,out] A m-by-n matrix.
-     *      On exit, the factors L and U from the factorization A=PLU;
-     *      the unit diagonal elements of L are not stored.
-     *      
-     * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
-     * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the algorithm,
-     * the j-th row needs to be swapped with i
-     * 
-     * @note To construct L and U, one proceeds as in the following steps
-     *      1. Set matrices L m-by-k, and U k-by-n be to matrices with all zeros, where k=min(m,n)
-     *      2. Set elements on the diagonal of L to 1
-     *      3. below the diagonal of A will be copied to L
-     *      4. On and above the diagonal of A will be copied to U
-     *
-     * @ingroup computational
-     */
-    template< class matrix_t, class vector_t >
-    int getrf_recursive( matrix_t& A, vector_t &Piv){
-        
-        using idx_t = size_type< matrix_t >;
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
+/** getrf_recursive computes an LU factorization of a general m-by-n matrix A
+ *  using partial pivoting with row interchanges.
+ *
+ *  The factorization has the form
+ * \[
+ *   P A = L U
+ * \]
+ *  where P is a permutation matrix constructed from our Piv vector, L is lower
+ * triangular with unit diagonal elements (lower trapezoidal if m > n), and U is
+ * upper triangular (upper trapezoidal if m < n).
+ *
+ *  This is a recursive version of the algorithm.
+ *
+ * @return  0 if success
+ * @return  i+1 if failed to compute the LU on iteration i
+ *
+ * @param[in,out] A m-by-n matrix.
+ *      On exit, the factors L and U from the factorization A=PLU;
+ *      the unit diagonal elements of L are not stored.
+ *
+ * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
+ * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
+ * algorithm, the j-th row needs to be swapped with i
+ *
+ * @note To construct L and U, one proceeds as in the following steps
+ *      1. Set matrices L m-by-k, and U k-by-n be to matrices with all zeros,
+ * where k=min(m,n)
+ *      2. Set elements on the diagonal of L to 1
+ *      3. below the diagonal of A will be copied to L
+ *      4. On and above the diagonal of A will be copied to U
+ *
+ * @ingroup computational
+ */
+template <class matrix_t, class vector_t>
+int getrf_recursive(matrix_t& A, vector_t& Piv)
+{
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
 
-        // constants
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-        const idx_t k = std::min<idx_t>( m, n );
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t k = std::min<idx_t>(m, n);
 
-        // check arguments
-        tlapack_check( (idx_t) size(Piv) >= k);
-        
-        // quick return
-        if (m<=0 || n <= 0) return 0;
+    // check arguments
+    tlapack_check((idx_t)size(Piv) >= k);
 
-        // base case of recursion; one column matrices or one row matrices
-        // one-row matrices
-        if( m==1 )
-        {
-            // Piv has one element
-            Piv[0] = 0;
-            if( A(Piv[0],0) == real_t(0) ){
-                // in case which A(0,0) is zero, then we return 1 since in the first iteration we stopped
-                return 1;
-            }
+    // quick return
+    if (m <= 0 || n <= 0) return 0;
 
-            return 0;
-
+    // base case of recursion; one column matrices or one row matrices
+    // one-row matrices
+    if (m == 1) {
+        // Piv has one element
+        Piv[0] = 0;
+        if (A(Piv[0], 0) == real_t(0)) {
+            // in case which A(0,0) is zero, then we return 1 since in the first
+            // iteration we stopped
+            return 1;
         }
 
-        // one-column matrices
-        else if( n==1 )
-        {    
-            // when n==1, Piv has one element, Piv[0] needs to be swapped by the first row
-            Piv[0] = iamax( col(A,0) );
-            
-            // in the following case all elements are zero, and we return 1
-            if( A(Piv[0],0) == real_t(0) )
-                return 1;
-            
-            // in this case, we can safely swap since A(Piv[0],0) is not zero
-            if( Piv[0]!=0)
-                std::swap( A(Piv[0],0), A(0,0) );
-            
-            // by the previous comment, we can safely scale all elements of 0th column by 1/A(0,0)
-            auto l = slice( A, range<idx_t>(1,m), 0 );
-            scal( real_t(1)/A(0,0), l );
-            
-            return 0;
+        return 0;
+    }
+
+    // one-column matrices
+    else if (n == 1) {
+        // when n==1, Piv has one element, Piv[0] needs to be swapped by the
+        // first row
+        Piv[0] = iamax(col(A, 0));
+
+        // in the following case all elements are zero, and we return 1
+        if (A(Piv[0], 0) == real_t(0)) return 1;
+
+        // in this case, we can safely swap since A(Piv[0],0) is not zero
+        if (Piv[0] != 0) std::swap(A(Piv[0], 0), A(0, 0));
+
+        // by the previous comment, we can safely scale all elements of 0th
+        // column by 1/A(0,0)
+        auto l = slice(A, range<idx_t>(1, m), 0);
+        scal(real_t(1) / A(0, 0), l);
+
+        return 0;
+    }
+
+    // the case where m<n, we simply slice A into two parts, A0, a square matrix
+    // and A1 where A=[A0 , A1]
+    else if (m < n) {
+        auto A0 = tlapack::cols(A, tlapack::range<idx_t>(0, m));
+        auto A1 = tlapack::cols(A, tlapack::range<idx_t>(m, n));
+
+        int info = getrf_recursive(A0, Piv);
+        if (info != 0) return info;
+
+        // swap the rows of A1 according to Piv
+        for (idx_t j = 0; j < k; j++) {
+            if (Piv[j] != j) {
+                auto vect1 = tlapack::row(A1, j);
+                auto vect2 = tlapack::row(A1, Piv[j]);
+                tlapack::swap(vect1, vect2);
+            }
         }
-        
-        // the case where m<n, we simply slice A into two parts, A0, a square matrix and A1 where A=[A0 , A1]
-        else if( m < n )
-        {
-            auto A0 = tlapack::cols(A,tlapack::range<idx_t>(0,m));
-            auto A1 = tlapack::cols(A,tlapack::range<idx_t>(m,n));
-            
-            int info = getrf_recursive(A0,Piv);
-            if( info != 0 )
-                return info;
-            
-            // swap the rows of A1 according to Piv
-            for(idx_t j=0;j<k;j++){
-                if (Piv[j]!=j){
-                    auto vect1=tlapack::row(A1,j);
-                    auto vect2=tlapack::row(A1,Piv[j]);
-                    tlapack::swap(vect1,vect2); 
-                }
-            }
-            
-            // Solve triangular system A0 X = A1 and update A1
-            trsm(Side::Left,Uplo::Lower,Op::NoTrans,Diag::Unit,T(1),A0,A1);
 
-            return 0;
+        // Solve triangular system A0 X = A1 and update A1
+        trsm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, T(1), A0, A1);
+
+        return 0;
+    }
+    else {
+        // Dimensions for the submatrices
+        idx_t k0 = k / 2;
+
+        // in this step, we break A into two matrices, A=[A0 , A1]
+        auto A0 = tlapack::cols(A, tlapack::range<idx_t>(0, k0));
+        auto A1 = tlapack::cols(A, tlapack::range<idx_t>(k0, n));
+
+        // Piv0 is the first k0 elements of Piv
+        auto Piv0 = tlapack::slice(Piv, tlapack::range<idx_t>(0, k0));
+
+        // Apply getrf on the left of half of the matrix
+        int info = getrf_recursive(A0, Piv0);
+        if (info != 0) return info;
+
+        // swap the rows of A1
+        for (idx_t j = 0; j < k0; j++) {
+            if (Piv0[j] != j) {
+                auto vect1 = tlapack::row(A1, j);
+                auto vect2 = tlapack::row(A1, Piv0[j]);
+                tlapack::swap(vect1, vect2);
+            }
         }
-        else
-        {
-            // Dimensions for the submatrices
-            idx_t k0 = k/2;
-            
-            // in this step, we break A into two matrices, A=[A0 , A1]
-            auto A0 = tlapack::cols(A,tlapack::range<idx_t>(0,k0));
-            auto A1 = tlapack::cols(A,tlapack::range<idx_t>(k0,n));
-            
-            // Piv0 is the first k0 elements of Piv
-            auto Piv0 = tlapack::slice(Piv,tlapack::range<idx_t>(0,k0));
 
-            // Apply getrf on the left of half of the matrix
-            int info = getrf_recursive(A0,Piv0);
-            if( info != 0 )
-                return info;
-            
-            //swap the rows of A1
-            for(idx_t j=0;j<k0;j++){
-                if (Piv0[j]!=j){
-                    auto vect1=tlapack::row(A1,j);
-                    auto vect2=tlapack::row(A1,Piv0[j]);
-                    tlapack::swap(vect1,vect2);
-                }   
+        // partition A into the following four blocks:
+        auto A00 = tlapack::slice(A, tlapack::range<idx_t>(0, k0),
+                                  tlapack::range<idx_t>(0, k0));
+        auto A01 = tlapack::slice(A, tlapack::range<idx_t>(0, k0),
+                                  tlapack::range<idx_t>(k0, n));
+        auto A10 = tlapack::slice(A, tlapack::range<idx_t>(k0, m),
+                                  tlapack::range<idx_t>(0, k0));
+        auto A11 = tlapack::slice(A, tlapack::range<idx_t>(k0, m),
+                                  tlapack::range<idx_t>(k0, n));
+
+        // Take Piv1 to be the second slice of of Piv, meaning Piv= [Piv0, Piv1]
+        auto Piv1 = tlapack::slice(Piv, tlapack::range<idx_t>(k0, k));
+
+        // Solve the triangular system of equations given by A00 X = A01
+        trsm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, T(1), A00, A01);
+
+        // A11 <---- A11 - (A10 * A01)
+        gemm(Op::NoTrans, Op::NoTrans, real_t(-1), A10, A01, real_t(1), A11);
+
+        // Finding LU factorization of A11 in place
+        info = getrf_recursive(A11, Piv1);
+        if (info != 0) return info + k0;
+
+        // swap the rows of A10 according to the swapped rows of A11 by refering
+        // to Piv1
+        for (idx_t j = 0; j < k - k0; j++) {
+            if (Piv1[j] != j) {
+                auto vect1 = tlapack::row(A10, j);
+                auto vect2 = tlapack::row(A10, Piv1[j]);
+                tlapack::swap(vect1, vect2);
             }
-            
-            // partition A into the following four blocks:
-            auto A00 = tlapack::slice(A,tlapack::range<idx_t>(0,k0),tlapack::range<idx_t>(0,k0));
-            auto A01 = tlapack::slice(A,tlapack::range<idx_t>(0,k0),tlapack::range<idx_t>(k0,n));
-            auto A10 = tlapack::slice(A,tlapack::range<idx_t>(k0,m),tlapack::range<idx_t>(0,k0));
-            auto A11 = tlapack::slice(A,tlapack::range<idx_t>(k0,m),tlapack::range<idx_t>(k0,n));
-
-            // Take Piv1 to be the second slice of of Piv, meaning Piv= [Piv0, Piv1]
-            auto Piv1 = tlapack::slice(Piv,tlapack::range<idx_t>(k0,k));
-
-            // Solve the triangular system of equations given by A00 X = A01
-            trsm(Side::Left,Uplo::Lower,Op::NoTrans,Diag::Unit,T(1),A00,A01);
-            
-            // A11 <---- A11 - (A10 * A01)
-            gemm(Op::NoTrans,Op::NoTrans,real_t(-1),A10,A01,real_t(1),A11);
-
-            // Finding LU factorization of A11 in place
-            info = getrf_recursive(A11,Piv1);
-            if( info != 0 )
-                return info+k0;
-            
-            //swap the rows of A10 according to the swapped rows of A11 by refering to Piv1
-            for(idx_t j=0;j<k-k0;j++){
-                if (Piv1[j]!=j){
-                    auto vect1=tlapack::row(A10,j);
-                    auto vect2=tlapack::row(A10,Piv1[j]);
-                    tlapack::swap(vect1,vect2);
-                }   
-            }
-            
-            // Shift Piv1, so Piv will have the accurate representation of overall pivots
-            for(idx_t i=0;i<k-k0;i++){
-                Piv1[i] += k0;
-            }
-            
-            return 0;
         }
-        
-    } // getrf_recursive
 
-} // tlapack
+        // Shift Piv1, so Piv will have the accurate representation of overall
+        // pivots
+        for (idx_t i = 0; i < k - k0; i++) {
+            Piv1[i] += k0;
+        }
 
-#endif // TLAPACK_GETRF_RECURSIVE_HH
+        return 0;
+    }
+
+}  // getrf_recursive
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_GETRF_RECURSIVE_HH

--- a/include/tlapack/lapack/getri.hpp
+++ b/include/tlapack/lapack/getri.hpp
@@ -12,111 +12,107 @@
 
 #include "tlapack/base/utils.hpp"
 #include "tlapack/blas/swap.hpp"
-
-#include "tlapack/lapack/getri_uxli.hpp"
 #include "tlapack/lapack/getri_uili.hpp"
+#include "tlapack/lapack/getri_uxli.hpp"
 
 namespace tlapack {
 
-    enum class GetriVariant : char {
-        UILI = 'D', ///< Method D from doi:10.1137/1.9780898718027
-        UXLI = 'C'  ///< Method C from doi:10.1137/1.9780898718027
-    };
+enum class GetriVariant : char {
+    UILI = 'D',  ///< Method D from doi:10.1137/1.9780898718027
+    UXLI = 'C'   ///< Method C from doi:10.1137/1.9780898718027
+};
 
-    struct getri_opts_t : public workspace_opts_t<>
-    {
-        inline constexpr getri_opts_t( const workspace_opts_t<>& opts = {} )
-        : workspace_opts_t<>( opts ) {};
+struct getri_opts_t : public workspace_opts_t<> {
+    inline constexpr getri_opts_t(const workspace_opts_t<>& opts = {})
+        : workspace_opts_t<>(opts){};
 
-        GetriVariant variant = GetriVariant::UILI;
-    };
+    GetriVariant variant = GetriVariant::UILI;
+};
 
-    /** Worspace query of getri()
-     *
-     * @param[in] A n-by-n matrix.
-     *      
-     * @param[in] Piv pivot vector of size at least n.
-     *
-     * @param[in] opts Options.
-     *      - @c opts.variant:
-     *          - UILI = 'D', ///< Method D from doi:10.1137/1.9780898718027
-     *          - UXLI = 'C'  ///< Method C from doi:10.1137/1.9780898718027
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template< class matrix_t, class vector_t >
-    inline constexpr
-    void getri_worksize( const matrix_t& A, const vector_t &Piv, workinfo_t& workinfo, const getri_opts_t& opts = {} )
-    {
-        if( opts.variant == GetriVariant::UXLI )
-            getri_uxli_worksize( A, workinfo, opts );
+/** Worspace query of getri()
+ *
+ * @param[in] A n-by-n matrix.
+ *
+ * @param[in] Piv pivot vector of size at least n.
+ *
+ * @param[in] opts Options.
+ *      - @c opts.variant:
+ *          - UILI = 'D', ///< Method D from doi:10.1137/1.9780898718027
+ *          - UXLI = 'C'  ///< Method C from doi:10.1137/1.9780898718027
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t, class vector_t>
+inline constexpr void getri_worksize(const matrix_t& A,
+                                     const vector_t& Piv,
+                                     workinfo_t& workinfo,
+                                     const getri_opts_t& opts = {})
+{
+    if (opts.variant == GetriVariant::UXLI)
+        getri_uxli_worksize(A, workinfo, opts);
+}
+
+/** getri computes inverse of a general n-by-n matrix A
+ *
+ * @return = 0: successful exit
+ * @return = i+1: if U(i,i) is exactly zero.  The triangular
+ *          matrix is singular and its inverse can not be computed.
+ *
+ * @param[in,out] A n-by-n matrix.
+ *      On entry, the factors L and U from the factorization P A = L U.
+ *          L is stored in the lower triangle of A, the unit diagonal elements
+ * of L are not stored. U is stored in the upper triangle of A. On exit, inverse
+ * of A is overwritten on A.
+ *
+ * @param[in] Piv pivot vector of size at least n.
+ *
+ * @param[in] opts Options.
+ *      - @c opts.variant:
+ *          - UILI = 'D', ///< Method D from doi:10.1137/1.9780898718027
+ *          - UXLI = 'C'  ///< Method C from doi:10.1137/1.9780898718027
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        Check the correct variant to obtain details.
+ *
+ * @ingroup computational
+ */
+template <class matrix_t, class vector_t>
+int getri(matrix_t& A, const vector_t& Piv, const getri_opts_t& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+
+    // check arguments
+    tlapack_check(nrows(A) == ncols(A));
+
+    // Constants
+    const idx_t n = ncols(A);
+
+    // Call variant
+    int info;
+    if (opts.variant == GetriVariant::UXLI)
+        info = getri_uxli(A, opts);
+    else
+        info = getri_uili(A);
+
+    // Return is matrix is not invertible
+    if (info != 0) return info;
+
+    // swap columns of X to find A^{-1} since A^{-1}=X P
+    for (idx_t j = n; j-- > 0;) {
+        if (Piv[j] != j) {
+            auto vect1 = tlapack::col(A, j);
+            auto vect2 = tlapack::col(A, Piv[j]);
+            tlapack::swap(vect1, vect2);
+        }
     }
 
-    /** getri computes inverse of a general n-by-n matrix A
-     *
-     * @return = 0: successful exit
-     * @return = i+1: if U(i,i) is exactly zero.  The triangular
-     *          matrix is singular and its inverse can not be computed.
-     *
-     * @param[in,out] A n-by-n matrix.
-     *      On entry, the factors L and U from the factorization P A = L U.
-     *          L is stored in the lower triangle of A, the unit diagonal elements of L are not stored.
-     *          U is stored in the upper triangle of A.
-     *      On exit, inverse of A is overwritten on A.
-     *      
-     * @param[in] Piv pivot vector of size at least n.
-     * 
-     * @param[in] opts Options.
-     *      - @c opts.variant:
-     *          - UILI = 'D', ///< Method D from doi:10.1137/1.9780898718027
-     *          - UXLI = 'C'  ///< Method C from doi:10.1137/1.9780898718027
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        Check the correct variant to obtain details.
-     *      
-     * @ingroup computational
-     */
-    template< class matrix_t, class vector_t >
-    int getri( matrix_t& A, const vector_t &Piv, const getri_opts_t& opts = {} )
-    {
-        using idx_t = size_type< matrix_t >;
+    return 0;
 
-        // check arguments
-        tlapack_check( nrows(A)==ncols(A));
-        
-        // Constants
-        const idx_t n = ncols(A);
+}  // getri
 
-        // Call variant
-        int info;
-        if( opts.variant == GetriVariant::UXLI )
-            info = getri_uxli( A, opts );
-        else
-            info = getri_uili( A );
+}  // namespace tlapack
 
-        // Return is matrix is not invertible
-        if( info != 0 )
-            return info;
-        
-        // swap columns of X to find A^{-1} since A^{-1}=X P
-        for(idx_t j=n; j-->0;) {
-            if(Piv[j]!=j){
-                auto vect1=tlapack::col(A,j);
-                auto vect2=tlapack::col(A,Piv[j]);
-                tlapack::swap(vect1,vect2);
-            }
-        }
-        
-        return 0;
-        
-    } // getri
-
-} // lapack
-
-#endif // TLAPACK_GETRI_HH
-
-
-
+#endif  // TLAPACK_GETRI_HH

--- a/include/tlapack/lapack/getri_uili.hpp
+++ b/include/tlapack/lapack/getri_uili.hpp
@@ -18,7 +18,7 @@
 namespace tlapack {
 
 /** getri_uili calculates the inverse of a general n-by-n matrix A
- * 
+ *
  *  A is assumed to be in the form L U factors on the input,
  *  trtri is used to invert U and L in place
  *  thereafter, ul_mult is called to calculate U^(-1)L^(-1) in place.
@@ -32,33 +32,29 @@ namespace tlapack {
  *          L is stored in the lower triangle of A; unit diagonal is not stored.
  *          U is stored in the upper triangle of A.
  *      On exit, inverse of A is overwritten on A.
- * 
+ *
  * @ingroup computational
  */
-template< class matrix_t >
-int getri_uili( matrix_t& A )
+template <class matrix_t>
+int getri_uili(matrix_t& A)
 {
     // check arguments
-    tlapack_check( nrows(A)==ncols(A));
+    tlapack_check(nrows(A) == ncols(A));
 
     // Invert the upper part of A; U
     int info = trtri_recursive(Uplo::Upper, Diag::NonUnit, A);
-    if( info != 0 )
-        return info;
+    if (info != 0) return info;
 
     // Invert the lower part of A; L which has 1 on the diagonal
     trtri_recursive(Uplo::Lower, Diag::Unit, A);
 
-    //multiply U^{-1} and L^{-1} in place using ul_mult
+    // multiply U^{-1} and L^{-1} in place using ul_mult
     ul_mult(A);
-    
+
     return 0;
-    
-} //getri_uili
 
-} // lapack
+}  // getri_uili
 
-#endif // TLAPACK_getri_uili_HH
+}  // namespace tlapack
 
-
-
+#endif  // TLAPACK_getri_uili_HH

--- a/include/tlapack/lapack/lacpy.hpp
+++ b/include/tlapack/lapack/lacpy.hpp
@@ -17,58 +17,57 @@ namespace tlapack {
 
 /**
  * @brief Copies a matrix from A to B.
- * 
+ *
  * @tparam uplo_t Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper:   Upper triangle of A and B are referenced;
  *      - Uplo::Lower:   Lower triangle of A and B are referenced;
  *      - Uplo::General: All entries of A are referenced; the first m rows of B
  *                          and first n columns of B are referenced.
- * 
+ *
  * @param A m-by-n matrix.
  * @param B matrix with at least m rows and at least n columns.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class uplo_t, class matrixA_t, class matrixB_t >
-void lacpy( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
+template <class uplo_t, class matrixA_t, class matrixB_t>
+void lacpy(uplo_t uplo, const matrixA_t& A, matrixB_t& B)
 {
     // data traits
-    using idx_t = size_type< matrixA_t >;
+    using idx_t = size_type<matrixA_t>;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper &&
-                    uplo != Uplo::General );
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
 
-    if( uplo == Uplo::Upper ) {
+    if (uplo == Uplo::Upper) {
         // Set the strictly upper triangular or trapezoidal part of B
         for (idx_t j = 0; j < n; ++j) {
-            const idx_t M = std::min( m, j+1 );
+            const idx_t M = std::min(m, j + 1);
             for (idx_t i = 0; i < M; ++i)
-                B(i,j) = A(i,j);
+                B(i, j) = A(i, j);
         }
     }
-    else if( uplo == Uplo::Lower ) {
+    else if (uplo == Uplo::Lower) {
         // Set the strictly lower triangular or trapezoidal part of B
-        const idx_t N = std::min(m,n);
+        const idx_t N = std::min(m, n);
         for (idx_t j = 0; j < N; ++j)
             for (idx_t i = j; i < m; ++i)
-                B(i,j) = A(i,j);
+                B(i, j) = A(i, j);
     }
     else {
         // Set the whole m-by-n matrix B
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < m; ++i)
-                B(i,j) = A(i,j);
+                B(i, j) = A(i, j);
     }
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LACPY_HH
+#endif  // TLAPACK_LACPY_HH

--- a/include/tlapack/lapack/lacpy.hpp
+++ b/include/tlapack/lapack/lacpy.hpp
@@ -1,6 +1,7 @@
 /// @file lacpy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lacpy.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lacpy.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -16,7 +16,7 @@
 namespace tlapack {
 
 /** Performs complex division in real arithmetic.
- * 
+ *
  * \[
  *      p + iq = (a + ib) / (c + id)
  * \]
@@ -28,21 +28,21 @@ namespace tlapack {
  * @param[in] d Imaginary part of denominator.
  * @param[out] p Real part of quotient.
  * @param[out] q Imaginary part of quotient.
- * 
+ *
  * @ingroup auxiliary
  */
-template< typename real_t,
-    enable_if_t<(
-    /* Requires: */
-        ! is_complex<real_t>::value
-    ), int > = 0
->
-void ladiv(
-    const real_t& a, const real_t& b,
-    const real_t& c, const real_t& d,
-    real_t &p, real_t &q )
+template <typename real_t,
+          enable_if_t<(
+                          /* Requires: */
+                          !is_complex<real_t>::value),
+                      int> = 0>
+void ladiv(const real_t& a,
+           const real_t& b,
+           const real_t& c,
+           const real_t& d,
+           real_t& p,
+           real_t& q)
 {
-
     real_t e, f;
     if (abs(d) < abs(c)) {
         e = d / c;
@@ -59,26 +59,24 @@ void ladiv(
 }
 
 /** Performs complex division in real arithmetic with complex arguments.
- * 
+ *
  * @return x/y
  *
  * @tparam real_t Floating-point type.
  * @param[in] x Complex numerator.
  * @param[in] y Complex denominator.
- * 
+ *
  * @ingroup auxiliary
  */
-template< typename T, enable_if_t< is_complex<T>::value ,int> = 0 >
-inline T ladiv(
-    const T& x,
-    const T& y )
+template <typename T, enable_if_t<is_complex<T>::value, int> = 0>
+inline T ladiv(const T& x, const T& y)
 {
     real_type<T> zr, zi;
-    ladiv( real(x), imag(x), real(y), imag(y), zr, zi );
-    
-    return T( zr, zi );
+    ladiv(real(x), imag(x), real(y), imag(y), zr, zi);
+
+    return T(zr, zi);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LADIV_HH
+#endif  // TLAPACK_LADIV_HH

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -1,6 +1,7 @@
 /// @file ladiv.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ladiv.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/ladiv.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -1,6 +1,7 @@
 /// @file lahqr.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlahqr.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlahqr.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -12,662 +13,612 @@
 #define TLAPACK_LAHQR_HH
 
 #include "tlapack/base/utils.hpp"
-
 #include "tlapack/blas/rot.hpp"
 #include "tlapack/blas/rotg.hpp"
-
-#include "tlapack/lapack/larfg.hpp"
-#include "tlapack/lapack/larf.hpp"
 #include "tlapack/lapack/lahqr_eig22.hpp"
-#include "tlapack/lapack/lahqr_shiftcolumn.hpp"
 #include "tlapack/lapack/lahqr_schur22.hpp"
+#include "tlapack/lapack/lahqr_shiftcolumn.hpp"
+#include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/larfg.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** lahqr computes the eigenvalues and optionally the Schur
+ *  factorization of an upper Hessenberg matrix, using the double-shift
+ *  implicit QR algorithm.
+ *
+ *  The Schur factorization is returned in standard form. For complex matrices
+ *  this means that the matrix T is upper-triangular. The diagonal entries
+ *  of T are also its eigenvalues. For real matrices, this means that the
+ *  matrix T is block-triangular, with real eigenvalues appearing as 1x1 blocks
+ *  on the diagonal and imaginary eigenvalues appearing as 2x2 blocks on the
+ * diagonal. All 2x2 blocks are normalized so that the diagonal entries are
+ * equal to the real part of the eigenvalue.
+ *
+ *
+ * @return  0 if success
+ * @return -i if the ith argument is invalid
+ * @return  i if the QR algorithm failed to compute all the eigenvalues
+ *            in a total of 30 iterations per eigenvalue. elements
+ *            i:ihi of w contain those eigenvalues which have been
+ *            successfully computed.
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ * @param[in] ihi    integer.
+ *      The matrix A is assumed to be already quasi-triangular in rows and
+ *      columns ihi:n.
+ * @param[in,out] A  n by n matrix.
+ *      On entry, the matrix A.
+ *      On exit, if info=0 and want_t=true, the Schur factor T.
+ *      T is quasi-triangular in rows and columns ilo:ihi, with
+ *      the diagonal (block) entries in standard form (see above).
+ * @param[out] w  size n vector.
+ *      On exit, if info=0, w(ilo:ihi) contains the eigenvalues
+ *      of A(ilo:ihi,ilo:ihi). The eigenvalues appear in the same
+ *      order as the diagonal (block) entries of T.
+ * @param[in,out] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors
+ *      On exit, the orthogonal updates applied to A are accumulated
+ *      into Z.
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true,
+          enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
+int lahqr(bool want_t,
+          bool want_z,
+          size_type<matrix_t> ilo,
+          size_type<matrix_t> ihi,
+          matrix_t& A,
+          vector_t& w,
+          matrix_t& Z)
 {
+    using TA = type_t<matrix_t>;
+    using real_t = real_type<TA>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
 
-    /** lahqr computes the eigenvalues and optionally the Schur
-     *  factorization of an upper Hessenberg matrix, using the double-shift
-     *  implicit QR algorithm.
-     *
-     *  The Schur factorization is returned in standard form. For complex matrices
-     *  this means that the matrix T is upper-triangular. The diagonal entries
-     *  of T are also its eigenvalues. For real matrices, this means that the
-     *  matrix T is block-triangular, with real eigenvalues appearing as 1x1 blocks
-     *  on the diagonal and imaginary eigenvalues appearing as 2x2 blocks on the diagonal.
-     *  All 2x2 blocks are normalized so that the diagonal entries are equal to the real part
-     *  of the eigenvalue.
-     *
-     *
-     * @return  0 if success
-     * @return -i if the ith argument is invalid
-     * @return  i if the QR algorithm failed to compute all the eigenvalues
-     *            in a total of 30 iterations per eigenvalue. elements
-     *            i:ihi of w contain those eigenvalues which have been
-     *            successfully computed.
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     * @param[in] ihi    integer.
-     *      The matrix A is assumed to be already quasi-triangular in rows and
-     *      columns ihi:n.
-     * @param[in,out] A  n by n matrix.
-     *      On entry, the matrix A.
-     *      On exit, if info=0 and want_t=true, the Schur factor T.
-     *      T is quasi-triangular in rows and columns ilo:ihi, with
-     *      the diagonal (block) entries in standard form (see above).
-     * @param[out] w  size n vector.
-     *      On exit, if info=0, w(ilo:ihi) contains the eigenvalues
-     *      of A(ilo:ihi,ilo:ihi). The eigenvalues appear in the same
-     *      order as the diagonal (block) entries of T.
-     * @param[in,out] Z  n by n matrix.
-     *      On entry, the previously calculated Schur factors
-     *      On exit, the orthogonal updates applied to A are accumulated
-     *      into Z.
-     *
-     * @ingroup auxiliary
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true,
-        enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
-    int lahqr(bool want_t, bool want_z, size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t &A, vector_t &w, matrix_t &Z)
-    {
-        using TA = type_t<matrix_t>;
-        using real_t = real_type<TA>;
-        using idx_t = size_type<matrix_t>;
-        using pair = pair<idx_t, idx_t>;
+    // Functor
+    Create<vector_type<matrix_t, matrix_t>> new_vector;
 
-        // Functor
-        Create< vector_type<matrix_t,matrix_t> > new_vector;
+    // constants
+    const real_t zero(0);
+    const real_t one(1);
+    const real_t eps = ulp<real_t>();
+    const real_t small_num = safe_min<real_t>() / ulp<real_t>();
+    const idx_t non_convergence_limit = 10;
+    const real_t dat1(0.75);
+    const real_t dat2(-0.4375);
 
-        // constants
-        const real_t zero(0);
-        const real_t one(1);
-        const real_t eps = ulp<real_t>();
-        const real_t small_num = safe_min<real_t>() / ulp<real_t>();
-        const idx_t non_convergence_limit = 10;
-        const real_t dat1( 0.75 );
-        const real_t dat2( -0.4375 );
+    const idx_t n = ncols(A);
+    const idx_t nh = ihi - ilo;
 
-        const idx_t n = ncols(A);
-        const idx_t nh = ihi - ilo;
-
-        // check arguments
-        tlapack_check_false(n != nrows(A) );
-        tlapack_check_false((idx_t)size(w) != n );
-        if (want_z)
-        {
-            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)) );
-        }
-
-        // quick return
-        if (nh <= 0)
-            return 0;
-        if (nh == 1)
-            w[ilo] = A(ilo, ilo);
-
-        // itmax is the total number of QR iterations allowed.
-        // For most matrices, 3 shifts per eigenvalue is enough, so
-        // we set itmax to 30 times nh as a safe limit.
-        const idx_t itmax = 30 * std::max<idx_t>(10, nh);
-
-        // k_defl counts the number of iterations since a deflation
-        idx_t k_defl = 0;
-
-        // istop is the end of the active subblock.
-        // As more and more eigenvalues converge, it eventually
-        // becomes ilo+1 and the loop ends.
-        idx_t istop = ihi;
-        // istart is the start of the active subblock. Either
-        // istart = ilo, or H(istart, istart-1) = 0. This means
-        // that we can treat this subblock separately.
-        idx_t istart = ilo;
-
-        for (idx_t iter = 0; iter <= itmax; ++iter)
-        {
-            if (iter == itmax)
-            {
-                // The QR algorithm failed to converge, return with error.
-                tlapack_error( istop,
-                    "The QR algorithm failed to compute all the eigenvalues"
-                    " in a total of 30 iterations per eigenvalue. Elements"
-                    " i:ihi of w contain those eigenvalues which have been"
-                    " successfully computed." );
-                return istop;
-            }
-
-            if (istart + 1 >= istop)
-            {
-                if (istart + 1 == istop)
-                    w[istart] = A(istart, istart);
-                // All eigenvalues have been found, exit and return 0.
-                break;
-            }
-
-            // Determine range to apply rotations
-            idx_t istart_m;
-            idx_t istop_m;
-            if (!want_t)
-            {
-                istart_m = istart;
-                istop_m = istop;
-            }
-            else
-            {
-                istart_m = 0;
-                istop_m = n;
-            }
-
-            // Check if active subblock has split
-            for (idx_t i = istop - 1; i > istart; --i)
-            {
-
-                if (abs1(A(i, i - 1)) <= small_num)
-                {
-                    // A(i,i-1) is negligible, take i as new istart.
-                    A(i, i - 1) = zero;
-                    istart = i;
-                    break;
-                }
-
-                real_t tst = abs1(A(i - 1, i - 1)) + abs1(A(i, i));
-                if (tst == zero)
-                {
-                    if (i >= ilo + 2)
-                    {
-                        tst = tst + abs(A(i - 1, i - 2));
-                    }
-                    if (i < ihi)
-                    {
-                        tst = tst + abs(A(i + 1, i));
-                    }
-                }
-                if (abs1(A(i, i - 1)) <= eps * tst)
-                {
-                    //
-                    // The elementwise deflation test has passed
-                    // The following performs second deflation test due
-                    // to Ahues & Tisseur (LAWN 122, 1997). It has better
-                    // mathematical foundation and improves accuracy in some
-                    // examples.
-                    //
-                    // The test is |A(i,i-1)|*|A(i-1,i)| <= eps*|A(i,i)|*|A(i-1,i-1)|
-                    // The multiplications might overflow so we do some scaling first.
-                    //
-                    real_t ab = std::max(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                    real_t ba = std::min(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                    real_t aa = std::max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
-                    real_t bb = std::min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
-                    real_t s = aa + ab;
-                    if (ba * (ab / s) <= std::max(small_num, eps * (bb * (aa / s))))
-                    {
-                        // A(i,i-1) is negligible, take i as new istart.
-                        A(i, i - 1) = zero;
-                        istart = i;
-                        break;
-                    }
-                }
-            }
-
-            if (istart + 2 >= istop)
-            {
-                if (istart + 1 == istop)
-                {
-                    // 1x1 block
-                    k_defl = 0;
-                    w[istart] = A(istart, istart);
-                    istop = istart;
-                    istart = ilo;
-                    continue;
-                }
-                if (!is_complex<TA>::value && istart + 2 == istop)
-                {
-                    // 2x2 block, normalize the block
-                    real_t cs;
-                    TA sn;
-                    // We don't check the error flag here because it should never fail for real values.
-                    lahqr_schur22(A(istart, istart), A(istart, istart + 1),
-                                  A(istart + 1, istart), A(istart + 1, istart + 1),
-                                  w[istart], w[istart + 1], cs, sn);
-                    // Apply the rotations from the normalization to the rest of the matrix.
-                    if (want_t)
-                    {
-                        if (istart + 2 < istop_m)
-                        {
-                            auto x = slice(A, istart, pair{istart + 2, istop_m});
-                            auto y = slice(A, istart + 1, pair{istart + 2, istop_m});
-                            rot(x, y, cs, sn);
-                        }
-                        auto x2 = slice(A, pair{istart_m, istart}, istart);
-                        auto y2 = slice(A, pair{istart_m, istart}, istart + 1);
-                        rot(x2, y2, cs, sn);
-                    }
-                    if (want_z)
-                    {
-                        auto x = col(Z, istart);
-                        auto y = col(Z, istart + 1);
-                        rot(x, y, cs, sn);
-                    }
-                    k_defl = 0;
-                    istop = istart;
-                    istart = ilo;
-                    continue;
-                }
-            }
-
-            // Determine shift
-            TA a00, a01, a10, a11;
-            k_defl = k_defl + 1;
-            if (k_defl % non_convergence_limit == 0)
-            {
-                // Exceptional shift
-                real_t s = abs(A(istop - 1, istop - 2));
-                if (istop > ilo + 2)
-                    s = s + abs(A(istop - 2, istop - 3));
-                a00 = dat1 * s + A(istop - 1, istop - 1);
-                a01 = dat2 * s;
-                a10 = s;
-                a11 = a00;
-            }
-            else
-            {
-                // Wilkinson shift
-                a00 = A(istop - 2, istop - 2);
-                a10 = A(istop - 1, istop - 2);
-                a01 = A(istop - 2, istop - 1);
-                a11 = A(istop - 1, istop - 1);
-            }
-            complex_type<real_t> s1;
-            complex_type<real_t> s2;
-            lahqr_eig22(a00, a01, a10, a11, s1, s2);
-            if ((imag(s1) == zero and imag(s2) == zero) or is_complex<TA>::value)
-            {
-                // The eigenvalues are not complex conjugate, keep only the one closest to A(istop-1, istop-1)
-                if (abs1(s1 - A(istop - 1, istop - 1)) <= abs1(s2 - A(istop - 1, istop - 1)))
-                    s2 = s1;
-                else
-                    s1 = s2;
-            }
-
-            // We have already checked whether the subblock has split.
-            // If it has split, we can introduce any shift at the top of the new subblock.
-            // Now that we know the specific shift, we can also check whether we can introduce that shift
-            // somewhere else in the subblock.
-            std::vector<TA> v_; auto v = new_vector(v_,3);
-            TA t1;
-            idx_t istart2 = istart;
-            if (istart + 3 < istop)
-            {
-                for (idx_t i = istop - 3; i > istart; --i)
-                {
-                    auto H = slice(A, pair{i, i + 3}, pair{i, i + 3});
-                    lahqr_shiftcolumn(H, v, s1, s2);
-                    larfg(v, t1);
-                    v[0] = t1;
-                    const TA refsum = conj(v[0]) * A(i, i - 1) + conj(v[1]) * A(i + 1, i - 1);
-                    if (abs1(A(i + 1, i - 1) - refsum * v[1]) + abs1(refsum * v[2]) <=
-                        eps * (abs1(A(i, i - 1)) + abs1(A(i, i + 1)) + abs1(A(i + 1, i + 2))))
-                    {
-                        istart2 = i;
-                        break;
-                    }
-                }
-            }
-
-            for (idx_t i = istart2; i < istop - 1; ++i)
-            {
-                const idx_t nr = std::min<idx_t>(3, istop - i);
-                if (i == istart2)
-                {
-                    auto H = slice(A, pair{i, i + nr}, pair{i, i + nr});
-                    auto x = slice(v, pair{0, nr});
-                    lahqr_shiftcolumn(H, x, s1, s2);
-                    auto y = slice(v, pair{1, nr});
-                    larfg(v[0], y, t1);
-                    if (i > istart)
-                    {
-                        A(i, i - 1) = A(i, i - 1) * (one - conj(t1));
-                    }
-                }
-                else
-                {
-                    v[0] = A(i, i - 1);
-                    v[1] = A(i + 1, i - 1);
-                    if (nr == 3)
-                        v[2] = A(i + 2, i - 1);
-                    auto x = slice(v, pair{1, nr});
-                    larfg(v[0], x, t1);
-                    A(i, i - 1) = v[0];
-                    A(i + 1, i - 1) = zero;
-                    if (nr == 3)
-                        A(i + 2, i - 1) = zero;
-                }
-
-                // The following code applies the reflector we have just calculated.
-                // We write this out instead of using larf because a direct loop is more
-                // efficient for small reflectors.
-
-                t1 = conj(t1);
-                const TA v2 = v[1];
-                const TA t2 = t1 * v2;
-                TA sum;
-                if (nr == 3)
-                {
-                    const TA v3 = v[2];
-                    const TA t3 = t1 * v[2];
-
-                    // Apply G from the left to A
-                    for (idx_t j = i; j < istop_m; ++j)
-                    {
-                        sum = A(i, j) + conj(v2) * A(i + 1, j) + conj(v3) * A(i + 2, j);
-                        A(i, j) = A(i, j) - sum * t1;
-                        A(i + 1, j) = A(i + 1, j) - sum * t2;
-                        A(i + 2, j) = A(i + 2, j) - sum * t3;
-                    }
-                    // Apply G from the right to A
-                    for (idx_t j = istart_m; j < std::min(i + 4, istop); ++j)
-                    {
-                        sum = A(j, i) + v2 * A(j, i + 1) + v3 * A(j, i + 2);
-                        A(j, i) = A(j, i) - sum * conj(t1);
-                        A(j, i + 1) = A(j, i + 1) - sum * conj(t2);
-                        A(j, i + 2) = A(j, i + 2) - sum * conj(t3);
-                    }
-                    if (want_z)
-                    {
-                        // Apply G to Z from the right
-                        for (idx_t j = 0; j < n; ++j)
-                        {
-                            sum = Z(j, i) + v2 * Z(j, i + 1) + v3 * Z(j, i + 2);
-                            Z(j, i) = Z(j, i) - sum * conj(t1);
-                            Z(j, i + 1) = Z(j, i + 1) - sum * conj(t2);
-                            Z(j, i + 2) = Z(j, i + 2) - sum * conj(t3);
-                        }
-                    }
-                }
-                else
-                {
-                    // Apply G from the left to A
-                    for (idx_t j = i; j < istop_m; ++j)
-                    {
-                        sum = A(i, j) + conj(v2) * A(i + 1, j);
-                        A(i, j) = A(i, j) - sum * t1;
-                        A(i + 1, j) = A(i + 1, j) - sum * t2;
-                    }
-                    // Apply G from the right to A
-                    for (idx_t j = istart_m; j < std::min(i + 3, istop); ++j)
-                    {
-                        sum = A(j, i) + v2 * A(j, i + 1);
-                        A(j, i) = A(j, i) - sum * conj(t1);
-                        A(j, i + 1) = A(j, i + 1) - sum * conj(t2);
-                    }
-                    if (want_z)
-                    {
-                        // Apply G to Z from the right
-                        for (idx_t j = 0; j < n; ++j)
-                        {
-                            sum = Z(j, i) + v2 * Z(j, i + 1);
-                            Z(j, i) = Z(j, i) - sum * conj(t1);
-                            Z(j, i + 1) = Z(j, i + 1) - sum * conj(t2);
-                        }
-                    }
-                }
-            }
-        }
-
-        return 0;
+    // check arguments
+    tlapack_check_false(n != nrows(A));
+    tlapack_check_false((idx_t)size(w) != n);
+    if (want_z) {
+        tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)));
     }
 
-    /** lahqr computes the eigenvalues and optionally the Schur
-     *  factorization of an upper Hessenberg matrix, using the double-shift
-     *  implicit QR algorithm.
-     * 
-     * Implementation for complex matrices.
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true,
-        enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
-    int lahqr(bool want_t, bool want_z, size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t &A, vector_t &w, matrix_t &Z)
-    {
-        using TA = type_t<matrix_t>;
-        using real_t = real_type<TA>;
-        using idx_t = size_type<matrix_t>;
+    // quick return
+    if (nh <= 0) return 0;
+    if (nh == 1) w[ilo] = A(ilo, ilo);
 
-        // constants
-        const real_t zero(0);
-        const real_t eps = ulp<real_t>();
-        const real_t small_num = safe_min<real_t>() / ulp<real_t>();
-        const idx_t non_convergence_limit = 10;
-        const real_t dat1( 0.75 );
-        const real_t dat2( -0.4375 );
+    // itmax is the total number of QR iterations allowed.
+    // For most matrices, 3 shifts per eigenvalue is enough, so
+    // we set itmax to 30 times nh as a safe limit.
+    const idx_t itmax = 30 * std::max<idx_t>(10, nh);
 
-        const idx_t n = ncols(A);
-        const idx_t nh = ihi - ilo;
+    // k_defl counts the number of iterations since a deflation
+    idx_t k_defl = 0;
 
-        // check arguments
-        tlapack_check_false(n != nrows(A) );
-        tlapack_check_false((idx_t)size(w) != n );
-        if (want_z)
-        {
-            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)) );
+    // istop is the end of the active subblock.
+    // As more and more eigenvalues converge, it eventually
+    // becomes ilo+1 and the loop ends.
+    idx_t istop = ihi;
+    // istart is the start of the active subblock. Either
+    // istart = ilo, or H(istart, istart-1) = 0. This means
+    // that we can treat this subblock separately.
+    idx_t istart = ilo;
+
+    for (idx_t iter = 0; iter <= itmax; ++iter) {
+        if (iter == itmax) {
+            // The QR algorithm failed to converge, return with error.
+            tlapack_error(
+                istop,
+                "The QR algorithm failed to compute all the eigenvalues"
+                " in a total of 30 iterations per eigenvalue. Elements"
+                " i:ihi of w contain those eigenvalues which have been"
+                " successfully computed.");
+            return istop;
         }
 
-        // quick return
-        if (nh <= 0)
-            return 0;
-        if (nh == 1)
-            w[ilo] = A(ilo, ilo);
+        if (istart + 1 >= istop) {
+            if (istart + 1 == istop) w[istart] = A(istart, istart);
+            // All eigenvalues have been found, exit and return 0.
+            break;
+        }
 
-        // itmax is the total number of QR iterations allowed.
-        // For most matrices, 3 shifts per eigenvalue is enough, so
-        // we set itmax to 30 times nh as a safe limit.
-        const idx_t itmax = 30 * std::max<idx_t>(10, nh);
+        // Determine range to apply rotations
+        idx_t istart_m;
+        idx_t istop_m;
+        if (!want_t) {
+            istart_m = istart;
+            istop_m = istop;
+        }
+        else {
+            istart_m = 0;
+            istop_m = n;
+        }
 
-        // k_defl counts the number of iterations since a deflation
-        idx_t k_defl = 0;
-
-        // istop is the end of the active subblock.
-        // As more and more eigenvalues converge, it eventually
-        // becomes ilo+1 and the loop ends.
-        idx_t istop = ihi;
-        // istart is the start of the active subblock. Either
-        // istart = ilo, or H(istart, istart-1) = 0. This means
-        // that we can treat this subblock separately.
-        idx_t istart = ilo;
-
-        for (idx_t iter = 0; iter <= itmax; ++iter)
-        {
-            if (iter == itmax)
-            {
-                // The QR algorithm failed to converge, return with error.
-                return istop;
-            }
-
-            if (istart + 1 >= istop)
-            {
-                if (istart + 1 == istop)
-                    w[istart] = A(istart, istart);
-                // All eigenvalues have been found, exit and return 0.
+        // Check if active subblock has split
+        for (idx_t i = istop - 1; i > istart; --i) {
+            if (abs1(A(i, i - 1)) <= small_num) {
+                // A(i,i-1) is negligible, take i as new istart.
+                A(i, i - 1) = zero;
+                istart = i;
                 break;
             }
 
-            // Determine range to apply rotations
-            idx_t istart_m;
-            idx_t istop_m;
-            if (!want_t)
-            {
-                istart_m = istart;
-                istop_m = istop;
+            real_t tst = abs1(A(i - 1, i - 1)) + abs1(A(i, i));
+            if (tst == zero) {
+                if (i >= ilo + 2) {
+                    tst = tst + abs(A(i - 1, i - 2));
+                }
+                if (i < ihi) {
+                    tst = tst + abs(A(i + 1, i));
+                }
             }
-            else
-            {
-                istart_m = 0;
-                istop_m = n;
-            }
-
-            // Check if active subblock has split
-            for (idx_t i = istop - 1; i > istart; --i)
-            {
-
-                if (abs1(A(i, i - 1)) <= small_num)
-                {
+            if (abs1(A(i, i - 1)) <= eps * tst) {
+                //
+                // The elementwise deflation test has passed
+                // The following performs second deflation test due
+                // to Ahues & Tisseur (LAWN 122, 1997). It has better
+                // mathematical foundation and improves accuracy in some
+                // examples.
+                //
+                // The test is |A(i,i-1)|*|A(i-1,i)| <=
+                // eps*|A(i,i)|*|A(i-1,i-1)| The multiplications might overflow
+                // so we do some scaling first.
+                //
+                real_t ab = std::max(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
+                real_t ba = std::min(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
+                real_t aa =
+                    std::max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                real_t bb =
+                    std::min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                real_t s = aa + ab;
+                if (ba * (ab / s) <=
+                    std::max(small_num, eps * (bb * (aa / s)))) {
                     // A(i,i-1) is negligible, take i as new istart.
                     A(i, i - 1) = zero;
                     istart = i;
                     break;
                 }
-
-                real_t tst = abs1(A(i - 1, i - 1)) + abs1(A(i, i));
-                if (tst == zero)
-                {
-                    if (i >= ilo + 2)
-                    {
-                        tst = tst + tlapack::abs(A(i - 1, i - 2));
-                    }
-                    if (i < ihi)
-                    {
-                        tst = tst + tlapack::abs(A(i + 1, i));
-                    }
-                }
-                if (abs1(A(i, i - 1)) <= eps * tst)
-                {
-                    //
-                    // The elementwise deflation test has passed
-                    // The following performs second deflation test due
-                    // to Ahues & Tisseur (LAWN 122, 1997). It has better
-                    // mathematical foundation and improves accuracy in some
-                    // examples.
-                    //
-                    // The test is |A(i,i-1)|*|A(i-1,i)| <= eps*|A(i,i)|*|A(i-1,i-1)|
-                    // The multiplications might overflow so we do some scaling first.
-                    //
-                    real_t ab = std::max(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                    real_t ba = std::min(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                    real_t aa = std::max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
-                    real_t bb = std::min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
-                    real_t s = aa + ab;
-                    if (ba * (ab / s) <= std::max(small_num, eps * (bb * (aa / s))))
-                    {
-                        // A(i,i-1) is negligible, take i as new istart.
-                        A(i, i - 1) = zero;
-                        istart = i;
-                        break;
-                    }
-                }
             }
+        }
 
-            if (istart + 1 >= istop)
-            {
+        if (istart + 2 >= istop) {
+            if (istart + 1 == istop) {
+                // 1x1 block
                 k_defl = 0;
                 w[istart] = A(istart, istart);
                 istop = istart;
                 istart = ilo;
                 continue;
             }
-
-            // Determine shift
-            TA a00, a01, a10, a11;
-            k_defl = k_defl + 1;
-            if (k_defl % non_convergence_limit == 0)
-            {
-                // Exceptional shift
-                real_t s = tlapack::abs(A(istop - 1, istop - 2));
-                if (istop > ilo + 2)
-                    s = s + tlapack::abs(A(istop - 2, istop - 3));
-                a00 = dat1 * s + A(istop - 1, istop - 1);
-                a01 = dat2 * s;
-                a10 = s;
-                a11 = a00;
+            if (!is_complex<TA>::value && istart + 2 == istop) {
+                // 2x2 block, normalize the block
+                real_t cs;
+                TA sn;
+                // We don't check the error flag here because it should never
+                // fail for real values.
+                lahqr_schur22(A(istart, istart), A(istart, istart + 1),
+                              A(istart + 1, istart), A(istart + 1, istart + 1),
+                              w[istart], w[istart + 1], cs, sn);
+                // Apply the rotations from the normalization to the rest of the
+                // matrix.
+                if (want_t) {
+                    if (istart + 2 < istop_m) {
+                        auto x = slice(A, istart, pair{istart + 2, istop_m});
+                        auto y =
+                            slice(A, istart + 1, pair{istart + 2, istop_m});
+                        rot(x, y, cs, sn);
+                    }
+                    auto x2 = slice(A, pair{istart_m, istart}, istart);
+                    auto y2 = slice(A, pair{istart_m, istart}, istart + 1);
+                    rot(x2, y2, cs, sn);
+                }
+                if (want_z) {
+                    auto x = col(Z, istart);
+                    auto y = col(Z, istart + 1);
+                    rot(x, y, cs, sn);
+                }
+                k_defl = 0;
+                istop = istart;
+                istart = ilo;
+                continue;
             }
+        }
+
+        // Determine shift
+        TA a00, a01, a10, a11;
+        k_defl = k_defl + 1;
+        if (k_defl % non_convergence_limit == 0) {
+            // Exceptional shift
+            real_t s = abs(A(istop - 1, istop - 2));
+            if (istop > ilo + 2) s = s + abs(A(istop - 2, istop - 3));
+            a00 = dat1 * s + A(istop - 1, istop - 1);
+            a01 = dat2 * s;
+            a10 = s;
+            a11 = a00;
+        }
+        else {
+            // Wilkinson shift
+            a00 = A(istop - 2, istop - 2);
+            a10 = A(istop - 1, istop - 2);
+            a01 = A(istop - 2, istop - 1);
+            a11 = A(istop - 1, istop - 1);
+        }
+        complex_type<real_t> s1;
+        complex_type<real_t> s2;
+        lahqr_eig22(a00, a01, a10, a11, s1, s2);
+        if ((imag(s1) == zero and imag(s2) == zero) or is_complex<TA>::value) {
+            // The eigenvalues are not complex conjugate, keep only the one
+            // closest to A(istop-1, istop-1)
+            if (abs1(s1 - A(istop - 1, istop - 1)) <=
+                abs1(s2 - A(istop - 1, istop - 1)))
+                s2 = s1;
             else
-            {
-                // Wilkinson shift
-                a00 = A(istop - 2, istop - 2);
-                a10 = A(istop - 1, istop - 2);
-                a01 = A(istop - 2, istop - 1);
-                a11 = A(istop - 1, istop - 1);
-            }
-            complex_type<real_t> s1;
-            complex_type<real_t> s2;
-            lahqr_eig22(a00, a01, a10, a11, s1, s2);
-            if (abs1(s1 - A(istop - 1, istop - 1)) > abs1(s2 - A(istop - 1, istop - 1)))
                 s1 = s2;
+        }
 
-            // We have already checked whether the subblock has split.
-            // If it has split, we can introduce any shift at the top of the new subblock.
-            // Now that we know the specific shift, we can also check whether we can introduce that shift
-            // somewhere else in the subblock.
-            TA sn;
-            real_t cs;
-            idx_t istart2 = istart;
-            if (istart + 2 < istop)
-            {
-                for (idx_t i = istop - 2; i > istart; --i)
-                {
-                    TA h00 = A(i, i) - s1;
-                    TA h10 = A(i + 1, i);
-                    rotg(h00, h10, cs, sn);
-
-                    if (abs1(conj(sn) * A(i, i - 1)) <= eps * (abs1(A(i, i - 1)) + abs1(A(i, i + 1))))
-                    {
-                        istart2 = i;
-                        break;
-                    }
-                }
-            }
-
-            for (idx_t i = istart2; i < istop - 1; ++i)
-            {
-                if (i == istart2)
-                {
-                    TA h00 = A(i, i) - s1;
-                    TA h10 = A(i + 1, i);
-                    rotg(h00, h10, cs, sn);
-                    if (i > istart)
-                        A(i, i - 1) = A(i, i - 1) * cs;
-                }
-                else
-                {
-                    rotg(A(i, i - 1), A(i + 1, i - 1), cs, sn);
-                    A(i + 1, i - 1) = zero;
-                }
-
-                // Apply G from the left to A
-                for (idx_t j = i; j < istop_m; ++j)
-                {
-                    TA tmp = cs * A(i, j) + sn * A(i + 1, j);
-                    A(i + 1, j) = -conj(sn) * A(i, j) + cs * A(i + 1, j);
-                    A(i, j) = tmp;
-                }
-                // Apply G**H from the right to A
-                for (idx_t j = istart_m; j < std::min(i + 3, istop); ++j)
-                {
-                    TA tmp = cs * A(j, i) + conj(sn) * A(j, i + 1);
-                    A(j, i + 1) = -sn * A(j, i) + cs * A(j, i + 1);
-                    A(j, i) = tmp;
-                }
-                if (want_z)
-                {
-                    // Apply G**H to Z from the right
-                    for (idx_t j = 0; j < n; ++j)
-                    {
-                        TA tmp = cs * Z(j, i) + conj(sn) * Z(j, i + 1);
-                        Z(j, i + 1) = -sn * Z(j, i) + cs * Z(j, i + 1);
-                        Z(j, i) = tmp;
-                    }
+        // We have already checked whether the subblock has split.
+        // If it has split, we can introduce any shift at the top of the new
+        // subblock. Now that we know the specific shift, we can also check
+        // whether we can introduce that shift somewhere else in the subblock.
+        std::vector<TA> v_;
+        auto v = new_vector(v_, 3);
+        TA t1;
+        idx_t istart2 = istart;
+        if (istart + 3 < istop) {
+            for (idx_t i = istop - 3; i > istart; --i) {
+                auto H = slice(A, pair{i, i + 3}, pair{i, i + 3});
+                lahqr_shiftcolumn(H, v, s1, s2);
+                larfg(v, t1);
+                v[0] = t1;
+                const TA refsum =
+                    conj(v[0]) * A(i, i - 1) + conj(v[1]) * A(i + 1, i - 1);
+                if (abs1(A(i + 1, i - 1) - refsum * v[1]) +
+                        abs1(refsum * v[2]) <=
+                    eps * (abs1(A(i, i - 1)) + abs1(A(i, i + 1)) +
+                           abs1(A(i + 1, i + 2)))) {
+                    istart2 = i;
+                    break;
                 }
             }
         }
 
-        return 0;
+        for (idx_t i = istart2; i < istop - 1; ++i) {
+            const idx_t nr = std::min<idx_t>(3, istop - i);
+            if (i == istart2) {
+                auto H = slice(A, pair{i, i + nr}, pair{i, i + nr});
+                auto x = slice(v, pair{0, nr});
+                lahqr_shiftcolumn(H, x, s1, s2);
+                auto y = slice(v, pair{1, nr});
+                larfg(v[0], y, t1);
+                if (i > istart) {
+                    A(i, i - 1) = A(i, i - 1) * (one - conj(t1));
+                }
+            }
+            else {
+                v[0] = A(i, i - 1);
+                v[1] = A(i + 1, i - 1);
+                if (nr == 3) v[2] = A(i + 2, i - 1);
+                auto x = slice(v, pair{1, nr});
+                larfg(v[0], x, t1);
+                A(i, i - 1) = v[0];
+                A(i + 1, i - 1) = zero;
+                if (nr == 3) A(i + 2, i - 1) = zero;
+            }
+
+            // The following code applies the reflector we have just calculated.
+            // We write this out instead of using larf because a direct loop is
+            // more efficient for small reflectors.
+
+            t1 = conj(t1);
+            const TA v2 = v[1];
+            const TA t2 = t1 * v2;
+            TA sum;
+            if (nr == 3) {
+                const TA v3 = v[2];
+                const TA t3 = t1 * v[2];
+
+                // Apply G from the left to A
+                for (idx_t j = i; j < istop_m; ++j) {
+                    sum = A(i, j) + conj(v2) * A(i + 1, j) +
+                          conj(v3) * A(i + 2, j);
+                    A(i, j) = A(i, j) - sum * t1;
+                    A(i + 1, j) = A(i + 1, j) - sum * t2;
+                    A(i + 2, j) = A(i + 2, j) - sum * t3;
+                }
+                // Apply G from the right to A
+                for (idx_t j = istart_m; j < std::min(i + 4, istop); ++j) {
+                    sum = A(j, i) + v2 * A(j, i + 1) + v3 * A(j, i + 2);
+                    A(j, i) = A(j, i) - sum * conj(t1);
+                    A(j, i + 1) = A(j, i + 1) - sum * conj(t2);
+                    A(j, i + 2) = A(j, i + 2) - sum * conj(t3);
+                }
+                if (want_z) {
+                    // Apply G to Z from the right
+                    for (idx_t j = 0; j < n; ++j) {
+                        sum = Z(j, i) + v2 * Z(j, i + 1) + v3 * Z(j, i + 2);
+                        Z(j, i) = Z(j, i) - sum * conj(t1);
+                        Z(j, i + 1) = Z(j, i + 1) - sum * conj(t2);
+                        Z(j, i + 2) = Z(j, i + 2) - sum * conj(t3);
+                    }
+                }
+            }
+            else {
+                // Apply G from the left to A
+                for (idx_t j = i; j < istop_m; ++j) {
+                    sum = A(i, j) + conj(v2) * A(i + 1, j);
+                    A(i, j) = A(i, j) - sum * t1;
+                    A(i + 1, j) = A(i + 1, j) - sum * t2;
+                }
+                // Apply G from the right to A
+                for (idx_t j = istart_m; j < std::min(i + 3, istop); ++j) {
+                    sum = A(j, i) + v2 * A(j, i + 1);
+                    A(j, i) = A(j, i) - sum * conj(t1);
+                    A(j, i + 1) = A(j, i + 1) - sum * conj(t2);
+                }
+                if (want_z) {
+                    // Apply G to Z from the right
+                    for (idx_t j = 0; j < n; ++j) {
+                        sum = Z(j, i) + v2 * Z(j, i + 1);
+                        Z(j, i) = Z(j, i) - sum * conj(t1);
+                        Z(j, i + 1) = Z(j, i + 1) - sum * conj(t2);
+                    }
+                }
+            }
+        }
     }
 
-} // lapack
+    return 0;
+}
 
-#endif // TLAPACK_LAHQR_HH
+/** lahqr computes the eigenvalues and optionally the Schur
+ *  factorization of an upper Hessenberg matrix, using the double-shift
+ *  implicit QR algorithm.
+ *
+ * Implementation for complex matrices.
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true,
+          enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
+int lahqr(bool want_t,
+          bool want_z,
+          size_type<matrix_t> ilo,
+          size_type<matrix_t> ihi,
+          matrix_t& A,
+          vector_t& w,
+          matrix_t& Z)
+{
+    using TA = type_t<matrix_t>;
+    using real_t = real_type<TA>;
+    using idx_t = size_type<matrix_t>;
+
+    // constants
+    const real_t zero(0);
+    const real_t eps = ulp<real_t>();
+    const real_t small_num = safe_min<real_t>() / ulp<real_t>();
+    const idx_t non_convergence_limit = 10;
+    const real_t dat1(0.75);
+    const real_t dat2(-0.4375);
+
+    const idx_t n = ncols(A);
+    const idx_t nh = ihi - ilo;
+
+    // check arguments
+    tlapack_check_false(n != nrows(A));
+    tlapack_check_false((idx_t)size(w) != n);
+    if (want_z) {
+        tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)));
+    }
+
+    // quick return
+    if (nh <= 0) return 0;
+    if (nh == 1) w[ilo] = A(ilo, ilo);
+
+    // itmax is the total number of QR iterations allowed.
+    // For most matrices, 3 shifts per eigenvalue is enough, so
+    // we set itmax to 30 times nh as a safe limit.
+    const idx_t itmax = 30 * std::max<idx_t>(10, nh);
+
+    // k_defl counts the number of iterations since a deflation
+    idx_t k_defl = 0;
+
+    // istop is the end of the active subblock.
+    // As more and more eigenvalues converge, it eventually
+    // becomes ilo+1 and the loop ends.
+    idx_t istop = ihi;
+    // istart is the start of the active subblock. Either
+    // istart = ilo, or H(istart, istart-1) = 0. This means
+    // that we can treat this subblock separately.
+    idx_t istart = ilo;
+
+    for (idx_t iter = 0; iter <= itmax; ++iter) {
+        if (iter == itmax) {
+            // The QR algorithm failed to converge, return with error.
+            return istop;
+        }
+
+        if (istart + 1 >= istop) {
+            if (istart + 1 == istop) w[istart] = A(istart, istart);
+            // All eigenvalues have been found, exit and return 0.
+            break;
+        }
+
+        // Determine range to apply rotations
+        idx_t istart_m;
+        idx_t istop_m;
+        if (!want_t) {
+            istart_m = istart;
+            istop_m = istop;
+        }
+        else {
+            istart_m = 0;
+            istop_m = n;
+        }
+
+        // Check if active subblock has split
+        for (idx_t i = istop - 1; i > istart; --i) {
+            if (abs1(A(i, i - 1)) <= small_num) {
+                // A(i,i-1) is negligible, take i as new istart.
+                A(i, i - 1) = zero;
+                istart = i;
+                break;
+            }
+
+            real_t tst = abs1(A(i - 1, i - 1)) + abs1(A(i, i));
+            if (tst == zero) {
+                if (i >= ilo + 2) {
+                    tst = tst + tlapack::abs(A(i - 1, i - 2));
+                }
+                if (i < ihi) {
+                    tst = tst + tlapack::abs(A(i + 1, i));
+                }
+            }
+            if (abs1(A(i, i - 1)) <= eps * tst) {
+                //
+                // The elementwise deflation test has passed
+                // The following performs second deflation test due
+                // to Ahues & Tisseur (LAWN 122, 1997). It has better
+                // mathematical foundation and improves accuracy in some
+                // examples.
+                //
+                // The test is |A(i,i-1)|*|A(i-1,i)| <=
+                // eps*|A(i,i)|*|A(i-1,i-1)| The multiplications might overflow
+                // so we do some scaling first.
+                //
+                real_t ab = std::max(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
+                real_t ba = std::min(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
+                real_t aa =
+                    std::max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                real_t bb =
+                    std::min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                real_t s = aa + ab;
+                if (ba * (ab / s) <=
+                    std::max(small_num, eps * (bb * (aa / s)))) {
+                    // A(i,i-1) is negligible, take i as new istart.
+                    A(i, i - 1) = zero;
+                    istart = i;
+                    break;
+                }
+            }
+        }
+
+        if (istart + 1 >= istop) {
+            k_defl = 0;
+            w[istart] = A(istart, istart);
+            istop = istart;
+            istart = ilo;
+            continue;
+        }
+
+        // Determine shift
+        TA a00, a01, a10, a11;
+        k_defl = k_defl + 1;
+        if (k_defl % non_convergence_limit == 0) {
+            // Exceptional shift
+            real_t s = tlapack::abs(A(istop - 1, istop - 2));
+            if (istop > ilo + 2) s = s + tlapack::abs(A(istop - 2, istop - 3));
+            a00 = dat1 * s + A(istop - 1, istop - 1);
+            a01 = dat2 * s;
+            a10 = s;
+            a11 = a00;
+        }
+        else {
+            // Wilkinson shift
+            a00 = A(istop - 2, istop - 2);
+            a10 = A(istop - 1, istop - 2);
+            a01 = A(istop - 2, istop - 1);
+            a11 = A(istop - 1, istop - 1);
+        }
+        complex_type<real_t> s1;
+        complex_type<real_t> s2;
+        lahqr_eig22(a00, a01, a10, a11, s1, s2);
+        if (abs1(s1 - A(istop - 1, istop - 1)) >
+            abs1(s2 - A(istop - 1, istop - 1)))
+            s1 = s2;
+
+        // We have already checked whether the subblock has split.
+        // If it has split, we can introduce any shift at the top of the new
+        // subblock. Now that we know the specific shift, we can also check
+        // whether we can introduce that shift somewhere else in the subblock.
+        TA sn;
+        real_t cs;
+        idx_t istart2 = istart;
+        if (istart + 2 < istop) {
+            for (idx_t i = istop - 2; i > istart; --i) {
+                TA h00 = A(i, i) - s1;
+                TA h10 = A(i + 1, i);
+                rotg(h00, h10, cs, sn);
+
+                if (abs1(conj(sn) * A(i, i - 1)) <=
+                    eps * (abs1(A(i, i - 1)) + abs1(A(i, i + 1)))) {
+                    istart2 = i;
+                    break;
+                }
+            }
+        }
+
+        for (idx_t i = istart2; i < istop - 1; ++i) {
+            if (i == istart2) {
+                TA h00 = A(i, i) - s1;
+                TA h10 = A(i + 1, i);
+                rotg(h00, h10, cs, sn);
+                if (i > istart) A(i, i - 1) = A(i, i - 1) * cs;
+            }
+            else {
+                rotg(A(i, i - 1), A(i + 1, i - 1), cs, sn);
+                A(i + 1, i - 1) = zero;
+            }
+
+            // Apply G from the left to A
+            for (idx_t j = i; j < istop_m; ++j) {
+                TA tmp = cs * A(i, j) + sn * A(i + 1, j);
+                A(i + 1, j) = -conj(sn) * A(i, j) + cs * A(i + 1, j);
+                A(i, j) = tmp;
+            }
+            // Apply G**H from the right to A
+            for (idx_t j = istart_m; j < std::min(i + 3, istop); ++j) {
+                TA tmp = cs * A(j, i) + conj(sn) * A(j, i + 1);
+                A(j, i + 1) = -sn * A(j, i) + cs * A(j, i + 1);
+                A(j, i) = tmp;
+            }
+            if (want_z) {
+                // Apply G**H to Z from the right
+                for (idx_t j = 0; j < n; ++j) {
+                    TA tmp = cs * Z(j, i) + conj(sn) * Z(j, i + 1);
+                    Z(j, i + 1) = -sn * Z(j, i) + cs * Z(j, i + 1);
+                    Z(j, i) = tmp;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_LAHQR_HH

--- a/include/tlapack/lapack/lahqr_eig22.hpp
+++ b/include/tlapack/lapack/lahqr_eig22.hpp
@@ -12,55 +12,54 @@
 
 #include "tlapack/base/utils.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** Computes the eigenvalues of a 2x2 matrix A
+ *
+ * @param[in] a00
+ *      Element (0,0) of A.
+ * @param[in] a01
+ *      Element (0,1) of A.
+ * @param[in] a10
+ *      Element (1,0) of A.
+ * @param[in] a11
+ *      Element (1,1) of A.
+ * @param[out] s1
+ * @param[out] s2
+ *      s1 and s2 are the eigenvalues of A
+ *
+ * @ingroup auxiliary
+ */
+template <typename T>
+void lahqr_eig22(
+    T a00, T a01, T a10, T a11, complex_type<T>& s1, complex_type<T>& s2)
 {
+    // Using
+    using real_t = real_type<T>;
 
-    /** Computes the eigenvalues of a 2x2 matrix A
-     *
-     * @param[in] a00
-     *      Element (0,0) of A.
-     * @param[in] a01
-     *      Element (0,1) of A.
-     * @param[in] a10
-     *      Element (1,0) of A.
-     * @param[in] a11
-     *      Element (1,1) of A.
-     * @param[out] s1
-     * @param[out] s2
-     *      s1 and s2 are the eigenvalues of A
-     *
-     * @ingroup auxiliary
-     */
-    template < typename T >
-    void lahqr_eig22(T a00, T a01, T a10, T a11, complex_type<T> &s1, complex_type<T> &s2)
-    {
-        // Using
-        using real_t = real_type<T>;
-        
-        // Constants
-        const real_t zero(0);
-        const real_t two(2);
+    // Constants
+    const real_t zero(0);
+    const real_t two(2);
 
-        const T s = abs1(a00) + abs1(a01) + abs1(a10) + abs1(a11);
-        if (s == zero)
-        {
-            s1 = zero;
-            s2 = zero;
-            return;
-        }
-
-        a00 = a00 / s;
-        a01 = a01 / s;
-        a10 = a10 / s;
-        a11 = a11 / s;
-        const T tr = (a00 + a11) / two;
-        const complex_type<T> det = (a00 - tr) * (a00 - tr) + a01 * a10;
-        const complex_type<T> rtdisc = sqrt(det);
-
-        s1 = s*(tr + rtdisc);
-        s2 = s*(tr - rtdisc);
+    const T s = abs1(a00) + abs1(a01) + abs1(a10) + abs1(a11);
+    if (s == zero) {
+        s1 = zero;
+        s2 = zero;
+        return;
     }
 
-} // lapack
+    a00 = a00 / s;
+    a01 = a01 / s;
+    a10 = a10 / s;
+    a11 = a11 / s;
+    const T tr = (a00 + a11) / two;
+    const complex_type<T> det = (a00 - tr) * (a00 - tr) + a01 * a10;
+    const complex_type<T> rtdisc = sqrt(det);
 
-#endif // TLAPACK_LAHQR_EIG22_HH
+    s1 = s * (tr + rtdisc);
+    s2 = s * (tr - rtdisc);
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_LAHQR_EIG22_HH

--- a/include/tlapack/lapack/lahqr_schur22.hpp
+++ b/include/tlapack/lapack/lahqr_schur22.hpp
@@ -13,6 +13,7 @@
 #define TLAPACK_LAHQR_SCHUR22_HH
 
 #include "tlapack/base/utils.hpp"
+#include "tlapack/lapack/lapy2.hpp"
 
 namespace tlapack {
 

--- a/include/tlapack/lapack/lahqr_shiftcolumn.hpp
+++ b/include/tlapack/lapack/lahqr_shiftcolumn.hpp
@@ -1,6 +1,7 @@
 /// @file lahqr_shiftcolumn.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlaqr1.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlaqr1.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -13,162 +14,156 @@
 
 #include "tlapack/base/utils.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** Given a 2-by-2 or 3-by-3 matrix H, lahqr_shiftcolumn
+ *  calculates a multiple of the product:
+ *  (H - s1*I)*(H - s2*I)*e1
+ *
+ *  This is used to introduce shifts in the QR algorithm
+ *
+ * @return  0 if success
+ *
+ * @param[in] H 2x2 or 3x3 matrix.
+ *      The matrix H as in the formula above.
+ * @param[out] v vector of size 2 or 3
+ *      On exit, a multiple of the product
+ * @param[in] s1
+ *      The scalar s1 as in the formula above
+ * @param[in] s2
+ *      The scalar s2 as in the formula above
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
+int lahqr_shiftcolumn(matrix_t& H,
+                      vector_t& v,
+                      complex_type<type_t<matrix_t>> s1,
+                      complex_type<type_t<matrix_t>> s2)
 {
+    // Using
+    using idx_t = size_type<matrix_t>;
+    using TH = type_t<matrix_t>;
 
-   /** Given a 2-by-2 or 3-by-3 matrix H, lahqr_shiftcolumn
-    *  calculates a multiple of the product:
-    *  (H - s1*I)*(H - s2*I)*e1
-    *
-    *  This is used to introduce shifts in the QR algorithm
-    *
-    * @return  0 if success
-    *
-    * @param[in] H 2x2 or 3x3 matrix.
-    *      The matrix H as in the formula above.
-    * @param[out] v vector of size 2 or 3
-    *      On exit, a multiple of the product
-    * @param[in] s1
-    *      The scalar s1 as in the formula above
-    * @param[in] s2
-    *      The scalar s2 as in the formula above
-    *
-    * @ingroup auxiliary
-    */
-   template < class matrix_t, class vector_t,
-      enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true
-   >
-   int lahqr_shiftcolumn(
-      matrix_t &H, vector_t &v, 
-      complex_type<type_t<matrix_t>> s1, 
-      complex_type<type_t<matrix_t>> s2 )
-   {
-      // Using
-      using idx_t = size_type<matrix_t>;
-      using TH    = type_t<matrix_t>;
-      
-      // Constants
-      const idx_t n = ncols(H);
-      const TH zero(0);
+    // Constants
+    const idx_t n = ncols(H);
+    const TH zero(0);
 
-      // Check arguments
-      tlapack_check_false((n != 2 and n != 3) );
-      tlapack_check_false(n != nrows(H) );
-      tlapack_check_false((idx_t)size(v) != n );
+    // Check arguments
+    tlapack_check_false((n != 2 and n != 3));
+    tlapack_check_false(n != nrows(H));
+    tlapack_check_false((idx_t)size(v) != n);
 
-      if (n == 2)
-      {
-         const TH s = abs(H(0, 0) - real(s2)) + abs(imag(s2)) + abs(H(1, 0));
-         if (s == zero)
-         {
+    if (n == 2) {
+        const TH s = abs(H(0, 0) - real(s2)) + abs(imag(s2)) + abs(H(1, 0));
+        if (s == zero) {
             v[0] = zero;
             v[1] = zero;
-         }
-         else
-         {
+        }
+        else {
             const TH h10s = H(1, 0) / s;
-            v[0] = h10s * H(0, 1) + (H(0, 0) - real(s1)) * ((H(0, 0) - real(s2)) / s) - imag(s1) * (imag(s2) / s);
+            v[0] = h10s * H(0, 1) +
+                   (H(0, 0) - real(s1)) * ((H(0, 0) - real(s2)) / s) -
+                   imag(s1) * (imag(s2) / s);
             v[1] = h10s * (H(0, 0) + H(1, 1) - real(s1) - real(s2));
-         }
-      }
-      else
-      {
-         const TH s = abs(H(0, 0) - real(s2)) + abs(imag(s2)) + abs(H(1, 0)) + abs(H(2, 0));
-         if (s == zero)
-         {
+        }
+    }
+    else {
+        const TH s = abs(H(0, 0) - real(s2)) + abs(imag(s2)) + abs(H(1, 0)) +
+                     abs(H(2, 0));
+        if (s == zero) {
             v[0] = zero;
             v[1] = zero;
             v[2] = zero;
-         }
-         else
-         {
+        }
+        else {
             const TH h10s = H(1, 0) / s;
             const TH h20s = H(2, 0) / s;
-            v[0] = (H(0, 0) - real(s1)) * ((H(0, 0) - real(s2)) / s) - imag(s1) * (imag(s2) / s) + H(0, 1) * h10s + H(0, 2) * h20s;
-            v[1] = h10s * (H(0, 0) + H(1, 1) - real(s1) - real(s2)) + H(1, 2) * h20s;
-            v[2] = h20s * (H(0, 0) + H(2, 2) - real(s1) - real(s2)) + h10s * H(2, 1);
-         }
-      }
-      return 0;
-   }
+            v[0] = (H(0, 0) - real(s1)) * ((H(0, 0) - real(s2)) / s) -
+                   imag(s1) * (imag(s2) / s) + H(0, 1) * h10s + H(0, 2) * h20s;
+            v[1] = h10s * (H(0, 0) + H(1, 1) - real(s1) - real(s2)) +
+                   H(1, 2) * h20s;
+            v[2] = h20s * (H(0, 0) + H(2, 2) - real(s1) - real(s2)) +
+                   h10s * H(2, 1);
+        }
+    }
+    return 0;
+}
 
-   /** Given a 2-by-2 or 3-by-3 matrix H, lahqr_shiftcolumn
-    *  calculates a multiple of the product:
-    *  (H - s1*I)*(H - s2*I)*e1
-    *
-    *  This is used to introduce shifts in the QR algorithm
-    *
-    * @return  0 if success
-    *
-    * @param[in] H 2x2 or 3x3 matrix.
-    *      The matrix H as in the formula above.
-    * @param[out] v vector of size 2 or 3
-    *      On exit, a multiple of the product
-    * @param[in] s1
-    *      The scalar s1 as in the formula above
-    * @param[in] s2
-    *      The scalar s2 as in the formula above
-    *
-    * @ingroup auxiliary
-    */
-   template < class matrix_t, class vector_t,
-      enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true
-   >
-   int lahqr_shiftcolumn(
-      matrix_t &H, vector_t &v, 
-      type_t<matrix_t> s1, 
-      type_t<matrix_t> s2 )
-   {
-      // Using
-      using idx_t = size_type<matrix_t>;
-      using TH    = type_t<matrix_t>;
-      using real_t = real_type<TH>;
-  
-      // Constants
-      const idx_t n = ncols(H);
-      const real_t zero(0);
+/** Given a 2-by-2 or 3-by-3 matrix H, lahqr_shiftcolumn
+ *  calculates a multiple of the product:
+ *  (H - s1*I)*(H - s2*I)*e1
+ *
+ *  This is used to introduce shifts in the QR algorithm
+ *
+ * @return  0 if success
+ *
+ * @param[in] H 2x2 or 3x3 matrix.
+ *      The matrix H as in the formula above.
+ * @param[out] v vector of size 2 or 3
+ *      On exit, a multiple of the product
+ * @param[in] s1
+ *      The scalar s1 as in the formula above
+ * @param[in] s2
+ *      The scalar s2 as in the formula above
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
+int lahqr_shiftcolumn(matrix_t& H,
+                      vector_t& v,
+                      type_t<matrix_t> s1,
+                      type_t<matrix_t> s2)
+{
+    // Using
+    using idx_t = size_type<matrix_t>;
+    using TH = type_t<matrix_t>;
+    using real_t = real_type<TH>;
 
-      // Check arguments
-      tlapack_check_false((n != 2 and n != 3) );
-      tlapack_check_false(n != nrows(H) );
-      tlapack_check_false((idx_t)size(v) != n );
+    // Constants
+    const idx_t n = ncols(H);
+    const real_t zero(0);
 
-      if (n == 2)
-      {
-         const TH s = abs1(H(0, 0) - s2) + abs1(H(1, 0));
-         if (s == zero)
-         {
+    // Check arguments
+    tlapack_check_false((n != 2 and n != 3));
+    tlapack_check_false(n != nrows(H));
+    tlapack_check_false((idx_t)size(v) != n);
+
+    if (n == 2) {
+        const TH s = abs1(H(0, 0) - s2) + abs1(H(1, 0));
+        if (s == zero) {
             v[0] = zero;
             v[1] = zero;
-         }
-         else
-         {
+        }
+        else {
             const TH h10s = H(1, 0) / s;
             v[0] = h10s * H(0, 1) + (H(0, 0) - s1) * ((H(0, 0) - s2) / s);
             v[1] = h10s * (H(0, 0) + H(1, 1) - s1 - s2);
-         }
-      }
-      else
-      {
-         const TH s = abs1(H(0, 0) - s2) + abs1(H(1, 0)) + abs1(H(2, 0));
-         if (s == zero)
-         {
+        }
+    }
+    else {
+        const TH s = abs1(H(0, 0) - s2) + abs1(H(1, 0)) + abs1(H(2, 0));
+        if (s == zero) {
             v[0] = zero;
             v[1] = zero;
             v[2] = zero;
-         }
-         else
-         {
+        }
+        else {
             const TH h10s = H(1, 0) / s;
             const TH h20s = H(2, 0) / s;
-            v[0] = (H(0, 0) - s1) * ((H(0, 0) - s2) / s) + H(0, 1) * h10s + H(0, 2) * h20s;
+            v[0] = (H(0, 0) - s1) * ((H(0, 0) - s2) / s) + H(0, 1) * h10s +
+                   H(0, 2) * h20s;
             v[1] = h10s * (H(0, 0) + H(1, 1) - s1 - s2) + H(1, 2) * h20s;
             v[2] = h20s * (H(0, 0) + H(2, 2) - s1 - s2) + h10s * H(2, 1);
-         }
-      }
-      return 0;
-   }
+        }
+    }
+    return 0;
+}
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LAHQR_SHIFTCOLUMN_HH
+#endif  // TLAPACK_LAHQR_SHIFTCOLUMN_HH

--- a/include/tlapack/lapack/lahr2.hpp
+++ b/include/tlapack/lapack/lahr2.hpp
@@ -1,6 +1,7 @@
 /// @file lahqr.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlahqr.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlahqr.f
 //
 // This file is part of <T>LAPACK.
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
@@ -10,176 +11,176 @@
 #define TLAPACK_LAHR2_HH
 
 #include "tlapack/base/utils.hpp"
-
+#include "tlapack/blas/axpy.hpp"
+#include "tlapack/blas/copy.hpp"
 #include "tlapack/blas/gemm.hpp"
 #include "tlapack/blas/gemv.hpp"
-#include "tlapack/blas/copy.hpp"
+#include "tlapack/blas/scal.hpp"
 #include "tlapack/blas/trmm.hpp"
 #include "tlapack/blas/trmv.hpp"
-#include "tlapack/blas/axpy.hpp"
-#include "tlapack/blas/scal.hpp"
-#include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/larf.hpp"
+#include "tlapack/lapack/larfg.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** Reduces a general square matrix to upper Hessenberg form
+ *
+ * The matrix Q is represented as a product of elementary reflectors
+ * \[
+ *          Q = H_ilo H_ilo+1 ... H_ihi,
+ * \]
+ * Each H_i has the form
+ * \[
+ *          H_i = I - tau * v * v',
+ * \]
+ * where tau is a scalar, and v is a vector with
+ * \[
+ *          v[0] = v[1] = ... = v[i] = 0; v[i+1] = 1,
+ * \]
+ * with v[i+2] through v[ihi] stored on exit below the diagonal
+ * in the ith column of A, and tau in tau[i].
+ *
+ * @return  0 if success
+ *
+ * @param[in] k integer
+ * @param[in] nb integer
+ * @param[in,out] A n-by-n matrix.
+ * @param[out] tau Real vector of length n-1.
+ *      The scalar factors of the elementary reflectors.
+ * @param[in,out] T nb-by-nb matrix.
+ * @param[in,out] Y n-by-nb matrix.
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t, class vector_t, class T_t, class Y_t>
+int lahr2(size_type<matrix_t> k,
+          size_type<matrix_t> nb,
+          matrix_t& A,
+          vector_t& tau,
+          T_t& T,
+          Y_t& Y)
 {
+    using TA = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
+    using real_t = real_type<TA>;
 
-    /** Reduces a general square matrix to upper Hessenberg form
-     *
-     * The matrix Q is represented as a product of elementary reflectors
-     * \[
-     *          Q = H_ilo H_ilo+1 ... H_ihi,
-     * \]
-     * Each H_i has the form
-     * \[
-     *          H_i = I - tau * v * v',
-     * \]
-     * where tau is a scalar, and v is a vector with
-     * \[
-     *          v[0] = v[1] = ... = v[i] = 0; v[i+1] = 1,
-     * \]
-     * with v[i+2] through v[ihi] stored on exit below the diagonal
-     * in the ith column of A, and tau in tau[i].
-     *
-     * @return  0 if success
-     *
-     * @param[in] k integer
-     * @param[in] nb integer
-     * @param[in,out] A n-by-n matrix.
-     * @param[out] tau Real vector of length n-1.
-     *      The scalar factors of the elementary reflectors.
-     * @param[in,out] T nb-by-nb matrix.
-     * @param[in,out] Y n-by-nb matrix.
-     *
-     * @ingroup auxiliary
-     */
-    template <class matrix_t, class vector_t, class T_t, class Y_t>
-    int lahr2(size_type<matrix_t> k, size_type<matrix_t> nb, matrix_t &A, vector_t &tau, T_t &T, Y_t &Y)
-    {
-        using TA = type_t<matrix_t>;
-        using idx_t = size_type<matrix_t>;
-        using pair = pair<idx_t, idx_t>;
-        using real_t = real_type<TA>;
-                            
-        // constants
-        const real_t one(1);
-        const idx_t n = nrows(A);
+    // constants
+    const real_t one(1);
+    const idx_t n = nrows(A);
 
-        // quick return if possible
-        if (n <= 1)
-            return 0;
+    // quick return if possible
+    if (n <= 1) return 0;
 
-        TA ei(0);
-        for (idx_t i = 0; i < nb; ++i)
-        {
-            if (i > 0)
-            {
-                //
-                // Update A(K+1:N,I), this rest will be updated later via
-                // level 3 BLAS.
-                //
-
-                //
-                // Update I-th column of A - Y * V**T
-                // (Application of the reflectors from the right)
-                //
-                auto Y2 = slice(Y, pair{k + 1, n}, pair{0, i});
-                auto Vti = slice(A, k + i, pair{0, i});
-                auto b = slice(A, pair{k + 1, n}, i);
-                for( idx_t j = 0; j < i; ++j )
-                    Vti[j] = conj(Vti[j]);
-                gemv(Op::NoTrans, -one, Y2, Vti, one, b);
-                for( idx_t j = 0; j < i; ++j )
-                    Vti[j] = conj(Vti[j]);
-                //
-                // Apply I - V * T**T * V**T to this column (call it b) from the
-                // left, using the last column of T as workspace
-                //
-                // Let  V = ( V1 )   and   b = ( b1 )   (first i rows)
-                //          ( V2 )             ( b2 )
-                //
-                // where V1 is unit lower triangular
-                // 
-                auto b1 = slice(b, pair{0, i});
-                auto b2 = slice(b, pair{i, size(b)});
-                auto V = slice(A, pair{k + 1, n}, pair{0,i});
-                auto V1 = slice(V, pair{0, i}, pair{0, i});
-                auto V2 = slice(V, pair{i, nrows(V)}, pair{0, i});
-                //
-                // w := V1**T * b1
-                //
-                auto w = slice(T, pair{0, i}, nb - 1);
-                copy(b1, w);
-                trmv(Uplo::Lower, Op::ConjTrans, Diag::Unit, V1, w);
-                //
-                // w := w + V2**T * b2
-                //
-                gemv(Op::ConjTrans, one, V2, b2, one, w);
-                //
-                // w := T**T * w
-                //
-                auto T2 = slice(T, pair{0, i}, pair{0, i});
-                trmv(Uplo::Upper, Op::ConjTrans, Diag::NonUnit, T2, w);
-                //
-                // b2 := b2 - V2*w
-                //
-                gemv(Op::NoTrans, -one, V2, w, one, b2);
-                //
-                // b1 := b1 - V1*w
-                //
-                trmv(Uplo::Lower, Op::NoTrans, Diag::Unit, V1, w);
-                axpy(-one, w, b1);
-
-                A(k + i, i - 1) = ei;
-            }
-            auto v = slice(A, pair{k + i + 1, n}, i);
-            larfg(v, tau[i]);
-
-            // larf has been edited to not require A(k+i,i) = one
-            // this is for thread safety. Since we already modified
-            // A(k+i,i) before, this is not required here
-            ei = v[0];
-            v[0] = one;
+    TA ei(0);
+    for (idx_t i = 0; i < nb; ++i) {
+        if (i > 0) {
             //
-            // Compute  Y(K+1:N,I)
+            // Update A(K+1:N,I), this rest will be updated later via
+            // level 3 BLAS.
             //
-            auto A2 = slice(A, pair{k + 1, n}, pair{i + 1, n - k});
-            auto y = slice(Y, pair{k + 1, n}, i);
-            gemv(Op::NoTrans, one, A2, v, y);
-            auto t = slice(T, pair{0, i}, i);
-            auto A3 = slice(A, pair{k + i + 1, n}, pair{0, i});
-            gemv(Op::ConjTrans, one, A3, v, t);
+
+            //
+            // Update I-th column of A - Y * V**T
+            // (Application of the reflectors from the right)
+            //
             auto Y2 = slice(Y, pair{k + 1, n}, pair{0, i});
-            gemv(Op::NoTrans, -one, Y2, t, one, y);
-            scal(tau[i], y);
+            auto Vti = slice(A, k + i, pair{0, i});
+            auto b = slice(A, pair{k + 1, n}, i);
+            for (idx_t j = 0; j < i; ++j)
+                Vti[j] = conj(Vti[j]);
+            gemv(Op::NoTrans, -one, Y2, Vti, one, b);
+            for (idx_t j = 0; j < i; ++j)
+                Vti[j] = conj(Vti[j]);
             //
-            // Compute T(0:I+1,I)
+            // Apply I - V * T**T * V**T to this column (call it b) from the
+            // left, using the last column of T as workspace
             //
-            scal(-tau[i], t);
+            // Let  V = ( V1 )   and   b = ( b1 )   (first i rows)
+            //          ( V2 )             ( b2 )
+            //
+            // where V1 is unit lower triangular
+            //
+            auto b1 = slice(b, pair{0, i});
+            auto b2 = slice(b, pair{i, size(b)});
+            auto V = slice(A, pair{k + 1, n}, pair{0, i});
+            auto V1 = slice(V, pair{0, i}, pair{0, i});
+            auto V2 = slice(V, pair{i, nrows(V)}, pair{0, i});
+            //
+            // w := V1**T * b1
+            //
+            auto w = slice(T, pair{0, i}, nb - 1);
+            copy(b1, w);
+            trmv(Uplo::Lower, Op::ConjTrans, Diag::Unit, V1, w);
+            //
+            // w := w + V2**T * b2
+            //
+            gemv(Op::ConjTrans, one, V2, b2, one, w);
+            //
+            // w := T**T * w
+            //
             auto T2 = slice(T, pair{0, i}, pair{0, i});
-            trmv(Uplo::Upper, Op::NoTrans, Diag::NonUnit, T2, t);
-            T(i, i) = tau[i];
+            trmv(Uplo::Upper, Op::ConjTrans, Diag::NonUnit, T2, w);
+            //
+            // b2 := b2 - V2*w
+            //
+            gemv(Op::NoTrans, -one, V2, w, one, b2);
+            //
+            // b1 := b1 - V1*w
+            //
+            trmv(Uplo::Lower, Op::NoTrans, Diag::Unit, V1, w);
+            axpy(-one, w, b1);
+
+            A(k + i, i - 1) = ei;
         }
-        A( k+nb, nb-1 ) = ei;
-        // 
-        // Compute Y(0:k+1,0:nb)
+        auto v = slice(A, pair{k + i + 1, n}, i);
+        larfg(v, tau[i]);
+
+        // larf has been edited to not require A(k+i,i) = one
+        // this is for thread safety. Since we already modified
+        // A(k+i,i) before, this is not required here
+        ei = v[0];
+        v[0] = one;
         //
-        auto A4 = slice( A, pair{0,k+1}, pair{1,nb+1} );
-        auto Y3 = slice( Y, pair{0,k+1}, pair{0,nb});
-        lacpy( Uplo::General, A4, Y3);
-        auto V1 = slice( A, pair{k+1,k+nb+1}, pair{0,nb} );
-        auto Y1 = slice( Y, pair{0,k+1}, pair{0,nb} );
-        trmm( Side::Right, Uplo::Lower, Op::NoTrans, Diag::Unit, one, V1, Y1 );
-        if( k + nb + 1 < n ){
-            auto A5 = slice( A, pair{0,k+1}, pair{nb+1,n-k} );
-            auto V2 = slice( A, pair{k+nb+1,n}, pair{0,nb} );
-            gemm( Op::NoTrans, Op::NoTrans,  one, A5, V2, one, Y1);
-        }
-        trmm( Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, one, T, Y1 );
-
-        return 0;
+        // Compute  Y(K+1:N,I)
+        //
+        auto A2 = slice(A, pair{k + 1, n}, pair{i + 1, n - k});
+        auto y = slice(Y, pair{k + 1, n}, i);
+        gemv(Op::NoTrans, one, A2, v, y);
+        auto t = slice(T, pair{0, i}, i);
+        auto A3 = slice(A, pair{k + i + 1, n}, pair{0, i});
+        gemv(Op::ConjTrans, one, A3, v, t);
+        auto Y2 = slice(Y, pair{k + 1, n}, pair{0, i});
+        gemv(Op::NoTrans, -one, Y2, t, one, y);
+        scal(tau[i], y);
+        //
+        // Compute T(0:I+1,I)
+        //
+        scal(-tau[i], t);
+        auto T2 = slice(T, pair{0, i}, pair{0, i});
+        trmv(Uplo::Upper, Op::NoTrans, Diag::NonUnit, T2, t);
+        T(i, i) = tau[i];
     }
+    A(k + nb, nb - 1) = ei;
+    //
+    // Compute Y(0:k+1,0:nb)
+    //
+    auto A4 = slice(A, pair{0, k + 1}, pair{1, nb + 1});
+    auto Y3 = slice(Y, pair{0, k + 1}, pair{0, nb});
+    lacpy(Uplo::General, A4, Y3);
+    auto V1 = slice(A, pair{k + 1, k + nb + 1}, pair{0, nb});
+    auto Y1 = slice(Y, pair{0, k + 1}, pair{0, nb});
+    trmm(Side::Right, Uplo::Lower, Op::NoTrans, Diag::Unit, one, V1, Y1);
+    if (k + nb + 1 < n) {
+        auto A5 = slice(A, pair{0, k + 1}, pair{nb + 1, n - k});
+        auto V2 = slice(A, pair{k + nb + 1, n}, pair{0, nb});
+        gemm(Op::NoTrans, Op::NoTrans, one, A5, V2, one, Y1);
+    }
+    trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, one, T, Y1);
 
-} // lapack
+    return 0;
+}
 
-#endif // TLAPACK_LAHR2_HH
+}  // namespace tlapack
+
+#endif  // TLAPACK_LAHR2_HH

--- a/include/tlapack/lapack/lange.hpp
+++ b/include/tlapack/lapack/lange.hpp
@@ -17,160 +17,149 @@
 namespace tlapack {
 
 /** Worspace query of lange()
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] A m-by-n matrix.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< typename norm_t, typename matrix_t >
-inline constexpr
-void lange_worksize(
-    norm_t normType,
-    const matrix_t& A,
-    workinfo_t& workinfo ) { }
+template <typename norm_t, typename matrix_t>
+inline constexpr void lange_worksize(norm_t normType,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo)
+{}
 
 /** Worspace query of lange()
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] A m-by-n matrix.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< typename norm_t, typename matrix_t >
-inline constexpr
-void lange_worksize(
-    norm_t normType,
-    const matrix_t& A,
-    workinfo_t& workinfo,
-    const workspace_opts_t<>& opts )
+template <typename norm_t, typename matrix_t>
+inline constexpr void lange_worksize(norm_t normType,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts)
 {
-    using T = type_t< matrix_t >;
+    using T = type_t<matrix_t>;
 
-    if ( normType == Norm::Inf  )
-    {
-        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
-        workinfo.minMax( myWorkinfo );
+    if (normType == Norm::Inf) {
+        const workinfo_t myWorkinfo(sizeof(T), nrows(A));
+        workinfo.minMax(myWorkinfo);
     }
 }
 
 /** Calculates the norm of a matrix.
- * 
+ *
  * @tparam norm_t Either Norm or any class that implements `operator Norm()`.
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] A m-by-n matrix.
- * 
+ *
  * @ingroup auxiliary
  */
-template< typename norm_t, typename matrix_t >
-auto lange( norm_t normType, const matrix_t& A )
+template <typename norm_t, typename matrix_t>
+auto lange(norm_t normType, const matrix_t& A)
 {
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
 
     // quick return
-    if (m == 0 || n == 0)
-        return real_t( 0 );
+    if (m == 0 || n == 0) return real_t(0);
 
     // Norm value
-    real_t norm( 0 );
+    real_t norm(0);
 
-    if( normType == Norm::Max )
-    {
+    if (normType == Norm::Max) {
         for (idx_t j = 0; j < n; ++j) {
-            for (idx_t i = 0; i < m; ++i)
-            {
-                real_t temp = tlapack::abs( A(i,j) );
+            for (idx_t i = 0; i < m; ++i) {
+                real_t temp = tlapack::abs(A(i, j));
 
                 if (temp > norm)
                     norm = temp;
                 else {
-                    if ( isnan(temp) ) 
-                        return temp;
+                    if (isnan(temp)) return temp;
                 }
             }
         }
     }
-    else if ( normType == Norm::Inf )
-    {
-        for (idx_t i = 0; i < m; ++i)
-        {
-            real_t sum( 0 );
+    else if (normType == Norm::Inf) {
+        for (idx_t i = 0; i < m; ++i) {
+            real_t sum(0);
             for (idx_t j = 0; j < n; ++j)
-                sum += tlapack::abs( A(i,j) );
+                sum += tlapack::abs(A(i, j));
 
             if (sum > norm)
                 norm = sum;
             else {
-                if ( isnan(sum) ) 
-                    return sum;
+                if (isnan(sum)) return sum;
             }
         }
     }
-    else if ( normType == Norm::One )
-    {
-        for (idx_t j = 0; j < n; ++j)
-        {
-            real_t sum( 0 );
+    else if (normType == Norm::One) {
+        for (idx_t j = 0; j < n; ++j) {
+            real_t sum(0);
             for (idx_t i = 0; i < m; ++i)
-                sum += tlapack::abs( A(i,j) );
+                sum += tlapack::abs(A(i, j));
 
             if (sum > norm)
                 norm = sum;
             else {
-                if ( isnan(sum) ) 
-                    return sum;
+                if (isnan(sum)) return sum;
             }
         }
     }
-    else
-    {
+    else {
         real_t scale(0), sum(1);
         for (idx_t j = 0; j < n; ++j)
-            lassq( col(A,j), scale, sum );
+            lassq(col(A, j), scale, sum);
         norm = scale * sqrt(sum);
     }
 
@@ -178,86 +167,84 @@ auto lange( norm_t normType, const matrix_t& A )
 }
 
 /** Calculates the norm of a matrix.
- * 
- * Code optimized for the infinity norm on column-major layouts using a workspace
- * of size at least m, where m is the number of rows of A.
- * 
+ *
+ * Code optimized for the infinity norm on column-major layouts using a
+ * workspace of size at least m, where m is the number of rows of A.
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] A m-by-n matrix.
  *
  * @param[in] opts Options.
  *      - @c opts.work is used if whenever it has sufficient size.
  *        The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup auxiliary
  */
-template< typename norm_t, typename matrix_t >
-auto lange( norm_t normType, const matrix_t& A, const workspace_opts_t<>& opts )
+template <typename norm_t, typename matrix_t>
+auto lange(norm_t normType, const matrix_t& A, const workspace_opts_t<>& opts)
 {
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-        
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
 
     // quick return
-    if (m == 0 || n == 0)
-        return real_t( 0 );
+    if (m == 0 || n == 0) return real_t(0);
 
     // redirect for max-norm, one-norm and Frobenius norm
-    if      ( normType == Norm::Max  ) return lange( max_norm,  A );
-    else if ( normType == Norm::One  ) return lange( one_norm,  A );
-    else if ( normType == Norm::Fro  ) return lange( frob_norm, A );
-    else if ( normType == Norm::Inf  ) {
-
+    if (normType == Norm::Max)
+        return lange(max_norm, A);
+    else if (normType == Norm::One)
+        return lange(one_norm, A);
+    else if (normType == Norm::Fro)
+        return lange(frob_norm, A);
+    else if (normType == Norm::Inf) {
         // the code below uses a workspace and is meant for column-major layout
         // so as to do one pass on the data in a contiguous way when computing
-	    // the infinite norm.
+        // the infinite norm.
 
         // Allocates workspace
         vectorOfBytes localworkdata;
-        const Workspace work = [&]()
-        {
+        const Workspace work = [&]() {
             workinfo_t workinfo;
-            lange_worksize( normType, A, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
+            lange_worksize(normType, A, workinfo, opts);
+            return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T,idx_t> w( m, work );
+        legacyVector<T, idx_t> w(m, work);
 
         // Norm value
-        real_t norm( 0 );
+        real_t norm(0);
 
         for (idx_t i = 0; i < m; ++i)
-            w[i] = tlapack::abs( A(i,0) );
-    
+            w[i] = tlapack::abs(A(i, 0));
+
         for (idx_t j = 1; j < n; ++j)
             for (idx_t i = 0; i < m; ++i)
-                w[i] += tlapack::abs( A(i,j) );
+                w[i] += tlapack::abs(A(i, j));
 
-        for (idx_t i = 0; i < m; ++i)
-        {
+        for (idx_t i = 0; i < m; ++i) {
             real_t temp = w[i];
 
             if (temp > norm)
                 norm = temp;
             else {
-                if (isnan(temp))
-                    return temp;
+                if (isnan(temp)) return temp;
             }
         }
 
@@ -265,6 +252,6 @@ auto lange( norm_t normType, const matrix_t& A, const workspace_opts_t<>& opts )
     }
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LANGE_HH
+#endif  // TLAPACK_LANGE_HH

--- a/include/tlapack/lapack/lange.hpp
+++ b/include/tlapack/lapack/lange.hpp
@@ -1,6 +1,7 @@
 /// @file lange.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lange.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lange.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lanhe.hpp
+++ b/include/tlapack/lapack/lanhe.hpp
@@ -1,6 +1,7 @@
 /// @file lanhe.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lanhe.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lanhe.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lanhe.hpp
+++ b/include/tlapack/lapack/lanhe.hpp
@@ -17,146 +17,141 @@
 namespace tlapack {
 
 /** Worspace query of lanhe().
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n hermitian matrix.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< class norm_t, class uplo_t, class matrix_t >
-inline constexpr
-void lanhe_worksize(
-    norm_t normType,
-    uplo_t uplo,
-    const matrix_t& A,
-    workinfo_t& workinfo ) { }
+template <class norm_t, class uplo_t, class matrix_t>
+inline constexpr void lanhe_worksize(norm_t normType,
+                                     uplo_t uplo,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo)
+{}
 
 /** Worspace query of lanhe().
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n hermitian matrix.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< class norm_t, class uplo_t, class matrix_t >
-inline constexpr
-void lanhe_worksize(
-    norm_t normType,
-    uplo_t uplo,
-    const matrix_t& A,
-    workinfo_t& workinfo,
-    const workspace_opts_t<>& opts )
+template <class norm_t, class uplo_t, class matrix_t>
+inline constexpr void lanhe_worksize(norm_t normType,
+                                     uplo_t uplo,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts)
 {
-    using T     = type_t< matrix_t >;
+    using T = type_t<matrix_t>;
 
-    if ( normType == Norm::Inf || normType == Norm::One )
-    {
-        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
-        workinfo.minMax( myWorkinfo );
+    if (normType == Norm::Inf || normType == Norm::One) {
+        const workinfo_t myWorkinfo(sizeof(T), nrows(A));
+        workinfo.minMax(myWorkinfo);
     }
 }
 
 /** Calculates the norm of a hermitian matrix.
- * 
+ *
  * @tparam norm_t Either Norm or any class that implements `operator Norm()`.
  * @tparam uplo_t Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n hermitian matrix.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class norm_t, class uplo_t, class matrix_t >
-auto lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
+template <class norm_t, class uplo_t, class matrix_t>
+auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
 {
-    using T      = type_t<matrix_t>;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-    using pair   = pair<idx_t,idx_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // quick return
-    if ( n <= 0 ) return real_t( 0 );
+    if (n <= 0) return real_t(0);
 
     // Norm value
-    real_t norm( 0 );
+    real_t norm(0);
 
-    if( normType == Norm::Max )
-    {
-        if( uplo == Uplo::Upper ) {
+    if (normType == Norm::Max) {
+        if (uplo == Uplo::Upper) {
             for (idx_t j = 0; j < n; ++j) {
-                for (idx_t i = 0; i < j; ++i)
-                {
-                    real_t temp = tlapack::abs( A(i,j) );
+                for (idx_t i = 0; i < j; ++i) {
+                    real_t temp = tlapack::abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
                     else {
-                        if ( isnan(temp) ) 
-                            return temp;
+                        if (isnan(temp)) return temp;
                     }
                 }
                 {
-                    real_t temp = tlapack::abs( real(A(j,j)) );
+                    real_t temp = tlapack::abs(real(A(j, j)));
 
                     if (temp > norm)
                         norm = temp;
                     else {
-                        if ( isnan(temp) ) 
-                            return temp;
+                        if (isnan(temp)) return temp;
                     }
                 }
             }
@@ -164,93 +159,85 @@ auto lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
         else {
             for (idx_t j = 0; j < n; ++j) {
                 {
-                    real_t temp = tlapack::abs( real(A(j,j)) );
+                    real_t temp = tlapack::abs(real(A(j, j)));
 
                     if (temp > norm)
                         norm = temp;
                     else {
-                        if ( isnan(temp) ) 
-                            return temp;
+                        if (isnan(temp)) return temp;
                     }
                 }
-                for (idx_t i = j+1; i < n; ++i)
-                {
-                    real_t temp = tlapack::abs( A(i,j) );
+                for (idx_t i = j + 1; i < n; ++i) {
+                    real_t temp = tlapack::abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
                     else {
-                        if ( isnan(temp) ) 
-                            return temp;
+                        if (isnan(temp)) return temp;
                     }
                 }
             }
         }
     }
-    else if( normType == Norm::One || normType == Norm::Inf )
-    {
-        if( uplo == Uplo::Upper ) {
+    else if (normType == Norm::One || normType == Norm::Inf) {
+        if (uplo == Uplo::Upper) {
             for (idx_t j = 0; j < n; ++j) {
-                real_t temp( 0 );
+                real_t temp(0);
 
                 for (idx_t i = 0; i < j; ++i)
-                    temp += tlapack::abs( A(i,j) );
-                
-                temp += tlapack::abs( real(A(j,j)) );
+                    temp += tlapack::abs(A(i, j));
 
-                for (idx_t i = j+1; i < n; ++i)
-                    temp += tlapack::abs( A(j,i) );
-                
+                temp += tlapack::abs(real(A(j, j)));
+
+                for (idx_t i = j + 1; i < n; ++i)
+                    temp += tlapack::abs(A(j, i));
+
                 if (temp > norm)
                     norm = temp;
                 else {
-                    if ( isnan(temp) ) 
-                        return temp;
+                    if (isnan(temp)) return temp;
                 }
             }
         }
         else {
             for (idx_t j = 0; j < n; ++j) {
-                real_t temp( 0 );
+                real_t temp(0);
 
                 for (idx_t i = 0; i < j; ++i)
-                    temp += tlapack::abs( A(j,i) );
-                
-                temp += tlapack::abs( real(A(j,j)) );
+                    temp += tlapack::abs(A(j, i));
 
-                for (idx_t i = j+1; i < n; ++i)
-                    temp += tlapack::abs( A(i,j) );
-                
+                temp += tlapack::abs(real(A(j, j)));
+
+                for (idx_t i = j + 1; i < n; ++i)
+                    temp += tlapack::abs(A(i, j));
+
                 if (temp > norm)
                     norm = temp;
                 else {
-                    if ( isnan(temp) ) 
-                        return temp;
+                    if (isnan(temp)) return temp;
                 }
             }
         }
     }
-    else
-    {
+    else {
         // Scaled ssq
         real_t scale(0), ssq(1);
-        
+
         // Sum off-diagonals
-        if( uplo == Uplo::Upper ) {
+        if (uplo == Uplo::Upper) {
             for (idx_t j = 1; j < n; ++j)
-                lassq( slice(A, pair{0,j}, j ), scale, ssq );
+                lassq(slice(A, pair{0, j}, j), scale, ssq);
         }
         else {
-            for (idx_t j = 0; j < n-1; ++j)
-                lassq( slice(A, pair{j+1,n}, j ), scale, ssq );
+            for (idx_t j = 0; j < n - 1; ++j)
+                lassq(slice(A, pair{j + 1, n}, j), scale, ssq);
         }
         ssq *= real_t(2);
 
         // Sum the real part in the diagonal
-        lassq( diag(A,0), scale, ssq,
-            // Lambda function to get the absolute value of the real part :
-            []( const T& x ) { return tlapack::abs( real(x) ); }
-        );
+        lassq(diag(A, 0), scale, ssq,
+              // Lambda function to get the absolute value of the real part :
+              [](const T& x) { return tlapack::abs(real(x)); });
 
         // Compute the scaled square root
         norm = scale * sqrt(ssq);
@@ -260,54 +247,57 @@ auto lanhe( norm_t normType, uplo_t uplo, const matrix_t& A )
 }
 
 /** Calculates the norm of a hermitian matrix.
- * 
- * Code optimized for the infinity and one norm on column-major layouts using a workspace
- * of size at least n, where n is the number of rows of A.
+ *
+ * Code optimized for the infinity and one norm on column-major layouts using a
+ * workspace of size at least n, where n is the number of rows of A.
  * @see lanhe( norm_t normType, uplo_t uplo, const matrix_t& A ).
- * 
+ *
  * @tparam norm_t Either Norm or any class that implements `operator Norm()`.
  * @tparam uplo_t Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n hermitian matrix.
  *
  * @param[in] opts Options.
  *      - @c opts.work is used if whenever it has sufficient size.
  *        The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class norm_t, class uplo_t, class matrix_t >
-auto lanhe( norm_t normType, uplo_t uplo, const matrix_t& A, const workspace_opts_t<>& opts )
+template <class norm_t, class uplo_t, class matrix_t>
+auto lanhe(norm_t normType,
+           uplo_t uplo,
+           const matrix_t& A,
+           const workspace_opts_t<>& opts)
 {
-    using T      = type_t<matrix_t>;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // quick redirect for max-norm and Frobenius norm
-    if      ( normType == Norm::Max  ) return lanhe( max_norm,  uplo, A );
-    else if ( normType == Norm::Fro  ) return lanhe( frob_norm, uplo, A );
+    if (normType == Norm::Max)
+        return lanhe(max_norm, uplo, A);
+    else if (normType == Norm::Fro)
+        return lanhe(frob_norm, uplo, A);
     else {
-
         // the code below uses a workspace and is meant for column-major layout
         // so as to do one pass on the data in a contiguous way when computing
         // the infinite and one norm
@@ -316,60 +306,54 @@ auto lanhe( norm_t normType, uplo_t uplo, const matrix_t& A, const workspace_opt
         const idx_t n = nrows(A);
 
         // quick return
-        if ( n <= 0 ) return real_t( 0 );
+        if (n <= 0) return real_t(0);
 
         // Allocates workspace
         vectorOfBytes localworkdata;
-        const Workspace work = [&]()
-        {
+        const Workspace work = [&]() {
             workinfo_t workinfo;
-            lanhe_worksize( normType, uplo, A, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
+            lanhe_worksize(normType, uplo, A, workinfo, opts);
+            return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T,idx_t> w( n, work );
+        legacyVector<T, idx_t> w(n, work);
 
         // Norm value
-        real_t norm( 0 );
+        real_t norm(0);
 
         for (idx_t i = 0; i < n; ++i)
             w[i] = T(0);
 
-        if( uplo == Uplo::Upper ) {
-            for (idx_t j = 0; j < n; ++j)
-            {
-                real_t sum( 0 );
+        if (uplo == Uplo::Upper) {
+            for (idx_t j = 0; j < n; ++j) {
+                real_t sum(0);
                 for (idx_t i = 0; i < j; ++i) {
-                    const real_t absa = tlapack::abs( A(i,j) );
+                    const real_t absa = tlapack::abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }
-                w[j] = sum + tlapack::abs( real(A(j,j)) );
+                w[j] = sum + tlapack::abs(real(A(j, j)));
             }
-            for (idx_t i = 0; i < n; ++i)
-            {
+            for (idx_t i = 0; i < n; ++i) {
                 real_t sum = w[i];
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) )
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-            {
-                real_t sum = w[j] + tlapack::abs( real(A(j,j)) );
-                for (idx_t i = j+1; i < n; ++i) {
-                    const real_t absa = tlapack::abs( A(i,j) );
+            for (idx_t j = 0; j < n; ++j) {
+                real_t sum = w[j] + tlapack::abs(real(A(j, j)));
+                for (idx_t i = j + 1; i < n; ++i) {
+                    const real_t absa = tlapack::abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) )
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
@@ -378,6 +362,6 @@ auto lanhe( norm_t normType, uplo_t uplo, const matrix_t& A, const workspace_opt
     }
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LANHE_HH
+#endif  // TLAPACK_LANHE_HH

--- a/include/tlapack/lapack/lansy.hpp
+++ b/include/tlapack/lapack/lansy.hpp
@@ -1,6 +1,7 @@
 /// @file lansy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lansy.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lansy.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lansy.hpp
+++ b/include/tlapack/lapack/lansy.hpp
@@ -17,173 +17,165 @@
 namespace tlapack {
 
 /** Worspace query of lansy().
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n symmetric matrix.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< class norm_t, class uplo_t, class matrix_t >
-inline constexpr
-void lansy_worksize(
-    norm_t normType,
-    uplo_t uplo,
-    const matrix_t& A,
-    workinfo_t& workinfo ) { }
+template <class norm_t, class uplo_t, class matrix_t>
+inline constexpr void lansy_worksize(norm_t normType,
+                                     uplo_t uplo,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo)
+{}
 
 /** Worspace query of lansy().
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n symmetric matrix.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< class norm_t, class uplo_t, class matrix_t >
-inline constexpr
-void lansy_worksize(
-    norm_t normType,
-    uplo_t uplo,
-    const matrix_t& A,
-    workinfo_t& workinfo,
-    const workspace_opts_t<>& opts )
+template <class norm_t, class uplo_t, class matrix_t>
+inline constexpr void lansy_worksize(norm_t normType,
+                                     uplo_t uplo,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts)
 {
-    using T     = type_t< matrix_t >;
+    using T = type_t<matrix_t>;
 
-    if ( normType == Norm::Inf || normType == Norm::One )
-    {
-        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
-        workinfo.minMax( myWorkinfo );
+    if (normType == Norm::Inf || normType == Norm::One) {
+        const workinfo_t myWorkinfo(sizeof(T), nrows(A));
+        workinfo.minMax(myWorkinfo);
     }
 }
 
 /** Calculates the norm of a symmetric matrix.
- * 
+ *
  * @tparam norm_t Either Norm or any class that implements `operator Norm()`.
  * @tparam uplo_t Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n symmetric matrix.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class norm_t, class uplo_t, class matrix_t >
-auto lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
+template <class norm_t, class uplo_t, class matrix_t>
+auto lansy(norm_t normType, uplo_t uplo, const matrix_t& A)
 {
-    using T      = type_t<matrix_t>;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-    using pair   = pair<idx_t,idx_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
 
     // constants
     const idx_t n = nrows(A);
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // quick return
-    if ( n <= 0 ) return real_t( 0 );
+    if (n <= 0) return real_t(0);
 
     // Norm value
-    real_t norm( 0 );
+    real_t norm(0);
 
-    if( normType == Norm::Max )
-    {
-        if( uplo == Uplo::Upper ) {
+    if (normType == Norm::Max) {
+        if (uplo == Uplo::Upper) {
             for (idx_t j = 0; j < n; ++j) {
-                for (idx_t i = 0; i <= j; ++i)
-                {
-                    real_t temp = tlapack::abs( A(i,j) );
+                for (idx_t i = 0; i <= j; ++i) {
+                    real_t temp = tlapack::abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
                     else {
-                        if ( isnan(temp) ) 
-                            return temp;
+                        if (isnan(temp)) return temp;
                     }
                 }
             }
         }
         else {
             for (idx_t j = 0; j < n; ++j) {
-                for (idx_t i = j; i < n; ++i)
-                {
-                    real_t temp = tlapack::abs( A(i,j) );
+                for (idx_t i = j; i < n; ++i) {
+                    real_t temp = tlapack::abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
                     else {
-                        if ( isnan(temp) ) 
-                            return temp;
+                        if (isnan(temp)) return temp;
                     }
                 }
             }
         }
     }
-    else if( normType == Norm::One || normType == Norm::Inf )
-    {
-        if( uplo == Uplo::Upper ) {
+    else if (normType == Norm::One || normType == Norm::Inf) {
+        if (uplo == Uplo::Upper) {
             for (idx_t j = 0; j < n; ++j) {
                 real_t temp = 0;
 
                 for (idx_t i = 0; i <= j; ++i)
-                    temp += tlapack::abs( A(i,j) );
+                    temp += tlapack::abs(A(i, j));
 
-                for (idx_t i = j+1; i < n; ++i)
-                    temp += tlapack::abs( A(j,i) );
-                
+                for (idx_t i = j + 1; i < n; ++i)
+                    temp += tlapack::abs(A(j, i));
+
                 if (temp > norm)
                     norm = temp;
                 else {
-                    if ( isnan(temp) ) 
-                        return temp;
+                    if (isnan(temp)) return temp;
                 }
             }
         }
@@ -192,38 +184,36 @@ auto lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
                 real_t temp = 0;
 
                 for (idx_t i = 0; i <= j; ++i)
-                    temp += tlapack::abs( A(j,i) );
+                    temp += tlapack::abs(A(j, i));
 
-                for (idx_t i = j+1; i < n; ++i)
-                    temp += tlapack::abs( A(i,j) );
-                
+                for (idx_t i = j + 1; i < n; ++i)
+                    temp += tlapack::abs(A(i, j));
+
                 if (temp > norm)
                     norm = temp;
                 else {
-                    if ( isnan(temp) ) 
-                        return temp;
+                    if (isnan(temp)) return temp;
                 }
             }
         }
     }
-    else
-    {
+    else {
         // Scaled ssq
         real_t scale(0), ssq(1);
-        
+
         // Sum off-diagonals
-        if( uplo == Uplo::Upper ) {
+        if (uplo == Uplo::Upper) {
             for (idx_t j = 1; j < n; ++j)
-                lassq( slice( A, pair{0,j}, j ), scale, ssq );
+                lassq(slice(A, pair{0, j}, j), scale, ssq);
         }
         else {
-            for (idx_t j = 0; j < n-1; ++j)
-                lassq( slice( A, pair{j+1,n}, j ), scale, ssq );
+            for (idx_t j = 0; j < n - 1; ++j)
+                lassq(slice(A, pair{j + 1, n}, j), scale, ssq);
         }
         ssq *= 2;
 
         // Sum diagonal
-        lassq( diag(A,0), scale, ssq );
+        lassq(diag(A, 0), scale, ssq);
 
         // Compute the scaled square root
         norm = scale * sqrt(ssq);
@@ -233,54 +223,57 @@ auto lansy( norm_t normType, uplo_t uplo, const matrix_t& A )
 }
 
 /** Calculates the norm of a symmetric matrix.
- * 
- * Code optimized for the infinity and one norm on column-major layouts using a workspace
- * of size at least n, where n is the number of rows of A.
+ *
+ * Code optimized for the infinity and one norm on column-major layouts using a
+ * workspace of size at least n, where n is the number of rows of A.
  * @see lanhe( norm_t normType, uplo_t uplo, const matrix_t& A ).
- * 
+ *
  * @tparam norm_t Either Norm or any class that implements `operator Norm()`.
  * @tparam uplo_t Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced.
- * 
+ *
  * @param[in] A n-by-n symmetric matrix.
  *
  * @param[in] opts Options.
  *      - @c opts.work is used if whenever it has sufficient size.
  *        The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class norm_t, class uplo_t, class matrix_t >
-auto lansy( norm_t normType, uplo_t uplo, const matrix_t& A, const workspace_opts_t<>& opts )
+template <class norm_t, class uplo_t, class matrix_t>
+auto lansy(norm_t normType,
+           uplo_t uplo,
+           const matrix_t& A,
+           const workspace_opts_t<>& opts)
 {
-    using T      = type_t<matrix_t>;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // quick redirect for max-norm and Frobenius norm
-    if      ( normType == Norm::Max  ) return lansy( max_norm,  uplo, A );
-    else if ( normType == Norm::Fro  ) return lansy( frob_norm, uplo, A );
+    if (normType == Norm::Max)
+        return lansy(max_norm, uplo, A);
+    else if (normType == Norm::Fro)
+        return lansy(frob_norm, uplo, A);
     else {
-
         // the code below uses a workspace and is meant for column-major layout
         // so as to do one pass on the data in a contiguous way when computing
         // the infinite and one norm
@@ -289,60 +282,54 @@ auto lansy( norm_t normType, uplo_t uplo, const matrix_t& A, const workspace_opt
         const idx_t n = nrows(A);
 
         // quick return
-        if ( n <= 0 ) return real_t( 0 );
+        if (n <= 0) return real_t(0);
 
         // Allocates workspace
         vectorOfBytes localworkdata;
-        const Workspace work = [&]()
-        {
+        const Workspace work = [&]() {
             workinfo_t workinfo;
-            lansy_worksize( normType, uplo, A, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
+            lansy_worksize(normType, uplo, A, workinfo, opts);
+            return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T,idx_t> w( n, work );
+        legacyVector<T, idx_t> w(n, work);
 
         // Norm value
-        real_t norm( 0 );
+        real_t norm(0);
 
         for (idx_t i = 0; i < n; ++i)
             w[i] = T(0);
 
-        if( uplo == Uplo::Upper ) {
-            for (idx_t j = 0; j < n; ++j)
-            {
-                real_t sum( 0 );
+        if (uplo == Uplo::Upper) {
+            for (idx_t j = 0; j < n; ++j) {
+                real_t sum(0);
                 for (idx_t i = 0; i < j; ++i) {
-                    const real_t absa = tlapack::abs( A(i,j) );
+                    const real_t absa = tlapack::abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }
-                w[j] = sum + tlapack::abs( A(j,j) );
+                w[j] = sum + tlapack::abs(A(j, j));
             }
-            for (idx_t i = 0; i < n; ++i)
-            {
+            for (idx_t i = 0; i < n; ++i) {
                 real_t sum = w[i];
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) )
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-            {
-                real_t sum = w[j] + tlapack::abs( A(j,j) );
-                for (idx_t i = j+1; i < n; ++i) {
-                    const real_t absa = tlapack::abs( A(i,j) );
+            for (idx_t j = 0; j < n; ++j) {
+                real_t sum = w[j] + tlapack::abs(A(j, j));
+                for (idx_t i = j + 1; i < n; ++i) {
+                    const real_t absa = tlapack::abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) )
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
@@ -351,6 +338,6 @@ auto lansy( norm_t normType, uplo_t uplo, const matrix_t& A, const workspace_opt
     }
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LANSY_HH
+#endif  // TLAPACK_LANSY_HH

--- a/include/tlapack/lapack/lantr.hpp
+++ b/include/tlapack/lapack/lantr.hpp
@@ -17,15 +17,17 @@
 namespace tlapack {
 
 /** Worspace query of lantr().
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: A is a upper triangle matrix;
  *      - Uplo::Lower: A is a lower triangle matrix.
@@ -34,38 +36,35 @@ namespace tlapack {
  *     Whether A has a unit or non-unit diagonal:
  *     - Diag::Unit:    A is assumed to be unit triangular.
  *     - Diag::NonUnit: A is not assumed to be unit triangular.
- * 
+ *
  * @param[in] A m-by-n triangular matrix.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template<
-    class norm_t, 
-    class uplo_t, 
-    class diag_t, 
-    class matrix_t >
-inline constexpr
-void lantr_worksize(
-    norm_t normType,
-    uplo_t uplo,
-    diag_t diag,
-    const matrix_t& A,
-    workinfo_t& workinfo ) { }
+template <class norm_t, class uplo_t, class diag_t, class matrix_t>
+inline constexpr void lantr_worksize(norm_t normType,
+                                     uplo_t uplo,
+                                     diag_t diag,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo)
+{}
 
 /** Worspace query of lantr().
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: A is a upper triangle matrix;
  *      - Uplo::Lower: A is a lower triangle matrix.
@@ -74,54 +73,49 @@ void lantr_worksize(
  *     Whether A has a unit or non-unit diagonal:
  *     - Diag::Unit:    A is assumed to be unit triangular.
  *     - Diag::NonUnit: A is not assumed to be unit triangular.
- * 
+ *
  * @param[in] A m-by-n triangular matrix.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template<
-    class norm_t, 
-    class uplo_t, 
-    class diag_t, 
-    class matrix_t >
-inline constexpr
-void lantr_worksize(
-    norm_t normType,
-    uplo_t uplo,
-    diag_t diag,
-    const matrix_t& A,
-    workinfo_t& workinfo,
-    const workspace_opts_t<>& opts )
+template <class norm_t, class uplo_t, class diag_t, class matrix_t>
+inline constexpr void lantr_worksize(norm_t normType,
+                                     uplo_t uplo,
+                                     diag_t diag,
+                                     const matrix_t& A,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts)
 {
-    using T     = type_t< matrix_t >;
+    using T = type_t<matrix_t>;
 
-    if ( normType == Norm::Inf )
-    {
-        const workinfo_t myWorkinfo( sizeof(T), nrows(A) );
-        workinfo.minMax( myWorkinfo );
+    if (normType == Norm::Inf) {
+        const workinfo_t myWorkinfo(sizeof(T), nrows(A));
+        workinfo.minMax(myWorkinfo);
     }
 }
 
 /** Calculates the norm of a symmetric matrix.
- * 
+ *
  * @tparam norm_t Either Norm or any class that implements `operator Norm()`.
  * @tparam uplo_t Either Uplo or any class that implements `operator Uplo()`.
  * @tparam diag_t Either Diag or any class that implements `operator Diag()`.
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: A is a upper triangle matrix;
  *      - Uplo::Lower: A is a lower triangle matrix.
@@ -130,221 +124,198 @@ void lantr_worksize(
  *     Whether A has a unit or non-unit diagonal:
  *     - Diag::Unit:    A is assumed to be unit triangular.
  *     - Diag::NonUnit: A is not assumed to be unit triangular.
- * 
+ *
  * @param[in] A m-by-n triangular matrix.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class norm_t, class uplo_t, class diag_t, class matrix_t >
-auto lantr( norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A )
+template <class norm_t, class uplo_t, class diag_t, class matrix_t>
+auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
 {
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                         diag != Diag::Unit );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
 
     // quick return
-    if (m == 0 || n == 0)
-        return real_t( 0 );
+    if (m == 0 || n == 0) return real_t(0);
 
     // Norm value
-    real_t norm( 0 );
+    real_t norm(0);
 
-    if( normType == Norm::Max )
-    {
-        if( diag == Diag::NonUnit ) {
-            if( uplo == Uplo::Upper ) {
+    if (normType == Norm::Max) {
+        if (diag == Diag::NonUnit) {
+            if (uplo == Uplo::Upper) {
                 for (idx_t j = 0; j < n; ++j) {
-                    for (idx_t i = 0; i <= std::min(j,m-1); ++i)
-                    {
-                        real_t temp = tlapack::abs( A(i,j) );
+                    for (idx_t i = 0; i <= std::min(j, m - 1); ++i) {
+                        real_t temp = tlapack::abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
                         else {
-                            if ( isnan(temp) ) 
-                                return temp;
+                            if (isnan(temp)) return temp;
                         }
                     }
                 }
             }
             else {
                 for (idx_t j = 0; j < n; ++j) {
-                    for (idx_t i = j; i < m; ++i)
-                    {
-                        real_t temp = tlapack::abs( A(i,j) );
+                    for (idx_t i = j; i < m; ++i) {
+                        real_t temp = tlapack::abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
                         else {
-                            if ( isnan(temp) ) 
-                                return temp;
+                            if (isnan(temp)) return temp;
                         }
                     }
                 }
             }
         }
         else {
-            norm = real_t( 1 );
-            if( uplo == Uplo::Upper ) {
+            norm = real_t(1);
+            if (uplo == Uplo::Upper) {
                 for (idx_t j = 0; j < n; ++j) {
-                    for (idx_t i = 0; i < std::min(j,m); ++i)
-                    {
-                        real_t temp = tlapack::abs( A(i,j) );
+                    for (idx_t i = 0; i < std::min(j, m); ++i) {
+                        real_t temp = tlapack::abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
                         else {
-                            if ( isnan(temp) ) 
-                                return temp;
+                            if (isnan(temp)) return temp;
                         }
                     }
                 }
             }
             else {
                 for (idx_t j = 0; j < n; ++j) {
-                    for (idx_t i = j+1; i < m; ++i)
-                    {
-                        real_t temp = tlapack::abs( A(i,j) );
+                    for (idx_t i = j + 1; i < m; ++i) {
+                        real_t temp = tlapack::abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
                         else {
-                            if ( isnan(temp) ) 
-                                return temp;
+                            if (isnan(temp)) return temp;
                         }
                     }
                 }
             }
         }
     }
-    else if( normType == Norm::Inf )
-    {
-        if( uplo == Uplo::Upper ) {
-            for (idx_t i = 0; i < m; ++i)
-            {
-                real_t sum( 0 );
-                if( diag == Diag::NonUnit )
+    else if (normType == Norm::Inf) {
+        if (uplo == Uplo::Upper) {
+            for (idx_t i = 0; i < m; ++i) {
+                real_t sum(0);
+                if (diag == Diag::NonUnit)
                     for (idx_t j = i; j < n; ++j)
-                        sum += tlapack::abs( A(i,j) );
+                        sum += tlapack::abs(A(i, j));
                 else {
-                    sum = real_t( 1 );
-                    for (idx_t j = i+1; j < n; ++j)
-                        sum += tlapack::abs( A(i,j) );
+                    sum = real_t(1);
+                    for (idx_t j = i + 1; j < n; ++j)
+                        sum += tlapack::abs(A(i, j));
                 }
 
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) ) 
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
         else {
-            for (idx_t i = 0; i < m; ++i)
-            {
-                real_t sum( 0 );
-                if( diag == Diag::NonUnit || i >= n )
-                    for (idx_t j = 0; j <= std::min(i,n-1); ++j)
-                        sum += tlapack::abs( A(i,j) );
+            for (idx_t i = 0; i < m; ++i) {
+                real_t sum(0);
+                if (diag == Diag::NonUnit || i >= n)
+                    for (idx_t j = 0; j <= std::min(i, n - 1); ++j)
+                        sum += tlapack::abs(A(i, j));
                 else {
-                    sum = real_t( 1 );
+                    sum = real_t(1);
                     for (idx_t j = 0; j < i; ++j)
-                        sum += tlapack::abs( A(i,j) );
+                        sum += tlapack::abs(A(i, j));
                 }
 
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) ) 
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
     }
-    else if( normType == Norm::One )
-    {
-        if( uplo == Uplo::Upper ) {
-            for (idx_t j = 0; j < n; ++j)
-            {
-                real_t sum( 0 );
-                if( diag == Diag::NonUnit || j >= m )
-                    for (idx_t i = 0; i <= std::min(j,m-1); ++i)
-                        sum += tlapack::abs( A(i,j) );
+    else if (normType == Norm::One) {
+        if (uplo == Uplo::Upper) {
+            for (idx_t j = 0; j < n; ++j) {
+                real_t sum(0);
+                if (diag == Diag::NonUnit || j >= m)
+                    for (idx_t i = 0; i <= std::min(j, m - 1); ++i)
+                        sum += tlapack::abs(A(i, j));
                 else {
-                    sum = real_t( 1 );
+                    sum = real_t(1);
                     for (idx_t i = 0; i < j; ++i)
-                        sum += tlapack::abs( A(i,j) );
+                        sum += tlapack::abs(A(i, j));
                 }
 
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) ) 
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-            {
-                real_t sum( 0 );
-                if( diag == Diag::NonUnit )
+            for (idx_t j = 0; j < n; ++j) {
+                real_t sum(0);
+                if (diag == Diag::NonUnit)
                     for (idx_t i = j; i < m; ++i)
-                        sum += tlapack::abs( A(i,j) );
+                        sum += tlapack::abs(A(i, j));
                 else {
-                    sum = real_t( 1 );
-                    for (idx_t i = j+1; i < m; ++i)
-                        sum += tlapack::abs( A(i,j) );
+                    sum = real_t(1);
+                    for (idx_t i = j + 1; i < m; ++i)
+                        sum += tlapack::abs(A(i, j));
                 }
 
                 if (sum > norm)
                     norm = sum;
                 else {
-                    if ( isnan(sum) ) 
-                        return sum;
+                    if (isnan(sum)) return sum;
                 }
             }
         }
     }
-    else
-    {
-        real_t scale(1), sum( 0 );
+    else {
+        real_t scale(1), sum(0);
 
-        if( uplo == Uplo::Upper ) {
-            if( diag == Diag::NonUnit ) {
+        if (uplo == Uplo::Upper) {
+            if (diag == Diag::NonUnit) {
                 for (idx_t j = 0; j < n; ++j)
-                    lassq( slice(A,range<idx_t>(0,std::min(j+1,m)),j), scale, sum );
+                    lassq(slice(A, range<idx_t>(0, std::min(j + 1, m)), j),
+                          scale, sum);
             }
             else {
-                sum = real_t( std::min(m,n) );
+                sum = real_t(std::min(m, n));
                 for (idx_t j = 1; j < n; ++j)
-                    lassq( slice(A,range<idx_t>(0,std::min(j,m)),j), scale, sum );
+                    lassq(slice(A, range<idx_t>(0, std::min(j, m)), j), scale,
+                          sum);
             }
         }
         else {
-            if( diag == Diag::NonUnit ) {
-                for (idx_t j = 0; j < std::min(m,n); ++j)
-                    lassq( slice(A,range<idx_t>(j,m),j), scale, sum );
+            if (diag == Diag::NonUnit) {
+                for (idx_t j = 0; j < std::min(m, n); ++j)
+                    lassq(slice(A, range<idx_t>(j, m), j), scale, sum);
             }
             else {
-                sum = real_t( std::min(m,n) );
-                for (idx_t j = 0; j < std::min(m-1,n); ++j)
-                    lassq( slice(A,range<idx_t>(j+1,m),j), scale, sum );
+                sum = real_t(std::min(m, n));
+                for (idx_t j = 0; j < std::min(m - 1, n); ++j)
+                    lassq(slice(A, range<idx_t>(j + 1, m), j), scale, sum);
             }
         }
         norm = scale * sqrt(sum);
@@ -354,23 +325,25 @@ auto lantr( norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A )
 }
 
 /** Calculates the norm of a triangular matrix.
- * 
- * Code optimized for the infinity norm on column-major layouts using a workspace
- * of size at least m, where m is the number of rows of A.
+ *
+ * Code optimized for the infinity norm on column-major layouts using a
+ * workspace of size at least m, where m is the number of rows of A.
  * @see lantr( norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A ).
- * 
+ *
  * @tparam norm_t Either Norm or any class that implements `operator Norm()`.
  * @tparam uplo_t Either Uplo or any class that implements `operator Uplo()`.
  * @tparam diag_t Either Diag or any class that implements `operator Diag()`.
- * 
+ *
  * @param[in] normType
  *      - Norm::Max: Maximum absolute value over all elements of the matrix.
  *          Note: this is not a consistent matrix norm.
- *      - Norm::One: 1-norm, the maximum value of the absolute sum of each column.
- *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each row.
+ *      - Norm::One: 1-norm, the maximum value of the absolute sum of each
+ * column.
+ *      - Norm::Inf: Inf-norm, the maximum value of the absolute sum of each
+ * row.
  *      - Norm::Fro: Frobenius norm of the matrix.
  *          Square root of the sum of the square of each entry in the matrix.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: A is a upper triangle matrix;
  *      - Uplo::Lower: A is a lower triangle matrix.
@@ -379,122 +352,111 @@ auto lantr( norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A )
  *     Whether A has a unit or non-unit diagonal:
  *     - Diag::Unit:    A is assumed to be unit triangular.
  *     - Diag::NonUnit: A is not assumed to be unit triangular.
- * 
+ *
  * @param[in] A m-by-n triangular matrix.
  *
  * @param[in] opts Options.
  *      - @c opts.work is used if whenever it has sufficient size.
  *        The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup auxiliary
  */
-template<
-    class norm_t, 
-    class uplo_t, 
-    class diag_t, 
-    class matrix_t >
-auto lantr(
-    norm_t normType,
-    uplo_t uplo,
-    diag_t diag,
-    const matrix_t& A,
-    const workspace_opts_t<>& opts )
+template <class norm_t, class uplo_t, class diag_t, class matrix_t>
+auto lantr(norm_t normType,
+           uplo_t uplo,
+           diag_t diag,
+           const matrix_t& A,
+           const workspace_opts_t<>& opts)
 {
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-        
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                         diag != Diag::Unit );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
 
     // quick return
-    if (m == 0 || n == 0)
-        return real_t( 0 );
+    if (m == 0 || n == 0) return real_t(0);
 
     // redirect for max-norm, one-norm and Frobenius norm
-    if      ( normType == Norm::Max  ) return lantr( max_norm, uplo, diag, A );
-    else if ( normType == Norm::One  ) return lantr( one_norm, uplo, diag,  A );
-    else if ( normType == Norm::Fro  ) return lantr( frob_norm, uplo, diag, A );
-    else if ( normType == Norm::Inf  ) {
-
+    if (normType == Norm::Max)
+        return lantr(max_norm, uplo, diag, A);
+    else if (normType == Norm::One)
+        return lantr(one_norm, uplo, diag, A);
+    else if (normType == Norm::Fro)
+        return lantr(frob_norm, uplo, diag, A);
+    else if (normType == Norm::Inf) {
         // the code below uses a workspace and is meant for column-major layout
         // so as to do one pass on the data in a contiguous way when computing
-	    // the infinite norm.
+        // the infinite norm.
 
         // Allocates workspace
         vectorOfBytes localworkdata;
-        const Workspace work = [&]()
-        {
+        const Workspace work = [&]() {
             workinfo_t workinfo;
-            lantr_worksize( normType, uplo, diag, A, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
+            lantr_worksize(normType, uplo, diag, A, workinfo, opts);
+            return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T,idx_t> w( n, work );
+        legacyVector<T, idx_t> w(n, work);
 
         // Norm value
-        real_t norm( 0 );
+        real_t norm(0);
 
-        if( uplo == Uplo::Upper ) {
-            if( diag == Diag::NonUnit ) {
+        if (uplo == Uplo::Upper) {
+            if (diag == Diag::NonUnit) {
                 for (idx_t i = 0; i < m; ++i)
                     w[i] = real_t(0);
-    
+
                 for (idx_t j = 0; j < n; ++j)
-                    for (idx_t i = 0; i <= std::min(j,m-1); ++i)
-                        w[i] += tlapack::abs( A(i,j) );
+                    for (idx_t i = 0; i <= std::min(j, m - 1); ++i)
+                        w[i] += tlapack::abs(A(i, j));
             }
             else {
                 for (idx_t i = 0; i < m; ++i)
                     w[i] = real_t(1);
-    
+
                 for (idx_t j = 1; j < n; ++j) {
-                    for (idx_t i = 0; i < std::min(j,m); ++i)
-                        w[i] += tlapack::abs( A(i,j) );
+                    for (idx_t i = 0; i < std::min(j, m); ++i)
+                        w[i] += tlapack::abs(A(i, j));
                 }
             }
         }
         else {
-            if( diag == Diag::NonUnit ) {
+            if (diag == Diag::NonUnit) {
                 for (idx_t i = 0; i < m; ++i)
                     w[i] = real_t(0);
-    
+
                 for (idx_t j = 0; j < n; ++j)
                     for (idx_t i = j; i < m; ++i)
-                        w[i] += tlapack::abs( A(i,j) );
+                        w[i] += tlapack::abs(A(i, j));
             }
             else {
-                for (idx_t i = 0; i < std::min(m,n); ++i)
+                for (idx_t i = 0; i < std::min(m, n); ++i)
                     w[i] = real_t(1);
                 for (idx_t i = n; i < m; ++i)
                     w[i] = real_t(0);
-    
+
                 for (idx_t j = 1; j < n; ++j) {
-                    for (idx_t i = j+1; i < m; ++i)
-                        w[i] += tlapack::abs( A(i,j) );
+                    for (idx_t i = j + 1; i < m; ++i)
+                        w[i] += tlapack::abs(A(i, j));
                 }
             }
         }
 
-        for (idx_t i = 0; i < m; ++i)
-        {
+        for (idx_t i = 0; i < m; ++i) {
             real_t temp = w[i];
 
             if (temp > norm)
                 norm = temp;
             else {
-                if (isnan(temp))
-                    return temp;
+                if (isnan(temp)) return temp;
             }
         }
 
@@ -502,6 +464,6 @@ auto lantr(
     }
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LANTR_HH
+#endif  // TLAPACK_LANTR_HH

--- a/include/tlapack/lapack/lantr.hpp
+++ b/include/tlapack/lapack/lantr.hpp
@@ -1,6 +1,7 @@
 /// @file lantr.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lantr.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lantr.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lapy2.hpp
+++ b/include/tlapack/lapack/lapy2.hpp
@@ -1,6 +1,7 @@
 /// @file lapy2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lapy2.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lapy2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lapy2.hpp
+++ b/include/tlapack/lapack/lapy2.hpp
@@ -14,33 +14,33 @@
 namespace tlapack {
 
 /** Finds $\sqrt{x^2+y^2}$, taking care not to cause unnecessary overflow.
- * 
+ *
  * @return $\sqrt{x^2+y^2}$
  *
  * @param[in] x scalar value x
  * @param[in] y scalar value y
- * 
+ *
  * @ingroup auxiliary
  */
-template< class TX, class TY,
-    enable_if_t<(
-    /* Requires: */
-        ! is_complex<TX>::value &&
-        ! is_complex<TY>::value
-    ), int > = 0 >
-real_type<TX,TY> lapy2( const TX& x, const TY& y )
+template <class TX,
+          class TY,
+          enable_if_t<(
+                          /* Requires: */
+                          !is_complex<TX>::value && !is_complex<TY>::value),
+                      int> = 0>
+real_type<TX, TY> lapy2(const TX& x, const TY& y)
 {
     // using
-    using real_t = real_type<TX,TY>;
+    using real_t = real_type<TX, TY>;
 
     // constants
-    const real_t one( 1 );
-    const real_t zero( 0 );
+    const real_t one(1);
+    const real_t zero(0);
     const TX xabs = abs(x);
     const TY yabs = abs(y);
 
     real_t w, z;
-    if( xabs > yabs ) {
+    if (xabs > yabs) {
         w = xabs;
         z = yabs;
     }
@@ -49,11 +49,9 @@ real_type<TX,TY> lapy2( const TX& x, const TY& y )
         z = xabs;
     }
 
-    return ( z == zero )
-        ? w
-        : w * sqrt( one + (z/w)*(z/w) );
+    return (z == zero) ? w : w * sqrt(one + (z / w) * (z / w));
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LAPY2_HH
+#endif  // TLAPACK_LAPY2_HH

--- a/include/tlapack/lapack/lapy3.hpp
+++ b/include/tlapack/lapack/lapy3.hpp
@@ -1,6 +1,7 @@
 /// @file lapy3.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lapy3.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lapy3.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lapy3.hpp
+++ b/include/tlapack/lapack/lapy3.hpp
@@ -15,46 +15,47 @@
 
 namespace tlapack {
 
-/** Finds $\sqrt{x^2+y^2+z^2}$, taking care not to cause unnecessary overflow or unnecessary underflow.
- * 
+/** Finds $\sqrt{x^2+y^2+z^2}$, taking care not to cause unnecessary overflow or
+ * unnecessary underflow.
+ *
  * @return $\sqrt{x^2+y^2+z^2}$
  *
  * @tparam real_t Floating-point type.
  * @param[in] x scalar value x
  * @param[in] y scalar value y
  * @param[in] z scalar value y
- * 
+ *
  * @ingroup auxiliary
  */
-template< class TX, class TY, class TZ,
-    enable_if_t<(
-    /* Requires: */
-        ! is_complex<TX>::value &&
-        ! is_complex<TY>::value &&
-        ! is_complex<TZ>::value
-    ), int > = 0 >
-real_type<TX,TY,TZ> lapy3(
-    const TX& x, const TY& y, const TZ& z )
+template <class TX,
+          class TY,
+          class TZ,
+          enable_if_t<(
+                          /* Requires: */
+                          !is_complex<TX>::value && !is_complex<TY>::value &&
+                          !is_complex<TZ>::value),
+                      int> = 0>
+real_type<TX, TY, TZ> lapy3(const TX& x, const TY& y, const TZ& z)
 {
     // using
-    using real_t = real_type<TX,TY,TZ>;
+    using real_t = real_type<TX, TY, TZ>;
 
     // constants
-    const real_t zero( 0 );
+    const real_t zero(0);
     const TX xabs = abs(x);
     const TY yabs = abs(y);
     const TZ zabs = abs(z);
-    const real_t w = max( xabs, yabs, zabs );
+    const real_t w = max(xabs, yabs, zabs);
 
-    return ( w == zero )
-        // W can be zero for max(0,nan,0)
-        // adding all three entries together will make sure
-        // NaN will not disappear.
-        ? xabs + yabs + zabs
-        : w * sqrt(
-            (xabs/w)*(xabs/w) + (yabs/w)*(yabs/w) + (zabs/w)*(zabs/w) );
+    return (w == zero)
+               // W can be zero for max(0,nan,0)
+               // adding all three entries together will make sure
+               // NaN will not disappear.
+               ? xabs + yabs + zabs
+               : w * sqrt((xabs / w) * (xabs / w) + (yabs / w) * (yabs / w) +
+                          (zabs / w) * (zabs / w));
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LAPY3_HH
+#endif  // TLAPACK_LAPY3_HH

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -1,6 +1,7 @@
 /// @file larf.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larf.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larf.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -12,9 +12,9 @@
 #define TLAPACK_LARFB_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/lacpy.hpp"
-#include "tlapack/blas/trmm.hpp"
 #include "tlapack/blas/gemm.hpp"
+#include "tlapack/blas/trmm.hpp"
+#include "tlapack/lapack/lacpy.hpp"
 
 namespace tlapack {
 
@@ -26,7 +26,8 @@ namespace tlapack {
  *
  * @param[in] trans
  *     - Op::NoTrans:   apply $H  $ (No transpose).
- *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of H is Real).
+ *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of H is
+ * Real).
  *     - Op::ConjTrans: apply $H^H$ (Conjugate transpose).
  *
  * @param[in] direction
@@ -35,7 +36,8 @@ namespace tlapack {
  *     - Direction::Backward: $H = H(k) ... H(2) H(1)$.
  *
  * @param[in] storeMode
- *     Indicates how the vectors which define the elementary reflectors are stored:
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
  *     - StoreV::Columnwise.
  *     - StoreV::Rowwise.
  *     See Further Details.
@@ -50,39 +52,42 @@ namespace tlapack {
  *
  * @param[in] Tmatrix
  *     The k-by-k matrix T.
- *     The triangular k-by-k matrix T in the representation of the block reflector.
+ *     The triangular k-by-k matrix T in the representation of the block
+ * reflector.
  *
  * @param[in] C
  *     On entry, the m-by-n matrix C.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template<
-    class matrixV_t, class matrixT_t, class matrixC_t,
-    class side_t, class trans_t, class direction_t, class storage_t,
-    class workW_t = void
->
-inline constexpr
-void larfb_worksize(
-    side_t side, trans_t trans,
-    direction_t direction, storage_t storeMode,
-    const matrixV_t& V, const matrixT_t& Tmatrix,
-    const matrixC_t& C,
-    workinfo_t& workinfo,
-    const workspace_opts_t<workW_t>& opts = {} )
+template <class matrixV_t,
+          class matrixT_t,
+          class matrixC_t,
+          class side_t,
+          class trans_t,
+          class direction_t,
+          class storage_t,
+          class workW_t = void>
+inline constexpr void larfb_worksize(side_t side,
+                                     trans_t trans,
+                                     direction_t direction,
+                                     storage_t storeMode,
+                                     const matrixV_t& V,
+                                     const matrixT_t& Tmatrix,
+                                     const matrixC_t& C,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<workW_t>& opts = {})
 {
-    using idx_t     = size_type< matrixC_t >;
-    using matrixW_t = deduce_work_t<
-                        workW_t,
-                        matrix_type< matrixV_t, matrixC_t >
-                      >;
-    using T         = type_t< matrixW_t >;
+    using idx_t = size_type<matrixC_t>;
+    using matrixW_t =
+        deduce_work_t<workW_t, matrix_type<matrixV_t, matrixC_t> >;
+    using T = type_t<matrixW_t>;
 
     // constants
     const idx_t m = nrows(C);
@@ -90,32 +95,31 @@ void larfb_worksize(
     const idx_t k = nrows(Tmatrix);
 
     workinfo_t myWorkinfo;
-    if( layout<matrixW_t> == Layout::RowMajor )
-    {
+    if (layout<matrixW_t> == Layout::RowMajor) {
         myWorkinfo.m = (side == Side::Left) ? k : m;
         myWorkinfo.n = sizeof(T) * ((side == Side::Left) ? n : k);
     }
-    else if( layout<matrixW_t> == Layout::ColMajor )
-    {
+    else if (layout<matrixW_t> == Layout::ColMajor) {
         myWorkinfo.m = sizeof(T) * ((side == Side::Left) ? k : m);
         myWorkinfo.n = (side == Side::Left) ? n : k;
     }
-    else
-    {
+    else {
         myWorkinfo.m = sizeof(T);
-        myWorkinfo.n = (side == Side::Left) ? k*n : m*k;
+        myWorkinfo.n = (side == Side::Left) ? k * n : m * k;
     }
 
-    workinfo.minMax( myWorkinfo );
+    workinfo.minMax(myWorkinfo);
 }
 
 /** Applies a block reflector $H$ or its conjugate transpose $H^H$ to a
  * m-by-n matrix C, from either the left or the right.
- * 
+ *
  * @tparam side_t Either Side or any class that implements `operator Side()`.
  * @tparam trans_t Either Op or any class that implements `operator Op()`.
- * @tparam direction_t Either Direction or any class that implements `operator Direction()`.
- * @tparam storage_t Either StoreV or any class that implements `operator StoreV()`.
+ * @tparam direction_t Either Direction or any class that implements `operator
+ * Direction()`.
+ * @tparam storage_t Either StoreV or any class that implements `operator
+ * StoreV()`.
  *
  * @param[in] side
  *     - Side::Left:  apply $H$ or $H^H$ from the Left.
@@ -123,7 +127,8 @@ void larfb_worksize(
  *
  * @param[in] trans
  *     - Op::NoTrans:   apply $H  $ (No transpose).
- *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of H is Real).
+ *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of H is
+ * Real).
  *     - Op::ConjTrans: apply $H^H$ (Conjugate transpose).
  *
  * @param[in] direction
@@ -132,7 +137,8 @@ void larfb_worksize(
  *     - Direction::Backward: $H = H(k) ... H(2) H(1)$.
  *
  * @param[in] storeMode
- *     Indicates how the vectors which define the elementary reflectors are stored:
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
  *     - StoreV::Columnwise.
  *     - StoreV::Rowwise.
  *     See Further Details.
@@ -147,7 +153,8 @@ void larfb_worksize(
  *
  * @param[in] Tmatrix
  *     The k-by-k matrix T.
- *     The triangular k-by-k matrix T in the representation of the block reflector.
+ *     The triangular k-by-k matrix T in the representation of the block
+ * reflector.
  *
  * @param[in,out] C
  *     On entry, the m-by-n matrix C.
@@ -181,426 +188,323 @@ void larfb_worksize(
  *         (  1 v2 v3 )                     ( v3 v3 v3 v3  1 )
  *         (     1 v3 )
  *         (        1 )
- * 
+ *
  * @ingroup auxiliary
  */
-template<
-    class matrixV_t, class matrixT_t, class matrixC_t,
-    class side_t, class trans_t, class direction_t, class storage_t,
-    class workW_t = void
->
-int larfb(
-    side_t side, trans_t trans,
-    direction_t direction, storage_t storeMode,
-    const matrixV_t& V, const matrixT_t& Tmatrix,
-    matrixC_t& C, const workspace_opts_t<workW_t>& opts = {} )
+template <class matrixV_t,
+          class matrixT_t,
+          class matrixC_t,
+          class side_t,
+          class trans_t,
+          class direction_t,
+          class storage_t,
+          class workW_t = void>
+int larfb(side_t side,
+          trans_t trans,
+          direction_t direction,
+          storage_t storeMode,
+          const matrixV_t& V,
+          const matrixT_t& Tmatrix,
+          matrixC_t& C,
+          const workspace_opts_t<workW_t>& opts = {})
 {
-    using idx_t     = size_type< matrixC_t >;
-    using matrixW_t = deduce_work_t<
-                        workW_t,
-                        matrix_type< matrixV_t, matrixC_t >
-                      >;
-    using T         = type_t< matrixW_t >;
-    using real_t    = real_type<T>;
+    using idx_t = size_type<matrixC_t>;
+    using matrixW_t =
+        deduce_work_t<workW_t, matrix_type<matrixV_t, matrixC_t> >;
+    using T = type_t<matrixW_t>;
+    using real_t = real_type<T>;
 
-    using pair  = pair<idx_t,idx_t>;
+    using pair = pair<idx_t, idx_t>;
 
     // Functor
-    Create< matrixW_t > new_matrix;
+    Create<matrixW_t> new_matrix;
 
     // constants
-    const real_t one( 1 );
+    const real_t one(1);
     const idx_t m = nrows(C);
     const idx_t n = ncols(C);
     const idx_t k = nrows(Tmatrix);
 
     // check arguments
-    tlapack_check_false(    side != Side::Left &&
-                        side != Side::Right );
-    tlapack_check_false(    trans != Op::NoTrans &&
-                        trans != Op::ConjTrans &&
-                        (
-                            (trans != Op::Trans) ||
-                            is_complex< type_t< matrixV_t > >::value
-                        ) );
-    tlapack_check_false(    direction != Direction::Backward &&
-                        direction != Direction::Forward );
-    tlapack_check_false(    storeMode != StoreV::Columnwise &&
-                        storeMode != StoreV::Rowwise );
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(
+        trans != Op::NoTrans && trans != Op::ConjTrans &&
+        ((trans != Op::Trans) || is_complex<type_t<matrixV_t> >::value));
+    tlapack_check_false(direction != Direction::Backward &&
+                        direction != Direction::Forward);
+    tlapack_check_false(storeMode != StoreV::Columnwise &&
+                        storeMode != StoreV::Rowwise);
 
     // Quick return
     if (m <= 0 || n <= 0 || k <= 0) return 0;
 
     // Allocates workspace
     vectorOfBytes localworkdata;
-    const Workspace work = [&]()
-    {
+    const Workspace work = [&]() {
         workinfo_t workinfo;
-        larfb_worksize( side, trans, direction, storeMode, V, Tmatrix, C, workinfo, opts );
-        return alloc_workspace( localworkdata, workinfo, opts.work );
+        larfb_worksize(side, trans, direction, storeMode, V, Tmatrix, C,
+                       workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
     }();
 
-    if( storeMode == StoreV::Columnwise ){
-        if( direction == Direction::Forward ){
-            if( side == Side::Left ){
+    if (storeMode == StoreV::Columnwise) {
+        if (direction == Direction::Forward) {
+            if (side == Side::Left) {
                 // W is an k-by-n matrix
                 // V is an m-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows( V, pair{0,k} );
-                const auto V2 = rows( V, ( m > k ) ? pair{k,m} : pair{0,0} );
-                auto C1 = rows( C, pair{0,k} );
-                auto C2 = rows( C, ( m > k ) ? pair{k,m} : pair{0,0} );
-                auto W  = new_matrix( work, k, n );
+                const auto V1 = rows(V, pair{0, k});
+                const auto V2 = rows(V, (m > k) ? pair{k, m} : pair{0, 0});
+                auto C1 = rows(C, pair{0, k});
+                auto C2 = rows(C, (m > k) ? pair{k, m} : pair{0, 0});
+                auto W = new_matrix(work, k, n);
 
                 // W := C1
-                lacpy( dense, C1, W );
+                lacpy(dense, C1, W);
                 // W := V1^H W
-                trmm(
-                    side, Uplo::Lower,
-                    Op::ConjTrans, Diag::Unit,
-                    one, V1, W );
-                if( m > k )
+                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, one, V1, W);
+                if (m > k)
                     // W := W + V2^H C2
-                    gemm(
-                        Op::ConjTrans, Op::NoTrans,
-                        one, V2, C2, one, W );
+                    gemm(Op::ConjTrans, Op::NoTrans, one, V2, C2, one, W);
                 // W := op(Tmatrix) W
-                trmm(
-                    side, Uplo::Upper,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( m > k )
+                trmm(side, Uplo::Upper, trans, Diag::NonUnit, one, Tmatrix, W);
+                if (m > k)
                     // C2 := C2 - V2 W
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        -one, V2, W, one, C2 );
+                    gemm(Op::NoTrans, Op::NoTrans, -one, V2, W, one, C2);
                 // W := - V1 W
-                trmm(
-                    side, Uplo::Lower,
-                    Op::NoTrans, Diag::Unit,
-                    -one, V1, W );
+                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, -one, V1, W);
 
                 // C1 := C1 + W
-                for( idx_t j = 0; j < n; ++j )
-                    for( idx_t i = 0; i < k; ++i )
-                        C1(i,j) += W(i,j);
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < k; ++i)
+                        C1(i, j) += W(i, j);
             }
-            else { // side == Side::Right
+            else {  // side == Side::Right
                 // W is an m-by-k matrix
                 // V is an n-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows( V, pair{0,k} );
-                const auto V2 = rows( V, ( n > k ) ? pair{k,n} : pair{0,0} );
-                auto C1 = cols( C, pair{0,k} );
-                auto C2 = cols( C, ( n > k ) ? pair{k,n} : pair{0,0} );
-                auto W  = new_matrix( work, m, k );
+                const auto V1 = rows(V, pair{0, k});
+                const auto V2 = rows(V, (n > k) ? pair{k, n} : pair{0, 0});
+                auto C1 = cols(C, pair{0, k});
+                auto C2 = cols(C, (n > k) ? pair{k, n} : pair{0, 0});
+                auto W = new_matrix(work, m, k);
 
                 // W := C1
-                lacpy( dense, C1, W );
+                lacpy(dense, C1, W);
                 // W := W V1
-                trmm(
-                    side, Uplo::Lower,
-                    Op::NoTrans, Diag::Unit,
-                    one, V1, W );
-                if( n > k )
+                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, one, V1, W);
+                if (n > k)
                     // W := W + C2 V2
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        one, C2, V2, one, W );
+                    gemm(Op::NoTrans, Op::NoTrans, one, C2, V2, one, W);
                 // W := W op(Tmatrix)
-                trmm(
-                    Side::Right, Uplo::Upper,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( n > k )
+                trmm(Side::Right, Uplo::Upper, trans, Diag::NonUnit, one,
+                     Tmatrix, W);
+                if (n > k)
                     // C2 := C2 - W V2^H
-                    gemm(
-                        Op::NoTrans, Op::ConjTrans,
-                        -one, W, V2, one, C2 );
+                    gemm(Op::NoTrans, Op::ConjTrans, -one, W, V2, one, C2);
                 // W := - W V1^H
-                trmm(
-                    side, Uplo::Lower,
-                    Op::ConjTrans, Diag::Unit,
-                    -one, V1, W );
-                
+                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, -one, V1, W);
+
                 // C1 := C1 + W
-                for( idx_t j = 0; j < k; ++j )
-                    for( idx_t i = 0; i < m; ++i )
-                        C1(i,j) += W(i,j);
+                for (idx_t j = 0; j < k; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C1(i, j) += W(i, j);
             }
         }
-        else { // direct == Direction::Backward
-            if( side == Side::Left ){
+        else {  // direct == Direction::Backward
+            if (side == Side::Left) {
                 // W is an k-by-n matrix
                 // V is an m-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows( V, pair{0,m-k} );
-                const auto V2 = rows( V, pair{m-k,m} );
-                auto C1 = rows( C, pair{0,m-k} );
-                auto C2 = rows( C, pair{m-k,m} );
-                auto W  = new_matrix( work, k, n );
+                const auto V1 = rows(V, pair{0, m - k});
+                const auto V2 = rows(V, pair{m - k, m});
+                auto C1 = rows(C, pair{0, m - k});
+                auto C2 = rows(C, pair{m - k, m});
+                auto W = new_matrix(work, k, n);
 
                 // W := C2
-                lacpy( dense, C2, W );
+                lacpy(dense, C2, W);
                 // W := V2^H W
-                trmm(
-                    side, Uplo::Upper,
-                    Op::ConjTrans, Diag::Unit,
-                    one, V2, W );
-                if( m > k )
+                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, one, V2, W);
+                if (m > k)
                     // W := W + V1^H C1
-                    gemm(
-                        Op::ConjTrans, Op::NoTrans,
-                        one, V1, C1, one, W );
+                    gemm(Op::ConjTrans, Op::NoTrans, one, V1, C1, one, W);
                 // W := op(Tmatrix) W
-                trmm(
-                    side, Uplo::Lower,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( m > k )
+                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                if (m > k)
                     // C1 := C1 - V1 W
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        -one, V1, W, one, C1 );
+                    gemm(Op::NoTrans, Op::NoTrans, -one, V1, W, one, C1);
                 // W := - V2 W
-                trmm(
-                    side, Uplo::Upper,
-                    Op::NoTrans, Diag::Unit,
-                    -one, V2, W );
+                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, -one, V2, W);
 
                 // C2 := C2 + W
-                for( idx_t j = 0; j < n; ++j )
-                    for( idx_t i = 0; i < k; ++i )
-                        C2(i,j) += W(i,j);
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < k; ++i)
+                        C2(i, j) += W(i, j);
             }
-            else { // side == Side::Right
+            else {  // side == Side::Right
                 // W is an m-by-k matrix
                 // V is an n-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows( V, pair{0,n-k} );
-                const auto V2 = rows( V, pair{n-k,n} );
-                auto C1 = cols( C, pair{0,n-k} );
-                auto C2 = cols( C, pair{n-k,n} );
-                auto W  = new_matrix( work, m, k );
+                const auto V1 = rows(V, pair{0, n - k});
+                const auto V2 = rows(V, pair{n - k, n});
+                auto C1 = cols(C, pair{0, n - k});
+                auto C2 = cols(C, pair{n - k, n});
+                auto W = new_matrix(work, m, k);
 
                 // W := C2
-                lacpy( dense, C2, W );
+                lacpy(dense, C2, W);
                 // W := W V2
-                trmm(
-                    side, Uplo::Upper,
-                    Op::NoTrans, Diag::Unit,
-                    one, V2, W );
-                if( n > k )
+                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, one, V2, W);
+                if (n > k)
                     // W := W + C1 V1
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        one, C1, V1, one, W );
+                    gemm(Op::NoTrans, Op::NoTrans, one, C1, V1, one, W);
                 // W := W op(Tmatrix)
-                trmm(
-                    side, Uplo::Lower,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( n > k )
+                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                if (n > k)
                     // C1 := C1 - W V1^H
-                    gemm(
-                        Op::NoTrans, Op::ConjTrans,
-                        -one, W, V1, one, C1 );
+                    gemm(Op::NoTrans, Op::ConjTrans, -one, W, V1, one, C1);
                 // W := - W V2^H
-                trmm(
-                    side, Uplo::Upper,
-                    Op::ConjTrans, Diag::Unit,
-                    -one, V2, W );
-                
+                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, -one, V2, W);
+
                 // C2 := C2 + W
-                for( idx_t j = 0; j < k; ++j )
-                    for( idx_t i = 0; i < m; ++i )
-                        C2(i,j) += W(i,j);
+                for (idx_t j = 0; j < k; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C2(i, j) += W(i, j);
             }
         }
     }
-    else { // storeV == StoreV::Rowwise
-        if( direction == Direction::Forward ){
-            if( side == Side::Left ){
+    else {  // storeV == StoreV::Rowwise
+        if (direction == Direction::Forward) {
+            if (side == Side::Left) {
                 // W is an k-by-n matrix
                 // V is an k-by-m matrix
 
                 // Matrix views
-                const auto V1 = cols( V, pair{0,k} );
-                const auto V2 = cols( V, ( m > k ) ? pair{k,m} : pair{0,0} );
-                auto C1 = rows( C, pair{0,k} );
-                auto C2 = rows( C, ( m > k ) ? pair{k,m} : pair{0,0} );
-                auto W  = new_matrix( work, k, n );
+                const auto V1 = cols(V, pair{0, k});
+                const auto V2 = cols(V, (m > k) ? pair{k, m} : pair{0, 0});
+                auto C1 = rows(C, pair{0, k});
+                auto C2 = rows(C, (m > k) ? pair{k, m} : pair{0, 0});
+                auto W = new_matrix(work, k, n);
 
                 // W := C1
-                lacpy( dense, C1, W );
+                lacpy(dense, C1, W);
                 // W := V1 W
-                trmm(
-                    side, Uplo::Upper,
-                    Op::NoTrans, Diag::Unit,
-                    one, V1, W );
-                if( m > k )
+                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, one, V1, W);
+                if (m > k)
                     // W := W + V2 C2
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        one, V2, C2, one, W );
+                    gemm(Op::NoTrans, Op::NoTrans, one, V2, C2, one, W);
                 // W := op(Tmatrix) W
-                trmm(
-                    side, Uplo::Upper,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( m > k )
+                trmm(side, Uplo::Upper, trans, Diag::NonUnit, one, Tmatrix, W);
+                if (m > k)
                     // C2 := C2 - V2^H W
-                    gemm(
-                        Op::ConjTrans, Op::NoTrans,
-                        -one, V2, W, one, C2 );
+                    gemm(Op::ConjTrans, Op::NoTrans, -one, V2, W, one, C2);
                 // W := - V1^H W
-                trmm(
-                    side, Uplo::Upper,
-                    Op::ConjTrans, Diag::Unit,
-                    -one, V1, W );
+                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, -one, V1, W);
 
                 // C1 := C1 - W
-                for( idx_t j = 0; j < n; ++j )
-                    for( idx_t i = 0; i < k; ++i )
-                        C1(i,j) += W(i,j);
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < k; ++i)
+                        C1(i, j) += W(i, j);
             }
-            else { // side == Side::Right
+            else {  // side == Side::Right
                 // W is an m-by-k matrix
                 // V is an k-by-n matrix
 
                 // Matrix views
-                const auto V1 = cols( V, pair{0,k} );
-                const auto V2 = cols( V, ( n > k ) ? pair{k,n} : pair{0,0} );
-                auto C1 = cols( C, pair{0,k} );
-                auto C2 = cols( C, ( n > k ) ? pair{k,n} : pair{0,0} );
-                auto W  = new_matrix( work, m, k );
+                const auto V1 = cols(V, pair{0, k});
+                const auto V2 = cols(V, (n > k) ? pair{k, n} : pair{0, 0});
+                auto C1 = cols(C, pair{0, k});
+                auto C2 = cols(C, (n > k) ? pair{k, n} : pair{0, 0});
+                auto W = new_matrix(work, m, k);
 
                 // W := C1
-                lacpy( dense, C1, W );
+                lacpy(dense, C1, W);
                 // W := W V1^H
-                trmm(
-                    side, Uplo::Upper,
-                    Op::ConjTrans, Diag::Unit,
-                    one, V1, W );
-                if( n > k )
+                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, one, V1, W);
+                if (n > k)
                     // W := W + C2 V2^H
-                    gemm(
-                        Op::NoTrans, Op::ConjTrans,
-                        one, C2, V2, one, W );
+                    gemm(Op::NoTrans, Op::ConjTrans, one, C2, V2, one, W);
                 // W := W op(Tmatrix)
-                trmm(
-                    side, Uplo::Upper,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( n > k )
+                trmm(side, Uplo::Upper, trans, Diag::NonUnit, one, Tmatrix, W);
+                if (n > k)
                     // C2 := C2 - W V2
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        -one, W, V2, one, C2 );
+                    gemm(Op::NoTrans, Op::NoTrans, -one, W, V2, one, C2);
                 // W := - W V1
-                trmm(
-                    side, Uplo::Upper,
-                    Op::NoTrans, Diag::Unit,
-                    -one, V1, W );
-                
+                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, -one, V1, W);
+
                 // C1 := C1 + W
-                for( idx_t j = 0; j < k; ++j )
-                    for( idx_t i = 0; i < m; ++i )
-                        C1(i,j) += W(i,j);
+                for (idx_t j = 0; j < k; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C1(i, j) += W(i, j);
             }
         }
-        else { // direct == Direction::Backward
-            if( side == Side::Left ){
+        else {  // direct == Direction::Backward
+            if (side == Side::Left) {
                 // W is an k-by-n matrix
                 // V is an k-by-m matrix
 
                 // Matrix views
-                const auto V1 = cols( V, pair{0,m-k} );
-                const auto V2 = cols( V, pair{m-k,m} );
-                auto C1 = rows( C, pair{0,m-k} );
-                auto C2 = rows( C, pair{m-k,m} );
-                auto W  = new_matrix( work, k, n );
+                const auto V1 = cols(V, pair{0, m - k});
+                const auto V2 = cols(V, pair{m - k, m});
+                auto C1 = rows(C, pair{0, m - k});
+                auto C2 = rows(C, pair{m - k, m});
+                auto W = new_matrix(work, k, n);
 
                 // W := C2
-                lacpy( dense, C2, W );
+                lacpy(dense, C2, W);
                 // W := V2 W
-                trmm(
-                    side, Uplo::Lower,
-                    Op::NoTrans, Diag::Unit,
-                    one, V2, W );
-                if( m > k )
+                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, one, V2, W);
+                if (m > k)
                     // W := W + V1 C1
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        one, V1, C1, one, W );
+                    gemm(Op::NoTrans, Op::NoTrans, one, V1, C1, one, W);
                 // W := op(Tmatrix) W
-                trmm(
-                    side, Uplo::Lower,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( m > k )
+                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                if (m > k)
                     // C1 := C1 - V1^H W
-                    gemm(
-                        Op::ConjTrans, Op::NoTrans,
-                        -one, V1, W, one, C1 );
+                    gemm(Op::ConjTrans, Op::NoTrans, -one, V1, W, one, C1);
                 // W := - V2^H W
-                trmm(
-                    side, Uplo::Lower,
-                    Op::ConjTrans, Diag::Unit,
-                    -one, V2, W );
+                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, -one, V2, W);
 
                 // C2 := C2 + W
-                for( idx_t j = 0; j < n; ++j )
-                    for( idx_t i = 0; i < k; ++i )
-                        C2(i,j) += W(i,j);
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < k; ++i)
+                        C2(i, j) += W(i, j);
             }
-            else { // side == Side::Right
+            else {  // side == Side::Right
                 // W is an m-by-k matrix
                 // V is an k-by-n matrix
 
                 // Matrix views
-                const auto V1 = cols( V, pair{0,n-k} );
-                const auto V2 = cols( V, pair{n-k,n} );
-                auto C1 = cols( C, pair{0,n-k} );
-                auto C2 = cols( C, pair{n-k,n} );
-                auto W  = new_matrix( work, m, k );
+                const auto V1 = cols(V, pair{0, n - k});
+                const auto V2 = cols(V, pair{n - k, n});
+                auto C1 = cols(C, pair{0, n - k});
+                auto C2 = cols(C, pair{n - k, n});
+                auto W = new_matrix(work, m, k);
 
                 // W := C2
-                lacpy( dense, C2, W );
+                lacpy(dense, C2, W);
                 // W := W V2^H
-                trmm(
-                    side, Uplo::Lower,
-                    Op::ConjTrans, Diag::Unit,
-                    one, V2, W );
-                if( n > k )
+                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, one, V2, W);
+                if (n > k)
                     // W := W + C1 V1^H
-                    gemm(
-                        Op::NoTrans, Op::ConjTrans,
-                        one, C1, V1, one, W );
+                    gemm(Op::NoTrans, Op::ConjTrans, one, C1, V1, one, W);
                 // W := W op(Tmatrix)
-                trmm(
-                    side, Uplo::Lower,
-                    trans, Diag::NonUnit,
-                    one, Tmatrix, W );
-                if( n > k )
+                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                if (n > k)
                     // C1 := C1 - W V1
-                    gemm(
-                        Op::NoTrans, Op::NoTrans,
-                        -one, W, V1, one, C1 );
+                    gemm(Op::NoTrans, Op::NoTrans, -one, W, V1, one, C1);
                 // W := - W V2
-                trmm(
-                    side, Uplo::Lower,
-                    Op::NoTrans, Diag::Unit,
-                    -one, V2, W );
-                
+                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, -one, V2, W);
+
                 // C2 := C2 + W
-                for( idx_t j = 0; j < k; ++j )
-                    for( idx_t i = 0; i < m; ++i )
-                        C2(i,j) += W(i,j);
+                for (idx_t j = 0; j < k; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C2(i, j) += W(i, j);
             }
         }
     }
@@ -608,6 +512,6 @@ int larfb(
     return 0;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LARFB_HH
+#endif  // TLAPACK_LARFB_HH

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -1,6 +1,7 @@
 /// @file larfb.hpp Applies a Householder block reflector to a matrix.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfb.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larfb.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -1,6 +1,7 @@
 /// @file larfg.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfg.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larfg.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -22,81 +22,77 @@ namespace tlapack {
 /** Generates a elementary Householder reflection.
  *
  * larfg generates a elementary Householder reflection H of order n, such that
- * 
+ *
  *        H' * ( alpha ) = ( beta ),   H' * H = I.
  *             (   x   )   (   0  )
- * 
- * where alpha and beta are scalars, with beta real, and x is an (n-1)-element vector.
- * H is represented in the form
- * 
- *        H = I - tau * ( 1 ) * ( 1 v' ) 
+ *
+ * where alpha and beta are scalars, with beta real, and x is an (n-1)-element
+ * vector. H is represented in the form
+ *
+ *        H = I - tau * ( 1 ) * ( 1 v' )
  *                      ( v )
- * 
+ *
  * where tau is a scalar and v is a (n-1)-element vector.
  * Note that H is symmetric but not hermitian.
- * 
+ *
  * If the elements of x are all zero and alpha is real, then tau = 0
  * and H is taken to be the identity matrix.
- * 
+ *
  * Otherwise  1 <= real(tau) <= 2 and abs(tau-1) <= 1.
- * 
+ *
  * @param[in,out] alpha
  *      On entry, the value alpha.
  *      On exit, it is overwritten with the value beta.
- * 
+ *
  * @param[in,out] x Vector of length n-1.
  *      On entry, the vector x.
  *      On exit, it is overwritten with the vector v.
- * 
+ *
  * @param[out] tau The value tau.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class vector_t, class alpha_t, class tau_t >
-void larfg( alpha_t& alpha, vector_t& x, tau_t& tau )
+template <class vector_t, class alpha_t, class tau_t>
+void larfg(alpha_t& alpha, vector_t& x, tau_t& tau)
 {
     // data traits
-    using TX    = type_t< vector_t >;
-    using idx_t = size_type< vector_t >;
+    using TX = type_t<vector_t>;
+    using idx_t = size_type<vector_t>;
 
     // using
-    using real_t = real_type< alpha_t, TX >;
+    using real_t = real_type<alpha_t, TX>;
 
     // constants
     const idx_t n = size(x) + 1;
-    const real_t one( 1 );
-    const real_t zero( 0 );
-    const real_t safemin  = safe_min<real_t>() / uroundoff<real_t>();
+    const real_t one(1);
+    const real_t zero(0);
+    const real_t safemin = safe_min<real_t>() / uroundoff<real_t>();
     const real_t rsafemin = one / safemin;
 
-    tau = tau_t( 0 );
-    if (n > 0)
-    {
+    tau = tau_t(0);
+    if (n > 0) {
         idx_t knt = 0;
-        real_t xnorm = nrm2( x );
-        if ( xnorm > zero || (imag(alpha) != zero) )
-        {
-            real_t temp = ( ! is_complex<alpha_t>::value )
-                        ? lapy2(real(alpha), xnorm)
-                        : lapy3(real(alpha), imag(alpha), xnorm);
+        real_t xnorm = nrm2(x);
+        if (xnorm > zero || (imag(alpha) != zero)) {
+            real_t temp = (!is_complex<alpha_t>::value)
+                              ? lapy2(real(alpha), xnorm)
+                              : lapy3(real(alpha), imag(alpha), xnorm);
             real_t beta = (real(alpha) < zero) ? temp : -temp;
-            if (abs(beta) < safemin)
-            {
-                while( (abs(beta) < safemin) && (knt < 20) )
-                {
+            if (abs(beta) < safemin) {
+                while ((abs(beta) < safemin) && (knt < 20)) {
                     knt++;
-                    scal( rsafemin, x );
+                    scal(rsafemin, x);
                     beta *= rsafemin;
                     alpha *= rsafemin;
                 }
-                xnorm = nrm2( x );
-                temp = ( ! is_complex<alpha_t>::value )
-                     ? lapy2(real(alpha), xnorm)
-                     : lapy3(real(alpha), imag(alpha), xnorm);
+                xnorm = nrm2(x);
+                temp = (!is_complex<alpha_t>::value)
+                           ? lapy2(real(alpha), xnorm)
+                           : lapy3(real(alpha), imag(alpha), xnorm);
                 beta = (real(alpha) < zero) ? temp : -temp;
             }
             tau = (beta - alpha) / beta;
-            scal( one/(alpha-beta), x );
+            scal(one / (alpha - beta), x);
             for (idx_t j = 0; j < knt; ++j)
                 beta *= safemin;
             alpha = beta;
@@ -105,28 +101,28 @@ void larfg( alpha_t& alpha, vector_t& x, tau_t& tau )
 }
 
 /** Generates a elementary Householder reflection.
- * 
+ *
  * @see larfg( alpha_t& alpha, vector_t& x, tau_t& tau )
- * 
+ *
  * @param[in,out] v Vector of length n.
  *      On entry, the vector (alpha, x).
  *      On exit, it is overwritten with the vector (beta,v).
- * 
+ *
  * @param[out] tau The value tau.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class vector_t, class tau_t >
-void larfg( vector_t& v, tau_t& tau )
+template <class vector_t, class tau_t>
+void larfg(vector_t& v, tau_t& tau)
 {
-    using idx_t = size_type< vector_t >;
-    using pair  = pair<idx_t,idx_t>;
+    using idx_t = size_type<vector_t>;
+    using pair = pair<idx_t, idx_t>;
 
     const idx_t n = size(v);
-    auto x = slice( v, n > 1 ? pair{1,n} : pair{0,0} );
-    larfg( v[0], x, tau );
+    auto x = slice(v, n > 1 ? pair{1, n} : pair{0, 0});
+    larfg(v[0], x, tau);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LARFG_HH
+#endif  // TLAPACK_LARFG_HH

--- a/include/tlapack/lapack/larft.hpp
+++ b/include/tlapack/lapack/larft.hpp
@@ -1,6 +1,7 @@
 /// @file larft.hpp Forms the triangular factor T of a block reflector.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larft.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larft.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larft.hpp
+++ b/include/tlapack/lapack/larft.hpp
@@ -12,8 +12,8 @@
 #define TLAPACK_LARFT_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/blas/gemv.hpp"
 #include "tlapack/blas/gemm.hpp"
+#include "tlapack/blas/gemv.hpp"
 #include "tlapack/blas/trmv.hpp"
 
 namespace tlapack {
@@ -21,8 +21,9 @@ namespace tlapack {
 /** Forms the triangular factor T of a block reflector H of order n,
  * which is defined as a product of k elementary reflectors.
  *
- * If direction = Direction::Forward,  H = H_1 H_2 ... H_k and T is upper triangular.
- * If direction = Direction::Backward, H = H_k ... H_2 H_1 and T is lower triangular.
+ * If direction = Direction::Forward,  H = H_1 H_2 ... H_k and T is upper
+ * triangular. If direction = Direction::Backward, H = H_k ... H_2 H_1 and T is
+ * lower triangular.
  *
  * If storeMode = StoreV::Columnwise, the vector which defines the elementary
  * reflector H(i) is stored in the i-th column of the array V, and
@@ -51,80 +52,83 @@ namespace tlapack {
  *         (  1 v2 v3 )                     ( v3 v3 v3 v3  1 )
  *         (     1 v3 )
  *         (        1 )
- * 
- * @tparam direction_t Either Direction or any class that implements `operator Direction()`.
- * @tparam storage_t Either StoreV or any class that implements `operator StoreV()`.
- * 
+ *
+ * @tparam direction_t Either Direction or any class that implements `operator
+ * Direction()`.
+ * @tparam storage_t Either StoreV or any class that implements `operator
+ * StoreV()`.
+ *
  * @param[in] direction
  *     Indicates how H is formed from a product of elementary reflectors.
  *     - Direction::Forward:  $H = H(1) H(2) ... H(k)$.
  *     - Direction::Backward: $H = H(k) ... H(2) H(1)$.
  *
  * @param[in] storeMode
- *     Indicates how the vectors which define the elementary reflectors are stored:
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
  *     - StoreV::Columnwise.
  *     - StoreV::Rowwise.
- * 
+ *
  * @param[in] V
  *     - If storeMode = StoreV::Columnwise: n-by-k matrix V.
  *     - If storeMode = StoreV::Rowwise:    k-by-n matrix V.
  *
  * @param[in] tau Vector of length k containing the scalar factors
  *      of the elementary reflectors H.
- * 
+ *
  * @param[out] T Matrix of size k-by-k containing the triangular factors
  *      of the block reflector.
  *     - Direction::Forward:  T is upper triangular.
  *     - Direction::Backward: T is lower triangular.
- * 
+ *
  * @ingroup auxiliary
  */
-template< 
-    class direction_t, class storage_t,
-    class matrixV_t, class vector_t, class matrixT_t >
-int larft(
-    direction_t direction, storage_t storeMode,
-    const matrixV_t& V, const vector_t& tau, matrixT_t& T)
+template <class direction_t,
+          class storage_t,
+          class matrixV_t,
+          class vector_t,
+          class matrixT_t>
+int larft(direction_t direction,
+          storage_t storeMode,
+          const matrixV_t& V,
+          const vector_t& tau,
+          matrixT_t& T)
 {
     // data traits
-    using scalar_t  = type_t< matrixT_t >;
-    using real_t    = real_type<scalar_t>;
-    using tau_t     = type_t< vector_t >;
-    using idx_t     = size_type< matrixV_t >;
+    using scalar_t = type_t<matrixT_t>;
+    using real_t = real_type<scalar_t>;
+    using tau_t = type_t<vector_t>;
+    using idx_t = size_type<matrixV_t>;
 
     // using
-    using pair = pair<idx_t,idx_t>;
+    using pair = pair<idx_t, idx_t>;
 
     // constants
     const real_t one(1);
     const real_t zero(0);
-    const idx_t n = (storeMode == StoreV::Columnwise) ? nrows( V ) : ncols( V );
-    const idx_t k = size( tau );
+    const idx_t n = (storeMode == StoreV::Columnwise) ? nrows(V) : ncols(V);
+    const idx_t k = size(tau);
 
     // check arguments
-    tlapack_check_false(    direction != Direction::Backward &&
-                        direction != Direction::Forward );
-    tlapack_check_false(    storeMode != StoreV::Columnwise &&
-                        storeMode != StoreV::Rowwise );
-    tlapack_check_false( k > ( (storeMode == StoreV::Columnwise)
-                            ? ncols( V )
-                            : nrows( V ) ) );
-    tlapack_check_false( nrows( T ) < k || ncols( T ) < k );
+    tlapack_check_false(direction != Direction::Backward &&
+                        direction != Direction::Forward);
+    tlapack_check_false(storeMode != StoreV::Columnwise &&
+                        storeMode != StoreV::Rowwise);
+    tlapack_check_false(
+        k > ((storeMode == StoreV::Columnwise) ? ncols(V) : nrows(V)));
+    tlapack_check_false(nrows(T) < k || ncols(T) < k);
 
     // Quick return
-    if (n == 0 || k == 0)
-        return 0;
+    if (n == 0 || k == 0) return 0;
 
-    if (direction == Direction::Forward)
-    {
+    if (direction == Direction::Forward) {
         // First iteration:
-        T(0,0) = tau[0];
+        T(0, 0) = tau[0];
 
         // Remaining iterations:
         for (idx_t i = 1; i < k; ++i) {
-
             // Column vector t := T(0:i,i)
-            auto t = slice( T, pair{0,i}, i );
+            auto t = slice(T, pair{0, i}, i);
 
             if (tau[i] == tau_t(0)) {
                 // H(i) =  I
@@ -135,111 +139,92 @@ int larft(
             else {
                 // General case
                 if (storeMode == StoreV::Columnwise) {
-
                     // t := - tau[i] conj( V(i,0:i) )
                     for (idx_t j = 0; j < i; ++j)
-                        t[j] = -tau[i] * conj(V(i,j));
-                    
+                        t[j] = -tau[i] * conj(V(i, j));
+
                     // t := t - tau[i] V(i+1:n,0:i)^H V(i+1:n,i)
-                    if( i+1 < n ) {
-                        gemv( conjTranspose,
-                            -tau[i],
-                            slice( V, pair{i+1,n}, pair{0,i} ),
-                            slice( V, pair{i+1,n}, i ),
-                            one, t
-                        );
+                    if (i + 1 < n) {
+                        gemv(conjTranspose, -tau[i],
+                             slice(V, pair{i + 1, n}, pair{0, i}),
+                             slice(V, pair{i + 1, n}, i), one, t);
                     }
                 }
                 else {
-
                     // t := - tau[i] V(0:i,i)
                     for (idx_t j = 0; j < i; ++j)
-                        t[j] = -tau[i] * V(j,i);
-                    
+                        t[j] = -tau[i] * V(j, i);
+
                     // t := t - tau[i] V(0:i,i:n) V(i,i+1:n)^H
-                    if( i+1 < n ) {
-                        auto Ti = slice( T, pair{0,i}, pair{i,i+1} );
-                        gemm( noTranspose, conjTranspose,
-                            -tau[i],
-                            slice( V, pair{0,i}, pair{i+1,n} ),
-                            slice( V, pair{i,i+1}, pair{i+1,n} ),
-                            one, Ti
-                        );
+                    if (i + 1 < n) {
+                        auto Ti = slice(T, pair{0, i}, pair{i, i + 1});
+                        gemm(noTranspose, conjTranspose, -tau[i],
+                             slice(V, pair{0, i}, pair{i + 1, n}),
+                             slice(V, pair{i, i + 1}, pair{i + 1, n}), one, Ti);
                     }
                 }
 
                 // t := T(0:i,0:i) * t
-                trmv( upperTriangle, noTranspose, nonUnit_diagonal,
-                    slice( T, pair{0,i}, pair{0,i} ), t 
-                );
+                trmv(upperTriangle, noTranspose, nonUnit_diagonal,
+                     slice(T, pair{0, i}, pair{0, i}), t);
             }
 
             // Update diagonal
-            T(i,i) = tau[i];
+            T(i, i) = tau[i];
         }
     }
-    else // direct==Direction::Backward
+    else  // direct==Direction::Backward
     {
         // First iteration:
-        T(k-1,k-1) = tau[k-1];
+        T(k - 1, k - 1) = tau[k - 1];
 
         // Remaining iterations:
-        for (idx_t i = k-2; i != idx_t(-1); --i) {
-
+        for (idx_t i = k - 2; i != idx_t(-1); --i) {
             // Column vector t := T(0:i,i)
-            auto t = slice( T, pair{i+1,k}, i );
+            auto t = slice(T, pair{i + 1, k}, i);
 
             if (tau[i] == tau_t(0)) {
                 // H(i) =  I
-                for (idx_t j = 0; j < k-i-1; ++j)
+                for (idx_t j = 0; j < k - i - 1; ++j)
                     t[j] = zero;
             }
 
             else {
                 // General case
                 if (storeMode == StoreV::Columnwise) {
-
                     // t := - tau[i] conj(V(n-k+i,i+1:k))
-                    for (idx_t j = 0; j < k-i-1; ++j)
-                        t[j] = -tau[i] * conj(V(n-k+i,j+i+1));
+                    for (idx_t j = 0; j < k - i - 1; ++j)
+                        t[j] = -tau[i] * conj(V(n - k + i, j + i + 1));
 
                     // t := t - tau[i] V(0:n-k+i,i+1:k)^H V(0:n-k+i,i)
-                    gemv( conjTranspose,
-                        -tau[i],
-                        slice( V, pair{0,n-k+i}, pair{i+1,k} ),
-                        slice( V, pair{0,n-k+i}, i ),
-                        one, t
-                    );
+                    gemv(conjTranspose, -tau[i],
+                         slice(V, pair{0, n - k + i}, pair{i + 1, k}),
+                         slice(V, pair{0, n - k + i}, i), one, t);
                 }
                 else {
-
                     // t := - tau[i] V(i+1:k,n-k+i)
-                    for (idx_t j = 0; j < k-i-1; ++j)
-                        t[j] = -tau[i] * V(j+i+1,n-k+i);
+                    for (idx_t j = 0; j < k - i - 1; ++j)
+                        t[j] = -tau[i] * V(j + i + 1, n - k + i);
 
                     // t := t - tau[i] V(i+1:k,0:n-k+i) V(i,0:n-k+i)^H
-                    auto Ti = slice( T, pair{i+1,k}, pair{i,i+1} );
-                    gemm( noTranspose, conjTranspose,
-                        -tau[i],
-                        slice( V, pair{i+1,k}, pair{0,n-k+i} ),
-                        slice( V, pair{i,i+1}, pair{0,n-k+i} ),
-                        one, Ti
-                    );
+                    auto Ti = slice(T, pair{i + 1, k}, pair{i, i + 1});
+                    gemm(noTranspose, conjTranspose, -tau[i],
+                         slice(V, pair{i + 1, k}, pair{0, n - k + i}),
+                         slice(V, pair{i, i + 1}, pair{0, n - k + i}), one, Ti);
                 }
 
                 // t := T(i+1:k,i+1:k) * t
-                trmv( lowerTriangle, noTranspose, nonUnit_diagonal,
-                    slice( T, pair{i+1,k}, pair{i+1,k} ), t 
-                );
+                trmv(lowerTriangle, noTranspose, nonUnit_diagonal,
+                     slice(T, pair{i + 1, k}, pair{i + 1, k}), t);
             }
 
             // Update diagonal
-            T(i,i) = tau[i];
+            T(i, i) = tau[i];
         }
     }
     return 0;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LARFT_HH
+#endif  // TLAPACK_LARFT_HH

--- a/include/tlapack/lapack/larnv.hpp
+++ b/include/tlapack/lapack/larnv.hpp
@@ -1,4 +1,5 @@
-/// @file larnv.hpp Returns a vector of random numbers from a uniform or normal distribution.
+/// @file larnv.hpp Returns a vector of random numbers from a uniform or normal
+/// distribution.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// Adapted from @see https://github.com/langou/latl/blob/mastUSA
 /// @note Adapted
@@ -12,39 +13,39 @@
 #define TLAPACK_LARNV_HH
 
 #include <random>
+
 #include "tlapack/base/types.hpp"
 
 namespace tlapack {
 
 /** Returns a vector of n random numbers from a uniform or normal distribution.
- * 
+ *
  * This implementation uses the Mersenne Twister 19937 generator (std::mt19937),
  * which is a Mersenne Twister pseudo-random generator of 32-bit numbers with
  * a state size of 19937 bits.
- * 
+ *
  * Requires ISO C++ 2011 random number generators.
- * 
+ *
  * @tparam idist Specifies the distribution:
  *      1.  real and imaginary parts each uniform (0,1).
  *      2.  real and imaginary parts each uniform (-1,1).
  *      3.  real and imaginary parts each normal (0,1).
  *      4.  uniformly distributed on the disc abs(z) < 1.
  *      5.  uniformly distributed on the circle abs(z) = 1.
- * 
+ *
  * @param[in,out] iseed Seed for the random number generator.
  *      The seed is updated inside the routine ( seed := seed + 1 ).
- * 
+ *
  * @param[out] x Vector of length n.
- * 
+ *
  * @ingroup auxiliary
  */
-template< int idist, class vector_t, class Sseq >
-void larnv( Sseq& iseed, vector_t& x )
+template <int idist, class vector_t, class Sseq>
+void larnv(Sseq& iseed, vector_t& x)
 {
-    using idx_t  = size_type< vector_t >;
-    using T      = type_t< vector_t >;
-    using real_t = real_type< T >;
-
+    using idx_t = size_type<vector_t>;
+    using T = type_t<vector_t>;
+    using real_t = real_type<T>;
 
     // Constants
     const idx_t n = size(x);
@@ -60,8 +61,8 @@ void larnv( Sseq& iseed, vector_t& x )
     if (idist == 1) {
         std::uniform_real_distribution<real_t> d1(0, 1);
         for (idx_t i = 0; i < n; ++i) {
-            if( is_complex<T>::value )
-                x[i] = make_scalar<T>( d1(generator), d1(generator) );
+            if (is_complex<T>::value)
+                x[i] = make_scalar<T>(d1(generator), d1(generator));
             else
                 x[i] = d1(generator);
         }
@@ -69,8 +70,8 @@ void larnv( Sseq& iseed, vector_t& x )
     else if (idist == 2) {
         std::uniform_real_distribution<real_t> d2(-1, 1);
         for (idx_t i = 0; i < n; ++i) {
-            if( is_complex<T>::value )
-                x[i] = make_scalar<T>( d2(generator), d2(generator) );
+            if (is_complex<T>::value)
+                x[i] = make_scalar<T>(d2(generator), d2(generator));
             else
                 x[i] = d2(generator);
         }
@@ -78,26 +79,26 @@ void larnv( Sseq& iseed, vector_t& x )
     else if (idist == 3) {
         std::normal_distribution<real_t> d3(0, 1);
         for (idx_t i = 0; i < n; ++i) {
-            if( is_complex<T>::value )
-                x[i] = make_scalar<T>( d3(generator), d3(generator) );
+            if (is_complex<T>::value)
+                x[i] = make_scalar<T>(d3(generator), d3(generator));
             else
                 x[i] = d3(generator);
         }
     }
-    else if ( is_complex<T>::value ) {
+    else if (is_complex<T>::value) {
         if (idist == 4) {
             std::uniform_real_distribution<real_t> d4(0, 1);
             for (idx_t i = 0; i < n; ++i) {
-                real_t r     = sqrt(d4(generator));
+                real_t r = sqrt(d4(generator));
                 real_t theta = twopi * d4(generator);
-                x[i] = make_scalar<T>( r*cos(theta), r*sin(theta) );
+                x[i] = make_scalar<T>(r * cos(theta), r * sin(theta));
             }
         }
         else if (idist == 5) {
             std::uniform_real_distribution<real_t> d5(0, 1);
             for (idx_t i = 0; i < n; ++i) {
                 real_t theta = twopi * d5(generator);
-                x[i] = make_scalar<T>( cos(theta), sin(theta) );
+                x[i] = make_scalar<T>(cos(theta), sin(theta));
             }
         }
     }
@@ -106,6 +107,6 @@ void larnv( Sseq& iseed, vector_t& x )
     iseed = iseed + 1;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LARNV_HH
+#endif  // TLAPACK_LARNV_HH

--- a/include/tlapack/lapack/lascl.hpp
+++ b/include/tlapack/lapack/lascl.hpp
@@ -1,6 +1,7 @@
 /// @file lascl.hpp Multiplies a matrix by a scalar.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lascl.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lascl.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lascl.hpp
+++ b/include/tlapack/lapack/lascl.hpp
@@ -11,8 +11,8 @@
 #ifndef TLAPACK_LASCL_HH
 #define TLAPACK_LASCL_HH
 
-#include "tlapack/base/utils.hpp"
 #include "tlapack/base/constants.hpp"
+#include "tlapack/base/utils.hpp"
 
 namespace tlapack {
 
@@ -21,7 +21,7 @@ namespace tlapack {
  *
  * Multiplication of a matrix A by scalar a/b is done without over/underflow as
  * long as the final result $a A/b$ does not over/underflow.
- * 
+ *
  * @tparam access_t Type of access inside the algorithm.
  *      Either MatrixAccessPolicy or any type that implements
  *          operator MatrixAccessPolicy().
@@ -30,7 +30,7 @@ namespace tlapack {
  *      a_type cannot be a complex type.
  * @tparam b_type Type of the coefficient b.
  *      b_type cannot be a complex type.
- * 
+ *
  * @param[in] accessType Determines the entries of A that are scaled by a/b.
  *      The following access types are allowed:
  *          MatrixAccessPolicy::Dense,
@@ -40,30 +40,33 @@ namespace tlapack {
  *          MatrixAccessPolicy::LowerTriangle,
  *          MatrixAccessPolicy::StrictUpper,
  *          MatrixAccessPolicy::StrictLower.
- * 
+ *
  * @param[in] b The denominator of the scalar a/b.
  * @param[in] a The numerator of the scalar a/b.
  * @param[in,out] A Matrix to be scaled by a/b.
- * 
+ *
  * @return  0 if success..
- * 
+ *
  * @ingroup auxiliary
  */
-template< class access_t, class matrix_t, class a_type, class b_type,
+template <
+    class access_t,
+    class matrix_t,
+    class a_type,
+    class b_type,
     enable_if_t<(
-    /* Requires: */
-        !is_complex< a_type >::value &&
-        !is_complex< b_type >::value
-    ), int > = 0 >
-int lascl(
-    access_t accessType,
-    const b_type& b, const a_type& a,
-    const matrix_t& A )
+                    /* Requires: */
+                    !is_complex<a_type>::value && !is_complex<b_type>::value),
+                int> = 0>
+int lascl(access_t accessType,
+          const b_type& b,
+          const a_type& a,
+          const matrix_t& A)
 {
     // data traits
-    using idx_t  = size_type< matrix_t >;
-    using real_t = real_type< a_type, b_type >;
-    
+    using idx_t = size_type<matrix_t>;
+    using real_t = real_type<a_type, b_type>;
+
     // using
 
     // constants
@@ -72,28 +75,25 @@ int lascl(
 
     // constants
     const real_t small = safe_min<real_t>();
-    const real_t big   = safe_max<real_t>();
-    
+    const real_t big = safe_max<real_t>();
+
     // check arguments
-    tlapack_check_false(
-        (accessType != MatrixAccessPolicy::Dense) && 
-        (accessType != MatrixAccessPolicy::UpperHessenberg) && 
-        (accessType != MatrixAccessPolicy::LowerHessenberg) && 
-        (accessType != MatrixAccessPolicy::UpperTriangle) && 
-        (accessType != MatrixAccessPolicy::LowerTriangle) && 
-        (accessType != MatrixAccessPolicy::StrictUpper) && 
-        (accessType != MatrixAccessPolicy::StrictLower) );
-    tlapack_check_false( (b == b_type(0)) || isnan(b) );
-    tlapack_check_false( isnan(a) );
+    tlapack_check_false((accessType != MatrixAccessPolicy::Dense) &&
+                        (accessType != MatrixAccessPolicy::UpperHessenberg) &&
+                        (accessType != MatrixAccessPolicy::LowerHessenberg) &&
+                        (accessType != MatrixAccessPolicy::UpperTriangle) &&
+                        (accessType != MatrixAccessPolicy::LowerTriangle) &&
+                        (accessType != MatrixAccessPolicy::StrictUpper) &&
+                        (accessType != MatrixAccessPolicy::StrictLower));
+    tlapack_check_false((b == b_type(0)) || isnan(b));
+    tlapack_check_false(isnan(a));
 
     // quick return
-    if( m <= 0 || n <= 0 )
-        return 0;
+    if (m <= 0 || n <= 0) return 0;
 
     bool done = false;
     real_t a_ = a, b_ = b;
-    while (!done)
-    {
+    while (!done) {
         real_t c, a1, b1 = b * small;
         if (b1 == b_) {
             // b is not finite:
@@ -102,15 +102,16 @@ int lascl(
             c = a_ / b_;
             done = true;
         }
-        else { // b is finite
+        else {  // b is finite
             a1 = a_ / big;
             if (a1 == a_) {
                 // a is either 0 or an infinity number:
-                //  in both cases, c = a serves as the correct multiplication factor.
+                //  in both cases, c = a serves as the correct multiplication
+                //  factor.
                 c = a_;
                 done = true;
             }
-            else if ( (abs(b1) > abs(a_)) && (a_ != real_t(0)) ) {
+            else if ((abs(b1) > abs(a_)) && (a_ != real_t(0))) {
                 // a is a non-zero finite number and abs(a/b) < small:
                 //  Set c = small as the multiplication factor,
                 //  Multiply b by the small factor.
@@ -134,47 +135,41 @@ int lascl(
             }
         }
 
-        if ( accessType == MatrixAccessPolicy::UpperHessenberg )
-        {
+        if (accessType == MatrixAccessPolicy::UpperHessenberg) {
             for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < ((j < m) ? j+2 : m); ++i)
-                    A(i,j) *= c;
+                for (idx_t i = 0; i < ((j < m) ? j + 2 : m); ++i)
+                    A(i, j) *= c;
         }
-        else if ( accessType == MatrixAccessPolicy::UpperTriangle )
-        {
+        else if (accessType == MatrixAccessPolicy::UpperTriangle) {
             for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < ((j < m) ? j+1 : m); ++i)
-                    A(i,j) *= c;
+                for (idx_t i = 0; i < ((j < m) ? j + 1 : m); ++i)
+                    A(i, j) *= c;
         }
-        else if ( accessType == MatrixAccessPolicy::StrictUpper )
-        {
+        else if (accessType == MatrixAccessPolicy::StrictUpper) {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < ((j < m) ? j : m); ++i)
-                    A(i,j) *= c;
+                    A(i, j) *= c;
         }
-        else if ( accessType == MatrixAccessPolicy::LowerHessenberg )
-        {
+        else if (accessType == MatrixAccessPolicy::LowerHessenberg) {
             for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = ((j > 1) ? j-1 : 0); i < m; ++i)
-                    A(i,j) *= c;
+                for (idx_t i = ((j > 1) ? j - 1 : 0); i < m; ++i)
+                    A(i, j) *= c;
         }
-        else if ( accessType == MatrixAccessPolicy::LowerTriangle )
-        {
+        else if (accessType == MatrixAccessPolicy::LowerTriangle) {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = j; i < m; ++i)
-                    A(i,j) *= c;
+                    A(i, j) *= c;
         }
-        else if ( accessType == MatrixAccessPolicy::StrictLower )
-        {
+        else if (accessType == MatrixAccessPolicy::StrictLower) {
             for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = j+1; i < m; ++i)
-                    A(i,j) *= c;
+                for (idx_t i = j + 1; i < m; ++i)
+                    A(i, j) *= c;
         }
-        else // if ( accessType == MatrixAccessPolicy::Dense )
+        else  // if ( accessType == MatrixAccessPolicy::Dense )
         {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < m; ++i)
-                    A(i,j) *= c;
+                    A(i, j) *= c;
         }
     }
 
@@ -183,37 +178,39 @@ int lascl(
 
 /**
  * @brief Multiplies a matrix A by the real scalar a/b.
- * 
+ *
  * Specific implementation for band access types.
- * 
+ *
  * @param[in] accessType Determines the entries of A that are scaled by a/b.
- * 
+ *
  * @param[in] b The denominator of the scalar a/b.
  * @param[in] a The numerator of the scalar a/b.
  * @param[in,out] A Matrix to be scaled by a/b.
- * 
+ *
  * @see lascl(
     access_t accessType,
     const b_type& b, const a_type& a,
     const matrix_t& A )
- * 
+ *
  * @ingroup auxiliary
  */
-template< class matrix_t, class a_type, class b_type,
+template <
+    class matrix_t,
+    class a_type,
+    class b_type,
     enable_if_t<(
-    /* Requires: */
-        !is_complex< a_type >::value &&
-        !is_complex< b_type >::value
-    ), int > = 0 >
-int lascl(
-    band_t accessType,
-    const b_type& b, const a_type& a,
-    const matrix_t& A )
+                    /* Requires: */
+                    !is_complex<a_type>::value && !is_complex<b_type>::value),
+                int> = 0>
+int lascl(band_t accessType,
+          const b_type& b,
+          const a_type& a,
+          const matrix_t& A)
 {
     // data traits
-    using idx_t  = size_type< matrix_t >;
-    using real_t = real_type< a_type, b_type >;
-    
+    using idx_t = size_type<matrix_t>;
+    using real_t = real_type<a_type, b_type>;
+
     // using
     using std::min;
 
@@ -225,21 +222,19 @@ int lascl(
 
     // constants
     const real_t small = safe_min<real_t>();
-    const real_t big   = safe_max<real_t>();
-    
+    const real_t big = safe_max<real_t>();
+
     // check arguments
-    tlapack_check_false( (kl < 0) || (kl >= m) || (ku < 0) || (ku >= n) );
-    tlapack_check_false( (b == b_type(0)) || isnan(b) );
-    tlapack_check_false( isnan(a) );
+    tlapack_check_false((kl < 0) || (kl >= m) || (ku < 0) || (ku >= n));
+    tlapack_check_false((b == b_type(0)) || isnan(b));
+    tlapack_check_false(isnan(a));
 
     // quick return
-    if( m <= 0 || n <= 0 )
-        return 0;
+    if (m <= 0 || n <= 0) return 0;
 
     bool done = false;
     real_t a_ = a, b_ = b;
-    while (!done)
-    {
+    while (!done) {
         real_t c, a1, b1 = b * small;
         if (b1 == b_) {
             // b is not finite:
@@ -248,15 +243,16 @@ int lascl(
             c = a_ / b_;
             done = true;
         }
-        else { // b is finite
+        else {  // b is finite
             a1 = a_ / big;
             if (a1 == a_) {
                 // a is either 0 or an infinity number:
-                //  in both cases, c = a serves as the correct multiplication factor.
+                //  in both cases, c = a serves as the correct multiplication
+                //  factor.
                 c = a_;
                 done = true;
             }
-            else if ( (abs(b1) > abs(a_)) && (a_ != real_t(0)) ) {
+            else if ((abs(b1) > abs(a_)) && (a_ != real_t(0))) {
                 // a is a non-zero finite number and abs(a/b) < small:
                 //  Set c = small as the multiplication factor,
                 //  Multiply b by the small factor.
@@ -281,13 +277,14 @@ int lascl(
         }
 
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = ((j >= ku) ? (j-ku) : 0); i < min(m,j+kl+1); ++i)
-                A(i,j) *= c;
+            for (idx_t i = ((j >= ku) ? (j - ku) : 0); i < min(m, j + kl + 1);
+                 ++i)
+                A(i, j) *= c;
     }
 
     return 0;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LASCL_HH
+#endif  // TLAPACK_LASCL_HH

--- a/include/tlapack/lapack/laset.hpp
+++ b/include/tlapack/lapack/laset.hpp
@@ -1,6 +1,7 @@
 /// @file laset.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/laset.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/laset.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/laset.hpp
+++ b/include/tlapack/lapack/laset.hpp
@@ -17,10 +17,10 @@ namespace tlapack {
 
 /**
  * @brief Initializes a matrix to diagonal and off-diagonal values.
- * 
+ *
  * @tparam uplo_t
  *      Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper: Upper triangle of A is referenced;
  *      - Uplo::Lower: Lower triangle of A is referenced;
@@ -28,18 +28,18 @@ namespace tlapack {
  *
  * @param[in] alpha Value to assign to the off-diagonal elements of A.
  * @param[in] beta Value to assign to the diagonal elements of A.
- * 
+ *
  * @param[out] A m-by-n matrix.
- * 
- * @ingroup auxiliary 
+ *
+ * @ingroup auxiliary
  */
-template< class uplo_t, class matrix_t >
-void laset(
-    uplo_t uplo,
-    const type_t<matrix_t>& alpha, const type_t<matrix_t>& beta,
-    matrix_t& A )
+template <class uplo_t, class matrix_t>
+void laset(uplo_t uplo,
+           const type_t<matrix_t>& alpha,
+           const type_t<matrix_t>& beta,
+           matrix_t& A)
 {
-    using idx_t  = size_type< matrix_t >;
+    using idx_t = size_type<matrix_t>;
     using std::min;
 
     // constants
@@ -47,41 +47,40 @@ void laset(
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper &&
-                    uplo != Uplo::General );
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
 
     if (uplo == Uplo::Upper) {
         // Set the strictly upper triangular or trapezoidal part of
         // the array to alpha.
         for (idx_t j = 1; j < n; ++j) {
-            const idx_t M = min(m,j);
+            const idx_t M = min(m, j);
             for (idx_t i = 0; i < M; ++i)
-                A(i,j) = alpha;
+                A(i, j) = alpha;
         }
     }
     else if (uplo == Uplo::Lower) {
         // Set the strictly lower triangular or trapezoidal part of
         // the array to alpha.
-        const idx_t N = min(m,n);
+        const idx_t N = min(m, n);
         for (idx_t j = 0; j < N; ++j) {
-            for (idx_t i = j+1; i < m; ++i)
-                A(i,j) = alpha;
+            for (idx_t i = j + 1; i < m; ++i)
+                A(i, j) = alpha;
         }
     }
     else {
         // Set all elements in A to alpha.
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < m; ++i)
-                A(i,j) = alpha;
+                A(i, j) = alpha;
     }
 
     // Set the first min(m,n) diagonal elements to beta.
-    const idx_t N = min(m,n);
+    const idx_t N = min(m, n);
     for (idx_t i = 0; i < N; ++i)
-        A(i,i) = beta;
+        A(i, i) = beta;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LASET_HH
+#endif  // TLAPACK_LASET_HH

--- a/include/tlapack/lapack/lassq.hpp
+++ b/include/tlapack/lapack/lassq.hpp
@@ -1,6 +1,6 @@
 /// @file lassq.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// 
+///
 /// Anderson E. (2017)
 /// Algorithm 978: Safe Scaling in the Level 1 BLAS
 /// ACM Trans Math Softw 44:1--28
@@ -15,8 +15,8 @@
 #ifndef TLAPACK_LASSQ_HH
 #define TLAPACK_LASSQ_HH
 
-#include "tlapack/base/utils.hpp"
 #include "tlapack/base/constants.hpp"
+#include "tlapack/base/utils.hpp"
 
 namespace tlapack {
 
@@ -25,7 +25,7 @@ namespace tlapack {
  *      scl smsq := \sum_{i = 0}^n |x_i|^2 + scale^2 sumsq,
  * \]
  * The value of  sumsq  is assumed to be non-negative.
- * 
+ *
  * If (scale * sqrt( sumsq )) > tbig on entry then
  *    we require:   scale >= sqrt( TINY*EPS ) / sbig   on entry,
  * and if 0 < (scale * sqrt( sumsq )) < tsml on entry then
@@ -38,58 +38,57 @@ namespace tlapack {
  * and
  *    TINY*EPS -- tiniest representable number;
  *    HUGE     -- biggest representable number.
- * 
+ *
  * @param[in] x Vector of size n.
- * 
+ *
  * @param[in,out] scale Real scalar.
  *      On entry, the value `scale` in the equation above.
  *      On exit, `scale` is overwritten with `scl`, the scaling factor
  *      for the sum of squares.
- * 
+ *
  * @param[in,out] sumsq Real scalar.
  *      On entry, the value `sumsq` in the equation above.
  *      On exit, `sumsq` is overwritten with `smsq`, the basic sum of
  *      squares from which  scl  has been factored out.
- * 
+ *
  * @param[in] absF Lambda function that computes the absolute value.
  * \code{.cpp}
  *      absF = []( const T& x ) -> real_type<T> { ... };
  * \endcode
- * 
+ *
  * @ingroup auxiliary
  */
-template< class abs_f, class vector_t, class T = type_t<vector_t> >
-void lassq(
-    const vector_t& x,
-    real_type<T> &scale,
-    real_type<T> &sumsq,
-    abs_f absF )
+template <class abs_f, class vector_t, class T = type_t<vector_t> >
+void lassq(const vector_t& x,
+           real_type<T>& scale,
+           real_type<T>& sumsq,
+           abs_f absF)
 {
     using real_t = real_type<T>;
-    using idx_t  = size_type< vector_t >;
+    using idx_t = size_type<vector_t>;
 
     // constants
     const idx_t n = size(x);
 
     // constants
-    const real_t zero( 0 );
-    const real_t one( 1 );
+    const real_t zero(0);
+    const real_t one(1);
     const real_t tsml = blue_min<real_t>();
     const real_t tbig = blue_max<real_t>();
     const real_t ssml = blue_scalingMin<real_t>();
     const real_t sbig = blue_scalingMax<real_t>();
 
     // quick return
-    if( isnan(scale) || isnan(sumsq) ) return;
+    if (isnan(scale) || isnan(sumsq)) return;
 
-    if( sumsq == zero ) scale = one;
-    if( scale == zero ) {
+    if (sumsq == zero) scale = one;
+    if (scale == zero) {
         scale = one;
         sumsq = zero;
     }
 
     // quick return
-    if( n <= 0 ) return;
+    if (n <= 0) return;
 
     //  Compute the sum of squares in 3 accumulators:
     //     abig -- sums of squares scaled down to avoid overflow
@@ -103,56 +102,56 @@ void lassq(
     real_t amed = zero;
     real_t abig = zero;
 
-    for (idx_t i = 0; i < n; ++i)
-    {
-        real_t ax = absF( x[i] );
-        if( ax > tbig )
-            abig += (ax*sbig) * (ax*sbig);
-        else if( ax < tsml ) {
-            if( abig == zero ) asml += (ax*ssml) * (ax*ssml);
-        } else
+    for (idx_t i = 0; i < n; ++i) {
+        real_t ax = absF(x[i]);
+        if (ax > tbig)
+            abig += (ax * sbig) * (ax * sbig);
+        else if (ax < tsml) {
+            if (abig == zero) asml += (ax * ssml) * (ax * ssml);
+        }
+        else
             amed += ax * ax;
     }
 
     // Put the existing sum of squares into one of the accumulators
-    if( sumsq > zero ) {
-        real_t ax = scale * sqrt( sumsq );
-        if( ax > tbig )
-            abig += ((scale*sbig) * (scale*sbig)) * sumsq;
-        else if( ax < tsml ) {
-            if( abig == zero ) asml += ((scale*ssml) * (scale*ssml)) * sumsq;
-        } else
+    if (sumsq > zero) {
+        real_t ax = scale * sqrt(sumsq);
+        if (ax > tbig)
+            abig += ((scale * sbig) * (scale * sbig)) * sumsq;
+        else if (ax < tsml) {
+            if (abig == zero) asml += ((scale * ssml) * (scale * ssml)) * sumsq;
+        }
+        else
             amed += (scale * scale) * sumsq;
     }
 
     // Combine abig and amed or amed and asml if
     // more than one accumulator was used.
 
-    if( abig > zero ) {
+    if (abig > zero) {
         // Combine abig and amed if abig > 0
-        if( amed > zero || isnan(amed) )
-            abig += (amed*sbig)*sbig;
+        if (amed > zero || isnan(amed)) abig += (amed * sbig) * sbig;
         scale = one / sbig;
         sumsq = abig;
     }
-    else if( asml > zero ) {
+    else if (asml > zero) {
         // Combine amed and asml if asml > 0
-        if( amed > zero || isnan(amed) ) {
-            
+        if (amed > zero || isnan(amed)) {
             amed = sqrt(amed);
             asml = sqrt(asml) / ssml;
-            
+
             real_t ymin, ymax;
-            if( asml > amed ) {
+            if (asml > amed) {
                 ymin = amed;
                 ymax = asml;
-            } else {
+            }
+            else {
                 ymin = asml;
                 ymax = amed;
             }
 
             scale = one;
-            sumsq = (ymax * ymax) * ( one + (ymin/ymax) * (ymin/ymax) );
+            sumsq = (ymax * ymax) * (one + (ymin / ymax) * (ymin / ymax));
         }
         else {
             scale = one / ssml;
@@ -176,27 +175,23 @@ void lassq(
     real_type<T> &sumsq,
     abs_f absF ).
  *
- * Specific implementation using  
+ * Specific implementation using
  * \code{.cpp}
  *      absF = []( const T& x ) { return tlapack::abs( x ); }
  * \endcode
  * where T is the type_t< vector_t >.
- * 
+ *
  * @ingroup auxiliary
  */
-template< class vector_t, class T = type_t<vector_t> >
-inline
-void lassq(
-    const vector_t& x,
-    real_type<T> &scale,
-    real_type<T> &sumsq)
-{    
-    return lassq( x, scale, sumsq,
+template <class vector_t, class T = type_t<vector_t> >
+inline void lassq(const vector_t& x, real_type<T>& scale, real_type<T>& sumsq)
+{
+    return lassq(
+        x, scale, sumsq,
         // Lambda function that returns the absolute value using tlapack::abs :
-        []( const T& x ) { return tlapack::abs( x ); }
-    );
+        [](const T& x) { return tlapack::abs(x); });
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LASSQ_HH
+#endif  // TLAPACK_LASSQ_HH

--- a/include/tlapack/lapack/lasy2.hpp
+++ b/include/tlapack/lapack/lasy2.hpp
@@ -1,6 +1,7 @@
 /// @file lasy2.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlasy2.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlasy2.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -14,232 +15,213 @@
 #include "tlapack/base/utils.hpp"
 #include "tlapack/blas/swap.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** lasy2 solves the Sylvester matrix equation where the matrices are of order 1
+ * or 2.
+ *
+ *  lasy2 solves for the N1 by N2 matrix X, 1 <= N1,N2 <= 2, in
+ *  op(TL)*X + ISGN*X*op(TR) = SCALE*B,
+ *
+ *  where TL is N1 by N1, TR is N2 by N2, B is N1 by N2, and ISGN = 1 or
+ *  -1.  op(T) = T or T**T, where T**T denotes the transpose of T.
+ *
+ * @ingroup auxiliary
+ */
+template <typename matrix_t,
+          enable_if_t<!is_complex<type_t<matrix_t> >::value, bool> = true>
+int lasy2(Op trans_l,
+          Op trans_r,
+          int isign,
+          const matrix_t& TL,
+          const matrix_t& TR,
+          const matrix_t& B,
+          type_t<matrix_t>& scale,
+          matrix_t& X,
+          type_t<matrix_t>& xnorm)
 {
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using std::max;
 
-    /** lasy2 solves the Sylvester matrix equation where the matrices are of order 1 or 2.
-     *
-     *  lasy2 solves for the N1 by N2 matrix X, 1 <= N1,N2 <= 2, in
-     *  op(TL)*X + ISGN*X*op(TR) = SCALE*B,
-     *
-     *  where TL is N1 by N1, TR is N2 by N2, B is N1 by N2, and ISGN = 1 or
-     *  -1.  op(T) = T or T**T, where T**T denotes the transpose of T.
-     *
-     * @ingroup auxiliary
-     */
-    template <
-        typename matrix_t,
-        enable_if_t<!is_complex< type_t<matrix_t> >::value, bool> = true>
-    int lasy2(
-        Op trans_l, Op trans_r, int isign, 
-        const matrix_t &TL, const matrix_t &TR, const matrix_t &B,
-        type_t<matrix_t> &scale,
-        matrix_t &X, type_t<matrix_t> &xnorm )
-    {
-        using idx_t = size_type<matrix_t>;
-        using T = type_t<matrix_t>;
-        using std::max;
+    // Functor for creating new matrices of type matrix_t
+    Create<matrix_t> new_matrix;
 
-        // Functor for creating new matrices of type matrix_t
-        Create<matrix_t> new_matrix;
-        
-        const idx_t n1 = ncols(TL);
-        const idx_t n2 = ncols(TR);
-        const T eps = ulp<T>();
-        const T small_num = safe_min<T>() / eps;
+    const idx_t n1 = ncols(TL);
+    const idx_t n2 = ncols(TR);
+    const T eps = ulp<T>();
+    const T small_num = safe_min<T>() / eps;
 
-        const T zero(0);
-        const T one(1);
-        const T eight(8);
+    const T zero(0);
+    const T one(1);
+    const T eight(8);
 
-        tlapack_check(isign == -1 or isign == 1);
+    tlapack_check(isign == -1 or isign == 1);
 
-        // Quick return
-        if (n1 == 0 or n2 == 0)
-            return 0;
+    // Quick return
+    if (n1 == 0 or n2 == 0) return 0;
 
-        T sgn( isign );
-        int info = 0;
+    T sgn(isign);
+    int info = 0;
 
-        if (n1 == 1 and n2 == 1)
-        {
-            T tau1 = TL(0, 0) + sgn * TR(0, 0);
-            T bet = abs(tau1);
-            if (bet < small_num)
-            {
-                tau1 = small_num;
-                bet = small_num;
-                info = 1;
-            }
-            scale = one;
-            const T gam = abs(B(0, 0));
-            if (small_num * gam > bet)
-                scale = one / gam;
-            X(0, 0) = (B(0, 0) * scale) / tau1;
-            xnorm = abs(X(0, 0));
-
-            return info;
+    if (n1 == 1 and n2 == 1) {
+        T tau1 = TL(0, 0) + sgn * TR(0, 0);
+        T bet = abs(tau1);
+        if (bet < small_num) {
+            tau1 = small_num;
+            bet = small_num;
+            info = 1;
         }
-        if ( (n1 == 2 and n2 == 1) or (n1 == 1 and n2 == 2) ){
-            // TODO 
-            return -1;
+        scale = one;
+        const T gam = abs(B(0, 0));
+        if (small_num * gam > bet) scale = one / gam;
+        X(0, 0) = (B(0, 0) * scale) / tau1;
+        xnorm = abs(X(0, 0));
+
+        return info;
+    }
+    if ((n1 == 2 and n2 == 1) or (n1 == 1 and n2 == 2)) {
+        // TODO
+        return -1;
+    }
+    if (n1 == 2 and n2 == 2) {
+        // 2x2 blocks, build a 4x4 matrix
+        std::vector<T> btmp(4);
+        std::vector<T> tmp(4);
+        std::vector<T> T16_;
+        auto T16 = new_matrix(T16_, 4, 4);
+        std::vector<idx_t> jpiv(4);
+
+        T smin = max(max(abs(TR(0, 0)), abs(TR(0, 1))),
+                     max(abs(TR(1, 0)), abs(TR(1, 1))));
+        smin = max(smin, max(max(abs(TL(0, 0)), abs(TL(0, 1))),
+                             max(abs(TL(1, 0)), abs(TL(1, 1)))));
+        smin = max(eps * smin, small_num);
+
+        for (idx_t i = 0; i < 4; ++i)
+            for (idx_t j = 0; j < 4; ++j)
+                T16(i, j) = zero;
+
+        T16(0, 0) = TL(0, 0) + sgn * TR(0, 0);
+        T16(1, 1) = TL(1, 1) + sgn * TR(0, 0);
+        T16(2, 2) = TL(0, 0) + sgn * TR(1, 1);
+        T16(3, 3) = TL(1, 1) + sgn * TR(1, 1);
+
+        if (trans_l == Op::Trans) {
+            T16(0, 1) = TL(1, 0);
+            T16(1, 0) = TL(0, 1);
+            T16(2, 3) = TL(1, 0);
+            T16(3, 2) = TL(0, 1);
         }
-        if (n1 == 2 and n2 == 2)
-        {
-            // 2x2 blocks, build a 4x4 matrix
-            std::vector<T> btmp(4);
-            std::vector<T> tmp(4);
-            std::vector<T> T16_; auto T16 = new_matrix(T16_, 4, 4);
-            std::vector<idx_t> jpiv(4);
+        else {
+            T16(0, 1) = TL(0, 1);
+            T16(1, 0) = TL(1, 0);
+            T16(2, 3) = TL(0, 1);
+            T16(3, 2) = TL(1, 0);
+        }
+        if (trans_r == Op::Trans) {
+            T16(0, 2) = sgn * TR(0, 1);
+            T16(1, 3) = sgn * TR(0, 1);
+            T16(2, 0) = sgn * TR(1, 0);
+            T16(3, 1) = sgn * TR(1, 0);
+        }
+        else {
+            T16(0, 2) = sgn * TR(1, 0);
+            T16(1, 3) = sgn * TR(1, 0);
+            T16(2, 0) = sgn * TR(0, 1);
+            T16(3, 1) = sgn * TR(0, 1);
+        }
+        btmp[0] = B(0, 0);
+        btmp[1] = B(1, 0);
+        btmp[2] = B(0, 1);
+        btmp[3] = B(1, 1);
 
-            T smin = max( max(abs(TR(0, 0)), abs(TR(0, 1))), max(abs(TR(1, 0)), abs(TR(1, 1))));
-            smin = max(smin, max(max(abs(TL(0, 0)), abs(TL(0, 1))), max(abs(TL(1, 0)), abs(TL(1, 1)))));
-            smin = max(eps * smin, small_num);
-
-            for (idx_t i = 0; i < 4; ++i)
-                for (idx_t j = 0; j < 4; ++j)
-                    T16(i, j) = zero;
-
-            T16(0, 0) = TL(0, 0) + sgn * TR(0, 0);
-            T16(1, 1) = TL(1, 1) + sgn * TR(0, 0);
-            T16(2, 2) = TL(0, 0) + sgn * TR(1, 1);
-            T16(3, 3) = TL(1, 1) + sgn * TR(1, 1);
-
-            if (trans_l == Op::Trans)
-            {
-                T16(0, 1) = TL(1, 0);
-                T16(1, 0) = TL(0, 1);
-                T16(2, 3) = TL(1, 0);
-                T16(3, 2) = TL(0, 1);
-            }
-            else
-            {
-                T16(0, 1) = TL(0, 1);
-                T16(1, 0) = TL(1, 0);
-                T16(2, 3) = TL(0, 1);
-                T16(3, 2) = TL(1, 0);
-            }
-            if (trans_r == Op::Trans)
-            {
-                T16(0, 2) = sgn * TR(0, 1);
-                T16(1, 3) = sgn * TR(0, 1);
-                T16(2, 0) = sgn * TR(1, 0);
-                T16(3, 1) = sgn * TR(1, 0);
-            }
-            else
-            {
-                T16(0, 2) = sgn * TR(1, 0);
-                T16(1, 3) = sgn * TR(1, 0);
-                T16(2, 0) = sgn * TR(0, 1);
-                T16(3, 1) = sgn * TR(0, 1);
-            }
-            btmp[0] = B(0, 0);
-            btmp[1] = B(1, 0);
-            btmp[2] = B(0, 1);
-            btmp[3] = B(1, 1);
-
-            // Perform elimination with pivoting to solve 4x4 system
-            idx_t ipsv, jpsv;
-            for (idx_t i = 0; i < 3; ++i)
-            {
-                ipsv = i;
-                jpsv = i;
-                // Do pivoting to get largest pivot element
-                T xmax = zero;
-                for (idx_t ip = i; ip < 4; ++ip)
-                {
-                    for (idx_t jp = i; jp < 4; ++jp)
-                    {
-                        if (abs(T16(ip, jp)) >= xmax)
-                        {
-                            xmax = abs(T16(ip, jp));
-                            ipsv = ip;
-                            jpsv = jp;
-                        }
-                    }
-                }
-                if (ipsv != i)
-                {
-                    auto row1 = row(T16, ipsv);
-                    auto row2 = row(T16, i);
-                    tlapack::swap(row1, row2);
-                    const T temp = btmp[i];
-                    btmp[i] = btmp[ipsv];
-                    btmp[ipsv] = temp;
-                }
-                if (jpsv != i)
-                {
-                    auto col1 = col(T16, jpsv);
-                    auto col2 = col(T16, i);
-                    tlapack::swap(col1, col2);
-                }
-                jpiv[i] = jpsv;
-                if (abs(T16(i, i)) < smin)
-                {
-                    info = 1;
-                    T16(i, i) = smin;
-                }
-                for (idx_t j = i + 1; j < 4 ; ++j)
-                {
-                    T16(j, i) = T16(j, i) / T16(i, i);
-                    btmp[j] = btmp[j] - T16(j, i) * btmp[i];
-                    for (idx_t k = i + 1; k < 4; ++k)
-                    {
-                        T16(j, k) = T16(j, k) - T16(j, i) * T16(i, k);
+        // Perform elimination with pivoting to solve 4x4 system
+        idx_t ipsv, jpsv;
+        for (idx_t i = 0; i < 3; ++i) {
+            ipsv = i;
+            jpsv = i;
+            // Do pivoting to get largest pivot element
+            T xmax = zero;
+            for (idx_t ip = i; ip < 4; ++ip) {
+                for (idx_t jp = i; jp < 4; ++jp) {
+                    if (abs(T16(ip, jp)) >= xmax) {
+                        xmax = abs(T16(ip, jp));
+                        ipsv = ip;
+                        jpsv = jp;
                     }
                 }
             }
-
-            if (abs(T16(3, 3)) < smin)
-            {
+            if (ipsv != i) {
+                auto row1 = row(T16, ipsv);
+                auto row2 = row(T16, i);
+                tlapack::swap(row1, row2);
+                const T temp = btmp[i];
+                btmp[i] = btmp[ipsv];
+                btmp[ipsv] = temp;
+            }
+            if (jpsv != i) {
+                auto col1 = col(T16, jpsv);
+                auto col2 = col(T16, i);
+                tlapack::swap(col1, col2);
+            }
+            jpiv[i] = jpsv;
+            if (abs(T16(i, i)) < smin) {
                 info = 1;
-                T16(3, 3) = smin;
+                T16(i, i) = smin;
             }
-            scale = one;
-            if (
-                (eight * small_num) * abs(btmp[0]) > abs(T16(0, 0)) or
-                (eight * small_num) * abs(btmp[1]) > abs(T16(1, 1)) or
-                (eight * small_num) * abs(btmp[2]) > abs(T16(2, 2)) or
-                (eight * small_num) * abs(btmp[3]) > abs(T16(3, 3)))
-            {
-                scale = (one / eight) / max(max(abs(btmp[0]), abs(btmp[1])), max(abs(btmp[2]), abs(btmp[3])));
-                btmp[0] = btmp[0] * scale;
-                btmp[1] = btmp[1] * scale;
-                btmp[2] = btmp[2] * scale;
-                btmp[3] = btmp[3] * scale;
-            }
-            for (idx_t i = 0; i < 4; ++i)
-            {
-                idx_t k = 3 - i;
-                T temp = one / T16(k, k);
-                tmp[k] = btmp[k] * temp;
-                for (idx_t j = k + 1; j < 4; ++j)
-                {
-                    tmp[k] = tmp[k] - (temp * T16(k, j)) * tmp[j];
+            for (idx_t j = i + 1; j < 4; ++j) {
+                T16(j, i) = T16(j, i) / T16(i, i);
+                btmp[j] = btmp[j] - T16(j, i) * btmp[i];
+                for (idx_t k = i + 1; k < 4; ++k) {
+                    T16(j, k) = T16(j, k) - T16(j, i) * T16(i, k);
                 }
             }
-            for (idx_t i = 0; i < 3; ++i)
-            {
-                if (jpiv[2 - i] != 2 - i)
-                {
-                    const T temp = tmp[2 - i];
-                    tmp[2 - i] = tmp[jpiv[2 - i]];
-                    tmp[jpiv[2 - i]] = temp;
-                }
-            }
-            X(0, 0) = tmp[0];
-            X(1, 0) = tmp[1];
-            X(0, 1) = tmp[2];
-            X(1, 1) = tmp[3];
-            xnorm = max(abs(tmp[0]) + abs(tmp[2]), abs(tmp[1]) + abs(tmp[3]));
-
-
-            return info;
         }
 
-        return 0;
+        if (abs(T16(3, 3)) < smin) {
+            info = 1;
+            T16(3, 3) = smin;
+        }
+        scale = one;
+        if ((eight * small_num) * abs(btmp[0]) > abs(T16(0, 0)) or
+            (eight * small_num) * abs(btmp[1]) > abs(T16(1, 1)) or
+            (eight * small_num) * abs(btmp[2]) > abs(T16(2, 2)) or
+            (eight * small_num) * abs(btmp[3]) > abs(T16(3, 3))) {
+            scale = (one / eight) / max(max(abs(btmp[0]), abs(btmp[1])),
+                                        max(abs(btmp[2]), abs(btmp[3])));
+            btmp[0] = btmp[0] * scale;
+            btmp[1] = btmp[1] * scale;
+            btmp[2] = btmp[2] * scale;
+            btmp[3] = btmp[3] * scale;
+        }
+        for (idx_t i = 0; i < 4; ++i) {
+            idx_t k = 3 - i;
+            T temp = one / T16(k, k);
+            tmp[k] = btmp[k] * temp;
+            for (idx_t j = k + 1; j < 4; ++j) {
+                tmp[k] = tmp[k] - (temp * T16(k, j)) * tmp[j];
+            }
+        }
+        for (idx_t i = 0; i < 3; ++i) {
+            if (jpiv[2 - i] != 2 - i) {
+                const T temp = tmp[2 - i];
+                tmp[2 - i] = tmp[jpiv[2 - i]];
+                tmp[jpiv[2 - i]] = temp;
+            }
+        }
+        X(0, 0) = tmp[0];
+        X(1, 0) = tmp[1];
+        X(0, 1) = tmp[2];
+        X(1, 1) = tmp[3];
+        xnorm = max(abs(tmp[0]) + abs(tmp[2]), abs(tmp[1]) + abs(tmp[3]));
+
+        return info;
     }
 
-} // lapack
+    return 0;
+}
 
-#endif // TLAPACK_LASY2_HH
+}  // namespace tlapack
+
+#endif  // TLAPACK_LASY2_HH

--- a/include/tlapack/lapack/lauum_recursive.hpp
+++ b/include/tlapack/lapack/lauum_recursive.hpp
@@ -11,101 +11,92 @@
 #include "tlapack/base/utils.hpp"
 #include "tlapack/blas/trmm.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** LAUUM is a specific type of inplace HERK. Given `C` a triangular
+ * matrix (lower or upper), LAUUM computes the Hermitian matrix
+ * `upper times lower`.
+ *
+ * If `C` is lower triangular, then LAUUM computes `C^H * C`. If `C`
+ * is upper triangular in input, then LAUUM computes `C*C^H`. The output
+ * (symmetric) matrix is stored in place of the input triangular matrix.
+ *
+ * This is the recursive variant.
+ *
+ * @param[in] uplo
+ *      - Uplo::Upper: Upper triangle of `C` is referenced; the strictly lower
+ *      triangular part of `C` is not referenced.
+ *      - Uplo::Lower: Lower triangle of `C` is referenced; the strictly upper
+ *      triangular part of `C` is not referenced.
+ *
+ * @param[in,out] C n-by-n (upper of lower) (triangular or symmetric) matrix.
+ *      On entry, the (upper of lower) part of the n-by-n triangular matrix.
+ *      On exit, the (upper of lower) part of the n-by-n symmetric matrix `C^H *
+ * C` or `C * C^H`.
+ *
+ * @return = 0: successful exit
+ *
+ * @todo: implement nx to bail out of recursion before 1-by-1 case
+ *
+ */
+template <typename matrix_t>
+int lauum_recursive(const Uplo& uplo, matrix_t& C)
+
 {
+    tlapack_check(nrows(C) == ncols(C));
 
-    /** LAUUM is a specific type of inplace HERK. Given `C` a triangular 
-     * matrix (lower or upper), LAUUM computes the Hermitian matrix 
-     * `upper times lower`. 
-     * 
-     * If `C` is lower triangular, then LAUUM computes `C^H * C`. If `C` 
-     * is upper triangular in input, then LAUUM computes `C*C^H`. The output 
-     * (symmetric) matrix is stored in place of the input triangular matrix.
-     * 
-     * This is the recursive variant.
-     *
-     * @param[in] uplo
-     *      - Uplo::Upper: Upper triangle of `C` is referenced; the strictly lower
-     *      triangular part of `C` is not referenced.
-     *      - Uplo::Lower: Lower triangle of `C` is referenced; the strictly upper
-     *      triangular part of `C` is not referenced.
-     *
-     * @param[in,out] C n-by-n (upper of lower) (triangular or symmetric) matrix.
-     *      On entry, the (upper of lower) part of the n-by-n triangular matrix.
-     *      On exit, the (upper of lower) part of the n-by-n symmetric matrix `C^H * C` or `C * C^H`.
-     * 
-     * @return = 0: successful exit
-     *
-     * @todo: implement nx to bail out of recursion before 1-by-1 case
-     *
-     */
-    template <typename matrix_t>
-    int lauum_recursive(const Uplo &uplo, matrix_t &C)
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    using range = std::pair<idx_t, idx_t>;
+    using real_t = real_type<T>;
 
-    {
-        tlapack_check(nrows(C) == ncols(C));
+    const idx_t n = nrows(C);
 
-        using T = type_t<matrix_t>;
-        using idx_t = size_type<matrix_t>;
-        using range = std::pair<idx_t, idx_t>;
-        using real_t = real_type<T>;
+    // check arguments
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(nrows(C) != ncols(C));
 
-        const idx_t n = nrows(C);
+    // Quick return
+    if (n <= 0) return 0;
 
-        // check arguments
-        tlapack_check_false(uplo != Uplo::Lower &&
-                                uplo != Uplo::Upper );
-        tlapack_check_false(nrows(C) != ncols(C) );
+    idx_t n0 = n / 2;
 
-        // Quick return
-        if (n <= 0)
-            return 0;
+    // 1-by-1 case for recursion
+    if (n == 1) {
+        real_t rC00 = real(C(0, 0));
+        real_t iC00 = imag(C(0, 0));
+        C(0, 0) = rC00 * rC00 + iC00 * iC00;
+    }
+    else {
+        if (uplo == Uplo::Lower) {
+            // Upper computes U * U_hermitian
+            auto C00 = slice(C, range(0, n0), range(0, n0));
+            auto C10 = slice(C, range(n0, n), range(0, n0));
+            auto C11 = slice(C, range(n0, n), range(n0, n));
 
-        idx_t n0 = n / 2;
-
-        // 1-by-1 case for recursion
-        if (n == 1)
-        {
-
-            real_t rC00 = real(C(0, 0));
-            real_t iC00 = imag(C(0, 0));
-            C(0, 0) = rC00*rC00 + iC00*iC00;
-
+            lauum_recursive(uplo, C00);
+            herk(Uplo::Lower, Op::ConjTrans, real_t(1), C10, real_t(1), C00);
+            trmm(Side::Left, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1), C11,
+                 C10);
+            lauum_recursive(uplo, C11);
         }
-        else
-        {
-            if (uplo == Uplo::Lower)
-            {
-                // Upper computes U * U_hermitian
-                auto C00 = slice(C, range(0, n0), range(0, n0));
-                auto C10 = slice(C, range(n0, n), range(0, n0));
-                auto C11 = slice(C, range(n0, n), range(n0, n));
+        else {
+            // Lower computes  L_hermitian * L
+            auto C00 = slice(C, range(0, n0), range(0, n0));
+            auto C01 = slice(C, range(0, n0), range(n0, n));
+            auto C11 = slice(C, range(n0, n), range(n0, n));
 
-                lauum_recursive(uplo, C00);
-                herk(Uplo::Lower, Op::ConjTrans, real_t(1), C10, real_t(1), C00);
-                trmm(Side::Left, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1), C11, C10);
-                lauum_recursive(uplo, C11);
-
-            }
-            else
-            {
-                // Lower computes  L_hermitian * L
-                auto C00 = slice(C, range(0, n0), range(0, n0));
-                auto C01 = slice(C, range(0, n0), range(n0, n));
-                auto C11 = slice(C, range(n0, n), range(n0, n));
-
-                lauum_recursive(uplo, C00);
-                herk(Uplo::Upper, Op::NoTrans, real_t(1), C01, real_t(1), C00);
-                trmm(Side::Right, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1), C11, C01);
-                lauum_recursive(Uplo::Upper, C11);
-
-            }
+            lauum_recursive(uplo, C00);
+            herk(Uplo::Upper, Op::NoTrans, real_t(1), C01, real_t(1), C00);
+            trmm(Side::Right, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1),
+                 C11, C01);
+            lauum_recursive(Uplo::Upper, C11);
         }
-
-        return 0;
-
     }
 
-} // namespace tlapack
+    return 0;
+}
 
-#endif // TLAPACK_LAUUM_RECURSIVETLAPACK_
+}  // namespace tlapack
+
+#endif  // TLAPACK_LAUUM_RECURSIVETLAPACK_

--- a/include/tlapack/lapack/lu_mult.hpp
+++ b/include/tlapack/lapack/lu_mult.hpp
@@ -16,8 +16,7 @@
 namespace tlapack {
 
 template <typename idx_t>
-struct lu_mult_opts_t
-{
+struct lu_mult_opts_t {
     // Optimization parameter. Matrices smaller than nx will not
     // be multiplied using recursion. Must be at least 1.
     idx_t nx = 1;
@@ -25,25 +24,24 @@ struct lu_mult_opts_t
 
 /**
  *
- * @brief in-place multiplication of lower triangular matrix L and upper triangular matrix U.
- *      this is the recursive variant
- * 
+ * @brief in-place multiplication of lower triangular matrix L and upper
+ * triangular matrix U. this is the recursive variant
+ *
  * @param[in,out] A n-by-n matrix
- *      On entry, the strictly lower triangular entries of A contain the matrix L.
- *      L is assumed to have unit diagonal.  
- *      The upper triangular entires of A contain the matrix U. 
- *      On exit, A contains the product L*U. 
+ *      On entry, the strictly lower triangular entries of A contain the matrix
+ * L. L is assumed to have unit diagonal. The upper triangular entires of A
+ * contain the matrix U. On exit, A contains the product L*U.
  *
  * @param[in] opts Options.
  *      - @c opts.work is used if whenever it has sufficient size.
  *        The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup auxiliary
  */
 template <class matrix_t>
-void lu_mult(matrix_t &A, const lu_mult_opts_t<size_type<matrix_t>> &opts = {})
+void lu_mult(matrix_t& A, const lu_mult_opts_t<size_type<matrix_t>>& opts = {})
 {
-    using idx_t = size_type< matrix_t >;
+    using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
     using range = std::pair<idx_t, idx_t>;
     using real_t = real_type<T>;
@@ -54,20 +52,15 @@ void lu_mult(matrix_t &A, const lu_mult_opts_t<size_type<matrix_t>> &opts = {})
     tlapack_check(opts.nx >= 1);
 
     // quick return
-    if (n == 0)
-        return;
+    if (n == 0) return;
 
-    if (n <= opts.nx)
-    { // Matrix is small, use for loops instead of recursion
-        for (idx_t i2 = n; i2 > 0; --i2)
-        {
+    if (n <= opts.nx) {  // Matrix is small, use for loops instead of recursion
+        for (idx_t i2 = n; i2 > 0; --i2) {
             idx_t i = i2 - 1;
-            for (idx_t j2 = n; j2 > 0; --j2)
-            {
+            for (idx_t j2 = n; j2 > 0; --j2) {
                 idx_t j = j2 - 1;
-                T sum( 0 );
-                for (idx_t k = 0; k <= min(i, j); ++k)
-                {
+                T sum(0);
+                for (idx_t k = 0; k <= min(i, j); ++k) {
                     if (i == k)
                         sum += A(k, j);
                     else
@@ -86,10 +79,10 @@ void lu_mult(matrix_t &A, const lu_mult_opts_t<size_type<matrix_t>> &opts = {})
         A = [ A00 A01 ]
             [ A10 A11 ]
         and, hereafter,
-            L00 is the strict lower triangular part of A00, with unitary main diagonal.
-            L11 is the strict lower triangular part of A11, with unitary main diagonal.
-            U00 is the upper triangular part of A00.
-            U11 is the upper triangular part of A11.
+            L00 is the strict lower triangular part of A00, with unitary main
+       diagonal. L11 is the strict lower triangular part of A11, with unitary
+       main diagonal. U00 is the upper triangular part of A00. U11 is the upper
+       triangular part of A11.
     */
     auto A00 = slice(A, range(0, n0), range(0, n0));
     auto A01 = slice(A, range(0, n0), range(n0, n));
@@ -102,12 +95,11 @@ void lu_mult(matrix_t &A, const lu_mult_opts_t<size_type<matrix_t>> &opts = {})
     gemm(Op::NoTrans, Op::NoTrans, T(1), A10, A01, T(1), A11);
 
     // A01 = L00*A01
-    trmm(Side::Left, Uplo::Lower, Op::NoTrans,
-                  Diag::Unit, real_t(1), A00, A01);
+    trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, real_t(1), A00, A01);
 
     // A10 = A10*U00
-    trmm(Side::Right, Uplo::Upper, Op::NoTrans,
-                  Diag::NonUnit, real_t(1), A00, A10);
+    trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, real_t(1), A00,
+         A10);
 
     // A00 = L00*U00
     lu_mult(A00, opts);
@@ -115,6 +107,6 @@ void lu_mult(matrix_t &A, const lu_mult_opts_t<size_type<matrix_t>> &opts = {})
     return;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LU_MULT_HH
+#endif  // TLAPACK_LU_MULT_HH

--- a/include/tlapack/lapack/move_bulge.hpp
+++ b/include/tlapack/lapack/move_bulge.hpp
@@ -11,96 +11,98 @@
 #define TLAPACK_MOVE_BULGE_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/lahqr_shiftcolumn.hpp"
+#include "tlapack/lapack/larfg.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** Given a 4-by-3 matrix H and small order reflector v,
+ *  move_bulge applies the delayed right update to the last
+ *  row and calculates a new reflector to move the bulge
+ *  down. If the bulge collapses, an attempt is made to
+ *  reintroduce it using shifts s1 and s2.
+ *
+ * @param[in] H 4x3 matrix.
+ * @param[out] v vector of size 3
+ *      On entry, the delayed reflector to apply
+ *      The first element of the reflector is assumed to be one, and v[0]
+ * instead stores tau. On exit, the reflector that moves the bulge down one
+ * position
+ * @param[in] s1 complex valued shift
+ * @param[in] s2 complex valued shift
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t, class vector_t>
+void move_bulge(matrix_t& H,
+                vector_t& v,
+                complex_type<type_t<matrix_t>> s1,
+                complex_type<type_t<matrix_t>> s2)
 {
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
 
-    /** Given a 4-by-3 matrix H and small order reflector v,
-     *  move_bulge applies the delayed right update to the last
-     *  row and calculates a new reflector to move the bulge
-     *  down. If the bulge collapses, an attempt is made to
-     *  reintroduce it using shifts s1 and s2.
-     *
-     * @param[in] H 4x3 matrix.
-     * @param[out] v vector of size 3
-     *      On entry, the delayed reflector to apply
-     *      The first element of the reflector is assumed to be one, and v[0] instead stores tau.
-     *      On exit, the reflector that moves the bulge down one position
-     * @param[in] s1 complex valued shift
-     * @param[in] s2 complex valued shift
-     *
-     * @ingroup auxiliary
-     */
-    template < class matrix_t, class vector_t >
-    void move_bulge(matrix_t &H, vector_t &v, complex_type<type_t<matrix_t>> s1, complex_type<type_t<matrix_t>> s2)
-    {
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
+    const real_t zero(0);
+    const real_t eps = ulp<real_t>();
 
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
-        const real_t zero(0);
-        const real_t eps = ulp<real_t>();
+    Create<vector_t> new_vector;
 
-        Create<vector_t> new_vector;
+    // Perform delayed update of row below the bulge
+    // Assumes the first two elements of the row are zero
+    scalar_type<type_t<vector_t>, T> refsum = v[0] * v[2] * H(3, 2);
+    H(3, 0) = -refsum;
+    H(3, 1) = -refsum * conj(v[1]);
+    H(3, 2) = H(3, 2) - refsum * conj(v[2]);
 
-        // Perform delayed update of row below the bulge
-        // Assumes the first two elements of the row are zero
-        scalar_type< type_t<vector_t>, T > refsum = v[0] * v[2] * H(3, 2);
-        H(3, 0) = -refsum;
-        H(3, 1) = -refsum * conj(v[1]);
-        H(3, 2) = H(3, 2) - refsum * conj(v[2]);
+    // Generate reflector to move bulge down
+    T tau, beta;
+    v[0] = H(1, 0);
+    v[1] = H(2, 0);
+    v[2] = H(3, 0);
+    larfg(v, tau);
+    beta = v[0];
+    v[0] = tau;
 
-        // Generate reflector to move bulge down
-        T tau, beta;
-        v[0] = H(1, 0);
-        v[1] = H(2, 0);
-        v[2] = H(3, 0);
-        larfg(v, tau);
-        beta = v[0];
-        v[0] = tau;
+    // Check for bulge collapse
+    if (H(3, 0) != zero or H(3, 1) != zero or H(3, 2) != zero) {
+        // The bulge hasn't collapsed, typical case
+        H(1, 0) = beta;
+        H(2, 0) = zero;
+        H(3, 0) = zero;
+    }
+    else {
+        // The bulge has collapsed, attempt to reintroduce using
+        // 2-small-subdiagonals trick
+        std::vector<T> vt_;
+        auto vt = new_vector(vt_, 3);
+        auto H2 = slice(H, pair{1, 4}, pair{1, 4});
+        lahqr_shiftcolumn(H2, vt, s1, s2);
+        larfg(vt, tau);
+        vt[0] = tau;
 
-        // Check for bulge collapse
-        if (H(3, 0) != zero or H(3, 1) != zero or H(3, 2) != zero)
-        {
-            // The bulge hasn't collapsed, typical case
+        refsum = conj(vt[0]) * H(1, 0) + conj(vt[1]) * H(2, 0);
+        if (abs1(H(2, 0) - refsum * vt[1]) + abs1(refsum * vt[2]) >
+            eps * (abs1(H(0, 0)) + abs1(H(1, 1)) + abs1(H(2, 2)))) {
+            // Starting a new bulge here would create non-negligible fill. Use
+            // the old one.
             H(1, 0) = beta;
             H(2, 0) = zero;
             H(3, 0) = zero;
         }
-        else
-        {
-            // The bulge has collapsed, attempt to reintroduce using
-            // 2-small-subdiagonals trick
-            std::vector<T> vt_; auto vt = new_vector(vt_, 3);
-            auto H2 = slice(H, pair{1, 4}, pair{1, 4});
-            lahqr_shiftcolumn(H2, vt, s1, s2);
-            larfg(vt, tau);
-            vt[0] = tau;
-
-            refsum = conj(vt[0]) * H(1, 0) + conj(vt[1]) * H(2, 0);
-            if (abs1(H(2, 0) - refsum * vt[1]) + abs1(refsum * vt[2]) > eps * (abs1(H(0, 0)) + abs1(H(1, 1)) + abs1(H(2, 2))))
-            {
-                // Starting a new bulge here would create non-negligible fill. Use the old one.
-                H(1, 0) = beta;
-                H(2, 0) = zero;
-                H(3, 0) = zero;
-            }
-            else
-            {
-                // Fill-in is negligible, use the new reflector.
-                H(1, 0) = H(1, 0) - refsum;
-                H(2, 0) = zero;
-                H(3, 0) = zero;
-                v[0] = vt[0];
-                v[1] = vt[1];
-                v[2] = vt[2];
-            }
+        else {
+            // Fill-in is negligible, use the new reflector.
+            H(1, 0) = H(1, 0) - refsum;
+            H(2, 0) = zero;
+            H(3, 0) = zero;
+            v[0] = vt[0];
+            v[1] = vt[1];
+            v[2] = vt[2];
         }
     }
+}
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_MOVE_BULGE_HH
+#endif  // TLAPACK_MOVE_BULGE_HH

--- a/include/tlapack/lapack/multishift_qr.hpp
+++ b/include/tlapack/lapack/multishift_qr.hpp
@@ -1,6 +1,7 @@
 /// @file multishift_qr.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlaqr0.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlaqr0.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -14,507 +15,455 @@
 #include <functional>
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/multishift_qr_sweep.hpp"
 #include "tlapack/lapack/agressive_early_deflation.hpp"
+#include "tlapack/lapack/multishift_qr_sweep.hpp"
 
-namespace tlapack
-{
+namespace tlapack {
 
-    /**
-     * Options struct for multishift_qr
-     */
-    template < class idx_t = size_t >
-    struct francis_opts_t : public workspace_opts_t<>
-    {
-        inline constexpr francis_opts_t( const workspace_opts_t<>& opts = {} )
-        : workspace_opts_t<>( opts ) {};
+/**
+ * Options struct for multishift_qr
+ */
+template <class idx_t = size_t>
+struct francis_opts_t : public workspace_opts_t<> {
+    inline constexpr francis_opts_t(const workspace_opts_t<>& opts = {})
+        : workspace_opts_t<>(opts){};
 
-        // Function that returns the number of shifts to use
-        // for a given matrix size
-        std::function<idx_t(idx_t, idx_t)> nshift_recommender = [](idx_t n, idx_t nh) -> idx_t
-        {
-            if (n < 30)
-                return 2;
-            if (n < 60)
-                return 4;
-            if (n < 150)
-                return 10;
-            if (n < 590)
-                return idx_t(n / log2(n));
-            if (n < 3000)
-                return 64;
-            if (n < 6000)
-                return 128;
-            return 256;
-        };
-
-        // Function that returns the number of shifts to use
-        // for a given matrix size
-        std::function<idx_t(idx_t, idx_t)> deflation_window_recommender = [](idx_t n, idx_t nh) -> idx_t
-        {
-            if (n < 30)
-                return 2;
-            if (n < 60)
-                return 4;
-            if (n < 150)
-                return 10;
-            if (n < 590)
-                return idx_t(n / log2(n));
-            if (n < 3000)
-                return 96;
-            if (n < 6000)
-                return 192;
-            return 384;
-        };
-
-        // On exit of the routine. Stores the number of times AED and sweep were called
-        // And the total number of shifts used.
-        int n_aed = 0;
-        int n_sweep = 0;
-        int n_shifts_total = 0;
-        // Threshold to switch between blocked and unblocked code
-        idx_t nmin = 75;
-        // Threshold of percent of AED window that must converge to skip a sweep
-        idx_t nibble = 14;
+    // Function that returns the number of shifts to use
+    // for a given matrix size
+    std::function<idx_t(idx_t, idx_t)> nshift_recommender =
+        [](idx_t n, idx_t nh) -> idx_t {
+        if (n < 30) return 2;
+        if (n < 60) return 4;
+        if (n < 150) return 10;
+        if (n < 590) return idx_t(n / log2(n));
+        if (n < 3000) return 64;
+        if (n < 6000) return 128;
+        return 256;
     };
 
-    /** Worspace query of multishift_qr()
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     * @param[in] ihi    integer.
-     *      The matrix A is assumed to be already quasi-triangular in rows and
-     *      columns ihi:n.
-     * @param[in] A  n by n matrix.
-     * @param w Not referenced.
-     * @param[in] Z  n by n matrix.
-     *
-     * @param[in,out] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<
-            is_complex< type_t<vector_t> >::value
-        , int > = 0
-    >
-    void multishift_qr_worksize(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        const matrix_t &A,
-        const vector_t &w,
-        const matrix_t &Z,
-        workinfo_t& workinfo,
-        const francis_opts_t< size_type<matrix_t> > &opts = {} )
+    // Function that returns the number of shifts to use
+    // for a given matrix size
+    std::function<idx_t(idx_t, idx_t)> deflation_window_recommender =
+        [](idx_t n, idx_t nh) -> idx_t {
+        if (n < 30) return 2;
+        if (n < 60) return 4;
+        if (n < 150) return 10;
+        if (n < 590) return idx_t(n / log2(n));
+        if (n < 3000) return 96;
+        if (n < 6000) return 192;
+        return 384;
+    };
+
+    // On exit of the routine. Stores the number of times AED and sweep were
+    // called And the total number of shifts used.
+    int n_aed = 0;
+    int n_sweep = 0;
+    int n_shifts_total = 0;
+    // Threshold to switch between blocked and unblocked code
+    idx_t nmin = 75;
+    // Threshold of percent of AED window that must converge to skip a sweep
+    idx_t nibble = 14;
+};
+
+/** Worspace query of multishift_qr()
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ * @param[in] ihi    integer.
+ *      The matrix A is assumed to be already quasi-triangular in rows and
+ *      columns ihi:n.
+ * @param[in] A  n by n matrix.
+ * @param w Not referenced.
+ * @param[in] Z  n by n matrix.
+ *
+ * @param[in,out] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t> >::value, int> = 0>
+void multishift_qr_worksize(
+    bool want_t,
+    bool want_z,
+    size_type<matrix_t> ilo,
+    size_type<matrix_t> ihi,
+    const matrix_t& A,
+    const vector_t& w,
+    const matrix_t& Z,
+    workinfo_t& workinfo,
+    const francis_opts_t<size_type<matrix_t> >& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
+
+    const idx_t n = ncols(A);
+    const idx_t nh = ihi - ilo;
+
+    // quick return
+    if (ilo + 1 >= ihi || n < opts.nmin || nh <= 0) return;
+
     {
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
-
-        const idx_t n = ncols(A);
-        const idx_t nh = ihi-ilo;
-
-        // quick return
-        if ( ilo + 1 >= ihi || n < opts.nmin || nh <= 0 )
-            return;
-
-        {
-            const idx_t nw_max = (n - 3) / 3;
-
-            idx_t ls, ld;
-            agressive_early_deflation_worksize(want_t, want_z, ilo, ihi, nw_max, A, w, Z, ls, ld, workinfo, opts);
-        }
-
-        {
-            const idx_t nsr = opts.nshift_recommender(n, nh);
-            const auto shifts = slice(w, pair{0,nsr});
-
-            multishift_QR_sweep_worksize(want_t, want_z, ilo, ihi, A, shifts, Z, workinfo, opts);
-        }
-    }
-
-    /** multishift_qr computes the eigenvalues and optionally the Schur
-     *  factorization of an upper Hessenberg matrix, using the multishift
-     *  implicit QR algorithm with AED.
-     *
-     *  The Schur factorization is returned in standard form. For complex matrices
-     *  this means that the matrix T is upper-triangular. The diagonal entries
-     *  of T are also its eigenvalues. For real matrices, this means that the
-     *  matrix T is block-triangular, with real eigenvalues appearing as 1x1 blocks
-     *  on the diagonal and imaginary eigenvalues appearing as 2x2 blocks on the diagonal.
-     *  All 2x2 blocks are normalized so that the diagonal entries are equal to the real part
-     *  of the eigenvalue.
-     *
-     *
-     * @return  0 if success
-     * @return -i if the ith argument is invalid
-     * @return  i if the QR algorithm failed to compute all the eigenvalues
-     *            elements i:ihi of w contain those eigenvalues which have been
-     *            successfully computed.
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     * @param[in] ihi    integer.
-     *      The matrix A is assumed to be already quasi-triangular in rows and
-     *      columns ihi:n.
-     * @param[in,out] A  n by n matrix.
-     *      On entry, the matrix A.
-     *      On exit, if info=0 and want_t=true, the Schur factor T.
-     *      T is quasi-triangular in rows and columns ilo:ihi, with
-     *      the diagonal (block) entries in standard form (see above).
-     * @param[out] w  size n vector.
-     *      On exit, if info=0, w(ilo:ihi) contains the eigenvalues
-     *      of A(ilo:ihi,ilo:ihi). The eigenvalues appear in the same
-     *      order as the diagonal (block) entries of T.
-     * @param[in,out] Z  n by n matrix.
-     *      On entry, the previously calculated Schur factors
-     *      On exit, the orthogonal updates applied to A are accumulated
-     *      into Z.
-     *
-     * @param[in,out] opts Options.
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        The sufficient size can be obtained through a workspace query.
-     *      - Output parameters
-     *          @c opts.n_aed,
-     *          @c opts.n_sweep and
-     *          @c opts.n_shifts_total
-     *      are updated inside the routine.
-     *
-     * @ingroup computational
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<
-            is_complex< type_t<vector_t> >::value
-        , int > = 0
-    >
-    int multishift_qr(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        matrix_t &A,
-        vector_t &w,
-        matrix_t &Z,
-        francis_opts_t< size_type<matrix_t> > &opts )
-    {
-        using TA = type_t<matrix_t>;
-        using real_t = real_type<TA>;
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
-
-        // constants
-        const real_t zero(0);
-        const idx_t non_convergence_limit_window = 5;
-        const idx_t non_convergence_limit_shift = 6;
-        const real_t dat1( 0.75 );
-        const real_t dat2( -0.4375 );
-
-        const idx_t n = ncols(A);
-        const idx_t nh = ihi - ilo;
-
-        // This routine uses the space below the subdiagonal as workspace
-        // For small matrices, this is not enough
-        // if n < nmin, the matrix will be passed to lahqr
-        const idx_t nmin = opts.nmin;
-
-        // Recommended number of shifts
-        const idx_t nsr = opts.nshift_recommender(n, nh);
-
-        // Recommended deflation window size
-        const idx_t nwr = opts.deflation_window_recommender(n, nh);
         const idx_t nw_max = (n - 3) / 3;
 
-        const idx_t nibble = opts.nibble;
+        idx_t ls, ld;
+        agressive_early_deflation_worksize(want_t, want_z, ilo, ihi, nw_max, A,
+                                           w, Z, ls, ld, workinfo, opts);
+    }
 
-        int n_aed = 0;
-        int n_sweep = 0;
-        int n_shifts_total = 0;
+    {
+        const idx_t nsr = opts.nshift_recommender(n, nh);
+        const auto shifts = slice(w, pair{0, nsr});
 
-        // check arguments
-        tlapack_check_false(n != nrows(A) );
-        tlapack_check_false((idx_t)size(w) != n );
-        if (want_z)
-        {
-            tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)) );
+        multishift_QR_sweep_worksize(want_t, want_z, ilo, ihi, A, shifts, Z,
+                                     workinfo, opts);
+    }
+}
+
+/** multishift_qr computes the eigenvalues and optionally the Schur
+ *  factorization of an upper Hessenberg matrix, using the multishift
+ *  implicit QR algorithm with AED.
+ *
+ *  The Schur factorization is returned in standard form. For complex matrices
+ *  this means that the matrix T is upper-triangular. The diagonal entries
+ *  of T are also its eigenvalues. For real matrices, this means that the
+ *  matrix T is block-triangular, with real eigenvalues appearing as 1x1 blocks
+ *  on the diagonal and imaginary eigenvalues appearing as 2x2 blocks on the
+ * diagonal. All 2x2 blocks are normalized so that the diagonal entries are
+ * equal to the real part of the eigenvalue.
+ *
+ *
+ * @return  0 if success
+ * @return -i if the ith argument is invalid
+ * @return  i if the QR algorithm failed to compute all the eigenvalues
+ *            elements i:ihi of w contain those eigenvalues which have been
+ *            successfully computed.
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ * @param[in] ihi    integer.
+ *      The matrix A is assumed to be already quasi-triangular in rows and
+ *      columns ihi:n.
+ * @param[in,out] A  n by n matrix.
+ *      On entry, the matrix A.
+ *      On exit, if info=0 and want_t=true, the Schur factor T.
+ *      T is quasi-triangular in rows and columns ilo:ihi, with
+ *      the diagonal (block) entries in standard form (see above).
+ * @param[out] w  size n vector.
+ *      On exit, if info=0, w(ilo:ihi) contains the eigenvalues
+ *      of A(ilo:ihi,ilo:ihi). The eigenvalues appear in the same
+ *      order as the diagonal (block) entries of T.
+ * @param[in,out] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors
+ *      On exit, the orthogonal updates applied to A are accumulated
+ *      into Z.
+ *
+ * @param[in,out] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *      - Output parameters
+ *          @c opts.n_aed,
+ *          @c opts.n_sweep and
+ *          @c opts.n_shifts_total
+ *      are updated inside the routine.
+ *
+ * @ingroup computational
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t> >::value, int> = 0>
+int multishift_qr(bool want_t,
+                  bool want_z,
+                  size_type<matrix_t> ilo,
+                  size_type<matrix_t> ihi,
+                  matrix_t& A,
+                  vector_t& w,
+                  matrix_t& Z,
+                  francis_opts_t<size_type<matrix_t> >& opts)
+{
+    using TA = type_t<matrix_t>;
+    using real_t = real_type<TA>;
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
+
+    // constants
+    const real_t zero(0);
+    const idx_t non_convergence_limit_window = 5;
+    const idx_t non_convergence_limit_shift = 6;
+    const real_t dat1(0.75);
+    const real_t dat2(-0.4375);
+
+    const idx_t n = ncols(A);
+    const idx_t nh = ihi - ilo;
+
+    // This routine uses the space below the subdiagonal as workspace
+    // For small matrices, this is not enough
+    // if n < nmin, the matrix will be passed to lahqr
+    const idx_t nmin = opts.nmin;
+
+    // Recommended number of shifts
+    const idx_t nsr = opts.nshift_recommender(n, nh);
+
+    // Recommended deflation window size
+    const idx_t nwr = opts.deflation_window_recommender(n, nh);
+    const idx_t nw_max = (n - 3) / 3;
+
+    const idx_t nibble = opts.nibble;
+
+    int n_aed = 0;
+    int n_sweep = 0;
+    int n_shifts_total = 0;
+
+    // check arguments
+    tlapack_check_false(n != nrows(A));
+    tlapack_check_false((idx_t)size(w) != n);
+    if (want_z) {
+        tlapack_check_false((n != ncols(Z)) or (n != nrows(Z)));
+    }
+
+    // quick return
+    if (nh <= 0) return 0;
+    if (nh == 1) w[ilo] = A(ilo, ilo);
+
+    // Tiny matrices must use lahqr
+    if (n < nmin) {
+        return lahqr(want_t, want_z, ilo, ihi, A, w, Z);
+    }
+
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    Workspace work = [&]() {
+        workinfo_t workinfo;
+        multishift_qr_worksize(want_t, want_z, ilo, ihi, A, w, Z, workinfo,
+                               opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+
+    // Options to forward
+    opts.work = work;
+    auto&& mQRsweepOpts = workspace_opts_t<>{work};
+
+    // itmax is the total number of QR iterations allowed.
+    // For most matrices, 3 shifts per eigenvalue is enough, so
+    // we set itmax to 30 times nh as a safe limit.
+    const idx_t itmax = 30 * std::max<idx_t>(10, nh);
+
+    // k_defl counts the number of iterations since a deflation
+    idx_t k_defl = 0;
+
+    // istop is the end of the active subblock.
+    // As more and more eigenvalues converge, it eventually
+    // becomes ilo+1 and the loop ends.
+    idx_t istop = ihi;
+
+    int info = 0;
+
+    // nw is the deflation window size
+    idx_t nw;
+
+    for (idx_t iter = 0; iter <= itmax; ++iter) {
+        if (iter == itmax) {
+            // The QR algorithm failed to converge, return with error.
+            info = istop;
+            break;
         }
 
-        // quick return
-        if (nh <= 0)
-            return 0;
-        if (nh == 1)
-            w[ilo] = A(ilo, ilo);
-
-        // Tiny matrices must use lahqr
-        if (n < nmin)
-        {
-            return lahqr(want_t, want_z, ilo, ihi, A, w, Z);
+        if (ilo + 1 >= istop) {
+            if (ilo + 1 == istop) w[ilo] = A(ilo, ilo);
+            // All eigenvalues have been found, exit and return 0.
+            break;
         }
 
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            multishift_qr_worksize( want_t, want_z, ilo, ihi, A, w, Z, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-        
-        // Options to forward
-        opts.work = work;
-        auto&& mQRsweepOpts = workspace_opts_t<>{ work };
+        // istart is the start of the active subblock. Either
+        // istart = ilo, or H(istart, istart-1) = 0. This means
+        // that we can treat this subblock separately.
+        idx_t istart = ilo;
 
-        // itmax is the total number of QR iterations allowed.
-        // For most matrices, 3 shifts per eigenvalue is enough, so
-        // we set itmax to 30 times nh as a safe limit.
-        const idx_t itmax = 30 * std::max<idx_t>(10, nh);
-
-        // k_defl counts the number of iterations since a deflation
-        idx_t k_defl = 0;
-
-        // istop is the end of the active subblock.
-        // As more and more eigenvalues converge, it eventually
-        // becomes ilo+1 and the loop ends.
-        idx_t istop = ihi;
-
-        int info = 0;
-
-        // nw is the deflation window size
-        idx_t nw;
-
-        for (idx_t iter = 0; iter <= itmax; ++iter)
-        {
-
-            if (iter == itmax)
-            {
-                // The QR algorithm failed to converge, return with error.
-                info = istop;
+        // Find active block
+        for (idx_t i = istop - 1; i > ilo; --i) {
+            if (A(i, i - 1) == zero) {
+                istart = i;
                 break;
             }
+        }
+        //
+        // Agressive early deflation
+        //
+        idx_t nh = istop - istart;
+        idx_t nwupbd = std::min(nh, nw_max);
+        if (k_defl < non_convergence_limit_window) {
+            nw = std::min(nwupbd, nwr);
+        }
+        else {
+            // There have been no deflations in many iterations
+            // Try to vary the deflation window size.
+            nw = std::min(nwupbd, 2 * nw);
+        }
+        if (nh <= 4) {
+            // n >= nmin, so there is always enough space for a 4x4 window
+            nw = nh;
+        }
+        if (nw < nw_max) {
+            if (nw + 1 >= nh) nw = nh;
+            idx_t kwtop = istop - nw;
+            if (kwtop > istart + 2)
+                if (abs1(A(kwtop, kwtop - 1)) > abs1(A(kwtop - 1, kwtop - 2)))
+                    nw = nw + 1;
+        }
 
-            if (ilo + 1 >= istop)
-            {
-                if (ilo + 1 == istop)
-                    w[ilo] = A(ilo, ilo);
-                // All eigenvalues have been found, exit and return 0.
-                break;
+        idx_t ls, ld;
+        n_aed = n_aed + 1;
+        agressive_early_deflation(want_t, want_z, istart, istop, nw, A, w, Z,
+                                  ls, ld, opts);
+
+        istop = istop - ld;
+
+        if (ld > 0) k_defl = 0;
+
+        // Skip an expensive QR sweep if there is a (partly heuristic)
+        // reason to expect that many eigenvalues will deflate without it.
+        // Here, the QR sweep is skipped if many eigenvalues have just been
+        // deflated or if the remaining active block is small.
+        if (ld > 0 and (100 * ld > nwr * nibble or
+                        (istop - istart) <= std::min(nmin, nw_max))) {
+            continue;
+        }
+
+        k_defl = k_defl + 1;
+        idx_t ns = std::min(nh - 1, std::min(ls, nsr));
+
+        idx_t i_shifts = istop - ls;
+
+        if (k_defl % non_convergence_limit_shift == 0) {
+            ns = nsr;
+            for (idx_t i = i_shifts; i < istop - 1; i = i + 2) {
+                real_t ss = abs1(A(i, i - 1)) + abs1(A(i - 1, i - 2));
+                TA aa = dat1 * ss + A(i, i);
+                TA bb = ss;
+                TA cc = dat2 * ss;
+                TA dd = aa;
+                lahqr_eig22(aa, bb, cc, dd, w[i], w[i + 1]);
             }
+        }
+        else {
+            if (ls < nsr / 2) {
+                // Got nsr/2 or fewer shifts? Then use multi/double shift qr to
+                // get more
+                auto temp = slice(A, pair{n - nsr, n}, pair{0, nsr});
+                auto shifts = slice(w, pair{istop - nsr, istop});
+                auto Z_slice = slice(Z, pair{0, nsr}, pair{0, nsr});
+                int ierr = lahqr(false, false, 0, nsr, temp, shifts, Z_slice);
 
-            // istart is the start of the active subblock. Either
-            // istart = ilo, or H(istart, istart-1) = 0. This means
-            // that we can treat this subblock separately.
-            idx_t istart = ilo;
+                ns = nsr - ierr;
 
-            // Find active block
-            for (idx_t i = istop - 1; i > ilo; --i)
-            {
-                if (A(i, i - 1) == zero)
-                {
-                    istart = i;
-                    break;
-                }
-            }
-            //
-            // Agressive early deflation
-            //
-            idx_t nh = istop - istart;
-            idx_t nwupbd = std::min(nh, nw_max);
-            if (k_defl < non_convergence_limit_window)
-            {
-                nw = std::min(nwupbd, nwr);
-            }
-            else
-            {
-                // There have been no deflations in many iterations
-                // Try to vary the deflation window size.
-                nw = std::min(nwupbd, 2 * nw);
-            }
-            if (nh <= 4)
-            {
-                // n >= nmin, so there is always enough space for a 4x4 window
-                nw = nh;
-            }
-            if (nw < nw_max)
-            {
-                if (nw + 1 >= nh)
-                    nw = nh;
-                idx_t kwtop = istop - nw;
-                if (kwtop > istart + 2)
-                    if (abs1(A(kwtop, kwtop - 1)) > abs1(A(kwtop - 1, kwtop - 2)))
-                        nw = nw + 1;
-            }
-
-            idx_t ls, ld;
-            n_aed = n_aed + 1;
-            agressive_early_deflation(want_t, want_z, istart, istop, nw, A, w, Z, ls, ld, opts);
-
-            istop = istop - ld;
-
-            if (ld > 0)
-                k_defl = 0;
-
-            // Skip an expensive QR sweep if there is a (partly heuristic)
-            // reason to expect that many eigenvalues will deflate without it.
-            // Here, the QR sweep is skipped if many eigenvalues have just been
-            // deflated or if the remaining active block is small.
-            if (ld > 0 and (100 * ld > nwr * nibble or (istop - istart) <= std::min(nmin, nw_max)))
-            {
-                continue;
-            }
-
-            k_defl = k_defl + 1;
-            idx_t ns = std::min(nh - 1, std::min(ls, nsr));
-
-            idx_t i_shifts = istop - ls;
-
-            if (k_defl % non_convergence_limit_shift == 0)
-            {
-                ns = nsr;
-                for (idx_t i = i_shifts; i < istop - 1; i = i + 2)
-                {
-                    real_t ss = abs1(A(i, i - 1)) + abs1(A(i - 1, i - 2));
-                    TA aa = dat1 * ss + A(i, i);
-                    TA bb = ss;
-                    TA cc = dat2 * ss;
-                    TA dd = aa;
-                    lahqr_eig22(aa, bb, cc, dd, w[i], w[i + 1]);
-                }
-            }
-            else
-            {
-
-                if( ls < nsr/2 ){
-                    // Got nsr/2 or fewer shifts? Then use multi/double shift qr to get more
-                    auto temp = slice(A, pair{ n-nsr, n }, pair{0,nsr});
-                    auto shifts = slice( w, pair{ istop - nsr, istop } );
-                    auto Z_slice = slice( Z,  pair{0,nsr},  pair{0,nsr} );
-                    int ierr = lahqr( false, false, 0, nsr, temp, shifts, Z_slice );
-
-                    ns = nsr - ierr;
-
-                    if( ns < 2 ){
-                        // In case of a rare QR failure, use eigenvalues
-                        // of the trailing 2x2 submatrix
-                        TA aa = A(istop-2, istop-2);
-                        TA bb = A(istop-2, istop-1);
-                        TA cc = A(istop-1, istop-2);
-                        TA dd = A(istop-1, istop-1);
-                        lahqr_eig22(aa, bb, cc, dd, w[istop-2], w[istop-1]);
-                        ns = 2;
-                    }
-
-                    i_shifts = istop - ns;
+                if (ns < 2) {
+                    // In case of a rare QR failure, use eigenvalues
+                    // of the trailing 2x2 submatrix
+                    TA aa = A(istop - 2, istop - 2);
+                    TA bb = A(istop - 2, istop - 1);
+                    TA cc = A(istop - 1, istop - 2);
+                    TA dd = A(istop - 1, istop - 1);
+                    lahqr_eig22(aa, bb, cc, dd, w[istop - 2], w[istop - 1]);
+                    ns = 2;
                 }
 
-                // Sort the shifts (helps a little)
-                // Bubble sort keeps complex conjugate pairs together
-                bool sorted = false;
-                idx_t k = istop;
-                while (!sorted && k > i_shifts)
-                {
-                    sorted = true;
-                    for (idx_t i = i_shifts; i < k - 1; ++i)
-                    {
-                        if (abs1(w[i]) < abs1(w[i + 1]))
-                        {
-                            sorted = false;
-                            const type_t<vector_t> tmp = w[i];
-                            w[i] = w[i + 1];
-                            w[i + 1] = tmp;
-                        }
-                    }
-                    --k;
-                }
-
-                // Shuffle shifts into pairs of real shifts
-                // and pairs of complex conjugate shifts
-                // assuming complex conjugate shifts are
-                // already adjacent to one another. (Yes,
-                // they are.)
-                for (idx_t i = istop - 1; i > i_shifts + 1; i = i - 2)
-                {
-                    if (imag(w[i]) != -imag(w[i - 1]))
-                    {
-                        const type_t<vector_t> tmp = w[i];
-                        w[i] = w[i - 1];
-                        w[i - 1] = w[i - 2];
-                        w[i - 2] = tmp;
-                    }
-                }
-
-                // Since we shuffled the shifts, we will only drop
-                // Real shifts
-                if (ns % 2 == 1)
-                    ns = ns - 1;
                 i_shifts = istop - ns;
             }
 
-            // If there are only two shifts and both are real
-            // then use only one (helps avoid interference)
-            if (!is_complex<TA>::value)
-            {
-                if (ns == 2)
-                {
-                    if (imag(w[i_shifts]) == zero)
-                    {
-                        if (tlapack::abs(real(w[i_shifts]) - A(istop - 1, istop - 1)) < tlapack::abs(real(w[i_shifts + 1]) - A(istop - 1, istop - 1)))
-                            w[i_shifts + 1] = w[i_shifts];
-                        else
-                            w[i_shifts] = w[i_shifts + 1];
+            // Sort the shifts (helps a little)
+            // Bubble sort keeps complex conjugate pairs together
+            bool sorted = false;
+            idx_t k = istop;
+            while (!sorted && k > i_shifts) {
+                sorted = true;
+                for (idx_t i = i_shifts; i < k - 1; ++i) {
+                    if (abs1(w[i]) < abs1(w[i + 1])) {
+                        sorted = false;
+                        const type_t<vector_t> tmp = w[i];
+                        w[i] = w[i + 1];
+                        w[i + 1] = tmp;
                     }
                 }
+                --k;
             }
-            auto shifts = slice(w, pair{i_shifts, i_shifts + ns});
 
-            n_sweep = n_sweep + 1;
-            n_shifts_total = n_shifts_total + ns;
-            multishift_QR_sweep(want_t, want_z, istart, istop, A, shifts, Z, mQRsweepOpts);
+            // Shuffle shifts into pairs of real shifts
+            // and pairs of complex conjugate shifts
+            // assuming complex conjugate shifts are
+            // already adjacent to one another. (Yes,
+            // they are.)
+            for (idx_t i = istop - 1; i > i_shifts + 1; i = i - 2) {
+                if (imag(w[i]) != -imag(w[i - 1])) {
+                    const type_t<vector_t> tmp = w[i];
+                    w[i] = w[i - 1];
+                    w[i - 1] = w[i - 2];
+                    w[i - 2] = tmp;
+                }
+            }
+
+            // Since we shuffled the shifts, we will only drop
+            // Real shifts
+            if (ns % 2 == 1) ns = ns - 1;
+            i_shifts = istop - ns;
         }
 
-        opts.n_aed = n_aed;
-        opts.n_shifts_total = n_shifts_total;
-        opts.n_sweep = n_sweep;
+        // If there are only two shifts and both are real
+        // then use only one (helps avoid interference)
+        if (!is_complex<TA>::value) {
+            if (ns == 2) {
+                if (imag(w[i_shifts]) == zero) {
+                    if (tlapack::abs(real(w[i_shifts]) -
+                                     A(istop - 1, istop - 1)) <
+                        tlapack::abs(real(w[i_shifts + 1]) -
+                                     A(istop - 1, istop - 1)))
+                        w[i_shifts + 1] = w[i_shifts];
+                    else
+                        w[i_shifts] = w[i_shifts + 1];
+                }
+            }
+        }
+        auto shifts = slice(w, pair{i_shifts, i_shifts + ns});
 
-        return info;
+        n_sweep = n_sweep + 1;
+        n_shifts_total = n_shifts_total + ns;
+        multishift_QR_sweep(want_t, want_z, istart, istop, A, shifts, Z,
+                            mQRsweepOpts);
     }
 
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<
-            is_complex< type_t<vector_t> >::value
-        , int > = 0
-    >
-    inline
-    int multishift_qr(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        matrix_t &A,
-        vector_t &w,
-        matrix_t &Z )
-    {
-        francis_opts_t< size_type<matrix_t> > opts = {};
-        return multishift_qr(want_t, want_z, ilo, ihi, A, w, Z, opts);
-    }
+    opts.n_aed = n_aed;
+    opts.n_shifts_total = n_shifts_total;
+    opts.n_sweep = n_sweep;
 
-} // lapack
+    return info;
+}
 
-#endif // TLAPACK_MULTISHIFT_QR_HH
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t> >::value, int> = 0>
+inline int multishift_qr(bool want_t,
+                         bool want_z,
+                         size_type<matrix_t> ilo,
+                         size_type<matrix_t> ihi,
+                         matrix_t& A,
+                         vector_t& w,
+                         matrix_t& Z)
+{
+    francis_opts_t<size_type<matrix_t> > opts = {};
+    return multishift_qr(want_t, want_z, ilo, ihi, A, w, Z, opts);
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_MULTISHIFT_QR_HH

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -12,231 +12,685 @@
 
 #include "tlapack/base/utils.hpp"
 #include "tlapack/blas/gemm.hpp"
-#include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/lahqr_shiftcolumn.hpp"
+#include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/move_bulge.hpp"
 
-namespace tlapack
+namespace tlapack {
+/** Worspace query of multishift_QR_sweep()
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ *
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ *
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ *
+ * @param[in] ihi    integer.
+ *      ilo and ihi determine an isolated block in A.
+ *
+ * @param[in] A  n by n matrix.
+ *      Hessenberg matrix on which AED will be performed
+ *
+ * @param[in] s  complex vector.
+ *      Vector containing the shifts to be used during the sweep
+ *
+ * @param[in] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true>
+inline constexpr void multishift_QR_sweep_worksize(
+    bool want_t,
+    bool want_z,
+    size_type<matrix_t> ilo,
+    size_type<matrix_t> ihi,
+    const matrix_t& A,
+    const vector_t& s,
+    const matrix_t& Z,
+    workinfo_t& workinfo,
+    const workspace_opts_t<>& opts = {})
 {
-    /** Worspace query of multishift_QR_sweep()
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     *
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     *
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     *
-     * @param[in] ihi    integer.
-     *      ilo and ihi determine an isolated block in A.
-     *
-     * @param[in] A  n by n matrix.
-     *      Hessenberg matrix on which AED will be performed
-     *
-     * @param[in] s  complex vector.
-     *      Vector containing the shifts to be used during the sweep
-     *
-     * @param[in] Z  n by n matrix.
-     *      On entry, the previously calculated Schur factors.
-     *
-     * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true
-    >
-    inline constexpr
-    void multishift_QR_sweep_worksize(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        const matrix_t &A, 
-        const vector_t &s, 
-        const matrix_t &Z, 
-        workinfo_t& workinfo,
-        const workspace_opts_t<> &opts = {} )
-    {
-        using T  = type_t< matrix_t >;
+    using T = type_t<matrix_t>;
 
-        const workinfo_t myWorkinfo( sizeof(T)*3, size(s)/2 );
-        workinfo.minMax( myWorkinfo );
+    const workinfo_t myWorkinfo(sizeof(T) * 3, size(s) / 2);
+    workinfo.minMax(myWorkinfo);
+}
+
+/** multishift_QR_sweep performs a single small-bulge multi-shift QR sweep.
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ *
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ *
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ *
+ * @param[in] ihi    integer.
+ *      ilo and ihi determine an isolated block in A.
+ *
+ * @param[in,out] A  n by n matrix.
+ *      Hessenberg matrix on which AED will be performed
+ *
+ * @param[in] s  complex vector.
+ *      Vector containing the shifts to be used during the sweep
+ *
+ * @param[in,out] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors
+ *      On exit, the orthogonal updates applied to A accumulated
+ *      into Z.
+ *
+ * @param[in] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup computational
+ */
+template <class matrix_t,
+          class vector_t,
+          enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true>
+void multishift_QR_sweep(bool want_t,
+                         bool want_z,
+                         size_type<matrix_t> ilo,
+                         size_type<matrix_t> ihi,
+                         matrix_t& A,
+                         const vector_t& s,
+                         matrix_t& Z,
+                         const workspace_opts_t<>& opts = {})
+{
+    using TA = type_t<matrix_t>;
+    using real_t = real_type<TA>;
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
+
+    // Functor
+    Create<matrix_t> new_matrix;
+
+    const real_t one(1);
+    const real_t zero(0);
+    const idx_t n = ncols(A);
+    const real_t eps = ulp<real_t>();
+    const real_t small_num = safe_min<real_t>() * ((real_t)n / eps);
+
+    // Assertions
+    assert(n >= 12);
+    assert(nrows(A) == n);
+    if (want_z) {
+        assert(ncols(Z) == n);
+        assert(nrows(Z) == n);
     }
 
-    /** multishift_QR_sweep performs a single small-bulge multi-shift QR sweep.
-     *
-     * @param[in] want_t bool.
-     *      If true, the full Schur factor T will be computed.
-     *
-     * @param[in] want_z bool.
-     *      If true, the Schur vectors Z will be computed.
-     *
-     * @param[in] ilo    integer.
-     *      Either ilo=0 or A(ilo,ilo-1) = 0.
-     *
-     * @param[in] ihi    integer.
-     *      ilo and ihi determine an isolated block in A.
-     *
-     * @param[in,out] A  n by n matrix.
-     *      Hessenberg matrix on which AED will be performed
-     *
-     * @param[in] s  complex vector.
-     *      Vector containing the shifts to be used during the sweep
-     *
-     * @param[in,out] Z  n by n matrix.
-     *      On entry, the previously calculated Schur factors
-     *      On exit, the orthogonal updates applied to A accumulated
-     *      into Z.
-     *
-     * @param[in] opts Options.
-     *      - @c opts.work is used if whenever it has sufficient size.
-     *        The sufficient size can be obtained through a workspace query.
-     *
-     * @ingroup computational
-     */
-    template <
-        class matrix_t,
-        class vector_t,
-        enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true
-    >
-    void multishift_QR_sweep(
-        bool want_t, 
-        bool want_z, 
-        size_type<matrix_t> ilo, 
-        size_type<matrix_t> ihi, 
-        matrix_t &A, 
-        const vector_t &s, 
-        matrix_t &Z, 
-        const workspace_opts_t<> &opts = {} )
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    const Workspace work = [&]() {
+        workinfo_t workinfo;
+        multishift_QR_sweep_worksize(want_t, want_z, ilo, ihi, A, s, Z,
+                                     workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+    auto V = new_matrix(work, 3, size(s) / 2);
+
+    const idx_t n_block_max = (n - 3) / 3;
+    const idx_t n_shifts_max =
+        std::min(ihi - ilo - 1, std::max<idx_t>(2, 3 * (n_block_max / 4)));
+
+    idx_t n_shifts = std::min<idx_t>(size(s), n_shifts_max);
+    if (n_shifts % 2 == 1) n_shifts = n_shifts - 1;
+    idx_t n_bulges = n_shifts / 2;
+
+    const idx_t n_block_desired = std::min<idx_t>(2 * n_shifts, n_block_max);
+
+    // Define workspace matrices
+    // We use the lower triangular part of A as workspace
+
+    // U stores the orthogonal transformations
+    auto U = slice(A, pair{n - n_block_desired, n}, pair{0, n_block_desired});
+
+    // Workspace for horizontal multiplications
+    auto WH = slice(A, pair{n - n_block_desired, n},
+                    pair{n_block_desired, n - n_block_desired - 3});
+
+    // Workspace for vertical multiplications
+    auto WV = slice(A, pair{n_block_desired + 3, n - n_block_desired},
+                    pair{0, n_block_desired});
+
+    // i_pos_block points to the start of the block of bulges
+    idx_t i_pos_block;
+
+    //
+    // The following code block introduces the bulges into the matrix
+    //
     {
-        using TA = type_t<matrix_t>;
-        using real_t = real_type<TA>;
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
+        // Near-the-diagonal bulge introduction
+        // The calculations are initially limited to the window:
+        // A(ilo:ilo+n_block,ilo:ilo+n_block) The rest is updated later via
+        // level 3 BLAS
+        idx_t n_block = std::min(n_block_desired, ihi - ilo);
+        idx_t istart_m = ilo;
+        idx_t istop_m = ilo + n_block;
+        auto U2 = slice(U, pair{0, n_block}, pair{0, n_block});
+        laset(Uplo::General, zero, one, U2);
 
-        // Functor
-        Create< matrix_t > new_matrix;
+        for (idx_t i_pos_last = ilo; i_pos_last < ilo + n_block - 2;
+             ++i_pos_last) {
+            // The number of bulges that are in the pencil
+            idx_t n_active_bulges =
+                std::min(n_bulges, ((i_pos_last - ilo) / 2) + 1);
+            for (idx_t i_bulge = 0; i_bulge < n_active_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                if (i_pos == ilo) {
+                    // Introduce bulge
+                    TA tau;
+                    auto H = slice(A, pair{ilo, ilo + 3}, pair{ilo, ilo + 3});
+                    lahqr_shiftcolumn(H, v, s[size(s) - 1 - 2 * i_bulge],
+                                      s[size(s) - 1 - 2 * i_bulge - 1]);
+                    larfg(v, tau);
+                    v[0] = tau;
+                }
+                else {
+                    // Chase bulge down
+                    auto H = slice(A, pair{i_pos - 1, i_pos + 3},
+                                   pair{i_pos - 1, i_pos + 3});
+                    move_bulge(H, v, s[size(s) - 1 - 2 * i_bulge],
+                               s[size(s) - 1 - 2 * i_bulge - 1]);
+                }
 
-        const real_t one(1);
-        const real_t zero(0);
-        const idx_t n = ncols(A);
-        const real_t eps = ulp<real_t>();
-        const real_t small_num = safe_min<real_t>() * ((real_t)n / eps);
+                // Apply the reflector we just calculated from the right
+                // We leave the last row for later (it interferes with the
+                // optimally packed bulges)
+                for (idx_t j = istart_m; j < i_pos + 3; ++j) {
+                    const TA sum = A(j, i_pos) + v[1] * A(j, i_pos + 1) +
+                                   v[2] * A(j, i_pos + 2);
+                    A(j, i_pos) = A(j, i_pos) - sum * v[0];
+                    A(j, i_pos + 1) = A(j, i_pos + 1) - sum * v[0] * conj(v[1]);
+                    A(j, i_pos + 2) = A(j, i_pos + 2) - sum * v[0] * conj(v[2]);
+                }
 
-        // Assertions
-        assert(n >= 12);
-        assert(nrows(A) == n);
-        if(want_z) {
-            assert(ncols(Z) == n);
-            assert(nrows(Z) == n);
+                // Apply the reflector we just calculated from the left
+                // We only update a single column, the rest is updated later
+                const TA sum = A(i_pos, i_pos) +
+                               conj(v[1]) * A(i_pos + 1, i_pos) +
+                               conj(v[2]) * A(i_pos + 2, i_pos);
+                A(i_pos, i_pos) = A(i_pos, i_pos) - sum * conj(v[0]);
+                A(i_pos + 1, i_pos) =
+                    A(i_pos + 1, i_pos) - sum * conj(v[0]) * v[1];
+                A(i_pos + 2, i_pos) =
+                    A(i_pos + 2, i_pos) - sum * conj(v[0]) * v[2];
+
+                // Test for deflation.
+                if (i_pos > ilo) {
+                    if (A(i_pos, i_pos - 1) != zero) {
+                        real_t tst1 = abs1(A(i_pos - 1, i_pos - 1)) +
+                                      abs1(A(i_pos, i_pos));
+                        if (tst1 == zero) {
+                            if (i_pos > ilo + 1)
+                                tst1 += abs1(A(i_pos - 1, i_pos - 2));
+                            if (i_pos > ilo + 2)
+                                tst1 += abs1(A(i_pos - 1, i_pos - 3));
+                            if (i_pos > ilo + 3)
+                                tst1 += abs1(A(i_pos - 1, i_pos - 4));
+                            if (i_pos < ihi - 1)
+                                tst1 += abs1(A(i_pos + 1, i_pos));
+                            if (i_pos < ihi - 2)
+                                tst1 += abs1(A(i_pos + 2, i_pos));
+                            if (i_pos < ihi - 3)
+                                tst1 += abs1(A(i_pos + 3, i_pos));
+                        }
+                        if (abs1(A(i_pos, i_pos - 1)) <
+                            std::max(small_num, eps * tst1)) {
+                            const real_t ab =
+                                std::max(abs1(A(i_pos, i_pos - 1)),
+                                         abs1(A(i_pos - 1, i_pos)));
+                            const real_t ba =
+                                std::min(abs1(A(i_pos, i_pos - 1)),
+                                         abs1(A(i_pos - 1, i_pos)));
+                            const real_t aa =
+                                std::max(abs1(A(i_pos, i_pos)),
+                                         abs1(A(i_pos, i_pos) -
+                                              A(i_pos - 1, i_pos - 1)));
+                            const real_t bb =
+                                std::min(abs1(A(i_pos, i_pos)),
+                                         abs1(A(i_pos, i_pos) -
+                                              A(i_pos - 1, i_pos - 1)));
+                            const real_t s = aa + ab;
+                            if (ba * (ab / s) <=
+                                std::max(small_num, eps * (bb * (aa / s)))) {
+                                A(i_pos, i_pos - 1) = zero;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // The following code performs the delayed update from the left
+            // it is optimized for column oriented matrices, but the increased
+            // complexity likely causes slower code for (idx_t j = ilo; j <
+            // istop_m; ++j)
+            // {
+            //     idx_t i_bulge_start = (i_pos_last + 2 > j) ? (i_pos_last + 2
+            //     - j) / 2 : 0; for (idx_t i_bulge = i_bulge_start; i_bulge <
+            //     n_active_bulges; ++i_bulge)
+            //     {
+            //         idx_t i_pos = i_pos_last - 2 * i_bulge;
+            //         auto v = col(V, i_bulge);
+            //         auto sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) +
+            //         conj(v[2]) * A(i_pos + 2, j); A(i_pos, j) = A(i_pos, j) -
+            //         sum * conj(v[0]); A(i_pos + 1, j) = A(i_pos + 1, j) - sum
+            //         * conj(v[0]) * v[1]; A(i_pos + 2, j) = A(i_pos + 2, j) -
+            //         sum * conj(v[0]) * v[2];
+            //     }
+            // }
+
+            // Delayed update from the left
+            for (idx_t i_bulge = 0; i_bulge < n_active_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                for (idx_t j = i_pos + 1; j < istop_m; ++j) {
+                    const TA sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) +
+                                   conj(v[2]) * A(i_pos + 2, j);
+                    A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
+                    A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
+                    A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
+                }
+            }
+
+            // Accumulate the reflectors into U
+            for (idx_t i_bulge = 0; i_bulge < n_active_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                idx_t i1 = 0;
+                idx_t i2 = std::min(
+                    nrows(U2), (i_pos_last - ilo) + (i_pos_last - ilo) + 3);
+                for (idx_t j = i1; j < i2; ++j) {
+                    const TA sum = U2(j, i_pos - ilo) +
+                                   v[1] * U2(j, i_pos - ilo + 1) +
+                                   v[2] * U2(j, i_pos - ilo + 2);
+                    U2(j, i_pos - ilo) = U2(j, i_pos - ilo) - sum * v[0];
+                    U2(j, i_pos - ilo + 1) =
+                        U2(j, i_pos - ilo + 1) - sum * v[0] * conj(v[1]);
+                    U2(j, i_pos - ilo + 2) =
+                        U2(j, i_pos - ilo + 2) - sum * v[0] * conj(v[2]);
+                }
+            }
+        }
+        // Update rest of the matrix
+        if (want_t) {
+            istart_m = 0;
+            istop_m = n;
+        }
+        else {
+            istart_m = ilo;
+            istop_m = ihi;
+        }
+        // Horizontal multiply
+        if (ilo + n_shifts + 1 < istop_m) {
+            idx_t i = ilo + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto A_slice =
+                    slice(A, pair{ilo, ilo + n_block}, pair{i, i + iblock});
+                auto WH_slice =
+                    slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+                gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
+                lacpy(Uplo::General, WH_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        // Vertical multiply
+        if (istart_m < ilo) {
+            idx_t i = istart_m;
+            while (i < ilo) {
+                idx_t iblock = std::min<idx_t>(ilo - i, nrows(WV));
+                auto A_slice =
+                    slice(A, pair{i, i + iblock}, pair{ilo, ilo + n_block});
+                auto WV_slice =
+                    slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
+                lacpy(Uplo::General, WV_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Z (also a vertical multiplication)
+        if (want_z) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Z_slice =
+                    slice(Z, pair{i, i + iblock}, pair{ilo, ilo + n_block});
+                auto WV_slice =
+                    slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
+                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
+                lacpy(Uplo::General, WV_slice, Z_slice);
+                i = i + iblock;
+            }
         }
 
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        const Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            multishift_QR_sweep_worksize( want_t, want_z, ilo, ihi, A, s, Z, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-        auto V = new_matrix( work, 3, size(s)/2 );
+        i_pos_block = ilo + n_block - n_shifts;
+    }
 
-        const idx_t n_block_max = (n - 3) / 3;
-        const idx_t n_shifts_max = std::min(ihi - ilo - 1, std::max<idx_t>(2, 3 * (n_block_max / 4)));
+    //
+    // The following code block moves the bulges down untill they are low enough
+    // to be removed
+    //
+    while (i_pos_block + n_block_desired < ihi) {
+        // Number of positions each bulge will be moved down
+        idx_t n_pos = std::min<idx_t>(n_block_desired - n_shifts,
+                                      ihi - n_shifts - 1 - i_pos_block);
+        // Actual blocksize
+        idx_t n_block = n_shifts + n_pos;
 
-        idx_t n_shifts = std::min<idx_t>(size(s), n_shifts_max);
-        if (n_shifts % 2 == 1)
-            n_shifts = n_shifts - 1;
-        idx_t n_bulges = n_shifts / 2;
+        auto U2 = slice(U, pair{0, n_block}, pair{0, n_block});
+        laset(Uplo::General, zero, one, U2);
 
-        const idx_t n_block_desired = std::min<idx_t>(2 * n_shifts, n_block_max);
+        // Near-the-diagonal bulge chase
+        // The calculations are initially limited to the window:
+        // A(i_pos_block-1:i_pos_block+n_block,i_pos_block:i_pos_block+n_block)
+        // The rest is updated later via level 3 BLAS
 
-        // Define workspace matrices
-        // We use the lower triangular part of A as workspace
+        idx_t istart_m = i_pos_block;
+        idx_t istop_m = i_pos_block + n_block;
+        for (idx_t i_pos_last = i_pos_block + n_shifts - 2;
+             i_pos_last < i_pos_block + n_shifts - 2 + n_pos; ++i_pos_last) {
+            for (idx_t i_bulge = 0; i_bulge < n_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                auto H = slice(A, pair{i_pos - 1, i_pos + 3},
+                               pair{i_pos - 1, i_pos + 3});
+                move_bulge(H, v, s[size(s) - 1 - 2 * i_bulge],
+                           s[size(s) - 1 - 2 * i_bulge - 1]);
 
-        // U stores the orthogonal transformations
-        auto U = slice(A, pair{n - n_block_desired, n}, pair{0, n_block_desired});
+                // Apply the reflector we just calculated from the right
+                // We leave the last row for later (it interferes with the
+                // optimally packed bulges)
+                for (idx_t j = istart_m; j < i_pos + 3; ++j) {
+                    const TA sum = A(j, i_pos) + v[1] * A(j, i_pos + 1) +
+                                   v[2] * A(j, i_pos + 2);
+                    A(j, i_pos) = A(j, i_pos) - sum * v[0];
+                    A(j, i_pos + 1) = A(j, i_pos + 1) - sum * v[0] * conj(v[1]);
+                    A(j, i_pos + 2) = A(j, i_pos + 2) - sum * v[0] * conj(v[2]);
+                }
 
-        // Workspace for horizontal multiplications
-        auto WH = slice(A, pair{n - n_block_desired, n}, pair{n_block_desired, n - n_block_desired - 3});
+                // Apply the reflector we just calculated from the left
+                // We only update a single column, the rest is updated later
+                const TA sum = A(i_pos, i_pos) +
+                               conj(v[1]) * A(i_pos + 1, i_pos) +
+                               conj(v[2]) * A(i_pos + 2, i_pos);
+                A(i_pos, i_pos) = A(i_pos, i_pos) - sum * conj(v[0]);
+                A(i_pos + 1, i_pos) =
+                    A(i_pos + 1, i_pos) - sum * conj(v[0]) * v[1];
+                A(i_pos + 2, i_pos) =
+                    A(i_pos + 2, i_pos) - sum * conj(v[0]) * v[2];
 
-        // Workspace for vertical multiplications
-        auto WV = slice(A, pair{n_block_desired + 3, n - n_block_desired}, pair{0, n_block_desired});
-
-        // i_pos_block points to the start of the block of bulges
-        idx_t i_pos_block;
-
-        //
-        // The following code block introduces the bulges into the matrix
-        //
-        {
-            // Near-the-diagonal bulge introduction
-            // The calculations are initially limited to the window: A(ilo:ilo+n_block,ilo:ilo+n_block)
-            // The rest is updated later via level 3 BLAS
-            idx_t n_block = std::min(n_block_desired, ihi - ilo);
-            idx_t istart_m = ilo;
-            idx_t istop_m = ilo + n_block;
-            auto U2 = slice(U, pair{0, n_block}, pair{0, n_block});
-            laset(Uplo::General, zero, one, U2);
-
-            for (idx_t i_pos_last = ilo; i_pos_last < ilo + n_block - 2; ++i_pos_last)
-            {
-                // The number of bulges that are in the pencil
-                idx_t n_active_bulges = std::min(n_bulges, ((i_pos_last - ilo) / 2) + 1);
-                for (idx_t i_bulge = 0; i_bulge < n_active_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    if (i_pos == ilo)
-                    {
-                        // Introduce bulge
-                        TA tau;
-                        auto H = slice(A, pair{ilo, ilo + 3}, pair{ilo, ilo + 3});
-                        lahqr_shiftcolumn(H, v, s[size(s)- 1 - 2 * i_bulge], s[size(s)- 1 - 2 * i_bulge - 1]);
-                        larfg(v, tau);
-                        v[0] = tau;
+                // Test for deflation.
+                if (i_pos > ilo) {
+                    if (A(i_pos, i_pos - 1) != zero) {
+                        real_t tst1 = abs1(A(i_pos - 1, i_pos - 1)) +
+                                      abs1(A(i_pos, i_pos));
+                        if (tst1 == zero) {
+                            if (i_pos > ilo + 1)
+                                tst1 += abs1(A(i_pos - 1, i_pos - 2));
+                            if (i_pos > ilo + 2)
+                                tst1 += abs1(A(i_pos - 1, i_pos - 3));
+                            if (i_pos > ilo + 3)
+                                tst1 += abs1(A(i_pos - 1, i_pos - 4));
+                            if (i_pos < ihi - 1)
+                                tst1 += abs1(A(i_pos + 1, i_pos));
+                            if (i_pos < ihi - 2)
+                                tst1 += abs1(A(i_pos + 2, i_pos));
+                            if (i_pos < ihi - 3)
+                                tst1 += abs1(A(i_pos + 3, i_pos));
+                        }
+                        if (abs1(A(i_pos, i_pos - 1)) <
+                            std::max(small_num, eps * tst1)) {
+                            const real_t ab =
+                                std::max(abs1(A(i_pos, i_pos - 1)),
+                                         abs1(A(i_pos - 1, i_pos)));
+                            const real_t ba =
+                                std::min(abs1(A(i_pos, i_pos - 1)),
+                                         abs1(A(i_pos - 1, i_pos)));
+                            const real_t aa =
+                                std::max(abs1(A(i_pos, i_pos)),
+                                         abs1(A(i_pos, i_pos) -
+                                              A(i_pos - 1, i_pos - 1)));
+                            const real_t bb =
+                                std::min(abs1(A(i_pos, i_pos)),
+                                         abs1(A(i_pos, i_pos) -
+                                              A(i_pos - 1, i_pos - 1)));
+                            const real_t s = aa + ab;
+                            if (ba * (ab / s) <=
+                                std::max(small_num, eps * (bb * (aa / s)))) {
+                                A(i_pos, i_pos - 1) = zero;
+                            }
+                        }
                     }
-                    else
-                    {
-                        // Chase bulge down
-                        auto H = slice(A, pair{i_pos - 1, i_pos + 3}, pair{i_pos - 1, i_pos + 3});
-                        move_bulge(H, v, s[size(s)- 1 - 2 * i_bulge], s[size(s)- 1 - 2 * i_bulge - 1]);
-                    }
+                }
+            }
 
+            // The following code performs the delayed update from the left
+            // it is optimized for column oriented matrices, but the increased
+            // complexity likely causes slower code for (idx_t j = i_pos_block;
+            // j < istop_m; ++j)
+            // {
+            //     idx_t i_bulge_start = (i_pos_last + 2 > j) ? (i_pos_last + 2
+            //     - j) / 2 : 0; for (idx_t i_bulge = i_bulge_start; i_bulge <
+            //     n_bulges; ++i_bulge)
+            //     {
+            //         idx_t i_pos = i_pos_last - 2 * i_bulge;
+            //         auto v = col(V, i_bulge);
+            //         auto sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) +
+            //         conj(v[2]) * A(i_pos + 2, j); A(i_pos, j) = A(i_pos, j) -
+            //         sum * conj(v[0]); A(i_pos + 1, j) = A(i_pos + 1, j) - sum
+            //         * conj(v[0]) * v[1]; A(i_pos + 2, j) = A(i_pos + 2, j) -
+            //         sum * conj(v[0]) * v[2];
+            //     }
+            // }
+
+            // Delayed update from the left
+            for (idx_t i_bulge = 0; i_bulge < n_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                for (idx_t j = i_pos + 1; j < istop_m; ++j) {
+                    const TA sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) +
+                                   conj(v[2]) * A(i_pos + 2, j);
+                    A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
+                    A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
+                    A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
+                }
+            }
+
+            // Accumulate the reflectors into U
+            for (idx_t i_bulge = 0; i_bulge < n_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                idx_t i1 = (i_pos - i_pos_block) -
+                           (i_pos_last - i_pos_block - n_shifts + 2);
+                idx_t i2 =
+                    std::min(nrows(U2),
+                             (i_pos_last - i_pos_block) +
+                                 (i_pos_last - i_pos_block - n_shifts + 2) + 3);
+                for (idx_t j = i1; j < i2; ++j) {
+                    const TA sum = U2(j, i_pos - i_pos_block) +
+                                   v[1] * U2(j, i_pos - i_pos_block + 1) +
+                                   v[2] * U2(j, i_pos - i_pos_block + 2);
+                    U2(j, i_pos - i_pos_block) =
+                        U2(j, i_pos - i_pos_block) - sum * v[0];
+                    U2(j, i_pos - i_pos_block + 1) =
+                        U2(j, i_pos - i_pos_block + 1) -
+                        sum * v[0] * conj(v[1]);
+                    U2(j, i_pos - i_pos_block + 2) =
+                        U2(j, i_pos - i_pos_block + 2) -
+                        sum * v[0] * conj(v[2]);
+                }
+            }
+        }
+        // Update rest of the matrix
+        if (want_t) {
+            istart_m = 0;
+            istop_m = n;
+        }
+        else {
+            istart_m = ilo;
+            istop_m = ihi;
+        }
+        // Horizontal multiply
+        if (i_pos_block + n_block < istop_m) {
+            idx_t i = i_pos_block + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto A_slice =
+                    slice(A, pair{i_pos_block, i_pos_block + n_block},
+                          pair{i, i + iblock});
+                auto WH_slice =
+                    slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+                gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
+                lacpy(Uplo::General, WH_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        // Vertical multiply
+        if (istart_m < i_pos_block) {
+            idx_t i = istart_m;
+            while (i < i_pos_block) {
+                idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
+                auto A_slice = slice(A, pair{i, i + iblock},
+                                     pair{i_pos_block, i_pos_block + n_block});
+                auto WV_slice =
+                    slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
+                lacpy(Uplo::General, WV_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Z (also a vertical multiplication)
+        if (want_z) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Z_slice = slice(Z, pair{i, i + iblock},
+                                     pair{i_pos_block, i_pos_block + n_block});
+                auto WV_slice =
+                    slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
+                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
+                lacpy(Uplo::General, WV_slice, Z_slice);
+                i = i + iblock;
+            }
+        }
+
+        i_pos_block = i_pos_block + n_pos;
+    }
+
+    //
+    // The following code removes the bulges from the matrix
+    //
+    {
+        idx_t n_block = ihi - i_pos_block;
+
+        auto U2 = slice(U, pair{0, n_block}, pair{0, n_block});
+        laset(Uplo::General, zero, one, U2);
+
+        // Near-the-diagonal bulge chase
+        // The calculations are initially limited to the window:
+        // A(i_pos_block-1:ihi,i_pos_block:ihi) The rest is updated later via
+        // level 3 BLAS
+
+        idx_t istart_m = i_pos_block;
+        idx_t istop_m = ihi;
+
+        for (idx_t i_pos_last = i_pos_block + n_shifts - 2;
+             i_pos_last < ihi + n_shifts - 1; ++i_pos_last) {
+            idx_t i_bulge_start =
+                (i_pos_last + 3 > ihi) ? (i_pos_last + 3 - ihi) / 2 : 0;
+            for (idx_t i_bulge = i_bulge_start; i_bulge < n_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                if (i_pos == ihi - 2) {
+                    // Special case, the bulge is at the bottom, needs a smaller
+                    // reflector (order 2)
+                    auto v = slice(V, pair{0, 2}, i_bulge);
+                    auto h = slice(A, pair{i_pos, i_pos + 2}, i_pos - 1);
+                    larfg(h, v[0]);
+                    v[1] = h[1];
+                    h[1] = zero;
+
+                    const TA t1 = conj(v[0]);
+                    const TA v2 = v[1];
+                    const TA t2 = t1 * v2;
                     // Apply the reflector we just calculated from the right
-                    // We leave the last row for later (it interferes with the optimally packed bulges)
-                    for (idx_t j = istart_m; j < i_pos + 3; ++j)
-                    {
-                        const TA sum = A(j, i_pos) + v[1] * A(j, i_pos + 1) + v[2] * A(j, i_pos + 2);
-                        A(j, i_pos) = A(j, i_pos) - sum * v[0];
-                        A(j, i_pos + 1) = A(j, i_pos + 1) - sum * v[0] * conj(v[1]);
-                        A(j, i_pos + 2) = A(j, i_pos + 2) - sum * v[0] * conj(v[2]);
+                    for (idx_t j = istart_m; j < i_pos + 2; ++j) {
+                        const TA sum = A(j, i_pos) + v2 * A(j, i_pos + 1);
+                        A(j, i_pos) = A(j, i_pos) - sum * conj(t1);
+                        A(j, i_pos + 1) = A(j, i_pos + 1) - sum * conj(t2);
+                    }
+                    // Apply the reflector we just calculated from the left
+                    for (idx_t j = i_pos; j < istop_m; ++j) {
+                        const TA sum = A(i_pos, j) + conj(v2) * A(i_pos + 1, j);
+                        A(i_pos, j) = A(i_pos, j) - sum * t1;
+                        A(i_pos + 1, j) = A(i_pos + 1, j) - sum * t2;
+                    }
+                    // Accumulate the reflector into U
+                    // The loop bounds should be changed to reflect the fact
+                    // that U2 starts off as diagonal
+                    for (idx_t j = 0; j < nrows(U2); ++j) {
+                        const TA sum = U2(j, i_pos - i_pos_block) +
+                                       v2 * U2(j, i_pos - i_pos_block + 1);
+                        U2(j, i_pos - i_pos_block) =
+                            U2(j, i_pos - i_pos_block) - sum * conj(t1);
+                        U2(j, i_pos - i_pos_block + 1) =
+                            U2(j, i_pos - i_pos_block + 1) - sum * conj(t2);
+                    }
+                }
+                else {
+                    auto v = col(V, i_bulge);
+                    auto H = slice(A, pair{i_pos - 1, i_pos + 3},
+                                   pair{i_pos - 1, i_pos + 3});
+                    move_bulge(H, v, s[size(s) - 1 - 2 * i_bulge],
+                               s[size(s) - 1 - 2 * i_bulge - 1]);
+
+                    const TA t1 = conj(v[0]);
+                    const TA v2 = v[1];
+                    const TA t2 = t1 * v2;
+                    const TA v3 = v[2];
+                    const TA t3 = t1 * v3;
+                    // Apply the reflector we just calculated from the right
+                    // (but leave the last row for later)
+                    for (idx_t j = istart_m; j < i_pos + 3; ++j) {
+                        const TA sum = A(j, i_pos) + v2 * A(j, i_pos + 1) +
+                                       v3 * A(j, i_pos + 2);
+                        A(j, i_pos) = A(j, i_pos) - sum * conj(t1);
+                        A(j, i_pos + 1) = A(j, i_pos + 1) - sum * conj(t2);
+                        A(j, i_pos + 2) = A(j, i_pos + 2) - sum * conj(t3);
                     }
 
                     // Apply the reflector we just calculated from the left
                     // We only update a single column, the rest is updated later
-                    const TA sum = A(i_pos, i_pos) + conj(v[1]) * A(i_pos + 1, i_pos) + conj(v[2]) * A(i_pos + 2, i_pos);
+                    const TA sum = A(i_pos, i_pos) +
+                                   conj(v[1]) * A(i_pos + 1, i_pos) +
+                                   conj(v[2]) * A(i_pos + 2, i_pos);
                     A(i_pos, i_pos) = A(i_pos, i_pos) - sum * conj(v[0]);
-                    A(i_pos + 1, i_pos) = A(i_pos + 1, i_pos) - sum * conj(v[0]) * v[1];
-                    A(i_pos + 2, i_pos) = A(i_pos + 2, i_pos) - sum * conj(v[0]) * v[2];
+                    A(i_pos + 1, i_pos) =
+                        A(i_pos + 1, i_pos) - sum * conj(v[0]) * v[1];
+                    A(i_pos + 2, i_pos) =
+                        A(i_pos + 2, i_pos) - sum * conj(v[0]) * v[2];
 
                     // Test for deflation.
-                    if (i_pos > ilo)
-                    {
-                        if (A(i_pos, i_pos - 1) != zero)
-                        {
-                            real_t tst1 = abs1(A(i_pos - 1, i_pos - 1)) + abs1(A(i_pos, i_pos));
-                            if (tst1 == zero)
-                            {
+                    if (i_pos > ilo) {
+                        if (A(i_pos, i_pos - 1) != zero) {
+                            real_t tst1 = abs1(A(i_pos - 1, i_pos - 1)) +
+                                          abs1(A(i_pos, i_pos));
+                            if (tst1 == zero) {
                                 if (i_pos > ilo + 1)
                                     tst1 += abs1(A(i_pos - 1, i_pos - 2));
                                 if (i_pos > ilo + 2)
@@ -250,541 +704,150 @@ namespace tlapack
                                 if (i_pos < ihi - 3)
                                     tst1 += abs1(A(i_pos + 3, i_pos));
                             }
-                            if (abs1(A(i_pos, i_pos - 1)) < std::max(small_num, eps * tst1))
-                            {
-                                const real_t ab = std::max(abs1(A(i_pos, i_pos - 1)), abs1(A(i_pos - 1, i_pos)));
-                                const real_t ba = std::min(abs1(A(i_pos, i_pos - 1)), abs1(A(i_pos - 1, i_pos)));
-                                const real_t aa = std::max(abs1(A(i_pos, i_pos)), abs1(A(i_pos, i_pos) - A(i_pos - 1, i_pos - 1)));
-                                const real_t bb = std::min(abs1(A(i_pos, i_pos)), abs1(A(i_pos, i_pos) - A(i_pos - 1, i_pos - 1)));
+                            if (abs1(A(i_pos, i_pos - 1)) <
+                                std::max(small_num, eps * tst1)) {
+                                const real_t ab =
+                                    std::max(abs1(A(i_pos, i_pos - 1)),
+                                             abs1(A(i_pos - 1, i_pos)));
+                                const real_t ba =
+                                    std::min(abs1(A(i_pos, i_pos - 1)),
+                                             abs1(A(i_pos - 1, i_pos)));
+                                const real_t aa =
+                                    std::max(abs1(A(i_pos, i_pos)),
+                                             abs1(A(i_pos, i_pos) -
+                                                  A(i_pos - 1, i_pos - 1)));
+                                const real_t bb =
+                                    std::min(abs1(A(i_pos, i_pos)),
+                                             abs1(A(i_pos, i_pos) -
+                                                  A(i_pos - 1, i_pos - 1)));
                                 const real_t s = aa + ab;
-                                if (ba * (ab / s) <= std::max(small_num, eps * (bb * (aa / s))))
-                                {
+                                if (ba * (ab / s) <=
+                                    std::max(small_num,
+                                             eps * (bb * (aa / s)))) {
                                     A(i_pos, i_pos - 1) = zero;
                                 }
                             }
                         }
                     }
                 }
+            }
 
-                // The following code performs the delayed update from the left
-                // it is optimized for column oriented matrices, but the increased complexity
-                // likely causes slower code
-                // for (idx_t j = ilo; j < istop_m; ++j)
-                // {
-                //     idx_t i_bulge_start = (i_pos_last + 2 > j) ? (i_pos_last + 2 - j) / 2 : 0;
-                //     for (idx_t i_bulge = i_bulge_start; i_bulge < n_active_bulges; ++i_bulge)
-                //     {
-                //         idx_t i_pos = i_pos_last - 2 * i_bulge;
-                //         auto v = col(V, i_bulge);
-                //         auto sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) + conj(v[2]) * A(i_pos + 2, j);
-                //         A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
-                //         A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
-                //         A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
-                //     }
-                // }
+            i_bulge_start =
+                (i_pos_last + 4 > ihi) ? (i_pos_last + 4 - ihi) / 2 : 0;
 
-                // Delayed update from the left
-                for (idx_t i_bulge = 0; i_bulge < n_active_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    for (idx_t j = i_pos + 1; j < istop_m; ++j)
-                    {
-                        const TA sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) + conj(v[2]) * A(i_pos + 2, j);
-                        A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
-                        A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
-                        A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
-                    }
-                }
+            // The following code performs the delayed update from the left
+            // it is optimized for column oriented matrices, but the increased
+            // complexity likely causes slower code for (idx_t j = i_pos_block;
+            // j < istop_m; ++j)
+            // {
+            //     idx_t i_bulge_start2 = (i_pos_last + 2 > j) ? (i_pos_last + 2
+            //     - j) / 2 : 0; i_bulge_start2 =
+            //     std::max(i_bulge_start,i_bulge_start2); for (idx_t i_bulge =
+            //     i_bulge_start2; i_bulge < n_bulges; ++i_bulge)
+            //     {
+            //         idx_t i_pos = i_pos_last - 2 * i_bulge;
+            //         auto v = col(V, i_bulge);
+            //         auto sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) +
+            //         conj(v[2]) * A(i_pos + 2, j); A(i_pos, j) = A(i_pos, j) -
+            //         sum * conj(v[0]); A(i_pos + 1, j) = A(i_pos + 1, j) - sum
+            //         * conj(v[0]) * v[1]; A(i_pos + 2, j) = A(i_pos + 2, j) -
+            //         sum * conj(v[0]) * v[2];
+            //     }
+            // }
 
-                // Accumulate the reflectors into U
-                for (idx_t i_bulge = 0; i_bulge < n_active_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    idx_t i1 = 0;
-                    idx_t i2 = std::min(nrows(U2), (i_pos_last - ilo) + (i_pos_last - ilo) + 3);
-                    for (idx_t j = i1; j < i2; ++j)
-                    {
-                        const TA sum = U2(j, i_pos - ilo) + v[1] * U2(j, i_pos - ilo + 1) + v[2] * U2(j, i_pos - ilo + 2);
-                        U2(j, i_pos - ilo) = U2(j, i_pos - ilo) - sum * v[0];
-                        U2(j, i_pos - ilo + 1) = U2(j, i_pos - ilo + 1) - sum * v[0] * conj(v[1]);
-                        U2(j, i_pos - ilo + 2) = U2(j, i_pos - ilo + 2) - sum * v[0] * conj(v[2]);
-                    }
-                }
-            }
-            // Update rest of the matrix
-            if (want_t)
-            {
-                istart_m = 0;
-                istop_m = n;
-            }
-            else
-            {
-                istart_m = ilo;
-                istop_m = ihi;
-            }
-            // Horizontal multiply
-            if (ilo + n_shifts + 1 < istop_m)
-            {
-                idx_t i = ilo + n_block;
-                while (i < istop_m)
-                {
-                    idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
-                    auto A_slice = slice(A, pair{ilo, ilo + n_block}, pair{i, i + iblock});
-                    auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
-                    lacpy(Uplo::General, WH_slice, A_slice);
-                    i = i + iblock;
-                }
-            }
-            // Vertical multiply
-            if (istart_m < ilo)
-            {
-                idx_t i = istart_m;
-                while (i < ilo)
-                {
-                    idx_t iblock = std::min<idx_t>(ilo - i, nrows(WV));
-                    auto A_slice = slice(A, pair{i, i + iblock}, pair{ilo, ilo + n_block});
-                    auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
-                    lacpy(Uplo::General, WV_slice, A_slice);
-                    i = i + iblock;
-                }
-            }
-            // Update Z (also a vertical multiplication)
-            if (want_z)
-            {
-                idx_t i = 0;
-                while (i < n)
-                {
-                    idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
-                    auto Z_slice = slice(Z, pair{i, i + iblock}, pair{ilo, ilo + n_block});
-                    auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
-                    lacpy(Uplo::General, WV_slice, Z_slice);
-                    i = i + iblock;
+            // Delayed update from the left
+            for (idx_t i_bulge = i_bulge_start; i_bulge < n_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                for (idx_t j = i_pos + 1; j < istop_m; ++j) {
+                    const TA sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) +
+                                   conj(v[2]) * A(i_pos + 2, j);
+                    A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
+                    A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
+                    A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
                 }
             }
 
-            i_pos_block = ilo + n_block - n_shifts;
+            // Accumulate the reflectors into U
+            for (idx_t i_bulge = i_bulge_start; i_bulge < n_bulges; ++i_bulge) {
+                idx_t i_pos = i_pos_last - 2 * i_bulge;
+                auto v = col(V, i_bulge);
+                idx_t i1 = (i_pos - i_pos_block) -
+                           (i_pos_last - i_pos_block - n_shifts + 2);
+                idx_t i2 =
+                    std::min(nrows(U2),
+                             (i_pos_last - i_pos_block) +
+                                 (i_pos_last - i_pos_block - n_shifts + 2) + 3);
+                for (idx_t j = i1; j < i2; ++j) {
+                    const TA sum = U2(j, i_pos - i_pos_block) +
+                                   v[1] * U2(j, i_pos - i_pos_block + 1) +
+                                   v[2] * U2(j, i_pos - i_pos_block + 2);
+                    U2(j, i_pos - i_pos_block) =
+                        U2(j, i_pos - i_pos_block) - sum * v[0];
+                    U2(j, i_pos - i_pos_block + 1) =
+                        U2(j, i_pos - i_pos_block + 1) -
+                        sum * v[0] * conj(v[1]);
+                    U2(j, i_pos - i_pos_block + 2) =
+                        U2(j, i_pos - i_pos_block + 2) -
+                        sum * v[0] * conj(v[2]);
+                }
+            }
         }
 
-        //
-        // The following code block moves the bulges down untill they are low enough to be removed
-        //
-        while (i_pos_block + n_block_desired < ihi)
-        {
-            // Number of positions each bulge will be moved down
-            idx_t n_pos = std::min<idx_t>(n_block_desired - n_shifts, ihi - n_shifts - 1 - i_pos_block);
-            // Actual blocksize
-            idx_t n_block = n_shifts + n_pos;
-
-            auto U2 = slice(U, pair{0, n_block}, pair{0, n_block});
-            laset(Uplo::General, zero, one, U2);
-
-            // Near-the-diagonal bulge chase
-            // The calculations are initially limited to the window: A(i_pos_block-1:i_pos_block+n_block,i_pos_block:i_pos_block+n_block)
-            // The rest is updated later via level 3 BLAS
-
-            idx_t istart_m = i_pos_block;
-            idx_t istop_m = i_pos_block + n_block;
-            for (idx_t i_pos_last = i_pos_block + n_shifts - 2; i_pos_last < i_pos_block + n_shifts - 2 + n_pos; ++i_pos_last)
-            {
-                for (idx_t i_bulge = 0; i_bulge < n_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    auto H = slice(A, pair{i_pos - 1, i_pos + 3}, pair{i_pos - 1, i_pos + 3});
-                    move_bulge(H, v, s[size(s)- 1 - 2 * i_bulge], s[size(s)- 1 - 2 * i_bulge - 1]);
-
-                    // Apply the reflector we just calculated from the right
-                    // We leave the last row for later (it interferes with the optimally packed bulges)
-                    for (idx_t j = istart_m; j < i_pos + 3; ++j)
-                    {
-                        const TA sum = A(j, i_pos) + v[1] * A(j, i_pos + 1) + v[2] * A(j, i_pos + 2);
-                        A(j, i_pos) = A(j, i_pos) - sum * v[0];
-                        A(j, i_pos + 1) = A(j, i_pos + 1) - sum * v[0] * conj(v[1]);
-                        A(j, i_pos + 2) = A(j, i_pos + 2) - sum * v[0] * conj(v[2]);
-                    }
-
-                    // Apply the reflector we just calculated from the left
-                    // We only update a single column, the rest is updated later
-                    const TA sum = A(i_pos, i_pos) + conj(v[1]) * A(i_pos + 1, i_pos) + conj(v[2]) * A(i_pos + 2, i_pos);
-                    A(i_pos, i_pos) = A(i_pos, i_pos) - sum * conj(v[0]);
-                    A(i_pos + 1, i_pos) = A(i_pos + 1, i_pos) - sum * conj(v[0]) * v[1];
-                    A(i_pos + 2, i_pos) = A(i_pos + 2, i_pos) - sum * conj(v[0]) * v[2];
-
-                    // Test for deflation.
-                    if (i_pos > ilo)
-                    {
-                        if (A(i_pos, i_pos - 1) != zero)
-                        {
-                            real_t tst1 = abs1(A(i_pos - 1, i_pos - 1)) + abs1(A(i_pos, i_pos));
-                            if (tst1 == zero)
-                            {
-                                if (i_pos > ilo + 1)
-                                    tst1 += abs1(A(i_pos - 1, i_pos - 2));
-                                if (i_pos > ilo + 2)
-                                    tst1 += abs1(A(i_pos - 1, i_pos - 3));
-                                if (i_pos > ilo + 3)
-                                    tst1 += abs1(A(i_pos - 1, i_pos - 4));
-                                if (i_pos < ihi - 1)
-                                    tst1 += abs1(A(i_pos + 1, i_pos));
-                                if (i_pos < ihi - 2)
-                                    tst1 += abs1(A(i_pos + 2, i_pos));
-                                if (i_pos < ihi - 3)
-                                    tst1 += abs1(A(i_pos + 3, i_pos));
-                            }
-                            if (abs1(A(i_pos, i_pos - 1)) < std::max(small_num, eps * tst1))
-                            {
-                                const real_t ab = std::max(abs1(A(i_pos, i_pos - 1)), abs1(A(i_pos - 1, i_pos)));
-                                const real_t ba = std::min(abs1(A(i_pos, i_pos - 1)), abs1(A(i_pos - 1, i_pos)));
-                                const real_t aa = std::max(abs1(A(i_pos, i_pos)), abs1(A(i_pos, i_pos) - A(i_pos - 1, i_pos - 1)));
-                                const real_t bb = std::min(abs1(A(i_pos, i_pos)), abs1(A(i_pos, i_pos) - A(i_pos - 1, i_pos - 1)));
-                                const real_t s = aa + ab;
-                                if (ba * (ab / s) <= std::max(small_num, eps * (bb * (aa / s))))
-                                {
-                                    A(i_pos, i_pos - 1) = zero;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // The following code performs the delayed update from the left
-                // it is optimized for column oriented matrices, but the increased complexity
-                // likely causes slower code
-                // for (idx_t j = i_pos_block; j < istop_m; ++j)
-                // {
-                //     idx_t i_bulge_start = (i_pos_last + 2 > j) ? (i_pos_last + 2 - j) / 2 : 0;
-                //     for (idx_t i_bulge = i_bulge_start; i_bulge < n_bulges; ++i_bulge)
-                //     {
-                //         idx_t i_pos = i_pos_last - 2 * i_bulge;
-                //         auto v = col(V, i_bulge);
-                //         auto sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) + conj(v[2]) * A(i_pos + 2, j);
-                //         A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
-                //         A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
-                //         A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
-                //     }
-                // }
-
-                // Delayed update from the left
-                for (idx_t i_bulge = 0; i_bulge < n_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    for (idx_t j = i_pos + 1; j < istop_m; ++j)
-                    {
-                        const TA sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) + conj(v[2]) * A(i_pos + 2, j);
-                        A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
-                        A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
-                        A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
-                    }
-                }
-
-                // Accumulate the reflectors into U
-                for (idx_t i_bulge = 0; i_bulge < n_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    idx_t i1 = (i_pos - i_pos_block) - (i_pos_last - i_pos_block - n_shifts + 2);
-                    idx_t i2 = std::min(nrows(U2), (i_pos_last - i_pos_block) + (i_pos_last - i_pos_block - n_shifts + 2) + 3);
-                    for (idx_t j = i1; j < i2; ++j)
-                    {
-                        const TA sum = U2(j, i_pos - i_pos_block) + v[1] * U2(j, i_pos - i_pos_block + 1) + v[2] * U2(j, i_pos - i_pos_block + 2);
-                        U2(j, i_pos - i_pos_block) = U2(j, i_pos - i_pos_block) - sum * v[0];
-                        U2(j, i_pos - i_pos_block + 1) = U2(j, i_pos - i_pos_block + 1) - sum * v[0] * conj(v[1]);
-                        U2(j, i_pos - i_pos_block + 2) = U2(j, i_pos - i_pos_block + 2) - sum * v[0] * conj(v[2]);
-                    }
-                }
-            }
-            // Update rest of the matrix
-            if (want_t)
-            {
-                istart_m = 0;
-                istop_m = n;
-            }
-            else
-            {
-                istart_m = ilo;
-                istop_m = ihi;
-            }
-            // Horizontal multiply
-            if (i_pos_block + n_block < istop_m)
-            {
-                idx_t i = i_pos_block + n_block;
-                while (i < istop_m)
-                {
-                    idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
-                    auto A_slice = slice(A, pair{i_pos_block, i_pos_block + n_block}, pair{i, i + iblock});
-                    auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
-                    lacpy(Uplo::General, WH_slice, A_slice);
-                    i = i + iblock;
-                }
-            }
-            // Vertical multiply
-            if (istart_m < i_pos_block)
-            {
-                idx_t i = istart_m;
-                while (i < i_pos_block)
-                {
-                    idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
-                    auto A_slice = slice(A, pair{i, i + iblock}, pair{i_pos_block, i_pos_block + n_block});
-                    auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
-                    lacpy(Uplo::General, WV_slice, A_slice);
-                    i = i + iblock;
-                }
-            }
-            // Update Z (also a vertical multiplication)
-            if (want_z)
-            {
-                idx_t i = 0;
-                while (i < n)
-                {
-                    idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
-                    auto Z_slice = slice(Z, pair{i, i + iblock}, pair{i_pos_block, i_pos_block + n_block});
-                    auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
-                    lacpy(Uplo::General, WV_slice, Z_slice);
-                    i = i + iblock;
-                }
-            }
-
-            i_pos_block = i_pos_block + n_pos;
+        // Update rest of the matrix
+        if (want_t) {
+            istart_m = 0;
+            istop_m = n;
         }
-
-        //
-        // The following code removes the bulges from the matrix
-        //
-        {
-            idx_t n_block = ihi - i_pos_block;
-
-            auto U2 = slice(U, pair{0, n_block}, pair{0, n_block});
-            laset(Uplo::General, zero, one, U2);
-
-            // Near-the-diagonal bulge chase
-            // The calculations are initially limited to the window: A(i_pos_block-1:ihi,i_pos_block:ihi)
-            // The rest is updated later via level 3 BLAS
-
-            idx_t istart_m = i_pos_block;
-            idx_t istop_m = ihi;
-
-            for (idx_t i_pos_last = i_pos_block + n_shifts - 2; i_pos_last < ihi + n_shifts - 1; ++i_pos_last)
-            {
-                idx_t i_bulge_start = (i_pos_last + 3 > ihi) ? (i_pos_last + 3 - ihi) / 2 : 0;
-                for (idx_t i_bulge = i_bulge_start; i_bulge < n_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    if (i_pos == ihi - 2)
-                    {
-                        // Special case, the bulge is at the bottom, needs a smaller reflector (order 2)
-                        auto v = slice(V, pair{0, 2}, i_bulge);
-                        auto h = slice(A, pair{i_pos, i_pos + 2}, i_pos - 1);
-                        larfg(h, v[0]);
-                        v[1] = h[1];
-                        h[1] = zero;
-
-                        const TA t1 = conj(v[0]);
-                        const TA v2 = v[1];
-                        const TA t2 = t1 * v2;
-                        // Apply the reflector we just calculated from the right
-                        for (idx_t j = istart_m; j < i_pos + 2; ++j)
-                        {
-                            const TA sum = A(j, i_pos) + v2 * A(j, i_pos + 1);
-                            A(j, i_pos) = A(j, i_pos) - sum * conj(t1);
-                            A(j, i_pos + 1) = A(j, i_pos + 1) - sum * conj(t2);
-                        }
-                        // Apply the reflector we just calculated from the left
-                        for (idx_t j = i_pos; j < istop_m; ++j)
-                        {
-                            const TA sum = A(i_pos, j) + conj(v2) * A(i_pos + 1, j);
-                            A(i_pos, j) = A(i_pos, j) - sum * t1;
-                            A(i_pos + 1, j) = A(i_pos + 1, j) - sum * t2;
-                        }
-                        // Accumulate the reflector into U
-                        // The loop bounds should be changed to reflect the fact that U2 starts off as diagonal
-                        for (idx_t j = 0; j < nrows(U2); ++j)
-                        {
-                            const TA sum = U2(j, i_pos - i_pos_block) + v2 * U2(j, i_pos - i_pos_block + 1);
-                            U2(j, i_pos - i_pos_block) = U2(j, i_pos - i_pos_block) - sum * conj(t1);
-                            U2(j, i_pos - i_pos_block + 1) = U2(j, i_pos - i_pos_block + 1) - sum * conj(t2);
-                        }
-                    }
-                    else
-                    {
-                        auto v = col(V, i_bulge);
-                        auto H = slice(A, pair{i_pos - 1, i_pos + 3}, pair{i_pos - 1, i_pos + 3});
-                        move_bulge(H, v, s[size(s)- 1 - 2 * i_bulge], s[size(s)- 1 - 2 * i_bulge - 1]);
-
-                        const TA t1 = conj(v[0]);
-                        const TA v2 = v[1];
-                        const TA t2 = t1 * v2;
-                        const TA v3 = v[2];
-                        const TA t3 = t1 * v3;
-                        // Apply the reflector we just calculated from the right (but leave the last row for later)
-                        for (idx_t j = istart_m; j < i_pos + 3; ++j)
-                        {
-                            const TA sum = A(j, i_pos) + v2 * A(j, i_pos + 1) + v3 * A(j, i_pos + 2);
-                            A(j, i_pos) = A(j, i_pos) - sum * conj(t1);
-                            A(j, i_pos + 1) = A(j, i_pos + 1) - sum * conj(t2);
-                            A(j, i_pos + 2) = A(j, i_pos + 2) - sum * conj(t3);
-                        }
-
-                        // Apply the reflector we just calculated from the left
-                        // We only update a single column, the rest is updated later
-                        const TA sum = A(i_pos, i_pos) + conj(v[1]) * A(i_pos + 1, i_pos) + conj(v[2]) * A(i_pos + 2, i_pos);
-                        A(i_pos, i_pos) = A(i_pos, i_pos) - sum * conj(v[0]);
-                        A(i_pos + 1, i_pos) = A(i_pos + 1, i_pos) - sum * conj(v[0]) * v[1];
-                        A(i_pos + 2, i_pos) = A(i_pos + 2, i_pos) - sum * conj(v[0]) * v[2];
-
-                        // Test for deflation.
-                        if (i_pos > ilo)
-                        {
-                            if (A(i_pos, i_pos - 1) != zero)
-                            {
-                                real_t tst1 = abs1(A(i_pos - 1, i_pos - 1)) + abs1(A(i_pos, i_pos));
-                                if (tst1 == zero)
-                                {
-                                    if (i_pos > ilo + 1)
-                                        tst1 += abs1(A(i_pos - 1, i_pos - 2));
-                                    if (i_pos > ilo + 2)
-                                        tst1 += abs1(A(i_pos - 1, i_pos - 3));
-                                    if (i_pos > ilo + 3)
-                                        tst1 += abs1(A(i_pos - 1, i_pos - 4));
-                                    if (i_pos < ihi - 1)
-                                        tst1 += abs1(A(i_pos + 1, i_pos));
-                                    if (i_pos < ihi - 2)
-                                        tst1 += abs1(A(i_pos + 2, i_pos));
-                                    if (i_pos < ihi - 3)
-                                        tst1 += abs1(A(i_pos + 3, i_pos));
-                                }
-                                if (abs1(A(i_pos, i_pos - 1)) < std::max(small_num, eps * tst1))
-                                {
-                                    const real_t ab = std::max(abs1(A(i_pos, i_pos - 1)), abs1(A(i_pos - 1, i_pos)));
-                                    const real_t ba = std::min(abs1(A(i_pos, i_pos - 1)), abs1(A(i_pos - 1, i_pos)));
-                                    const real_t aa = std::max(abs1(A(i_pos, i_pos)), abs1(A(i_pos, i_pos) - A(i_pos - 1, i_pos - 1)));
-                                    const real_t bb = std::min(abs1(A(i_pos, i_pos)), abs1(A(i_pos, i_pos) - A(i_pos - 1, i_pos - 1)));
-                                    const real_t s = aa + ab;
-                                    if (ba * (ab / s) <= std::max(small_num, eps * (bb * (aa / s))))
-                                    {
-                                        A(i_pos, i_pos - 1) = zero;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                i_bulge_start = (i_pos_last + 4 > ihi) ? (i_pos_last + 4 - ihi) / 2 : 0;
-
-                // The following code performs the delayed update from the left
-                // it is optimized for column oriented matrices, but the increased complexity
-                // likely causes slower code
-                // for (idx_t j = i_pos_block; j < istop_m; ++j)
-                // {
-                //     idx_t i_bulge_start2 = (i_pos_last + 2 > j) ? (i_pos_last + 2 - j) / 2 : 0;
-                //     i_bulge_start2 = std::max(i_bulge_start,i_bulge_start2);
-                //     for (idx_t i_bulge = i_bulge_start2; i_bulge < n_bulges; ++i_bulge)
-                //     {
-                //         idx_t i_pos = i_pos_last - 2 * i_bulge;
-                //         auto v = col(V, i_bulge);
-                //         auto sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) + conj(v[2]) * A(i_pos + 2, j);
-                //         A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
-                //         A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
-                //         A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
-                //     }
-                // }
-
-                // Delayed update from the left
-                for (idx_t i_bulge = i_bulge_start; i_bulge < n_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    for (idx_t j = i_pos + 1; j < istop_m; ++j)
-                    {
-                        const TA sum = A(i_pos, j) + conj(v[1]) * A(i_pos + 1, j) + conj(v[2]) * A(i_pos + 2, j);
-                        A(i_pos, j) = A(i_pos, j) - sum * conj(v[0]);
-                        A(i_pos + 1, j) = A(i_pos + 1, j) - sum * conj(v[0]) * v[1];
-                        A(i_pos + 2, j) = A(i_pos + 2, j) - sum * conj(v[0]) * v[2];
-                    }
-                }
-
-                // Accumulate the reflectors into U
-                for (idx_t i_bulge = i_bulge_start; i_bulge < n_bulges; ++i_bulge)
-                {
-                    idx_t i_pos = i_pos_last - 2 * i_bulge;
-                    auto v = col(V, i_bulge);
-                    idx_t i1 = (i_pos - i_pos_block) - (i_pos_last - i_pos_block - n_shifts + 2);
-                    idx_t i2 = std::min(nrows(U2), (i_pos_last - i_pos_block) + (i_pos_last - i_pos_block - n_shifts + 2) + 3);
-                    for (idx_t j = i1; j < i2; ++j)
-                    {
-                        const TA sum = U2(j, i_pos - i_pos_block) + v[1] * U2(j, i_pos - i_pos_block + 1) + v[2] * U2(j, i_pos - i_pos_block + 2);
-                        U2(j, i_pos - i_pos_block) = U2(j, i_pos - i_pos_block) - sum * v[0];
-                        U2(j, i_pos - i_pos_block + 1) = U2(j, i_pos - i_pos_block + 1) - sum * v[0] * conj(v[1]);
-                        U2(j, i_pos - i_pos_block + 2) = U2(j, i_pos - i_pos_block + 2) - sum * v[0] * conj(v[2]);
-                    }
-                }
+        else {
+            istart_m = ilo;
+            istop_m = ihi;
+        }
+        // Horizontal multiply
+        if (ihi < istop_m) {
+            idx_t i = ihi;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto A_slice =
+                    slice(A, pair{i_pos_block, ihi}, pair{i, i + iblock});
+                auto WH_slice =
+                    slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+                gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
+                lacpy(Uplo::General, WH_slice, A_slice);
+                i = i + iblock;
             }
-
-            // Update rest of the matrix
-            if (want_t)
-            {
-                istart_m = 0;
-                istop_m = n;
+        }
+        // Vertical multiply
+        if (istart_m < i_pos_block) {
+            idx_t i = istart_m;
+            while (i < i_pos_block) {
+                idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
+                auto A_slice =
+                    slice(A, pair{i, i + iblock}, pair{i_pos_block, ihi});
+                auto WV_slice =
+                    slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
+                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
+                lacpy(Uplo::General, WV_slice, A_slice);
+                i = i + iblock;
             }
-            else
-            {
-                istart_m = ilo;
-                istop_m = ihi;
-            }
-            // Horizontal multiply
-            if (ihi < istop_m)
-            {
-                idx_t i = ihi;
-                while (i < istop_m)
-                {
-                    idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
-                    auto A_slice = slice(A, pair{i_pos_block, ihi}, pair{i, i + iblock});
-                    auto WH_slice = slice(WH, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
-                    lacpy(Uplo::General, WH_slice, A_slice);
-                    i = i + iblock;
-                }
-            }
-            // Vertical multiply
-            if (istart_m < i_pos_block)
-            {
-                idx_t i = istart_m;
-                while (i < i_pos_block)
-                {
-                    idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
-                    auto A_slice = slice(A, pair{i, i + iblock}, pair{i_pos_block, ihi});
-                    auto WV_slice = slice(WV, pair{0, nrows(A_slice)}, pair{0, ncols(A_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
-                    lacpy(Uplo::General, WV_slice, A_slice);
-                    i = i + iblock;
-                }
-            }
-            // Update Z (also a vertical multiplication)
-            if (want_z)
-            {
-                idx_t i = 0;
-                while (i < n)
-                {
-                    idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
-                    auto Z_slice = slice(Z, pair{i, i + iblock}, pair{i_pos_block, ihi});
-                    auto WV_slice = slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
-                    gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
-                    lacpy(Uplo::General, WV_slice, Z_slice);
-                    i = i + iblock;
-                }
+        }
+        // Update Z (also a vertical multiplication)
+        if (want_z) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Z_slice =
+                    slice(Z, pair{i, i + iblock}, pair{i_pos_block, ihi});
+                auto WV_slice =
+                    slice(WV, pair{0, nrows(Z_slice)}, pair{0, ncols(Z_slice)});
+                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
+                lacpy(Uplo::General, WV_slice, Z_slice);
+                i = i + iblock;
             }
         }
     }
+}
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_QR_SWEEP_HH
+#endif  // TLAPACK_QR_SWEEP_HH

--- a/include/tlapack/lapack/potrf.hpp
+++ b/include/tlapack/lapack/potrf.hpp
@@ -17,18 +17,14 @@
 
 namespace tlapack {
 
-enum class PotrfVariant : char {
-    Blocked = 'B',
-    Recursive = 'R'
-};
+enum class PotrfVariant : char { Blocked = 'B', Recursive = 'R' };
 
-template< typename idx_t >
-struct potrf_opts_t : public ec_opts_t
-{
-    inline constexpr potrf_opts_t( const ec_opts_t& opts = {} )
-    : ec_opts_t( opts ) {};
+template <typename idx_t>
+struct potrf_opts_t : public ec_opts_t {
+    inline constexpr potrf_opts_t(const ec_opts_t& opts = {})
+        : ec_opts_t(opts){};
 
-    idx_t nb = 32;      ///< Block size
+    idx_t nb = 32;  ///< Block size
 
     PotrfVariant variant = PotrfVariant::Blocked;
 };
@@ -74,10 +70,9 @@ struct potrf_opts_t : public ec_opts_t
  * @ingroup computational
  */
 template <class uplo_t, class matrix_t>
-inline int potrf(
-    uplo_t uplo, 
-    matrix_t &A, 
-    const potrf_opts_t< size_type<matrix_t> >& opts = {} )
+inline int potrf(uplo_t uplo,
+                 matrix_t& A,
+                 const potrf_opts_t<size_type<matrix_t> >& opts = {})
 {
     // check arguments
     tlapack_check(uplo == Uplo::Lower || uplo == Uplo::Upper);
@@ -86,12 +81,12 @@ inline int potrf(
                   opts.variant == PotrfVariant::Recursive);
 
     // Call variant
-    if( opts.variant == PotrfVariant::Blocked )
-        return potrf_blocked( uplo, A, opts );
-    else // if( opts.variant == PotrfVariant::Recursive )
-        return potrf2( uplo, A, opts );
+    if (opts.variant == PotrfVariant::Blocked)
+        return potrf_blocked(uplo, A, opts);
+    else  // if( opts.variant == PotrfVariant::Recursive )
+        return potrf2(uplo, A, opts);
 }
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_POTRF_HH
+#endif  // TLAPACK_POTRF_HH

--- a/include/tlapack/lapack/potrf_blocked.hpp
+++ b/include/tlapack/lapack/potrf_blocked.hpp
@@ -12,16 +12,16 @@
 #define TLAPACK_POTRF_BLOCKED_HH
 
 #include "tlapack/base/utils.hpp"
-
-#include "tlapack/lapack/potrf2.hpp"
-#include "tlapack/blas/herk.hpp"
 #include "tlapack/blas/gemm.hpp"
+#include "tlapack/blas/herk.hpp"
 #include "tlapack/blas/trsm.hpp"
+#include "tlapack/lapack/potrf2.hpp"
 
 namespace tlapack {
 
 // Forward declarations
-template< typename idx_t > struct potrf_opts_t;
+template <typename idx_t>
+struct potrf_opts_t;
 
 /** Computes the Cholesky factorization of a Hermitian
  * positive definite matrix A using a blocked algorithm.
@@ -30,7 +30,7 @@ template< typename idx_t > struct potrf_opts_t;
  *      $A = U^H U,$ if uplo = Upper, or
  *      $A = L L^H,$ if uplo = Lower,
  * where U is an upper triangular matrix and L is lower triangular.
- * 
+ *
  * @tparam uplo_t
  *      Access type: Upper or Lower.
  *      Either Uplo or any class that implements `operator Uplo()`.
@@ -41,7 +41,7 @@ template< typename idx_t > struct potrf_opts_t;
  *
  * @param[in,out] A
  *      On entry, the Hermitian matrix A of size n-by-n.
- *      
+ *
  *      - If uplo = Uplo::Upper, the strictly lower
  *      triangular part of A is not referenced.
  *
@@ -60,111 +60,111 @@ template< typename idx_t > struct potrf_opts_t;
  *
  * @ingroup computational
  */
-template< class uplo_t, class matrix_t >
-int potrf_blocked(
-    uplo_t uplo,
-    matrix_t& A,
-    const potrf_opts_t< size_type<matrix_t> >& opts = {} )
+template <class uplo_t, class matrix_t>
+int potrf_blocked(uplo_t uplo,
+                  matrix_t& A,
+                  const potrf_opts_t<size_type<matrix_t> >& opts = {})
 {
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-    using pair   = pair<idx_t,idx_t>;
-    
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
+
     using std::min;
 
     // Constants
-    const real_t one( 1 );
-    const idx_t n  = nrows(A);
+    const real_t one(1);
+    const idx_t n = nrows(A);
     const idx_t nb = opts.nb;
 
     // check arguments
-    tlapack_check( uplo == Uplo::Lower || uplo == Uplo::Upper );
-    tlapack_check( nrows(A) == ncols(A) );
+    tlapack_check(uplo == Uplo::Lower || uplo == Uplo::Upper);
+    tlapack_check(nrows(A) == ncols(A));
 
     // Quick return
-    if (n <= 0)
-        return 0;
+    if (n <= 0) return 0;
 
     // Unblocked code
-    else if ( nb <= 1 || nb >= n )
-        return potrf2( uplo, A );
-    
+    else if (nb <= 1 || nb >= n)
+        return potrf2(uplo, A);
+
     // Blocked code
     else {
-        if( uplo == Uplo::Upper ) {
-            for (idx_t j = 0; j < n; j+=nb)
-            {
-                idx_t jb = min( nb, n-j );
+        if (uplo == Uplo::Upper) {
+            for (idx_t j = 0; j < n; j += nb) {
+                idx_t jb = min(nb, n - j);
 
                 // Define AJJ and A1J
-                auto AJJ = slice( A, pair{j,j+jb}, pair{j,j+jb} );
-                auto A1J = slice( A, pair{0,j}, pair{j,j+jb} );
+                auto AJJ = slice(A, pair{j, j + jb}, pair{j, j + jb});
+                auto A1J = slice(A, pair{0, j}, pair{j, j + jb});
 
-                herk( uplo, conjTranspose, -one, A1J, one, AJJ );
-                
-                int info = potrf2( uplo, AJJ, noErrorCheck );
-                if( info != 0 ) {
-                    tlapack_error( info + j,
-                        "The leading minor of the reported order is not positive definite,"
-                        " and the factorization could not be completed." );
+                herk(uplo, conjTranspose, -one, A1J, one, AJJ);
+
+                int info = potrf2(uplo, AJJ, noErrorCheck);
+                if (info != 0) {
+                    tlapack_error(
+                        info + j,
+                        "The leading minor of the reported order is not "
+                        "positive definite,"
+                        " and the factorization could not be completed.");
                     return info + j;
                 }
 
-                if( j+jb < n ){
-
+                if (j + jb < n) {
                     // Define B and C
-                    auto B = slice( A, pair{0,j}, pair{j+jb,n} );
-                    auto C = slice( A, pair{j,j+jb}, pair{j+jb,n} );
-                
+                    auto B = slice(A, pair{0, j}, pair{j + jb, n});
+                    auto C = slice(A, pair{j, j + jb}, pair{j + jb, n});
+
                     // Compute the current block row
-                    gemm( conjTranspose, noTranspose, -one, A1J, B, one, C );
-                    trsm( left_side, uplo, conjTranspose, nonUnit_diagonal, one, AJJ, C );
+                    gemm(conjTranspose, noTranspose, -one, A1J, B, one, C);
+                    trsm(left_side, uplo, conjTranspose, nonUnit_diagonal, one,
+                         AJJ, C);
                 }
             }
         }
         else {
-            for (idx_t j = 0; j < n; j+=nb)
-            {
-                idx_t jb = min( nb, n-j );
+            for (idx_t j = 0; j < n; j += nb) {
+                idx_t jb = min(nb, n - j);
 
                 // Define AJJ and AJ1
-                auto AJJ = slice( A, pair{j,j+jb}, pair{j,j+jb} );
-                auto AJ1 = slice( A, pair{j,j+jb}, pair{0,j} );
+                auto AJJ = slice(A, pair{j, j + jb}, pair{j, j + jb});
+                auto AJ1 = slice(A, pair{j, j + jb}, pair{0, j});
 
-                herk( uplo, noTranspose, -one, AJ1, one, AJJ );
-                
-                int info = potrf2( uplo, AJJ, noErrorCheck );
-                if( info != 0 ) {
-                    tlapack_error( info + j,
-                        "The leading minor of the reported order is not positive definite,"
-                        " and the factorization could not be completed." );
+                herk(uplo, noTranspose, -one, AJ1, one, AJJ);
+
+                int info = potrf2(uplo, AJJ, noErrorCheck);
+                if (info != 0) {
+                    tlapack_error(
+                        info + j,
+                        "The leading minor of the reported order is not "
+                        "positive definite,"
+                        " and the factorization could not be completed.");
                     return info + j;
                 }
 
-                if( j+jb < n ){
-
+                if (j + jb < n) {
                     // Define B and C
-                    auto B = slice( A, pair{j+jb,n}, pair{0,j} );
-                    auto C = slice( A, pair{j+jb,n}, pair{j,j+jb} );
-                
+                    auto B = slice(A, pair{j + jb, n}, pair{0, j});
+                    auto C = slice(A, pair{j + jb, n}, pair{j, j + jb});
+
                     // Compute the current block row
-                    gemm( noTranspose, conjTranspose, -one, B, AJ1, one, C );
-                    trsm( right_side, uplo, conjTranspose, nonUnit_diagonal, one, AJJ, C );
+                    gemm(noTranspose, conjTranspose, -one, B, AJ1, one, C);
+                    trsm(right_side, uplo, conjTranspose, nonUnit_diagonal, one,
+                         AJJ, C);
                 }
             }
         }
 
         // Report infs and nans on the output
-        tlapack_warn_nans_in_matrix( opts.ec, uplo, A, n+1,
-            "The factorization has some nans." );
-        tlapack_warn_infs_in_matrix( opts.ec, uplo, A, n+1,
-            "The factorization has some infs." );
-        
+        tlapack_warn_nans_in_matrix(opts.ec, uplo, A, n + 1,
+                                    "The factorization has some nans.");
+        tlapack_warn_infs_in_matrix(opts.ec, uplo, A, n + 1,
+                                    "The factorization has some infs.");
+
         return 0;
     }
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_POTRF_BLOCKED_HH
+#endif  // TLAPACK_POTRF_BLOCKED_HH

--- a/include/tlapack/lapack/potrs.hpp
+++ b/include/tlapack/lapack/potrs.hpp
@@ -23,7 +23,7 @@ namespace tlapack {
  *      $A = U^H U,$ if uplo = Upper, or
  *      $A = L L^H,$ if uplo = Lower,
  * where U is an upper triangular matrix and L is lower triangular.
- * 
+ *
  * @tparam uplo_t
  *      Access type: Upper or Lower.
  *      Either Uplo or any class that implements `operator Uplo()`.
@@ -35,7 +35,7 @@ namespace tlapack {
  *
  * @param[in] A
  *      The factor U or L from the Cholesky factorization of A.
- *      
+ *
  *      - If uplo = Uplo::Upper, the strictly lower
  *      triangular part of A is not referenced.
  *
@@ -45,39 +45,38 @@ namespace tlapack {
  * @param[in,out] B
  *      On entry, the matrix B.
  *      On exit,  the matrix X.
- * 
+ *
  * @return = 0: successful exit.
  *
  * @ingroup computational
  */
-template< class uplo_t, class matrixA_t, class matrixB_t >
-int potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
+template <class uplo_t, class matrixA_t, class matrixB_t>
+int potrs(uplo_t uplo, const matrixA_t& A, matrixB_t& B)
 {
-    using T = type_t< matrixB_t >;
-    using real_t = real_type< T >;
+    using T = type_t<matrixB_t>;
+    using real_t = real_type<T>;
 
     // Constants
-    const real_t one( 1 );
+    const real_t one(1);
 
     // Check arguments
-    tlapack_check_false(    uplo != Uplo::Lower &&
-                        uplo != Uplo::Upper );
-    tlapack_check_false(    nrows(A) != ncols(A) );
-    tlapack_check_false(    nrows(B) != ncols(A) );
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(nrows(A) != ncols(A));
+    tlapack_check_false(nrows(B) != ncols(A));
 
-    if( uplo == Uplo::Upper ) {
+    if (uplo == Uplo::Upper) {
         // Solve A*X = B where A = U**H *U.
-        trsm( left_side, uplo, conjTranspose, nonUnit_diagonal, one, A, B );
-        trsm( left_side, uplo, noTranspose,   nonUnit_diagonal, one, A, B );
+        trsm(left_side, uplo, conjTranspose, nonUnit_diagonal, one, A, B);
+        trsm(left_side, uplo, noTranspose, nonUnit_diagonal, one, A, B);
     }
     else {
         // Solve A*X = B where A = L*L**H.
-        trsm( left_side, uplo, noTranspose,   nonUnit_diagonal, one, A, B );
-        trsm( left_side, uplo, conjTranspose, nonUnit_diagonal, one, A, B );
+        trsm(left_side, uplo, noTranspose, nonUnit_diagonal, one, A, B);
+        trsm(left_side, uplo, conjTranspose, nonUnit_diagonal, one, A, B);
     }
     return 0;
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_POTRS_HH
+#endif  // TLAPACK_POTRS_HH

--- a/include/tlapack/lapack/schur_move.hpp
+++ b/include/tlapack/lapack/schur_move.hpp
@@ -1,6 +1,7 @@
 /// @file schur_move.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dtrexc.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dtrexc.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -14,128 +15,115 @@
 #include "tlapack/base/utils.hpp"
 #include "tlapack/lapack/schur_swap.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** schur_move reorders the Schur factorization of a matrix
+ *  S = Q*A*Q**H, so that the diagonal element of T with row index IFST
+ *  is moved to row ILST.
+ *
+ *
+ * @return  0 if success
+ * @return  1 two adjacent blocks were too close to swap (the problem
+              is very ill-conditioned); T may have been partially
+              reordered, and ILST points to the first row of the
+              current position of the block being moved.
+ *
+ * @param[in]     want_q bool
+ *                Whether or not to apply the transformations to Q
+ * @param[in,out] A n-by-n matrix.
+ *                Must be in Schur form
+ * @param[in,out] Q n-by-n matrix.
+ *                Orthogonal matrix, not referenced if want_q is false
+ * @param[in,out] ifst integer
+ *                Initial row index of the eigenvalue block
+ * @param[in,out] ilst integer
+ *                Index of the eigenvalue block at the exit of the routine.
+ *                If it is not possible to move the eigenvalue block to the
+ *                given ilst, the value may be changed.
+ *
+ * @ingroup auxiliary
+ */
+template <typename matrix_t>
+int schur_move(bool want_q,
+               matrix_t& A,
+               matrix_t& Q,
+               size_type<matrix_t>& ifst,
+               size_type<matrix_t>& ilst)
 {
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
 
-    /** schur_move reorders the Schur factorization of a matrix
-     *  S = Q*A*Q**H, so that the diagonal element of T with row index IFST
-     *  is moved to row ILST.
-     *
-     *
-     * @return  0 if success
-     * @return  1 two adjacent blocks were too close to swap (the problem
-                  is very ill-conditioned); T may have been partially
-                  reordered, and ILST points to the first row of the
-                  current position of the block being moved.
-     *
-     * @param[in]     want_q bool
-     *                Whether or not to apply the transformations to Q
-     * @param[in,out] A n-by-n matrix.
-     *                Must be in Schur form
-     * @param[in,out] Q n-by-n matrix.
-     *                Orthogonal matrix, not referenced if want_q is false
-     * @param[in,out] ifst integer
-     *                Initial row index of the eigenvalue block
-     * @param[in,out] ilst integer
-     *                Index of the eigenvalue block at the exit of the routine.
-     *                If it is not possible to move the eigenvalue block to the
-     *                given ilst, the value may be changed.
-     *
-     * @ingroup auxiliary
-     */
-    template < typename matrix_t >
-    int schur_move(bool want_q, matrix_t &A, matrix_t &Q, size_type<matrix_t> &ifst, size_type<matrix_t> &ilst)
-    {
-        using idx_t = size_type<matrix_t>;
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
+    const idx_t n = ncols(A);
+    const real_t zero(0);
 
-        const idx_t n = ncols(A);
-        const real_t zero(0);
+    // Quick return
+    if (n == 0) return 0;
 
-        // Quick return
-        if (n == 0)
-            return 0;
+    // Check if ifst points to the middle of a 2x2 block
+    if (!is_complex<T>::value)
+        if (ifst > 0)
+            if (A(ifst, ifst - 1) != zero) ifst = ifst - 1;
 
-        // Check if ifst points to the middle of a 2x2 block
-        if (!is_complex<T>::value)
-            if (ifst > 0)
-                if (A(ifst, ifst - 1) != zero)
-                    ifst = ifst - 1;
+    // Size of the current block, can be either 1, 2
+    idx_t nbf = 1;
+    if (!is_complex<T>::value)
+        if (ifst < n - 1)
+            if (A(ifst + 1, ifst) != zero) nbf = 2;
 
-        // Size of the current block, can be either 1, 2
-        idx_t nbf = 1;
-        if (!is_complex<T>::value)
-            if (ifst < n - 1)
-                if (A(ifst + 1, ifst) != zero)
-                    nbf = 2;
+    // Check if ilst points to the middle of a 2x2 block
+    if (!is_complex<T>::value)
+        if (ilst > 0)
+            if (A(ilst, ilst - 1) != zero) ilst = ilst - 1;
 
-        // Check if ilst points to the middle of a 2x2 block
-        if (!is_complex<T>::value)
-            if (ilst > 0)
-                if (A(ilst, ilst - 1) != zero)
-                    ilst = ilst - 1;
+    // Size of the final block, can be either 1, 2
+    idx_t nbl = 1;
+    if (!is_complex<T>::value)
+        if (ilst < n - 1)
+            if (A(ilst + 1, ilst) != zero) nbl = 2;
 
-        // Size of the final block, can be either 1, 2
-        idx_t nbl = 1;
-        if (!is_complex<T>::value)
-            if (ilst < n - 1)
-                if (A(ilst + 1, ilst) != zero)
-                    nbl = 2;
+    idx_t here = ifst;
+    if (ifst < ilst) {
+        if (nbf == 2 and nbl == 1) ilst = ilst - 1;
+        if (nbf == 1 and nbl == 2) ilst = ilst + 1;
 
-        idx_t here = ifst;
-        if (ifst < ilst)
-        {
-            if( nbf == 2 and nbl == 1 )
-                ilst = ilst - 1;
-            if( nbf == 1 and nbl == 2 )
-                ilst = ilst + 1;
+        while (here != ilst) {
+            // Size of the next eigenvalue block
+            idx_t nbnext = 1;
+            if (!is_complex<T>::value)
+                if (here + nbf + 1 < n)
+                    if (A(here + nbf + 1, here + nbf) != zero) nbnext = 2;
 
-
-            while (here != ilst)
-            {
-                // Size of the next eigenvalue block
-                idx_t nbnext = 1;
-                if (!is_complex<T>::value)
-                    if (here + nbf + 1 < n)
-                        if (A(here + nbf + 1, here + nbf) != zero)
-                            nbnext = 2;
-
-                int ierr = schur_swap(want_q, A, Q, here, nbf, nbnext);
-                if (ierr)
-                {
-                    // The swap failed, return with error
-                    ilst = here;
-                    return 1;
-                }
-                here = here + nbnext;
+            int ierr = schur_swap(want_q, A, Q, here, nbf, nbnext);
+            if (ierr) {
+                // The swap failed, return with error
+                ilst = here;
+                return 1;
             }
+            here = here + nbnext;
         }
-        else
-        {
-            while (here != ilst)
-            {
-                // Size of the next eigenvalue block
-                idx_t nbnext = 1;
-                if (!is_complex<T>::value)
-                    if (here > 1)
-                        if (A(here - 1, here - 2) != zero)
-                            nbnext = 2;
+    }
+    else {
+        while (here != ilst) {
+            // Size of the next eigenvalue block
+            idx_t nbnext = 1;
+            if (!is_complex<T>::value)
+                if (here > 1)
+                    if (A(here - 1, here - 2) != zero) nbnext = 2;
 
-                int ierr = schur_swap(want_q, A, Q, here - nbnext, nbnext, nbf);
-                if (ierr)
-                {
-                    // The swap failed, return with error
-                    ilst = here;
-                    return 1;
-                }
-                here = here - nbnext;
+            int ierr = schur_swap(want_q, A, Q, here - nbnext, nbnext, nbf);
+            if (ierr) {
+                // The swap failed, return with error
+                ilst = here;
+                return 1;
             }
+            here = here - nbnext;
         }
-
-        return 0;
     }
 
-} // lapack
+    return 0;
+}
 
-#endif // TLAPACK_SCHUR_MOVE_HH
+}  // namespace tlapack
+
+#endif  // TLAPACK_SCHUR_MOVE_HH

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -1,6 +1,7 @@
 /// @file schur_swap.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlaexc.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlaexc.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -12,488 +13,97 @@
 #define TLAPACK_SCHUR_SWAP_HH
 
 #include "tlapack/base/utils.hpp"
-
-#include "tlapack/blas/swap.hpp"
 #include "tlapack/blas/rot.hpp"
 #include "tlapack/blas/rotg.hpp"
-#include "tlapack/lapack/lange.hpp"
-#include "tlapack/lapack/lasy2.hpp"
-#include "tlapack/lapack/larfg.hpp"
+#include "tlapack/blas/swap.hpp"
 #include "tlapack/lapack/lahqr_schur22.hpp"
+#include "tlapack/lapack/lange.hpp"
+#include "tlapack/lapack/larfg.hpp"
+#include "tlapack/lapack/lasy2.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** schur_swap, swaps 2 eigenvalues of A.
+ *
+ * @return  0 if success
+ * @return  1 the swap failed, this usually means the eigenvalues
+ *            of the blocks are too close.
+ *
+ * @param[in]     want_q bool
+ *                Whether or not to apply the transformations to Q
+ * @param[in,out] A n-by-n matrix.
+ *                Must be in Schur form
+ * @param[in,out] Q n-by-n matrix.
+ *                Orthogonal matrix, not referenced if want_q is false
+ * @param[in]     j0 integer
+ *                Index of first eigenvalue block
+ * @param[in]     n1 integer
+ *                Size of first eigenvalue block
+ * @param[in]     n2 integer
+ *                Size of second eigenvalue block
+ *
+ * @ingroup auxiliary
+ */
+template <typename matrix_t,
+          enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
+int schur_swap(bool want_q,
+               matrix_t& A,
+               matrix_t& Q,
+               const size_type<matrix_t>& j0,
+               const size_type<matrix_t>& n1,
+               const size_type<matrix_t>& n2)
 {
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
+    using std::max;
 
-    /** schur_swap, swaps 2 eigenvalues of A.
-     *
-     * @return  0 if success
-     * @return  1 the swap failed, this usually means the eigenvalues
-     *            of the blocks are too close.
-     * 
-     * @param[in]     want_q bool
-     *                Whether or not to apply the transformations to Q
-     * @param[in,out] A n-by-n matrix.
-     *                Must be in Schur form
-     * @param[in,out] Q n-by-n matrix.
-     *                Orthogonal matrix, not referenced if want_q is false
-     * @param[in]     j0 integer
-     *                Index of first eigenvalue block
-     * @param[in]     n1 integer
-     *                Size of first eigenvalue block
-     * @param[in]     n2 integer
-     *                Size of second eigenvalue block
-     *
-     * @ingroup auxiliary
-     */
-    template < typename matrix_t,
-        enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true
-    >
-    int schur_swap(bool want_q, matrix_t &A, matrix_t &Q, const size_type<matrix_t> &j0, const size_type<matrix_t> &n1, const size_type<matrix_t> &n2)
-    {
-        using idx_t = size_type<matrix_t>;
-        using T = type_t<matrix_t>;
-        using pair = pair<idx_t, idx_t>;
-        using std::max;
+    // Functor for creating new matrices
+    Create<matrix_t> new_matrix;
 
-        // Functor for creating new matrices
-        Create<matrix_t> new_matrix;
+    const idx_t n = ncols(A);
+    const T zero(0);
+    const T ten(10);
 
-        const idx_t n = ncols(A);
-        const T zero(0);
-        const T ten(10);
+    tlapack_check(nrows(A) == n);
+    tlapack_check(nrows(Q) == n);
+    tlapack_check(ncols(Q) == n);
+    tlapack_check(0 <= j0);
+    tlapack_check(j0 + n1 + n2 <= n);
+    tlapack_check(n1 == 1 or n1 == 2);
+    tlapack_check(n2 == 1 or n2 == 2);
 
-        tlapack_check(nrows(A) == n);
-        tlapack_check(nrows(Q) == n);
-        tlapack_check(ncols(Q) == n);
-        tlapack_check(0 <= j0);
-        tlapack_check(j0 + n1 + n2 <= n);
-        tlapack_check(n1 == 1 or n1 == 2);
-        tlapack_check(n2 == 1 or n2 == 2);
+    const idx_t j1 = j0 + 1;
+    const idx_t j2 = j0 + 2;
+    const idx_t j3 = j0 + 3;
 
-        const idx_t j1 = j0 + 1;
-        const idx_t j2 = j0 + 2;
-        const idx_t j3 = j0 + 3;
-
-        // Check if the 2x2 eigenvalue blocks consist of 2 1x1 blocks
-        // If so, treat them separately
-        if (n1 == 2)
-            if (A(j1, j0) == zero)
-            {
-                // only 2x2 swaps can fail, so we don't need to check for error
-                schur_swap(want_q, A, Q, j1, (idx_t)1, n2);
-                schur_swap(want_q, A, Q, j0, (idx_t)1, n2);
-                return 0;
-            }
-        if (n2 == 2)
-            if (A(j0 + n1 + 1, j0 + n1) == zero)
-            {
-                // only 2x2 swaps can fail, so we don't need to check for error
-                schur_swap(want_q, A, Q, j0, n1, (idx_t)1);
-                schur_swap(want_q, A, Q, j1, n1, (idx_t)1);
-                return 0;
-            }
-
-        if (n1 == 1 and n2 == 1)
-        {
-            //
-            // Swap two 1-by-1 blocks.
-            //
-            const T t00 = A(j0, j0);
-            const T t11 = A(j1, j1);
-            //
-            // Determine the transformation to perform the interchange
-            //
-            T cs, sn;
-            T temp = A(j0, j1);
-            T temp2 = t11 - t00;
-            rotg(temp, temp2, cs, sn);
-
-            A(j1, j1) = t00;
-            A(j0, j0) = t11;
-
-            // Apply transformation from the left
-            if (j2 < n)
-            {
-                auto row1 = slice(A, j0, pair{j2, n});
-                auto row2 = slice(A, j1, pair{j2, n});
-                rot(row1, row2, cs, sn);
-            }
-            // Apply transformation from the right
-            if (j0 > 0)
-            {
-                auto col1 = slice(A, pair{0, j0}, j0);
-                auto col2 = slice(A, pair{0, j0}, j1);
-                rot(col1, col2, cs, sn);
-            }
-            if (want_q)
-            {
-                auto row1 = col(Q, j0);
-                auto row2 = col(Q, j1);
-                rot(row1, row2, cs, sn);
-            }
+    // Check if the 2x2 eigenvalue blocks consist of 2 1x1 blocks
+    // If so, treat them separately
+    if (n1 == 2)
+        if (A(j1, j0) == zero) {
+            // only 2x2 swaps can fail, so we don't need to check for error
+            schur_swap(want_q, A, Q, j1, (idx_t)1, n2);
+            schur_swap(want_q, A, Q, j0, (idx_t)1, n2);
+            return 0;
         }
-        if (n1 == 1 and n2 == 2)
-        {
-            //
-            // Swap 1-by-1 block with 2-by-2 block
-            //
-
-            std::vector<T> B_; auto B = new_matrix(B_, 3, 2);
-            B(0, 0) = A(j0, j1);
-            B(1, 0) = A(j1, j1) - A(j0, j0);
-            B(2, 0) = A(j2, j1);
-            B(0, 1) = A(j0, j2);
-            B(1, 1) = A(j1, j2);
-            B(2, 1) = A(j2, j2) - A(j0, j0);
-
-            // Make B upper triangular
-            T tau1, tau2;
-            auto v1 = slice(B, pair{0, 3}, 0);
-            auto v2 = slice(B, pair{1, 3}, 1);
-            larfg(v1, tau1);
-            const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
-            B(0, 1) = B(0, 1) - sum * tau1;
-            B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
-            B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
-            larfg(v2, tau2);
-
-            //
-            // Apply reflections to A and Q
-            //
-
-            // Reflections from the left
-            for (idx_t j = j0; j < n; ++j)
-            {
-                T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j);
-                A(j0, j) = A(j0, j) - sum * tau1;
-                A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
-                A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
-
-                sum = A(j1, j) + v2[1] * A(j2, j);
-                A(j1, j) = A(j1, j) - sum * tau2;
-                A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
-            }
-            // Reflections from the right
-            for (idx_t j = 0; j < j3; ++j)
-            {
-                T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2);
-                A(j, j0) = A(j, j0) - sum * tau1;
-                A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
-                A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
-
-                sum = A(j, j1) + v2[1] * A(j, j2);
-                A(j, j1) = A(j, j1) - sum * tau2;
-                A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
-            }
-
-            if (want_q)
-            {
-
-                for (idx_t j = 0; j < n; ++j)
-                {
-                    T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2);
-                    Q(j, j0) = Q(j, j0) - sum * tau1;
-                    Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
-                    Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
-
-                    sum = Q(j, j1) + v2[1] * Q(j, j2);
-                    Q(j, j1) = Q(j, j1) - sum * tau2;
-                    Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
-                }
-            }
-
-            A(j2, j0) = zero;
-            A(j2, j1) = zero;
-        }
-        if (n1 == 2 and n2 == 1)
-        {
-            //
-            // Swap 2-by-2 block with 1-by-1 block
-            //
-
-            std::vector<T> B_; auto B = new_matrix(B_, 3, 2);
-            B(0, 0) = A(j1, j2);
-            B(1, 0) = A(j1, j1) - A(j2, j2);
-            B(2, 0) = A(j1, j0);
-            B(0, 1) = A(j0, j2);
-            B(1, 1) = A(j0, j1);
-            B(2, 1) = A(j0, j0) - A(j2, j2);
-
-            // Make B upper triangular
-            T tau1, tau2;
-            auto v1 = slice(B, pair{0, 3}, 0);
-            auto v2 = slice(B, pair{1, 3}, 1);
-            larfg(v1, tau1);
-            const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
-            B(0, 1) = B(0, 1) - sum * tau1;
-            B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
-            B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
-            larfg(v2, tau2);
-
-            //
-            // Apply reflections to A and Q
-            //
-
-            // Reflections from the left
-            for (idx_t j = j0; j < n; ++j)
-            {
-                T sum = A(j2, j) + v1[1] * A(j1, j) + v1[2] * A(j0, j);
-                A(j2, j) = A(j2, j) - sum * tau1;
-                A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
-                A(j0, j) = A(j0, j) - sum * tau1 * v1[2];
-
-                sum = A(j1, j) + v2[1] * A(j0, j);
-                A(j1, j) = A(j1, j) - sum * tau2;
-                A(j0, j) = A(j0, j) - sum * tau2 * v2[1];
-            }
-            // Reflections from the right
-            for (idx_t j = 0; j < j3; ++j)
-            {
-                T sum = A(j, j2) + v1[1] * A(j, j1) + v1[2] * A(j, j0);
-                A(j, j2) = A(j, j2) - sum * tau1;
-                A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
-                A(j, j0) = A(j, j0) - sum * tau1 * v1[2];
-
-                sum = A(j, j1) + v2[1] * A(j, j0);
-                A(j, j1) = A(j, j1) - sum * tau2;
-                A(j, j0) = A(j, j0) - sum * tau2 * v2[1];
-            }
-
-            if (want_q)
-            {
-                for (idx_t j = 0; j < n; ++j)
-                {
-                    T sum = Q(j, j2) + v1[1] * Q(j, j1) + v1[2] * Q(j, j0);
-                    Q(j, j2) = Q(j, j2) - sum * tau1;
-                    Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
-                    Q(j, j0) = Q(j, j0) - sum * tau1 * v1[2];
-
-                    sum = Q(j, j1) + v2[1] * Q(j, j0);
-                    Q(j, j1) = Q(j, j1) - sum * tau2;
-                    Q(j, j0) = Q(j, j0) - sum * tau2 * v2[1];
-                }
-            }
-
-            A(j1, j0) = zero;
-            A(j2, j0) = zero;
-        }
-        if (n1 == 2 and n2 == 2)
-        {
-            std::vector<T> D_; auto D = new_matrix(D_, 4, 4);
-
-            auto AD_slice = slice(A, pair{j0, j0 + 4}, pair{j0, j0 + 4});
-            lacpy(Uplo::General, AD_slice, D);
-            auto dnorm = lange(Norm::Max, D);
-
-            const T eps = ulp<T>();
-            const T small_num = safe_min<T>() / eps;
-            T thresh = max(ten * eps * dnorm, small_num);
-
-            std::vector<T> V_; auto V = new_matrix(V_, 4, 2);
-            auto X = slice(V, pair{0, 2}, pair{0, 2});
-            auto TL = slice(D, pair{0, 2}, pair{0, 2});
-            auto TR = slice(D, pair{2, 4}, pair{2, 4});
-            auto B = slice(D, pair{0, 2}, pair{2, 4});
-            T scale, xnorm;
-            lasy2(Op::NoTrans, Op::NoTrans, -1, TL, TR, B, scale, X, xnorm);
-
-            V(2, 0) = -scale;
-            V(2, 1) = zero;
-            V(3, 0) = zero;
-            V(3, 1) = -scale;
-
-            // Make V upper triangular
-            T tau1, tau2;
-            auto v1 = slice(V, pair{0, 4}, 0);
-            auto v2 = slice(V, pair{1, 4}, 1);
-            larfg(v1, tau1);
-            const T sum = V(0, 1) + v1[1] * V(1, 1) + v1[2] * V(2, 1) + v1[3] * V(3, 1);
-            V(0, 1) = V(0, 1) - sum * tau1;
-            V(1, 1) = V(1, 1) - sum * tau1 * v1[1];
-            V(2, 1) = V(2, 1) - sum * tau1 * v1[2];
-            V(3, 1) = V(3, 1) - sum * tau1 * v1[3];
-            larfg(v2, tau2);
-
-            // Apply reflections to D to check error
-            for (idx_t j = 0; j < 4; ++j)
-            {
-                T sum = D(0, j) + v1[1] * D(1, j) + v1[2] * D(2, j) + v1[3] * D(3, j);
-                D(0, j) = D(0, j) - sum * tau1;
-                D(1, j) = D(1, j) - sum * tau1 * v1[1];
-                D(2, j) = D(2, j) - sum * tau1 * v1[2];
-                D(3, j) = D(3, j) - sum * tau1 * v1[3];
-
-                sum = D(1, j) + v2[1] * D(2, j) + v2[2] * D(3, j);
-                D(1, j) = D(1, j) - sum * tau2;
-                D(2, j) = D(2, j) - sum * tau2 * v2[1];
-                D(3, j) = D(3, j) - sum * tau2 * v2[2];
-            }
-            for (idx_t j = 0; j < 4; ++j)
-            {
-                T sum = D(j, 0) + v1[1] * D(j, 1) + v1[2] * D(j, 2) + v1[3] * D(j, 3);
-                D(j, 0) = D(j, 0) - sum * tau1;
-                D(j, 1) = D(j, 1) - sum * tau1 * v1[1];
-                D(j, 2) = D(j, 2) - sum * tau1 * v1[2];
-                D(j, 3) = D(j, 3) - sum * tau1 * v1[3];
-
-                sum = D(j, 1) + v2[1] * D(j, 2) + v2[2] * D(j, 3);
-                D(j, 1) = D(j, 1) - sum * tau2;
-                D(j, 2) = D(j, 2) - sum * tau2 * v2[1];
-                D(j, 3) = D(j, 3) - sum * tau2 * v2[2];
-            }
-
-            if (max(max(abs(D(2, 0)), abs(D(2, 1))), max(abs(D(3, 0)), abs(D(3, 1)))) > thresh)
-                return 1;
-
-            // Reflections from the left
-            for (idx_t j = j0; j < n; ++j)
-            {
-                T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j) + v1[3] * A(j3, j);
-                A(j0, j) = A(j0, j) - sum * tau1;
-                A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
-                A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
-                A(j3, j) = A(j3, j) - sum * tau1 * v1[3];
-
-                sum = A(j1, j) + v2[1] * A(j2, j) + v2[2] * A(j3, j);
-                A(j1, j) = A(j1, j) - sum * tau2;
-                A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
-                A(j3, j) = A(j3, j) - sum * tau2 * v2[2];
-            }
-            // Reflections from the right
-            for (idx_t j = 0; j < j0 + 4; ++j)
-            {
-                T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2) + v1[3] * A(j, j3);
-                A(j, j0) = A(j, j0) - sum * tau1;
-                A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
-                A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
-                A(j, j3) = A(j, j3) - sum * tau1 * v1[3];
-
-                sum = A(j, j1) + v2[1] * A(j, j2) + v2[2] * A(j, j3);
-                A(j, j1) = A(j, j1) - sum * tau2;
-                A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
-                A(j, j3) = A(j, j3) - sum * tau2 * v2[2];
-            }
-
-            if (want_q)
-            {
-
-                for (idx_t j = 0; j < n; ++j)
-                {
-                    T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2) + v1[3] * Q(j, j3);
-                    Q(j, j0) = Q(j, j0) - sum * tau1;
-                    Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
-                    Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
-                    Q(j, j3) = Q(j, j3) - sum * tau1 * v1[3];
-
-                    sum = Q(j, j1) + v2[1] * Q(j, j2) + v2[2] * Q(j, j3);
-                    Q(j, j1) = Q(j, j1) - sum * tau2;
-                    Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
-                    Q(j, j3) = Q(j, j3) - sum * tau2 * v2[2];
-                }
-            }
-
-            A(j2, j0) = zero;
-            A(j2, j1) = zero;
-            A(j3, j0) = zero;
-            A(j3, j1) = zero;
+    if (n2 == 2)
+        if (A(j0 + n1 + 1, j0 + n1) == zero) {
+            // only 2x2 swaps can fail, so we don't need to check for error
+            schur_swap(want_q, A, Q, j0, n1, (idx_t)1);
+            schur_swap(want_q, A, Q, j1, n1, (idx_t)1);
+            return 0;
         }
 
-        // Standardize the 2x2 Schur blocks (if any)
-        if (n2 == 2)
-        {
-            T cs, sn;
-            complex_type<T> s1, s2;
-            lahqr_schur22(A(j0, j0), A(j0, j1), A(j1, j0), A(j1, j1), s1, s2, cs, sn); // Apply transformation from the left
-            if (j2 < n)
-            {
-                auto row1 = slice(A, j0, pair{j2, n});
-                auto row2 = slice(A, j1, pair{j2, n});
-                rot(row1, row2, cs, sn);
-            }
-            // Apply transformation from the right
-            if (j0 > 0)
-            {
-                auto col1 = slice(A, pair{0, j0}, j0);
-                auto col2 = slice(A, pair{0, j0}, j1);
-                rot(col1, col2, cs, sn);
-            }
-            if (want_q)
-            {
-                auto row1 = col(Q, j0);
-                auto row2 = col(Q, j1);
-                rot(row1, row2, cs, sn);
-            }
-        }
-        if (n1 == 2)
-        {
-            idx_t j0_2 = j0 + n2;
-            idx_t j1_2 = j0_2 + 1;
-
-            T cs, sn;
-            complex_type<T> s1, s2;
-            lahqr_schur22(A(j0_2, j0_2), A(j0_2, j1_2), A(j1_2, j0_2), A(j1_2, j1_2), s1, s2, cs, sn); // Apply transformation from the left
-            if (j0_2 + 2 < n)
-            {
-                auto row1 = slice(A, j0_2, pair{j0_2 + 2, n});
-                auto row2 = slice(A, j1_2, pair{j0_2 + 2, n});
-                rot(row1, row2, cs, sn);
-            }
-            // Apply transformation from the right
-            if (j0_2 > 0)
-            {
-                auto col1 = slice(A, pair{0, j0_2}, j0_2);
-                auto col2 = slice(A, pair{0, j0_2}, j1_2);
-                rot(col1, col2, cs, sn);
-            }
-            if (want_q)
-            {
-                auto row1 = col(Q, j0_2);
-                auto row2 = col(Q, j1_2);
-                rot(row1, row2, cs, sn);
-            }
-        }
-
-        return 0;
-    }
-
-    /** schur_swap, swaps 2 eigenvalues of A.
-     * 
-     * Implementation for complex matrices
-     *
-     * @ingroup auxiliary
-     */
-    template < typename matrix_t,
-        enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true
-    >
-    int schur_swap(bool want_q, matrix_t &A, matrix_t &Q, const size_type<matrix_t> &j0, const size_type<matrix_t> &n1, const size_type<matrix_t> &n2)
-    {
-        using idx_t = size_type<matrix_t>;
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
-        using pair = pair<idx_t, idx_t>;
-
-        const idx_t n = ncols(A);
-
-        tlapack_check(nrows(A) == n);
-        tlapack_check(nrows(Q) == n);
-        tlapack_check(ncols(Q) == n);
-        tlapack_check(0 <= j0 and j0 < n);
-        tlapack_check(n1 == 1);
-        tlapack_check(n2 == 1);
-
-        const idx_t j1 = j0 + 1;
-        const idx_t j2 = j0 + 2;
-
+    if (n1 == 1 and n2 == 1) {
         //
-        // In the complex case, there can only be 1x1 blocks to swap
+        // Swap two 1-by-1 blocks.
         //
         const T t00 = A(j0, j0);
         const T t11 = A(j1, j1);
         //
         // Determine the transformation to perform the interchange
         //
-        real_t cs;
-        T sn;
+        T cs, sn;
         T temp = A(j0, j1);
         T temp2 = t11 - t00;
         rotg(temp, temp2, cs, sn);
@@ -502,29 +112,404 @@ namespace tlapack
         A(j0, j0) = t11;
 
         // Apply transformation from the left
-        if (j2 < n)
-        {
+        if (j2 < n) {
             auto row1 = slice(A, j0, pair{j2, n});
             auto row2 = slice(A, j1, pair{j2, n});
             rot(row1, row2, cs, sn);
         }
         // Apply transformation from the right
-        if (j0 > 0)
-        {
+        if (j0 > 0) {
             auto col1 = slice(A, pair{0, j0}, j0);
             auto col2 = slice(A, pair{0, j0}, j1);
-            rot(col1, col2, cs, conj(sn));
+            rot(col1, col2, cs, sn);
         }
-        if (want_q)
-        {
+        if (want_q) {
             auto row1 = col(Q, j0);
             auto row2 = col(Q, j1);
-            rot(row1, row2, cs, conj(sn));
+            rot(row1, row2, cs, sn);
+        }
+    }
+    if (n1 == 1 and n2 == 2) {
+        //
+        // Swap 1-by-1 block with 2-by-2 block
+        //
+
+        std::vector<T> B_;
+        auto B = new_matrix(B_, 3, 2);
+        B(0, 0) = A(j0, j1);
+        B(1, 0) = A(j1, j1) - A(j0, j0);
+        B(2, 0) = A(j2, j1);
+        B(0, 1) = A(j0, j2);
+        B(1, 1) = A(j1, j2);
+        B(2, 1) = A(j2, j2) - A(j0, j0);
+
+        // Make B upper triangular
+        T tau1, tau2;
+        auto v1 = slice(B, pair{0, 3}, 0);
+        auto v2 = slice(B, pair{1, 3}, 1);
+        larfg(v1, tau1);
+        const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
+        B(0, 1) = B(0, 1) - sum * tau1;
+        B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
+        B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
+        larfg(v2, tau2);
+
+        //
+        // Apply reflections to A and Q
+        //
+
+        // Reflections from the left
+        for (idx_t j = j0; j < n; ++j) {
+            T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j);
+            A(j0, j) = A(j0, j) - sum * tau1;
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
+            A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
+
+            sum = A(j1, j) + v2[1] * A(j2, j);
+            A(j1, j) = A(j1, j) - sum * tau2;
+            A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
+        }
+        // Reflections from the right
+        for (idx_t j = 0; j < j3; ++j) {
+            T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2);
+            A(j, j0) = A(j, j0) - sum * tau1;
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
+            A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
+
+            sum = A(j, j1) + v2[1] * A(j, j2);
+            A(j, j1) = A(j, j1) - sum * tau2;
+            A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
         }
 
-        return 0;
+        if (want_q) {
+            for (idx_t j = 0; j < n; ++j) {
+                T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2);
+                Q(j, j0) = Q(j, j0) - sum * tau1;
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
+                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
+
+                sum = Q(j, j1) + v2[1] * Q(j, j2);
+                Q(j, j1) = Q(j, j1) - sum * tau2;
+                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
+            }
+        }
+
+        A(j2, j0) = zero;
+        A(j2, j1) = zero;
+    }
+    if (n1 == 2 and n2 == 1) {
+        //
+        // Swap 2-by-2 block with 1-by-1 block
+        //
+
+        std::vector<T> B_;
+        auto B = new_matrix(B_, 3, 2);
+        B(0, 0) = A(j1, j2);
+        B(1, 0) = A(j1, j1) - A(j2, j2);
+        B(2, 0) = A(j1, j0);
+        B(0, 1) = A(j0, j2);
+        B(1, 1) = A(j0, j1);
+        B(2, 1) = A(j0, j0) - A(j2, j2);
+
+        // Make B upper triangular
+        T tau1, tau2;
+        auto v1 = slice(B, pair{0, 3}, 0);
+        auto v2 = slice(B, pair{1, 3}, 1);
+        larfg(v1, tau1);
+        const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
+        B(0, 1) = B(0, 1) - sum * tau1;
+        B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
+        B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
+        larfg(v2, tau2);
+
+        //
+        // Apply reflections to A and Q
+        //
+
+        // Reflections from the left
+        for (idx_t j = j0; j < n; ++j) {
+            T sum = A(j2, j) + v1[1] * A(j1, j) + v1[2] * A(j0, j);
+            A(j2, j) = A(j2, j) - sum * tau1;
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
+            A(j0, j) = A(j0, j) - sum * tau1 * v1[2];
+
+            sum = A(j1, j) + v2[1] * A(j0, j);
+            A(j1, j) = A(j1, j) - sum * tau2;
+            A(j0, j) = A(j0, j) - sum * tau2 * v2[1];
+        }
+        // Reflections from the right
+        for (idx_t j = 0; j < j3; ++j) {
+            T sum = A(j, j2) + v1[1] * A(j, j1) + v1[2] * A(j, j0);
+            A(j, j2) = A(j, j2) - sum * tau1;
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
+            A(j, j0) = A(j, j0) - sum * tau1 * v1[2];
+
+            sum = A(j, j1) + v2[1] * A(j, j0);
+            A(j, j1) = A(j, j1) - sum * tau2;
+            A(j, j0) = A(j, j0) - sum * tau2 * v2[1];
+        }
+
+        if (want_q) {
+            for (idx_t j = 0; j < n; ++j) {
+                T sum = Q(j, j2) + v1[1] * Q(j, j1) + v1[2] * Q(j, j0);
+                Q(j, j2) = Q(j, j2) - sum * tau1;
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
+                Q(j, j0) = Q(j, j0) - sum * tau1 * v1[2];
+
+                sum = Q(j, j1) + v2[1] * Q(j, j0);
+                Q(j, j1) = Q(j, j1) - sum * tau2;
+                Q(j, j0) = Q(j, j0) - sum * tau2 * v2[1];
+            }
+        }
+
+        A(j1, j0) = zero;
+        A(j2, j0) = zero;
+    }
+    if (n1 == 2 and n2 == 2) {
+        std::vector<T> D_;
+        auto D = new_matrix(D_, 4, 4);
+
+        auto AD_slice = slice(A, pair{j0, j0 + 4}, pair{j0, j0 + 4});
+        lacpy(Uplo::General, AD_slice, D);
+        auto dnorm = lange(Norm::Max, D);
+
+        const T eps = ulp<T>();
+        const T small_num = safe_min<T>() / eps;
+        T thresh = max(ten * eps * dnorm, small_num);
+
+        std::vector<T> V_;
+        auto V = new_matrix(V_, 4, 2);
+        auto X = slice(V, pair{0, 2}, pair{0, 2});
+        auto TL = slice(D, pair{0, 2}, pair{0, 2});
+        auto TR = slice(D, pair{2, 4}, pair{2, 4});
+        auto B = slice(D, pair{0, 2}, pair{2, 4});
+        T scale, xnorm;
+        lasy2(Op::NoTrans, Op::NoTrans, -1, TL, TR, B, scale, X, xnorm);
+
+        V(2, 0) = -scale;
+        V(2, 1) = zero;
+        V(3, 0) = zero;
+        V(3, 1) = -scale;
+
+        // Make V upper triangular
+        T tau1, tau2;
+        auto v1 = slice(V, pair{0, 4}, 0);
+        auto v2 = slice(V, pair{1, 4}, 1);
+        larfg(v1, tau1);
+        const T sum =
+            V(0, 1) + v1[1] * V(1, 1) + v1[2] * V(2, 1) + v1[3] * V(3, 1);
+        V(0, 1) = V(0, 1) - sum * tau1;
+        V(1, 1) = V(1, 1) - sum * tau1 * v1[1];
+        V(2, 1) = V(2, 1) - sum * tau1 * v1[2];
+        V(3, 1) = V(3, 1) - sum * tau1 * v1[3];
+        larfg(v2, tau2);
+
+        // Apply reflections to D to check error
+        for (idx_t j = 0; j < 4; ++j) {
+            T sum =
+                D(0, j) + v1[1] * D(1, j) + v1[2] * D(2, j) + v1[3] * D(3, j);
+            D(0, j) = D(0, j) - sum * tau1;
+            D(1, j) = D(1, j) - sum * tau1 * v1[1];
+            D(2, j) = D(2, j) - sum * tau1 * v1[2];
+            D(3, j) = D(3, j) - sum * tau1 * v1[3];
+
+            sum = D(1, j) + v2[1] * D(2, j) + v2[2] * D(3, j);
+            D(1, j) = D(1, j) - sum * tau2;
+            D(2, j) = D(2, j) - sum * tau2 * v2[1];
+            D(3, j) = D(3, j) - sum * tau2 * v2[2];
+        }
+        for (idx_t j = 0; j < 4; ++j) {
+            T sum =
+                D(j, 0) + v1[1] * D(j, 1) + v1[2] * D(j, 2) + v1[3] * D(j, 3);
+            D(j, 0) = D(j, 0) - sum * tau1;
+            D(j, 1) = D(j, 1) - sum * tau1 * v1[1];
+            D(j, 2) = D(j, 2) - sum * tau1 * v1[2];
+            D(j, 3) = D(j, 3) - sum * tau1 * v1[3];
+
+            sum = D(j, 1) + v2[1] * D(j, 2) + v2[2] * D(j, 3);
+            D(j, 1) = D(j, 1) - sum * tau2;
+            D(j, 2) = D(j, 2) - sum * tau2 * v2[1];
+            D(j, 3) = D(j, 3) - sum * tau2 * v2[2];
+        }
+
+        if (max(max(abs(D(2, 0)), abs(D(2, 1))),
+                max(abs(D(3, 0)), abs(D(3, 1)))) > thresh)
+            return 1;
+
+        // Reflections from the left
+        for (idx_t j = j0; j < n; ++j) {
+            T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j) +
+                    v1[3] * A(j3, j);
+            A(j0, j) = A(j0, j) - sum * tau1;
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
+            A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
+            A(j3, j) = A(j3, j) - sum * tau1 * v1[3];
+
+            sum = A(j1, j) + v2[1] * A(j2, j) + v2[2] * A(j3, j);
+            A(j1, j) = A(j1, j) - sum * tau2;
+            A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
+            A(j3, j) = A(j3, j) - sum * tau2 * v2[2];
+        }
+        // Reflections from the right
+        for (idx_t j = 0; j < j0 + 4; ++j) {
+            T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2) +
+                    v1[3] * A(j, j3);
+            A(j, j0) = A(j, j0) - sum * tau1;
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
+            A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
+            A(j, j3) = A(j, j3) - sum * tau1 * v1[3];
+
+            sum = A(j, j1) + v2[1] * A(j, j2) + v2[2] * A(j, j3);
+            A(j, j1) = A(j, j1) - sum * tau2;
+            A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
+            A(j, j3) = A(j, j3) - sum * tau2 * v2[2];
+        }
+
+        if (want_q) {
+            for (idx_t j = 0; j < n; ++j) {
+                T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2) +
+                        v1[3] * Q(j, j3);
+                Q(j, j0) = Q(j, j0) - sum * tau1;
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
+                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
+                Q(j, j3) = Q(j, j3) - sum * tau1 * v1[3];
+
+                sum = Q(j, j1) + v2[1] * Q(j, j2) + v2[2] * Q(j, j3);
+                Q(j, j1) = Q(j, j1) - sum * tau2;
+                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
+                Q(j, j3) = Q(j, j3) - sum * tau2 * v2[2];
+            }
+        }
+
+        A(j2, j0) = zero;
+        A(j2, j1) = zero;
+        A(j3, j0) = zero;
+        A(j3, j1) = zero;
     }
 
-} // lapack
+    // Standardize the 2x2 Schur blocks (if any)
+    if (n2 == 2) {
+        T cs, sn;
+        complex_type<T> s1, s2;
+        lahqr_schur22(A(j0, j0), A(j0, j1), A(j1, j0), A(j1, j1), s1, s2, cs,
+                      sn);  // Apply transformation from the left
+        if (j2 < n) {
+            auto row1 = slice(A, j0, pair{j2, n});
+            auto row2 = slice(A, j1, pair{j2, n});
+            rot(row1, row2, cs, sn);
+        }
+        // Apply transformation from the right
+        if (j0 > 0) {
+            auto col1 = slice(A, pair{0, j0}, j0);
+            auto col2 = slice(A, pair{0, j0}, j1);
+            rot(col1, col2, cs, sn);
+        }
+        if (want_q) {
+            auto row1 = col(Q, j0);
+            auto row2 = col(Q, j1);
+            rot(row1, row2, cs, sn);
+        }
+    }
+    if (n1 == 2) {
+        idx_t j0_2 = j0 + n2;
+        idx_t j1_2 = j0_2 + 1;
 
-#endif // TLAPACK_SCHUR_SWAP_HH
+        T cs, sn;
+        complex_type<T> s1, s2;
+        lahqr_schur22(A(j0_2, j0_2), A(j0_2, j1_2), A(j1_2, j0_2),
+                      A(j1_2, j1_2), s1, s2, cs,
+                      sn);  // Apply transformation from the left
+        if (j0_2 + 2 < n) {
+            auto row1 = slice(A, j0_2, pair{j0_2 + 2, n});
+            auto row2 = slice(A, j1_2, pair{j0_2 + 2, n});
+            rot(row1, row2, cs, sn);
+        }
+        // Apply transformation from the right
+        if (j0_2 > 0) {
+            auto col1 = slice(A, pair{0, j0_2}, j0_2);
+            auto col2 = slice(A, pair{0, j0_2}, j1_2);
+            rot(col1, col2, cs, sn);
+        }
+        if (want_q) {
+            auto row1 = col(Q, j0_2);
+            auto row2 = col(Q, j1_2);
+            rot(row1, row2, cs, sn);
+        }
+    }
+
+    return 0;
+}
+
+/** schur_swap, swaps 2 eigenvalues of A.
+ *
+ * Implementation for complex matrices
+ *
+ * @ingroup auxiliary
+ */
+template <typename matrix_t,
+          enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
+int schur_swap(bool want_q,
+               matrix_t& A,
+               matrix_t& Q,
+               const size_type<matrix_t>& j0,
+               const size_type<matrix_t>& n1,
+               const size_type<matrix_t>& n2)
+{
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using pair = pair<idx_t, idx_t>;
+
+    const idx_t n = ncols(A);
+
+    tlapack_check(nrows(A) == n);
+    tlapack_check(nrows(Q) == n);
+    tlapack_check(ncols(Q) == n);
+    tlapack_check(0 <= j0 and j0 < n);
+    tlapack_check(n1 == 1);
+    tlapack_check(n2 == 1);
+
+    const idx_t j1 = j0 + 1;
+    const idx_t j2 = j0 + 2;
+
+    //
+    // In the complex case, there can only be 1x1 blocks to swap
+    //
+    const T t00 = A(j0, j0);
+    const T t11 = A(j1, j1);
+    //
+    // Determine the transformation to perform the interchange
+    //
+    real_t cs;
+    T sn;
+    T temp = A(j0, j1);
+    T temp2 = t11 - t00;
+    rotg(temp, temp2, cs, sn);
+
+    A(j1, j1) = t00;
+    A(j0, j0) = t11;
+
+    // Apply transformation from the left
+    if (j2 < n) {
+        auto row1 = slice(A, j0, pair{j2, n});
+        auto row2 = slice(A, j1, pair{j2, n});
+        rot(row1, row2, cs, sn);
+    }
+    // Apply transformation from the right
+    if (j0 > 0) {
+        auto col1 = slice(A, pair{0, j0}, j0);
+        auto col2 = slice(A, pair{0, j0}, j1);
+        rot(col1, col2, cs, conj(sn));
+    }
+    if (want_q) {
+        auto row1 = col(Q, j0);
+        auto row2 = col(Q, j1);
+        rot(row1, row2, cs, conj(sn));
+    }
+
+    return 0;
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_SCHUR_SWAP_HH

--- a/include/tlapack/lapack/transpose.hpp
+++ b/include/tlapack/lapack/transpose.hpp
@@ -12,129 +12,128 @@
 
 #include "tlapack/base/utils.hpp"
 
-namespace tlapack
+namespace tlapack {
+template <typename idx_t>
+struct transpose_opts_t {
+    // Optimization parameter. Matrices smaller than nx will not
+    // be transposed using recursion. Must be at least 2.s
+    idx_t nx = 16;
+};
+
+/**
+ *
+ * @brief conjugate transpose a matrix A into a matrix B.
+ *
+ * @param[in] A m-by-n matrix
+ *      The matrix to be transposed
+ *
+ * @param[out] B n-by-m matrix
+ *      On exit, B = A**H
+ *
+ * @param[in] opts Options.
+ *
+ * @ingroup auxiliary
+ */
+template <class matrixA_t, class matrixB_t>
+void conjtranspose(matrixA_t& A,
+                   matrixB_t& B,
+                   const transpose_opts_t<size_type<matrixA_t>>& opts = {})
 {
-    template <typename idx_t>
-    struct transpose_opts_t {
-        // Optimization parameter. Matrices smaller than nx will not
-        // be transposed using recursion. Must be at least 2.s
-        idx_t nx = 16;
-    };
+    using idx_t = size_type<matrixA_t>;
+    using pair = std::pair<idx_t, idx_t>;
 
-    /**
-     *
-     * @brief conjugate transpose a matrix A into a matrix B.
-     *
-     * @param[in] A m-by-n matrix
-     *      The matrix to be transposed
-     *
-     * @param[out] B n-by-m matrix
-     *      On exit, B = A**H
-     * 
-     * @param[in] opts Options.
-     *
-     * @ingroup auxiliary
-     */
-    template <class matrixA_t, class matrixB_t>
-    void conjtranspose(matrixA_t &A, matrixB_t &B, const transpose_opts_t<size_type<matrixA_t>> &opts = {} )
-    {
-        using idx_t = size_type<matrixA_t>;
-        using pair = std::pair<idx_t, idx_t>;
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
 
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
+    tlapack_check(m == ncols(B));
+    tlapack_check(n == nrows(B));
+    tlapack_check(opts.nx >= 2);
 
-        tlapack_check(m == ncols(B));
-        tlapack_check(n == nrows(B));
-        tlapack_check( opts.nx >= 2 );
-
-        if (min(m, n) <= opts.nx)
-        {
-            // The matrix is small, use direct method and end recursion
-            for (idx_t i = 0; i < m; ++i)
-                for (idx_t j = 0; j < n; ++j)
-                    B(j, i) = conj(A(i, j));
-        }
-        else
-        {
-            // The matrix is large, split into subblocks and use recursion
-            const idx_t m1 = m / 2;
-            const idx_t n1 = n / 2;
-
-            auto A00 = slice(A, pair(0, m1), pair(0, n1));
-            auto A01 = slice(A, pair(0, m1), pair(n1, n));
-            auto A10 = slice(A, pair(m1, m), pair(0, n1));
-            auto A11 = slice(A, pair(m1, m), pair(n1, n));
-
-            auto B00 = slice(B, pair(0, n1), pair(0, m1));
-            auto B01 = slice(B, pair(0, n1), pair(m1, m));
-            auto B10 = slice(B, pair(n1, n), pair(0, m1));
-            auto B11 = slice(B, pair(n1, n), pair(m1, m));
-
-            conjtranspose(A00, B00, opts);
-            conjtranspose(A01, B10, opts);
-            conjtranspose(A10, B01, opts);
-            conjtranspose(A11, B11, opts);
-        }
+    if (min(m, n) <= opts.nx) {
+        // The matrix is small, use direct method and end recursion
+        for (idx_t i = 0; i < m; ++i)
+            for (idx_t j = 0; j < n; ++j)
+                B(j, i) = conj(A(i, j));
     }
+    else {
+        // The matrix is large, split into subblocks and use recursion
+        const idx_t m1 = m / 2;
+        const idx_t n1 = n / 2;
 
-    /**
-     *
-     * @brief transpose a matrix A into a matrix B.
-     *
-     * @param[in] A m-by-n matrix
-     *      The matrix to be transposed
-     *
-     * @param[out] B n-by-m matrix
-     *      On exit, B = A**T
-     * 
-     * @param[in] opts Options.
-     *
-     * @ingroup auxiliary
-     */
-    template <class matrixA_t, class matrixB_t>
-    void transpose(matrixA_t &A, matrixB_t &B, const transpose_opts_t<size_type<matrixA_t>> &opts = {} )
-    {
-        using idx_t = size_type<matrixA_t>;
-        using pair = std::pair<idx_t, idx_t>;
+        auto A00 = slice(A, pair(0, m1), pair(0, n1));
+        auto A01 = slice(A, pair(0, m1), pair(n1, n));
+        auto A10 = slice(A, pair(m1, m), pair(0, n1));
+        auto A11 = slice(A, pair(m1, m), pair(n1, n));
 
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
+        auto B00 = slice(B, pair(0, n1), pair(0, m1));
+        auto B01 = slice(B, pair(0, n1), pair(m1, m));
+        auto B10 = slice(B, pair(n1, n), pair(0, m1));
+        auto B11 = slice(B, pair(n1, n), pair(m1, m));
 
-        tlapack_check(m == ncols(B));
-        tlapack_check(n == nrows(B));
-        tlapack_check( opts.nx >= 2 );
-
-        if (min(m, n) <= opts.nx)
-        {
-            // The matrix is small, use direct method and end recursion
-            for (idx_t i = 0; i < m; ++i)
-                for (idx_t j = 0; j < n; ++j)
-                    B(j, i) = A(i, j);
-        }
-        else
-        {
-            // The matrix is large, split into subblocks and use recursion
-            const idx_t m1 = m / 2;
-            const idx_t n1 = n / 2;
-
-            auto A00 = slice(A, pair(0, m1), pair(0, n1));
-            auto A01 = slice(A, pair(0, m1), pair(n1, n));
-            auto A10 = slice(A, pair(m1, m), pair(0, n1));
-            auto A11 = slice(A, pair(m1, m), pair(n1, n));
-
-            auto B00 = slice(B, pair(0, n1), pair(0, m1));
-            auto B01 = slice(B, pair(0, n1), pair(m1, m));
-            auto B10 = slice(B, pair(n1, n), pair(0, m1));
-            auto B11 = slice(B, pair(n1, n), pair(m1, m));
-
-            transpose(A00, B00, opts);
-            transpose(A01, B10, opts);
-            transpose(A10, B01, opts);
-            transpose(A11, B11, opts);
-        }
+        conjtranspose(A00, B00, opts);
+        conjtranspose(A01, B10, opts);
+        conjtranspose(A10, B01, opts);
+        conjtranspose(A11, B11, opts);
     }
+}
 
-} // lapack
+/**
+ *
+ * @brief transpose a matrix A into a matrix B.
+ *
+ * @param[in] A m-by-n matrix
+ *      The matrix to be transposed
+ *
+ * @param[out] B n-by-m matrix
+ *      On exit, B = A**T
+ *
+ * @param[in] opts Options.
+ *
+ * @ingroup auxiliary
+ */
+template <class matrixA_t, class matrixB_t>
+void transpose(matrixA_t& A,
+               matrixB_t& B,
+               const transpose_opts_t<size_type<matrixA_t>>& opts = {})
+{
+    using idx_t = size_type<matrixA_t>;
+    using pair = std::pair<idx_t, idx_t>;
 
-#endif // TLAPACK_TRANSPOSE_HH
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+
+    tlapack_check(m == ncols(B));
+    tlapack_check(n == nrows(B));
+    tlapack_check(opts.nx >= 2);
+
+    if (min(m, n) <= opts.nx) {
+        // The matrix is small, use direct method and end recursion
+        for (idx_t i = 0; i < m; ++i)
+            for (idx_t j = 0; j < n; ++j)
+                B(j, i) = A(i, j);
+    }
+    else {
+        // The matrix is large, split into subblocks and use recursion
+        const idx_t m1 = m / 2;
+        const idx_t n1 = n / 2;
+
+        auto A00 = slice(A, pair(0, m1), pair(0, n1));
+        auto A01 = slice(A, pair(0, m1), pair(n1, n));
+        auto A10 = slice(A, pair(m1, m), pair(0, n1));
+        auto A11 = slice(A, pair(m1, m), pair(n1, n));
+
+        auto B00 = slice(B, pair(0, n1), pair(0, m1));
+        auto B01 = slice(B, pair(0, n1), pair(m1, m));
+        auto B10 = slice(B, pair(n1, n), pair(0, m1));
+        auto B11 = slice(B, pair(n1, n), pair(m1, m));
+
+        transpose(A00, B00, opts);
+        transpose(A01, B10, opts);
+        transpose(A10, B01, opts);
+        transpose(A11, B11, opts);
+    }
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_TRANSPOSE_HH

--- a/include/tlapack/lapack/trtri_recursive.hpp
+++ b/include/tlapack/lapack/trtri_recursive.hpp
@@ -13,154 +13,147 @@
 #include "tlapack/base/utils.hpp"
 #include "tlapack/blas/trsm.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** TRTRI computes the inverse of a triangular matrix in-place
+ * Input is a triangular matrix, output is its inverse
+ * This is the recursive variant
+ *
+ * @param[in] uplo
+ *      - Uplo::Upper: Upper triangle of C is referenced; the strictly lower
+ *      triangular part of C is not referenced.
+ *      - Uplo::Lower: Lower triangle of C is referenced; the strictly upper
+ *      triangular part of C is not referenced.
+ *
+ * @param[in] diag
+ *     Whether C has a unit or non-unit diagonal:
+ *      - Diag::Unit:    C is assumed to be unit triangular.
+ *      - Diag::NonUnit: C is not assumed to be unit triangular.
+ * @param[in,out] C n-by-n matrix.
+ *      On entry, the n-by-n triangular matrix to be inverted.
+ *      On exit, the inverse.
+ *
+ * @param[in] opts Options.
+ *
+ * @return = 0: successful exit
+ * @return = i+1: if C(i,i) is exactly zero.  The triangular
+ *          matrix is singular and its inverse can not be computed.
+ *
+ * @todo: implement nx to bail out of recursion before 1-by-1 case
+ *
+ * @ingroup computational
+ *
+ */
+template <typename uplo_t, typename matrix_t>
+int trtri_recursive(uplo_t uplo,
+                    Diag diag,
+                    matrix_t& C,
+                    const ec_opts_t& opts = {})
 {
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    using range = std::pair<idx_t, idx_t>;
+    using real_t = real_type<T>;
 
-    /** TRTRI computes the inverse of a triangular matrix in-place
-     * Input is a triangular matrix, output is its inverse
-     * This is the recursive variant
-     *
-     * @param[in] uplo
-     *      - Uplo::Upper: Upper triangle of C is referenced; the strictly lower
-     *      triangular part of C is not referenced.
-     *      - Uplo::Lower: Lower triangle of C is referenced; the strictly upper
-     *      triangular part of C is not referenced.
-     *
-     * @param[in] diag
-     *     Whether C has a unit or non-unit diagonal:
-     *      - Diag::Unit:    C is assumed to be unit triangular.
-     *      - Diag::NonUnit: C is not assumed to be unit triangular.
-     * @param[in,out] C n-by-n matrix.
-     *      On entry, the n-by-n triangular matrix to be inverted.
-     *      On exit, the inverse.
-     *
-     * @param[in] opts Options.
-     *
-     * @return = 0: successful exit
-     * @return = i+1: if C(i,i) is exactly zero.  The triangular
-     *          matrix is singular and its inverse can not be computed.
-     *
-     * @todo: implement nx to bail out of recursion before 1-by-1 case
-     * 
-     * @ingroup computational
-     *
-     */
-    template <typename uplo_t, typename matrix_t>
-    int trtri_recursive(uplo_t uplo, Diag diag, matrix_t &C, const ec_opts_t &opts = {})
-    {
+    const idx_t n = nrows(C);
+    const real_t zero(0);
 
-        using T = type_t<matrix_t>;
-        using idx_t = size_type<matrix_t>;
-        using range = std::pair<idx_t, idx_t>;
-        using real_t = real_type<T>;
+    // check arguments
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+    tlapack_check_false(nrows(C) != ncols(C));
 
-        const idx_t n = nrows(C);
-        const real_t zero(0);
+    // Quick return
+    if (n <= 0) return 0;
 
-        // check arguments
-        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-        tlapack_check_false( diag != Diag::NonUnit && diag != Diag::Unit );
-        tlapack_check_false(nrows(C) != ncols(C));
+    idx_t n0 = n / 2;
 
-        // Quick return
-        if (n <= 0)
-            return 0;
-
-        idx_t n0 = n / 2;
-
-        if (n == 1)
-        {
-            if (diag == Diag::NonUnit){
-                if (C(0, 0) != zero)
-                {
-                    C(0, 0) = real_t(1.) / C(0, 0);
-                    return 0;
-                }
-                else
-                {
-                    tlapack_error_internal(opts.ec, 1,
-                                        "A diagonal of entry of triangular matrix is exactly zero.");
-                    return 1;
-                }
-            }
-            else{
+    if (n == 1) {
+        if (diag == Diag::NonUnit) {
+            if (C(0, 0) != zero) {
+                C(0, 0) = real_t(1.) / C(0, 0);
                 return 0;
             }
-            
+            else {
+                tlapack_error_internal(opts.ec, 1,
+                                       "A diagonal of entry of triangular "
+                                       "matrix is exactly zero.");
+                return 1;
+            }
         }
-        else
-        {
-
-            if (uplo == Uplo::Lower)
-            {
-
-                auto C00 = slice(C, range(0, n0), range(0, n0));
-                auto C10 = slice(C, range(n0, n), range(0, n0));
-                auto C11 = slice(C, range(n0, n), range(n0, n));
-
-                trsm(Side::Right, Uplo::Lower, Op::NoTrans, diag, T(-1), C00, C10);
-                trsm(Side::Left, Uplo::Lower, Op::NoTrans, diag, T(+1), C11, C10);
-                int info = trtri_recursive(Uplo::Lower, diag, C00, opts);
-                
-                if (info != 0)
-                {
-                    tlapack_error_internal(opts.ec, info,
-                                           "A diagonal of entry of triangular matrix is exactly zero.");
-                    return info;
-                }
-                info = trtri_recursive(Uplo::Lower, diag, C11, opts);
-                if (info == 0)
-                    return 0;
-                else
-                {
-                    tlapack_error_internal(opts.ec, info + n0,
-                                           "A diagonal of entry of triangular matrix is exactly zero.");
-                    return info + n0;
-                }
-
-                // there are two variants, the code below also works
-
-                // trtri_recursive( Uplo::Lower, C00);
-                // trtri_recursive( Uplo::Lower, C11);
-                // trmm(Side::Right, Uplo::Lower, Op::NoTrans, Diag::NonUnit, T(-1), C00, C10);
-                // trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::NonUnit, T(+1), C11, C10);
-            }
-            else
-            {
-
-                auto C00 = slice(C, range(0, n0), range(0, n0));
-                auto C01 = slice(C, range(0, n0), range(n0, n));
-                auto C11 = slice(C, range(n0, n), range(n0, n));
-
-                trsm(Side::Left, Uplo::Upper, Op::NoTrans, diag, T(-1), C00, C01);
-                trsm(Side::Right, Uplo::Upper, Op::NoTrans, diag, T(+1), C11, C01);
-                int info = trtri_recursive(Uplo::Upper, diag,C00, opts);
-                if (info != 0)
-                {
-                    tlapack_error_internal(opts.ec, info,
-                                           "A diagonal of entry of triangular matrix is exactly zero.");
-                    return info;
-                }
-                info = trtri_recursive(Uplo::Upper, diag, C11, opts);
-                if (info == 0)
-                    return 0;
-                else
-                {
-                    tlapack_error_internal(opts.ec, info + n0,
-                                           "A diagonal of entry of triangular matrix is exactly zero.");
-                    return info + n0;
-                }
-
-                // there are two variants, the code below also works
-
-                // trtri_recursive( C00, Uplo::Upper);
-                // trtri_recursive( C11, Uplo::Upper);
-                // trmm(Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(-1), C00, C01);
-                // trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(+1), C11, C01);
-            }
+        else {
+            return 0;
         }
     }
+    else {
+        if (uplo == Uplo::Lower) {
+            auto C00 = slice(C, range(0, n0), range(0, n0));
+            auto C10 = slice(C, range(n0, n), range(0, n0));
+            auto C11 = slice(C, range(n0, n), range(n0, n));
 
-} // tlapack
+            trsm(Side::Right, Uplo::Lower, Op::NoTrans, diag, T(-1), C00, C10);
+            trsm(Side::Left, Uplo::Lower, Op::NoTrans, diag, T(+1), C11, C10);
+            int info = trtri_recursive(Uplo::Lower, diag, C00, opts);
 
-#endif // TLAPACK_TRTRI_RECURSIVE_HH
+            if (info != 0) {
+                tlapack_error_internal(opts.ec, info,
+                                       "A diagonal of entry of triangular "
+                                       "matrix is exactly zero.");
+                return info;
+            }
+            info = trtri_recursive(Uplo::Lower, diag, C11, opts);
+            if (info == 0)
+                return 0;
+            else {
+                tlapack_error_internal(opts.ec, info + n0,
+                                       "A diagonal of entry of triangular "
+                                       "matrix is exactly zero.");
+                return info + n0;
+            }
+
+            // there are two variants, the code below also works
+
+            // trtri_recursive( Uplo::Lower, C00);
+            // trtri_recursive( Uplo::Lower, C11);
+            // trmm(Side::Right, Uplo::Lower, Op::NoTrans, Diag::NonUnit, T(-1),
+            // C00, C10); trmm(Side::Left, Uplo::Lower, Op::NoTrans,
+            // Diag::NonUnit, T(+1), C11, C10);
+        }
+        else {
+            auto C00 = slice(C, range(0, n0), range(0, n0));
+            auto C01 = slice(C, range(0, n0), range(n0, n));
+            auto C11 = slice(C, range(n0, n), range(n0, n));
+
+            trsm(Side::Left, Uplo::Upper, Op::NoTrans, diag, T(-1), C00, C01);
+            trsm(Side::Right, Uplo::Upper, Op::NoTrans, diag, T(+1), C11, C01);
+            int info = trtri_recursive(Uplo::Upper, diag, C00, opts);
+            if (info != 0) {
+                tlapack_error_internal(opts.ec, info,
+                                       "A diagonal of entry of triangular "
+                                       "matrix is exactly zero.");
+                return info;
+            }
+            info = trtri_recursive(Uplo::Upper, diag, C11, opts);
+            if (info == 0)
+                return 0;
+            else {
+                tlapack_error_internal(opts.ec, info + n0,
+                                       "A diagonal of entry of triangular "
+                                       "matrix is exactly zero.");
+                return info + n0;
+            }
+
+            // there are two variants, the code below also works
+
+            // trtri_recursive( C00, Uplo::Upper);
+            // trtri_recursive( C11, Uplo::Upper);
+            // trmm(Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(-1),
+            // C00, C01); trmm(Side::Right, Uplo::Upper, Op::NoTrans,
+            // Diag::NonUnit, T(+1), C11, C01);
+        }
+    }
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_TRTRI_RECURSIVE_HH

--- a/include/tlapack/lapack/ul_mult.hpp
+++ b/include/tlapack/lapack/ul_mult.hpp
@@ -16,62 +16,67 @@
 
 namespace tlapack {
 
-/** ul_mult computes the matrix product of an upper triangular matrix U and a lower triangular unital matrix L 
- *  Given input matrix A, nonzero part of L is the subdiagonal of A and on the diagonal of L is assumed to be 1,
- *  and the nonzero part of U is diagonal and super-diagonal part of A 
+/** ul_mult computes the matrix product of an upper triangular matrix U and a
+ * lower triangular unital matrix L Given input matrix A, nonzero part of L is
+ * the subdiagonal of A and on the diagonal of L is assumed to be 1, and the
+ * nonzero part of U is diagonal and super-diagonal part of A
  *
  * @return  0 if success.
  *
  * @param[in,out] A n-by-n complex matrix.
- *      On entry, subdiagonal of A contains L(lower triangular and unital) and diagonal and superdiagonal part of A contains U(upper triangular).
- *      On exit, A is overwritten by L*U
- * 
+ *      On entry, subdiagonal of A contains L(lower triangular and unital) and
+ * diagonal and superdiagonal part of A contains U(upper triangular). On exit, A
+ * is overwritten by L*U
+ *
  * @ingroup auxiliary
  */
-template< class matrix_t>
-int ul_mult( matrix_t& A){
-    using idx_t = size_type< matrix_t >;
+template <class matrix_t>
+int ul_mult(matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
 
     // check arguments
-    tlapack_check( nrows(A)==ncols(A));
-    
+    tlapack_check(nrows(A) == ncols(A));
+
     // constant
     const idx_t n = ncols(A);
 
     // if L and U are 1-by-1, then L is 1 and we simply UL=A(0,0)
-    if(n==1)
-        return 0;
+    if (n == 1) return 0;
 
     // if n>1
     idx_t n0 = n / 2;
-    
+
     // break A into four parts
-    auto A00 = tlapack::slice(A,tlapack::range<idx_t>(0,n0),tlapack::range<idx_t>(0,n0));
-    auto A10 = tlapack::slice(A,tlapack::range<idx_t>(n0,n),tlapack::range<idx_t>(0,n0));
-    auto A01 = tlapack::slice(A,tlapack::range<idx_t>(0,n0),tlapack::range<idx_t>(n0,n));
-    auto A11 = tlapack::slice(A,tlapack::range<idx_t>(n0,n),tlapack::range<idx_t>(n0,n));
-    
+    auto A00 = tlapack::slice(A, tlapack::range<idx_t>(0, n0),
+                              tlapack::range<idx_t>(0, n0));
+    auto A10 = tlapack::slice(A, tlapack::range<idx_t>(n0, n),
+                              tlapack::range<idx_t>(0, n0));
+    auto A01 = tlapack::slice(A, tlapack::range<idx_t>(0, n0),
+                              tlapack::range<idx_t>(n0, n));
+    auto A11 = tlapack::slice(A, tlapack::range<idx_t>(n0, n),
+                              tlapack::range<idx_t>(n0, n));
+
     // calculate top left corner
     ul_mult(A00);
-    tlapack::gemm(Op::NoTrans,Op::NoTrans,T(1),A01,A10,T(1),A00);
+    tlapack::gemm(Op::NoTrans, Op::NoTrans, T(1), A01, A10, T(1), A00);
 
     // calculate bottom left corner
-    tlapack::trmm(Side::Left,Uplo::Upper,Op::NoTrans,Diag::NonUnit,T(1),A11,A10);
-    
+    tlapack::trmm(Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(1),
+                  A11, A10);
+
     // calculate top right
-    tlapack::trmm(Side::Right,Uplo::Lower,Op::NoTrans,Diag::Unit,T(1),A11,A01);
-    
+    tlapack::trmm(Side::Right, Uplo::Lower, Op::NoTrans, Diag::Unit, T(1), A11,
+                  A01);
+
     // calculate bottom right
     ul_mult(A11);
-    
+
     return 0;
-    
-} // ul_mult
 
-} // lapack
+}  // ul_mult
 
-#endif // TLAPACK_ul_mult_HH
+}  // namespace tlapack
 
-
-
+#endif  // TLAPACK_ul_mult_HH

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -1,6 +1,7 @@
 /// @file ung2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/ung2r.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -12,44 +12,45 @@
 #define TLAPACK_UNG2R_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larf.hpp"
 #include "tlapack/blas/scal.hpp"
+#include "tlapack/lapack/larf.hpp"
 
 namespace tlapack {
 
 /** Worspace query of ung2r()
- * 
+ *
  * @param[in] k
  *      The number of elementary reflectors whose product defines the matrix Q.
  *      Note that: `n >= k >= 0`.
- * 
+ *
  * @param[in] A m-by-n matrix.
 
  * @param[in] tau Real vector of length min(m,n).
  *      The scalar factors of the elementary reflectors.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< class matrix_t, class vector_t >
-inline constexpr
-void ung2r_worksize(
-    size_type< matrix_t > k, const matrix_t& A, const vector_t &tau,
-    workinfo_t& workinfo, const workspace_opts_t<>& opts = {} )
+template <class matrix_t, class vector_t>
+inline constexpr void ung2r_worksize(size_type<matrix_t> k,
+                                     const matrix_t& A,
+                                     const vector_t& tau,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts = {})
 {
-    using idx_t = size_type< matrix_t >;
+    using idx_t = size_type<matrix_t>;
 
     // constants
     const idx_t n = ncols(A);
 
-    if( n > 1 ) {
-        auto C = cols( A, range<idx_t>{1,n} );
-        larf_worksize( left_side, forward, col(A,0), tau[0], C, workinfo, opts );
+    if (n > 1) {
+        auto C = cols(A, range<idx_t>{1, n});
+        larf_worksize(left_side, forward, col(A, 0), tau[0], C, workinfo, opts);
     }
 }
 
@@ -58,11 +59,11 @@ void ung2r_worksize(
  * \[
  *     Q  =  H_1 H_2 ... H_k
  * \]
- * 
+ *
  * @param[in] k
  *      The number of elementary reflectors whose product defines the matrix Q.
  *      Note that: `n >= k >= 0`.
- * 
+ *
  * @param[in,out] A m-by-n matrix.
  *      On entry, the i-th column must contains the vector which defines the
  *      elementary reflector $H_i$, for $i=0,1,...,k-1$, as returned by geqrf.
@@ -74,77 +75,76 @@ void ung2r_worksize(
  * @param[in] opts Options.
  *      @c opts.work is used if whenever it has sufficient size.
  *      The sufficient size can be obtained through a workspace query.
- * 
- * @return 0 if success 
- * 
+ *
+ * @return 0 if success
+ *
  * @ingroup computational
  */
-template< class matrix_t, class vector_t >
-int ung2r(
-    size_type< matrix_t > k, matrix_t& A, const vector_t &tau, const workspace_opts_t<>& opts = {} )
+template <class matrix_t, class vector_t>
+int ung2r(size_type<matrix_t> k,
+          matrix_t& A,
+          const vector_t& tau,
+          const workspace_opts_t<>& opts = {})
 {
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-    using pair  = pair<idx_t,idx_t>;
-    
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
+
     // constants
-    const real_t zero( 0 );
-    const real_t one ( 1 );
+    const real_t zero(0);
+    const real_t one(1);
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false( k < 0 || k > n );
-    tlapack_check_false( (idx_t) size(tau)  < k );
+    tlapack_check_false(k < 0 || k > n);
+    tlapack_check_false((idx_t)size(tau) < k);
 
     // quick return
     if (n <= 0) return 0;
 
     // Allocates workspace
     vectorOfBytes localworkdata;
-    Workspace work = [&]()
-    {
+    Workspace work = [&]() {
         workinfo_t workinfo;
-        ung2r_worksize( k, A, tau, workinfo, opts );
-        return alloc_workspace( localworkdata, workinfo, opts.work );
+        ung2r_worksize(k, A, tau, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
     }();
-        
+
     // Options to forward
-    auto&& larfOpts = workspace_opts_t<>{ work };
-    
+    auto&& larfOpts = workspace_opts_t<>{work};
+
     // Initialise columns k:n-1 to columns of the unit matrix
     for (idx_t j = k; j < n; ++j) {
         for (idx_t l = 0; l < m; ++l)
-	        A(l,j) = zero;
-        A(j,j) = one;
+            A(l, j) = zero;
+        A(j, j) = one;
     }
 
-    for (idx_t i = k-1; i != idx_t(-1); --i) {
-
+    for (idx_t i = k - 1; i != idx_t(-1); --i) {
         // Apply $H_{i+1}$ to $A( i:m-1, i:n-1 )$ from the left
-        if ( i+1 < n ){
-            
+        if (i + 1 < n) {
             // Define v and C
-            auto v = slice( A, pair{i,m}, i );
-            auto C = slice( A, pair{i,m}, pair{i+1,n} );
+            auto v = slice(A, pair{i, m}, i);
+            auto C = slice(A, pair{i, m}, pair{i + 1, n});
 
-            larf( left_side, forward, v, tau[i], C, larfOpts );
+            larf(left_side, forward, v, tau[i], C, larfOpts);
         }
-        if ( i+1 < m ) {
-            auto v = slice( A, pair{i+1,m}, i );
-            scal( -tau[i], v );
+        if (i + 1 < m) {
+            auto v = slice(A, pair{i + 1, m}, i);
+            scal(-tau[i], v);
         }
-        A(i,i) = one - tau[i];
+        A(i, i) = one - tau[i];
 
         // Set A( 0:i-1, i ) to zero
         for (idx_t l = 0; l < i; l++)
-            A(l,i) = zero;
+            A(l, i) = zero;
     }
 
     return 0;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_UNG2R_HH
+#endif  // TLAPACK_UNG2R_HH

--- a/include/tlapack/lapack/unghr.hpp
+++ b/include/tlapack/lapack/unghr.hpp
@@ -1,6 +1,7 @@
 /// @file unghr.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dorghr.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dorghr.f
 //
 // This file is part of <T>LAPACK.
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
@@ -16,49 +17,48 @@
 namespace tlapack {
 
 /** Generates a m-by-n matrix Q with orthogonal columns.
- * 
+ *
  * @param[in] ilo integer
  * @param[in] ihi integer
  *      ilo and ihi must have the same values as in the
  *      previous call to gehrd. Q is equal to the unit
  *      matrix except in the submatrix Q(ilo+1:ihi,ilo+1:ihi).
  *      0 <= ilo <= ihi <= max(1,n).
- * 
+ *
  * @param[in,out] A m-by-n matrix.
  *      On entry, the vectors which define the elementary reflectors.
  *      On exit, the m-by-n matrix Q.
- * 
+ *
  * @param[in] tau Real vector of length n-1.
  *      The scalar factors of the elementary reflectors.
- * 
+ *
  * @param[in] opts Options.
  *      @c opts.work is used if whenever it has sufficient size.
  *      The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup computational
  */
-template< class matrix_t, class vector_t >
-int unghr(
-    size_type< matrix_t > ilo,
-    size_type< matrix_t > ihi,
-    matrix_t& A,
-    const vector_t& tau,
-    const workspace_opts_t<>& opts = {} )
+template <class matrix_t, class vector_t>
+int unghr(size_type<matrix_t> ilo,
+          size_type<matrix_t> ihi,
+          matrix_t& A,
+          const vector_t& tau,
+          const workspace_opts_t<>& opts = {})
 {
-    using T      = type_t< matrix_t >;
-    using real_t = real_type< T >;
-    using idx_t  = size_type< matrix_t >;
-    using pair  = pair<idx_t,idx_t>;
-    
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
+
     // constants
-    const real_t zero( 0 );
-    const real_t one ( 1 );
+    const real_t zero(0);
+    const real_t one(1);
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
-    const idx_t nh = ihi > ilo +1 ? ihi-1-ilo : 0;
+    const idx_t nh = ihi > ilo + 1 ? ihi - 1 - ilo : 0;
 
     // check arguments
-    tlapack_check_false( (idx_t) size(tau)  < std::min<idx_t>( m, n ) );
+    tlapack_check_false((idx_t)size(tau) < std::min<idx_t>(m, n));
 
     // Shift the vectors which define the elementary reflectors one
     // column to the right, and set the first ilo and the last n-ihi
@@ -66,85 +66,84 @@ int unghr(
 
     // This is currently optimised for column matrices, it may be interesting
     // to also write these loops for row matrices
-    for(idx_t j = ihi-1; j > ilo; --j) {
-        for(idx_t i = 0; i < j; ++i) {
-            A(i,j) = zero;
+    for (idx_t j = ihi - 1; j > ilo; --j) {
+        for (idx_t i = 0; i < j; ++i) {
+            A(i, j) = zero;
         }
-        for(idx_t i = j+1; i < ihi; ++i) {
-            A(i,j) = A(i,j-1);
+        for (idx_t i = j + 1; i < ihi; ++i) {
+            A(i, j) = A(i, j - 1);
         }
-        for(idx_t i = ihi; i < n; ++i ) {
-            A(i,j) = zero;
+        for (idx_t i = ihi; i < n; ++i) {
+            A(i, j) = zero;
         }
     }
-    for(idx_t j = 0; j<ilo+1; ++j) {
-        for(idx_t i = 0; i<n; ++i ) {
-            A(i,j) = zero;
+    for (idx_t j = 0; j < ilo + 1; ++j) {
+        for (idx_t i = 0; i < n; ++i) {
+            A(i, j) = zero;
         }
-        A(j,j) = one;
+        A(j, j) = one;
     }
-    for(idx_t j = ihi; j<n; ++j ) {
-        for(idx_t i = 0; i<n; ++i ) {
-            A(i,j) = zero;
+    for (idx_t j = ihi; j < n; ++j) {
+        for (idx_t i = 0; i < n; ++i) {
+            A(i, j) = zero;
         }
-        A(j,j) = one;
+        A(j, j) = one;
     }
 
-    // Now that the vectors are shifted, we can call orgqr to generate the matrix
-    // orgqr is not yet implemented, so we call org2r instead
-    if( nh > 0 ){
-        auto A_s = slice( A, pair{ilo+1,ihi}, pair{ilo+1,ihi} );
-        auto tau_s = slice( tau, pair{ilo,ihi-1} );
-        ung2r( nh, A_s, tau_s, opts );
+    // Now that the vectors are shifted, we can call orgqr to generate the
+    // matrix orgqr is not yet implemented, so we call org2r instead
+    if (nh > 0) {
+        auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo + 1, ihi});
+        auto tau_s = slice(tau, pair{ilo, ihi - 1});
+        ung2r(nh, A_s, tau_s, opts);
     }
 
     return 0;
 }
 
 /** Worspace query of unghr()
- * 
+ *
  * @param[in] ilo integer
  * @param[in] ihi integer
  *      ilo and ihi must have the same values as in the
  *      previous call to gehrd. Q is equal to the unit
  *      matrix except in the submatrix Q(ilo+1:ihi,ilo+1:ihi).
  *      0 <= ilo <= ihi <= max(1,n).
- * 
+ *
  * @param[in] A m-by-n matrix.
- * 
+ *
  * @param[in] tau Real vector of length n-1.
  *      The scalar factors of the elementary reflectors.
- * 
+ *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template< class matrix_t, class vector_t >
-inline constexpr
-void unghr_worksize(
-    size_type< matrix_t > ilo,
-    size_type< matrix_t > ihi,
-    const matrix_t& A,
-    const vector_t& tau,
-    workinfo_t& workinfo, const workspace_opts_t<>& opts = {} )
+template <class matrix_t, class vector_t>
+inline constexpr void unghr_worksize(size_type<matrix_t> ilo,
+                                     size_type<matrix_t> ihi,
+                                     const matrix_t& A,
+                                     const vector_t& tau,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts = {})
 {
-    using idx_t = size_type< matrix_t >;
-    using pair  = pair<idx_t,idx_t>;
-    
-    // constants
-    const idx_t nh = (ihi > ilo +1) ? ihi-1-ilo : 0;
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
 
-    if( nh > 0 && ilo+1 < ihi ) {
-        auto A_s = slice( A, pair{ilo+1,ihi}, pair{ilo+1,ihi} );
-        auto tau_s = slice( tau, pair{ilo,ihi-1} );
-        ung2r_worksize( nh, A_s, tau_s, workinfo, opts );
+    // constants
+    const idx_t nh = (ihi > ilo + 1) ? ihi - 1 - ilo : 0;
+
+    if (nh > 0 && ilo + 1 < ihi) {
+        auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo + 1, ihi});
+        auto tau_s = slice(tau, pair{ilo, ihi - 1});
+        ung2r_worksize(nh, A_s, tau_s, workinfo, opts);
     }
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_UNGHR_HH
+#endif  // TLAPACK_UNGHR_HH

--- a/include/tlapack/lapack/ungl2.hpp
+++ b/include/tlapack/lapack/ungl2.hpp
@@ -1,6 +1,7 @@
 /// @file ungl2.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zungl2.f
+/// @note Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zungl2.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -14,146 +15,144 @@
 #include "tlapack/base/utils.hpp"
 #include "tlapack/lapack/larf.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** Worspace query of ungl2()
+ *
+ * @param[in] Q k-by-n matrix.
+ *
+ * @param[in] tauw Complex vector of length min(m,n).
+ *      tauw(j) must contain the scalar factor of the elementary
+ *      reflector H(j), as returned by gelq2.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t, class vector_t>
+inline constexpr void ungl2_worksize(const matrix_t& Q,
+                                     const vector_t& tauw,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts = {})
 {
+    using idx_t = size_type<matrix_t>;
 
-    /** Worspace query of ungl2()
-     *
-     * @param[in] Q k-by-n matrix.
-     *
-     * @param[in] tauw Complex vector of length min(m,n).
-     *      tauw(j) must contain the scalar factor of the elementary
-     *      reflector H(j), as returned by gelq2.
-     *
-    * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template< class matrix_t, class vector_t >
-    inline constexpr
-    void ungl2_worksize(
-        const matrix_t& Q, const vector_t &tauw, workinfo_t& workinfo,
-        const workspace_opts_t<>& opts = {} )
-    {
-        using idx_t = size_type< matrix_t >;
+    // constants
+    const idx_t k = nrows(Q);
 
-        // constants
-        const idx_t k = nrows(Q);
-
-        if( k > 1 ) {
-            auto C = rows( Q, range<idx_t>{1,k} );
-            larf_worksize( right_side, forward, row(Q,0), tauw[0], C, workinfo, opts );
-        }
-    }
-    
-    /**
-     * Generates all or part of the unitary matrix Q from an LQ factorization
-     * determined by gelq2 (unblocked algorithm).
-     *
-     * The matrix Q is defined as the first k rows of a product of k elementary
-     * reflectors of order n
-     * \[
-     *          Q = H(k)**H ... H(2)**H H(1)**H
-     * \]
-     * as returned by gelq2 and k <= n.
-     *
-     * @return  0 if success
-     *
-     * @param[in,out] Q k-by-n matrix.
-     *      On entry, the i-th row must contain the vector which defines
-     *      the elementary reflector H(j), for j = 1,2,...,k, as returned
-     *      by gelq2 in the first k rows of its array argument A.
-     *      On exit, the k by n matrix Q.
-     *
-     * @param[in] tauw Complex vector of length min(m,n).
-     *      tauw(j) must contain the scalar factor of the elementary
-     *      reflector H(j), as returned by gelq2.
-     *
-    * @param[in] opts Options.
-     *      @c opts.work is used if whenever it has sufficient size.
-     *      The sufficient size can be obtained through a workspace query.
-     *
-     * @ingroup computational
-     */
-    template <typename matrix_t, class vector_t>
-    int ungl2(matrix_t &Q, const vector_t &tauw, const workspace_opts_t<>& opts = {})
-    {
-        using idx_t = size_type<matrix_t>;
-        using T = type_t<matrix_t>;
-        using range = std::pair<idx_t, idx_t>;
-        using real_t = real_type<T>;
-
-        // constants
-        const idx_t k = nrows(Q);
-        const idx_t n = ncols(Q);
-        const idx_t m = size(tauw); // maximum number of Householder reflectors to use
-        const idx_t t = min(k, m);  // desired number of Householder reflectors to use
-
-        // check arguments
-        tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n) );
-
-        // Allocates workspace
-        vectorOfBytes localworkdata;
-        Workspace work = [&]()
-        {
-            workinfo_t workinfo;
-            ungl2_worksize( Q, tauw, workinfo, opts );
-            return alloc_workspace( localworkdata, workinfo, opts.work );
-        }();
-        
-        // Options to forward
-        auto&& larfOpts = workspace_opts_t<>{ work };
-
-        // Initialise columns t:k-1 to rows of the unit matrix
-        if (k > m)
-        {
-            for (idx_t j = 0; j < n; ++j)
-            {
-                for (idx_t i = t; i < k; ++i)
-                    Q(i, j) = real_t(0);
-                if (j < k && j > t - 1)
-                    Q(j, j) = real_t(1);
-            }
-        }
-
-        for (idx_t j = t - 1; j != idx_t(-1); --j)
-        {
-            // Apply H(j)**H to Q(j:k,j:n) from the right
-            if (j + 1 < n)
-            {
-                auto w = slice(Q, j, range(j, n));
-
-                // Apply to the Q11 below the w
-                if( (k > m && j + 1 == t) || (j + 1 < t) )
-                {
-                    // When k > m, we need to start from the (t-1)th row of w and apply to Q(j+1:k,j:n)
-                    // This procedure is only used once when both conditions are satisfied
-                    
-                    for (idx_t i = 0; i < n - j; ++i)
-                        w[i] = conj(w[i]);
-
-                    auto Q11 = slice(Q, range(j + 1, k), range(j, n));
-                    larf(Side::Right, forward, w, conj(tauw[j]), Q11, larfOpts);
-                    
-                    for (idx_t i = 0; i < n - j; ++i)
-                        w[i] = conj(w[i]);
-                }
-
-                scal(-conj(tauw[j]), w);
-            }
-
-            Q(j, j) = real_t(1.) - conj(tauw[j]);
-
-            // Set Q(j,0:j-1) to zero
-            for (idx_t l = 0; l < j; l++)
-                Q(j, l) = real_t(0);
-        }
-
-        return 0;
+    if (k > 1) {
+        auto C = rows(Q, range<idx_t>{1, k});
+        larf_worksize(right_side, forward, row(Q, 0), tauw[0], C, workinfo,
+                      opts);
     }
 }
-#endif // TLAPACK_UNGL2_HH
+
+/**
+ * Generates all or part of the unitary matrix Q from an LQ factorization
+ * determined by gelq2 (unblocked algorithm).
+ *
+ * The matrix Q is defined as the first k rows of a product of k elementary
+ * reflectors of order n
+ * \[
+ *          Q = H(k)**H ... H(2)**H H(1)**H
+ * \]
+ * as returned by gelq2 and k <= n.
+ *
+ * @return  0 if success
+ *
+ * @param[in,out] Q k-by-n matrix.
+ *      On entry, the i-th row must contain the vector which defines
+ *      the elementary reflector H(j), for j = 1,2,...,k, as returned
+ *      by gelq2 in the first k rows of its array argument A.
+ *      On exit, the k by n matrix Q.
+ *
+ * @param[in] tauw Complex vector of length min(m,n).
+ *      tauw(j) must contain the scalar factor of the elementary
+ *      reflector H(j), as returned by gelq2.
+ *
+ * @param[in] opts Options.
+ *      @c opts.work is used if whenever it has sufficient size.
+ *      The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup computational
+ */
+template <typename matrix_t, class vector_t>
+int ungl2(matrix_t& Q,
+          const vector_t& tauw,
+          const workspace_opts_t<>& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using range = std::pair<idx_t, idx_t>;
+    using real_t = real_type<T>;
+
+    // constants
+    const idx_t k = nrows(Q);
+    const idx_t n = ncols(Q);
+    const idx_t m =
+        size(tauw);  // maximum number of Householder reflectors to use
+    const idx_t t =
+        min(k, m);  // desired number of Householder reflectors to use
+
+    // check arguments
+    tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
+
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    Workspace work = [&]() {
+        workinfo_t workinfo;
+        ungl2_worksize(Q, tauw, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+
+    // Options to forward
+    auto&& larfOpts = workspace_opts_t<>{work};
+
+    // Initialise columns t:k-1 to rows of the unit matrix
+    if (k > m) {
+        for (idx_t j = 0; j < n; ++j) {
+            for (idx_t i = t; i < k; ++i)
+                Q(i, j) = real_t(0);
+            if (j < k && j > t - 1) Q(j, j) = real_t(1);
+        }
+    }
+
+    for (idx_t j = t - 1; j != idx_t(-1); --j) {
+        // Apply H(j)**H to Q(j:k,j:n) from the right
+        if (j + 1 < n) {
+            auto w = slice(Q, j, range(j, n));
+
+            // Apply to the Q11 below the w
+            if ((k > m && j + 1 == t) || (j + 1 < t)) {
+                // When k > m, we need to start from the (t-1)th row of w and
+                // apply to Q(j+1:k,j:n) This procedure is only used once when
+                // both conditions are satisfied
+
+                for (idx_t i = 0; i < n - j; ++i)
+                    w[i] = conj(w[i]);
+
+                auto Q11 = slice(Q, range(j + 1, k), range(j, n));
+                larf(Side::Right, forward, w, conj(tauw[j]), Q11, larfOpts);
+
+                for (idx_t i = 0; i < n - j; ++i)
+                    w[i] = conj(w[i]);
+            }
+
+            scal(-conj(tauw[j]), w);
+        }
+
+        Q(j, j) = real_t(1.) - conj(tauw[j]);
+
+        // Set Q(j,0:j-1) to zero
+        for (idx_t l = 0; l < j; l++)
+            Q(j, l) = real_t(0);
+    }
+
+    return 0;
+}
+}  // namespace tlapack
+#endif  // TLAPACK_UNGL2_HH

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -1,6 +1,7 @@
 /// @file unm2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/ormr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -16,47 +16,49 @@
 
 namespace tlapack {
 
-/** Worspace query of unm2r() 
- * 
+/** Worspace query of unm2r()
+ *
  * @param[in] side Specifies which side op(Q) is to be applied.
  *      - Side::Left:  C := op(Q) C;
  *      - Side::Right: C := C op(Q).
- * 
+ *
  * @param[in] trans The operation $op(Q)$ to be used:
  *      - Op::NoTrans:      $op(Q) = Q$;
  *      - Op::ConjTrans:    $op(Q) = Q^H$.
  *      Op::Trans is a valid value if the data type of A is real. In this case,
  *      the algorithm treats Op::Trans as Op::ConjTrans.
- * 
+ *
  * @param[in] A
  *      - side = Side::Left:    m-by-k matrix;
  *      - side = Side::Right:   n-by-k matrix.
- * 
+ *
  * @param[in] tau Vector of length k
  *      Contains the scalar factors of the elementary reflectors.
- * 
+ *
  * @param[in] C m-by-n matrix.
  *
  * @param[in] opts Options.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
  */
-template<
-    class matrixA_t, class matrixC_t, class tau_t,
-    class side_t, class trans_t >
-inline constexpr
-void unm2r_worksize(
-    side_t side, trans_t trans,
-    const matrixA_t& A,
-    const tau_t& tau,
-    const matrixC_t& C, workinfo_t& workinfo,
-    const workspace_opts_t<>& opts = {} )
+template <class matrixA_t,
+          class matrixC_t,
+          class tau_t,
+          class side_t,
+          class trans_t>
+inline constexpr void unm2r_worksize(side_t side,
+                                     trans_t trans,
+                                     const matrixA_t& A,
+                                     const tau_t& tau,
+                                     const matrixC_t& C,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts = {})
 {
-    using idx_t = size_type< matrixA_t >;
+    using idx_t = size_type<matrixA_t>;
     using pair = std::pair<idx_t, idx_t>;
 
     // constants
@@ -64,12 +66,12 @@ void unm2r_worksize(
     const idx_t n = ncols(C);
     const idx_t nA = (side == Side::Left) ? m : n;
 
-    auto v = slice( A, pair{0,nA}, 0 );
-    larf_worksize( side, forward, v, tau[0], C, workinfo, opts );
+    auto v = slice(A, pair{0, nA}, 0);
+    larf_worksize(side, forward, v, tau[0], C, workinfo, opts);
 }
 
 /** Applies unitary matrix Q to a matrix C.
- * 
+ *
  * - side = Side::Left  & trans = Op::NoTrans:    $C := Q C$;
  * - side = Side::Right & trans = Op::NoTrans:    $C := C Q$;
  * - side = Side::Left  & trans = Op::ConjTrans:  $C := C Q^H$;
@@ -89,28 +91,28 @@ void unm2r_worksize(
  * \]
  * with v[i+1] through v[m-1] stored on exit below the diagonal
  * in the ith column of A, and tau in tau[i].
- * 
+ *
  * @tparam side_t Either Side or any class that implements `operator Side()`.
- * @tparam trans_t Either Op or any class that implements `operator Op()`. 
- * 
+ * @tparam trans_t Either Op or any class that implements `operator Op()`.
+ *
  * @param[in] side Specifies which side op(Q) is to be applied.
  *      - Side::Left:  C := op(Q) C;
  *      - Side::Right: C := C op(Q).
- * 
+ *
  * @param[in] trans The operation $op(Q)$ to be used:
  *      - Op::NoTrans:      $op(Q) = Q$;
  *      - Op::ConjTrans:    $op(Q) = Q^H$.
  *      Op::Trans is a valid value if the data type of A is real. In this case,
  *      the algorithm treats Op::Trans as Op::ConjTrans.
- * 
+ *
  * @param[in] A
  *      - side = Side::Left:    m-by-k matrix;
  *      - side = Side::Right:   n-by-k matrix.
- * 
+ *
  * @param[in] tau Vector of length k
  *      Contains the scalar factors of the elementary reflectors.
- * 
- * @param[in,out] C m-by-n matrix. 
+ *
+ * @param[in,out] C m-by-n matrix.
  *      On exit, C is replaced by one of the following:
  *      - side = Side::Left  & trans = Op::NoTrans:    $C := Q C$;
  *      - side = Side::Right & trans = Op::NoTrans:    $C := C Q$;
@@ -120,20 +122,22 @@ void unm2r_worksize(
  * @param[in] opts Options.
  *      @c opts.work is used if whenever it has sufficient size.
  *      The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup computational
  */
-template<
-    class matrixA_t, class matrixC_t, class tau_t,
-    class side_t, class trans_t >
-int unm2r(
-    side_t side, trans_t trans,
-    const matrixA_t& A,
-    const tau_t& tau,
-    matrixC_t& C,
-    const workspace_opts_t<>& opts = {} )
+template <class matrixA_t,
+          class matrixC_t,
+          class tau_t,
+          class side_t,
+          class trans_t>
+int unm2r(side_t side,
+          trans_t trans,
+          const matrixA_t& A,
+          const tau_t& tau,
+          matrixC_t& C,
+          const workspace_opts_t<>& opts = {})
 {
-    using idx_t = size_type< matrixA_t >;
+    using idx_t = size_type<matrixA_t>;
     using pair = std::pair<idx_t, idx_t>;
 
     // constants
@@ -143,64 +147,54 @@ int unm2r(
     const idx_t nA = (side == Side::Left) ? m : n;
 
     // check arguments
-    tlapack_check_false( side != Side::Left &&
-                     side != Side::Right );
-    tlapack_check_false( trans != Op::NoTrans &&
-                     trans != Op::Trans &&
-                     trans != Op::ConjTrans );
-    tlapack_check_false( trans == Op::Trans && is_complex<matrixA_t>::value );
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
 
     // quick return
-    if ((m == 0) || (n == 0) || (k == 0))
-        return 0;
+    if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Allocates workspace
     vectorOfBytes localworkdata;
-    Workspace work = [&]()
-    {
+    Workspace work = [&]() {
         workinfo_t workinfo;
-        unm2r_worksize( side, trans, A, tau, C, workinfo, opts );
-        return alloc_workspace( localworkdata, workinfo, opts.work );
+        unm2r_worksize(side, trans, A, tau, C, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
     }();
-        
+
     // Options to forward
-    auto&& larfOpts = workspace_opts_t<>{ work };
+    auto&& larfOpts = workspace_opts_t<>{work};
 
     // const expressions
-    const bool positiveInc = (
-        ( (side == Side::Left) && !(trans == Op::NoTrans) ) ||
-        (!(side == Side::Left) &&  (trans == Op::NoTrans) )
-    );
-    const idx_t i0 = (positiveInc) ? 0 : k-1;
-    const idx_t iN = (positiveInc) ? k :  -1;
+    const bool positiveInc =
+        (((side == Side::Left) && !(trans == Op::NoTrans)) ||
+         (!(side == Side::Left) && (trans == Op::NoTrans)));
+    const idx_t i0 = (positiveInc) ? 0 : k - 1;
+    const idx_t iN = (positiveInc) ? k : -1;
     const idx_t inc = (positiveInc) ? 1 : -1;
 
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
-        
-        auto v = slice( A, pair{i,nA}, i );
-        
-        if( side == Side::Left )
-        {
-            auto Ci = rows( C, pair{i,m} );
-            larf(
-                left_side, forward, v,
-                (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i],
-                Ci, larfOpts );
+        auto v = slice(A, pair{i, nA}, i);
+
+        if (side == Side::Left) {
+            auto Ci = rows(C, pair{i, m});
+            larf(left_side, forward, v,
+                 (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
+                 larfOpts);
         }
-        else
-        {
-            auto Ci = cols( C, pair{i,n} );
-            larf(
-                right_side, forward, v,
-                (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i],
-                Ci, larfOpts );
+        else {
+            auto Ci = cols(C, pair{i, n});
+            larf(right_side, forward, v,
+                 (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
+                 larfOpts);
         }
     }
 
     return 0;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_UNM2R_HH
+#endif  // TLAPACK_UNM2R_HH

--- a/include/tlapack/lapack/unmhr.hpp
+++ b/include/tlapack/lapack/unmhr.hpp
@@ -1,6 +1,7 @@
 /// @file unmhr.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/tree/master/SRC/zunmhr.f
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/zunmhr.f
 //
 // This file is part of <T>LAPACK.
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
@@ -14,122 +15,123 @@
 #include "tlapack/lapack/ung2r.hpp"
 #include "tlapack/lapack/unm2r.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/** Applies unitary matrix Q to a matrix C.
+ *
+ * @param[in] side Specifies which side op(Q) is to be applied.
+ *      - Side::Left:  C := op(Q) C;
+ *      - Side::Right: C := C op(Q).
+ *
+ * @param[in] trans The operation $op(Q)$ to be used:
+ *      - Op::NoTrans:      $op(Q) = Q$;
+ *      - Op::ConjTrans:    $op(Q) = Q^H$.
+ *      Op::Trans is a valid value if the data type of A is real. In this case,
+ *      the algorithm treats Op::Trans as Op::ConjTrans.
+ *
+ * @param[in] ilo integer
+ * @param[in] ihi integer
+ *      ilo and ihi must have the same values as in the
+ *      previous call to gehrd. Q is equal to the unit
+ *      matrix except in the submatrix Q(ilo+1:ihi,ilo+1:ihi).
+ *      0 <= ilo <= ihi <= max(1,n).
+ * @param[in] A n-by-n matrix
+ *      Matrix containing orthogonal vectors, as returned by gehrd
+ * @param[in] tau Vector of length n-1
+ *      Contains the scalar factors of the elementary reflectors.
+ *
+ * @param[in,out] C m-by-n matrix.
+ *      On exit, C is replaced by one of the following:
+ *      - side = Side::Left  & trans = Op::NoTrans:    $C := Q C$;
+ *      - side = Side::Right & trans = Op::NoTrans:    $C := C Q$;
+ *      - side = Side::Left  & trans = Op::ConjTrans:  $C := C Q^H$;
+ *      - side = Side::Right & trans = Op::ConjTrans:  $C := Q^H C$.
+ *
+ * @param[in] opts Options.
+ *      @c opts.work is used if whenever it has sufficient size.
+ *      The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup computational
+ */
+template <class matrix_t, class vector_t>
+int unmhr(Side side,
+          Op trans,
+          size_type<matrix_t> ilo,
+          size_type<matrix_t> ihi,
+          const matrix_t& A,
+          const vector_t& tau,
+          matrix_t& C,
+          const workspace_opts_t<>& opts = {})
 {
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
 
-    /** Applies unitary matrix Q to a matrix C.
-     * 
-     * @param[in] side Specifies which side op(Q) is to be applied.
-     *      - Side::Left:  C := op(Q) C;
-     *      - Side::Right: C := C op(Q).
-     * 
-     * @param[in] trans The operation $op(Q)$ to be used:
-     *      - Op::NoTrans:      $op(Q) = Q$;
-     *      - Op::ConjTrans:    $op(Q) = Q^H$.
-     *      Op::Trans is a valid value if the data type of A is real. In this case,
-     *      the algorithm treats Op::Trans as Op::ConjTrans.
-     *
-     * @param[in] ilo integer
-     * @param[in] ihi integer
-     *      ilo and ihi must have the same values as in the
-     *      previous call to gehrd. Q is equal to the unit
-     *      matrix except in the submatrix Q(ilo+1:ihi,ilo+1:ihi).
-     *      0 <= ilo <= ihi <= max(1,n).
-     * @param[in] A n-by-n matrix
-     *      Matrix containing orthogonal vectors, as returned by gehrd
-     * @param[in] tau Vector of length n-1
-     *      Contains the scalar factors of the elementary reflectors.
-     *
-     * @param[in,out] C m-by-n matrix.
-     *      On exit, C is replaced by one of the following:
-     *      - side = Side::Left  & trans = Op::NoTrans:    $C := Q C$;
-     *      - side = Side::Right & trans = Op::NoTrans:    $C := C Q$;
-     *      - side = Side::Left  & trans = Op::ConjTrans:  $C := C Q^H$;
-     *      - side = Side::Right & trans = Op::ConjTrans:  $C := Q^H C$.
-     *
-     * @param[in] opts Options.
-     *      @c opts.work is used if whenever it has sufficient size.
-     *      The sufficient size can be obtained through a workspace query.
-     *
-     * @ingroup computational
-     */
-    template < class matrix_t, class vector_t >
-    int unmhr(
-        Side side,
-        Op trans,
-        size_type<matrix_t> ilo,
-        size_type<matrix_t> ihi,
-        const matrix_t &A,
-        const vector_t &tau,
-        matrix_t &C,
-        const workspace_opts_t<>& opts = {} )
-    {
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
+    auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo, ihi - 1});
+    auto tau_s = slice(tau, pair{ilo, ihi - 1});
+    auto C_s = (side == Side::Left)
+                   ? slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)})
+                   : slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
 
-        auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo, ihi-1});
-        auto tau_s = slice(tau, pair{ilo, ihi - 1});
-        auto C_s = (side == Side::Left) ? slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)}) : slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
+    unm2r(side, trans, A_s, tau_s, C_s, opts);
 
-        unm2r(side, trans, A_s, tau_s, C_s, opts);
-
-        return 0;
-    }
-
-    /** Worspace query of unmhr()
-     * 
-     * @param[in] side Specifies which side op(Q) is to be applied.
-     *      - Side::Left:  C := op(Q) C;
-     *      - Side::Right: C := C op(Q).
-     * 
-     * @param[in] trans The operation $op(Q)$ to be used:
-     *      - Op::NoTrans:      $op(Q) = Q$;
-     *      - Op::ConjTrans:    $op(Q) = Q^H$.
-     *      Op::Trans is a valid value if the data type of A is real. In this case,
-     *      the algorithm treats Op::Trans as Op::ConjTrans.
-     *
-     * @param[in] ilo integer
-     * @param[in] ihi integer
-     *      ilo and ihi must have the same values as in the
-     *      previous call to gehrd. Q is equal to the unit
-     *      matrix except in the submatrix Q(ilo+1:ihi,ilo+1:ihi).
-     *      0 <= ilo <= ihi <= max(1,n).
-     * @param[in] A n-by-n matrix
-     *      Matrix containing orthogonal vectors, as returned by gehrd
-     * @param[in] tau Vector of length n-1
-     *      Contains the scalar factors of the elementary reflectors.
-     *
-     * @param[in] C m-by-n matrix.
-     *
-     * @param[in] opts Options.
-     * 
-     * @param[in,out] workinfo
-     *      On output, the amount workspace required. It is larger than or equal
-     *      to that given on input.
-     *
-     * @ingroup workspace_query
-     */
-    template < class matrix_t, class vector_t >
-    inline constexpr
-    void unmhr_worksize(
-        Side side,
-        Op trans,
-        size_type<matrix_t> ilo,
-        size_type<matrix_t> ihi,
-        const matrix_t &A,
-        const vector_t &tau,
-        const matrix_t &C, workinfo_t& workinfo,
-        const workspace_opts_t<>& opts = {} )
-    {
-        using idx_t = size_type<matrix_t>;
-        using pair = std::pair<idx_t, idx_t>;
-
-        auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo, ihi-1});
-        auto tau_s = slice(tau, pair{ilo, ihi - 1});
-        auto C_s = (side == Side::Left) ? slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)}) : slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
-
-        unm2r_worksize(side, trans, A_s, tau_s, C_s, workinfo, opts);
-    }
+    return 0;
 }
 
-#endif // TLAPACK_UNMHR_HH
+/** Worspace query of unmhr()
+ *
+ * @param[in] side Specifies which side op(Q) is to be applied.
+ *      - Side::Left:  C := op(Q) C;
+ *      - Side::Right: C := C op(Q).
+ *
+ * @param[in] trans The operation $op(Q)$ to be used:
+ *      - Op::NoTrans:      $op(Q) = Q$;
+ *      - Op::ConjTrans:    $op(Q) = Q^H$.
+ *      Op::Trans is a valid value if the data type of A is real. In this case,
+ *      the algorithm treats Op::Trans as Op::ConjTrans.
+ *
+ * @param[in] ilo integer
+ * @param[in] ihi integer
+ *      ilo and ihi must have the same values as in the
+ *      previous call to gehrd. Q is equal to the unit
+ *      matrix except in the submatrix Q(ilo+1:ihi,ilo+1:ihi).
+ *      0 <= ilo <= ihi <= max(1,n).
+ * @param[in] A n-by-n matrix
+ *      Matrix containing orthogonal vectors, as returned by gehrd
+ * @param[in] tau Vector of length n-1
+ *      Contains the scalar factors of the elementary reflectors.
+ *
+ * @param[in] C m-by-n matrix.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class matrix_t, class vector_t>
+inline constexpr void unmhr_worksize(Side side,
+                                     Op trans,
+                                     size_type<matrix_t> ilo,
+                                     size_type<matrix_t> ihi,
+                                     const matrix_t& A,
+                                     const vector_t& tau,
+                                     const matrix_t& C,
+                                     workinfo_t& workinfo,
+                                     const workspace_opts_t<>& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using pair = std::pair<idx_t, idx_t>;
+
+    auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo, ihi - 1});
+    auto tau_s = slice(tau, pair{ilo, ihi - 1});
+    auto C_s = (side == Side::Left)
+                   ? slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)})
+                   : slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
+
+    unm2r_worksize(side, trans, A_s, tau_s, C_s, workinfo, opts);
+}
+}  // namespace tlapack
+
+#endif  // TLAPACK_UNMHR_HH

--- a/include/tlapack/lapack/unmqr.hpp
+++ b/include/tlapack/lapack/unmqr.hpp
@@ -1,4 +1,5 @@
-/// @file unmqr.hpp Multiplies the general m-by-n matrix C by Q from tlapack::geqrf()
+/// @file unmqr.hpp Multiplies the general m-by-n matrix C by Q from
+/// tlapack::geqrf()
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -11,21 +12,20 @@
 #define TLAPACK_UNMQR_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larft.hpp"
 #include "tlapack/lapack/larfb.hpp"
+#include "tlapack/lapack/larft.hpp"
 
 namespace tlapack {
 
 /**
  * Options struct for unmqr
  */
-template< class workT_t = void >
-struct unmqr_opts_t : public workspace_opts_t<workT_t>
-{
-    inline constexpr unmqr_opts_t( const workspace_opts_t<workT_t>& opts = {} )
-    : workspace_opts_t<workT_t>( opts ) {};
-    
-    size_type<workT_t> nb = 32; ///< Block size
+template <class workT_t = void>
+struct unmqr_opts_t : public workspace_opts_t<workT_t> {
+    inline constexpr unmqr_opts_t(const workspace_opts_t<workT_t>& opts = {})
+        : workspace_opts_t<workT_t>(opts){};
+
+    size_type<workT_t> nb = 32;  ///< Block size
 };
 
 /** Worspace query of unmqr()
@@ -33,62 +33,59 @@ struct unmqr_opts_t : public workspace_opts_t<workT_t>
  * @param[in] side Specifies which side op(Q) is to be applied.
  *      - Side::Left:  C := op(Q) C;
  *      - Side::Right: C := C op(Q).
- * 
+ *
  * @param[in] trans The operation $op(Q)$ to be used:
  *      - Op::NoTrans:      $op(Q) = Q$;
  *      - Op::ConjTrans:    $op(Q) = Q^H$.
  *      Op::Trans is a valid value if the data type of A is real. In this case,
  *      the algorithm treats Op::Trans as Op::ConjTrans.
- * 
+ *
  * @param[in] A
  *      - side = Side::Left:    m-by-k matrix;
  *      - side = Side::Right:   n-by-k matrix.
- * 
+ *
  * @param[in] tau Vector of length k
  *      Contains the scalar factors of the elementary reflectors.
- * 
+ *
  * @param[in] C m-by-n matrix.
  *
  * @param[in] opts Options.
  *      @c opts.work is used if whenever it has sufficient size.
  *      The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @param[in,out] workinfo
  *      On output, the amount workspace required. It is larger than or equal
  *      to that given on input.
  *
  * @ingroup workspace_query
- * 
+ *
  * @see unmqr
  */
-template<
-    class matrixA_t, class matrixC_t,
-    class tau_t, class side_t, class trans_t,
-    class workT_t = void
->
-inline constexpr
-void unmqr_worksize(
-    side_t side, trans_t trans,
-    const matrixA_t& A,
-    const tau_t& tau,
-    const matrixC_t& C,
-    workinfo_t& workinfo,
-    const unmqr_opts_t<workT_t>& opts = {} )
+template <class matrixA_t,
+          class matrixC_t,
+          class tau_t,
+          class side_t,
+          class trans_t,
+          class workT_t = void>
+inline constexpr void unmqr_worksize(side_t side,
+                                     trans_t trans,
+                                     const matrixA_t& A,
+                                     const tau_t& tau,
+                                     const matrixC_t& C,
+                                     workinfo_t& workinfo,
+                                     const unmqr_opts_t<workT_t>& opts = {})
 {
-    using idx_t     = size_type< matrixC_t >;
-    using matrixT_t = deduce_work_t<
-                        workT_t,
-                        matrix_type< matrixA_t, tau_t >
-                      >;
-    using T         = type_t< matrixT_t >;
-    using pair      = std::pair<idx_t, idx_t>;
+    using idx_t = size_type<matrixC_t>;
+    using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
+    using T = type_t<matrixT_t>;
+    using pair = std::pair<idx_t, idx_t>;
 
     // Constants
     const idx_t k = size(tau);
-    const idx_t nb = min<idx_t>( opts.nb, k );
+    const idx_t nb = min<idx_t>(opts.nb, k);
 
     // Local workspace sizes
-    const workinfo_t myWorkinfo( nb*sizeof(T), nb );
+    const workinfo_t myWorkinfo(nb * sizeof(T), nb);
 
     // larfb:
     {
@@ -99,15 +96,16 @@ void unmqr_worksize(
 
         // Functors
         Create<matrixT_t> new_matrix;
-        
+
         // Empty matrices
-        const auto V = slice( A, pair{0,nA}, pair{0,nb} );
-        const auto matrixT = new_matrix( nullptr, nb, nb );
+        const auto V = slice(A, pair{0, nA}, pair{0, nb});
+        const auto matrixT = new_matrix(nullptr, nb, nb);
 
         // Internal workspace queries
-        larfb_worksize( side, trans, forward, columnwise_storage, V, matrixT, C, workinfo, opts );
+        larfb_worksize(side, trans, forward, columnwise_storage, V, matrixT, C,
+                       workinfo, opts);
     }
-    
+
     // Additional workspace needed inside the routine
     workinfo += myWorkinfo;
 }
@@ -133,28 +131,28 @@ void unmqr_worksize(
  * \]
  * with v[i+1] through v[m-1] stored on exit below the diagonal
  * in the ith column of A, and tau in tau[i].
- * 
+ *
  * @tparam side_t Either Side or any class that implements `operator Side()`.
- * @tparam trans_t Either Op or any class that implements `operator Op()`. 
+ * @tparam trans_t Either Op or any class that implements `operator Op()`.
  *
  * @param[in] side Specifies which side op(Q) is to be applied.
  *      - Side::Left:  C := op(Q) C;
  *      - Side::Right: C := C op(Q).
- * 
+ *
  * @param[in] trans The operation $op(Q)$ to be used:
  *      - Op::NoTrans:      $op(Q) = Q$;
  *      - Op::ConjTrans:    $op(Q) = Q^H$.
  *      Op::Trans is a valid value if the data type of A is real. In this case,
  *      the algorithm treats Op::Trans as Op::ConjTrans.
- * 
+ *
  * @param[in] A
  *      - side = Side::Left:    m-by-k matrix;
  *      - side = Side::Right:   n-by-k matrix.
- * 
+ *
  * @param[in] tau Vector of length k
  *      Contains the scalar factors of the elementary reflectors.
- * 
- * @param[in,out] C m-by-n matrix. 
+ *
+ * @param[in,out] C m-by-n matrix.
  *      On exit, C is replaced by one of the following:
  *      - side = Side::Left  & trans = Op::NoTrans:    $C := Q C$;
  *      - side = Side::Right & trans = Op::NoTrans:    $C := C Q$;
@@ -164,31 +162,29 @@ void unmqr_worksize(
  * @param[in] opts Options.
  *      @c opts.work is used if whenever it has sufficient size.
  *      The sufficient size can be obtained through a workspace query.
- * 
+ *
  * @ingroup computational
  */
-template<
-    class matrixA_t, class matrixC_t,
-    class tau_t, class side_t, class trans_t,
-    class workT_t = void
->
-int unmqr(
-    side_t side, trans_t trans,
-    const matrixA_t& A,
-    const tau_t& tau,
-    matrixC_t& C,
-    const unmqr_opts_t<workT_t>& opts = {} )
+template <class matrixA_t,
+          class matrixC_t,
+          class tau_t,
+          class side_t,
+          class trans_t,
+          class workT_t = void>
+int unmqr(side_t side,
+          trans_t trans,
+          const matrixA_t& A,
+          const tau_t& tau,
+          matrixC_t& C,
+          const unmqr_opts_t<workT_t>& opts = {})
 {
-    using idx_t     = size_type< matrixC_t >;
-    using matrixT_t = deduce_work_t<
-                        workT_t,
-                        matrix_type< matrixA_t, tau_t >
-                      >;
-    
-    using pair  = pair<idx_t,idx_t>;
+    using idx_t = size_type<matrixC_t>;
+    using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
+
+    using pair = pair<idx_t, idx_t>;
     using std::max;
     using std::min;
-    
+
     // Functor
     Create<matrixT_t> new_matrix;
 
@@ -197,69 +193,62 @@ int unmqr(
     const idx_t n = ncols(C);
     const idx_t k = size(tau);
     const idx_t nA = (side == Side::Left) ? m : n;
-    const idx_t nb = min<idx_t>( opts.nb, k );
+    const idx_t nb = min<idx_t>(opts.nb, k);
 
     // check arguments
-    tlapack_check_false( side != Side::Left &&
-                         side != Side::Right );
-    tlapack_check_false( trans != Op::NoTrans &&
-                         trans != Op::Trans &&
-                         trans != Op::ConjTrans );
-    tlapack_check_false( trans == Op::Trans && is_complex<matrixA_t>::value );
-    
-    
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+
     // quick return
-    if ((m == 0) || (n == 0) || (k == 0))
-        return 0;
+    if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Allocates workspace
     vectorOfBytes localworkdata;
-    Workspace work = [&]()
-    {
+    Workspace work = [&]() {
         workinfo_t workinfo;
-        unmqr_worksize( side, trans, A, tau, C, workinfo, opts );
-        return alloc_workspace( localworkdata, workinfo, opts.work );
+        unmqr_worksize(side, trans, A, tau, C, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
     }();
 
     // Matrix T and recompute work
-    auto matrixT = new_matrix( work, nb, nb, work );
-    
+    auto matrixT = new_matrix(work, nb, nb, work);
+
     // Options to forward
-    auto&& larfbOpts = workspace_opts_t<void>{ work };
+    auto&& larfbOpts = workspace_opts_t<void>{work};
 
     // Preparing loop indexes
-    const bool positiveInc = (
-        ( (side == Side::Left) && !(trans == Op::NoTrans) ) ||
-        (!(side == Side::Left) &&  (trans == Op::NoTrans) )
-    );
-    const idx_t i0  = (positiveInc) ? 0     : ( (k-1) / nb ) * nb;
-    const idx_t iN  = (positiveInc) ? ( (k-1) / nb + 1 ) * nb : -nb;
-    const idx_t inc = (positiveInc) ? nb    : -nb;
-    
+    const bool positiveInc =
+        (((side == Side::Left) && !(trans == Op::NoTrans)) ||
+         (!(side == Side::Left) && (trans == Op::NoTrans)));
+    const idx_t i0 = (positiveInc) ? 0 : ((k - 1) / nb) * nb;
+    const idx_t iN = (positiveInc) ? ((k - 1) / nb + 1) * nb : -nb;
+    const idx_t inc = (positiveInc) ? nb : -nb;
+
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
-        
-        idx_t ib = min<idx_t>( nb, k-i );
-        const auto V = slice( A, pair{i,nA}, pair{i,i+ib} );
-        const auto taui = slice( tau, pair{i,i+ib} );
-        auto matrixTi   = slice( matrixT, pair{0,ib}, pair{0,ib} );
+        idx_t ib = min<idx_t>(nb, k - i);
+        const auto V = slice(A, pair{i, nA}, pair{i, i + ib});
+        const auto taui = slice(tau, pair{i, i + ib});
+        auto matrixTi = slice(matrixT, pair{0, ib}, pair{0, ib});
 
         // Form the triangular factor of the block reflector
         // $H = H(i) H(i+1) ... H(i+ib-1)$
-        larft( forward, columnwise_storage, V, taui, matrixTi );
+        larft(forward, columnwise_storage, V, taui, matrixTi);
 
         // H or H**H is applied to either C[i:m,0:n] or C[0:m,i:n]
-        auto Ci = ( side == Side::Left )
-           ? slice( C, pair{i,m}, pair{0,n} )
-           : slice( C, pair{0,m}, pair{i,n} );
+        auto Ci = (side == Side::Left) ? slice(C, pair{i, m}, pair{0, n})
+                                       : slice(C, pair{0, m}, pair{i, n});
 
         // Apply H or H**H
-        larfb( side, trans, forward, columnwise_storage, V, matrixTi, Ci, larfbOpts );
+        larfb(side, trans, forward, columnwise_storage, V, matrixTi, Ci,
+              larfbOpts);
     }
 
     return 0;
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_UNMQR_HH
+#endif  // TLAPACK_UNMQR_HH

--- a/include/tlapack/legacy_api/base/legacyArray.hpp
+++ b/include/tlapack/legacy_api/base/legacyArray.hpp
@@ -17,81 +17,64 @@ namespace tlapack {
 
 namespace internal {
 
-    template< typename T >
-    inline constexpr auto colmajor_matrix(
-        T* A, 
-        idx_t m, 
-        idx_t n, 
-        idx_t lda )
+    template <typename T>
+    inline constexpr auto colmajor_matrix(T* A, idx_t m, idx_t n, idx_t lda)
     {
-        return legacyMatrix<T,idx_t,Layout::ColMajor>{ m, n, A, lda };
-    }
-    
-    template< typename T >
-    inline constexpr auto colmajor_matrix(
-        T* A, 
-        idx_t m, 
-        idx_t n )
-    {
-        return legacyMatrix<T,idx_t,Layout::ColMajor>{ m, n, A, m };
+        return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, lda};
     }
 
-    template< typename T >
-    inline constexpr auto rowmajor_matrix(
-        T* A, 
-        idx_t m, 
-        idx_t n, 
-        idx_t lda )
+    template <typename T>
+    inline constexpr auto colmajor_matrix(T* A, idx_t m, idx_t n)
     {
-        return legacyMatrix<T,idx_t,Layout::RowMajor>{ m, n, A, lda };
+        return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, m};
     }
 
-    template< typename T >
-    inline constexpr auto rowmajor_matrix(
-        T* A, 
-        idx_t m, 
-        idx_t n )
+    template <typename T>
+    inline constexpr auto rowmajor_matrix(T* A, idx_t m, idx_t n, idx_t lda)
     {
-        return legacyMatrix<T,idx_t,Layout::RowMajor>{ m, n, A, n };
+        return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, lda};
     }
 
-    template< typename T >
+    template <typename T>
+    inline constexpr auto rowmajor_matrix(T* A, idx_t m, idx_t n)
+    {
+        return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, n};
+    }
+
+    template <typename T>
     inline constexpr auto banded_matrix(
-        T* A, 
-        idx_t m, 
-        idx_t n, 
-        idx_t kl, 
-        idx_t ku )
+        T* A, idx_t m, idx_t n, idx_t kl, idx_t ku)
     {
-        return legacyBandedMatrix<T,idx_t>{ m, n, kl, ku, A };
+        return legacyBandedMatrix<T, idx_t>{m, n, kl, ku, A};
     }
 
-    template< typename T, typename int_t >
-    inline constexpr auto vector( T* x, idx_t n, int_t inc )
+    template <typename T, typename int_t>
+    inline constexpr auto vector(T* x, idx_t n, int_t inc)
     {
-        return legacyVector<T,idx_t,int_t>{ n, x, inc };
+        return legacyVector<T, idx_t, int_t>{n, x, inc};
     }
 
-    template< typename T >
-    inline constexpr auto vector( T* x, idx_t n )
+    template <typename T>
+    inline constexpr auto vector(T* x, idx_t n)
     {
-        return legacyVector<T,idx_t>{ n, x };
+        return legacyVector<T, idx_t>{n, x};
     }
 
-    template< typename T, typename int_t >
-    inline constexpr auto backward_vector( T* x, idx_t n, int_t inc )
+    template <typename T, typename int_t>
+    inline constexpr auto backward_vector(T* x, idx_t n, int_t inc)
     {
-        return legacyVector<T,idx_t,int_t,Direction::Backward>{ n, x, inc };
+        return legacyVector<T, idx_t, int_t, Direction::Backward>{n, x, inc};
     }
 
-    template< typename T >
-    inline constexpr auto backward_vector( T* x, idx_t n )
+    template <typename T>
+    inline constexpr auto backward_vector(T* x, idx_t n)
     {
-        return legacyVector<T,idx_t,internal::StrongOne,Direction::Backward>{ n, x };
+        return legacyVector<T, idx_t, internal::StrongOne, Direction::Backward>{
+            n, x};
     }
 
-} // namespace internal
+}  // namespace internal
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LEGACYARRAY_HH
+#endif  // TLAPACK_LEGACY_LEGACYARRAY_HH

--- a/include/tlapack/legacy_api/base/mdspan.hpp
+++ b/include/tlapack/legacy_api/base/mdspan.hpp
@@ -10,7 +10,7 @@
 #ifndef TLAPACK_LEGACY_MDSPAN_HH
 #define TLAPACK_LEGACY_MDSPAN_HH
 
-#include <experimental/mdspan> // Use mdspan for multidimensional arrays
+#include <experimental/mdspan>  // Use mdspan for multidimensional arrays
 
 namespace tlapack {
 
@@ -20,186 +20,167 @@ namespace internal {
 
     // -----------------------------------------------------------------------------
     /** Returns a Matrix object representing a column major matrix
-     * 
+     *
      * @param A                 serial data
      * @param m                 number of rows
      * @param n                 number of columns
-     * @param lda               leading dimension 
-     * 
-     * @return mdspan< T, dextents<2>, layout_stride > 
+     * @param lda               leading dimension
+     *
+     * @return mdspan< T, dextents<2>, layout_stride >
      *      matrix object using the abstraction A(i,j) = i + j * lda
      */
-    template< typename T, typename integral_type >
+    template <typename T, typename integral_type>
     inline constexpr auto colmajor_matrix(
-        T* A, 
-        std::experimental::dextents<2>::size_type m, 
-        std::experimental::dextents<2>::size_type n, 
-        integral_type lda ) noexcept
+        T* A,
+        std::experimental::dextents<2>::size_type m,
+        std::experimental::dextents<2>::size_type n,
+        integral_type lda) noexcept
     {
         using std::array;
         using std::experimental::dextents;
         using extents_t = dextents<2>;
         using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping< extents_t >;
+        using mapping = typename layout_stride::template mapping<extents_t>;
 
-        return mdspan< T, extents_t, layout_stride > (
-            A, mapping( extents_t(m,n), array<integral_type, 2>{1,lda} )
-        );
+        return mdspan<T, extents_t, layout_stride>(
+            A, mapping(extents_t(m, n), array<integral_type, 2>{1, lda}));
     }
-    
-    template< typename T >
+
+    template <typename T>
     inline constexpr auto colmajor_matrix(
-        T* A, 
-        std::experimental::dextents<2>::size_type m, 
-        std::experimental::dextents<2>::size_type n ) noexcept
+        T* A,
+        std::experimental::dextents<2>::size_type m,
+        std::experimental::dextents<2>::size_type n) noexcept
     {
         using std::experimental::dextents;
         using extents_t = dextents<2>;
         using std::experimental::layout_left;
-        using mapping = typename layout_left::template mapping< extents_t >;
+        using mapping = typename layout_left::template mapping<extents_t>;
 
-        return mdspan< T, extents_t, layout_left > (
-            A, mapping( extents_t(m,n) )
-        );
+        return mdspan<T, extents_t, layout_left>(A, mapping(extents_t(m, n)));
     }
-    
-    template< typename T, typename integral_type >
+
+    template <typename T, typename integral_type>
     inline constexpr auto rowmajor_matrix(
-        T* A, 
-        std::experimental::dextents<2>::size_type m, 
-        std::experimental::dextents<2>::size_type n, 
-        integral_type lda ) noexcept
+        T* A,
+        std::experimental::dextents<2>::size_type m,
+        std::experimental::dextents<2>::size_type n,
+        integral_type lda) noexcept
     {
         using std::array;
         using std::experimental::dextents;
         using extents_t = dextents<2>;
         using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping< extents_t >;
+        using mapping = typename layout_stride::template mapping<extents_t>;
 
-        return mdspan< T, extents_t, layout_stride > (
-            A, mapping( extents_t(m,n), array<integral_type, 2>{lda,1} )
-        );
+        return mdspan<T, extents_t, layout_stride>(
+            A, mapping(extents_t(m, n), array<integral_type, 2>{lda, 1}));
     }
-    
-    template< typename T >
+
+    template <typename T>
     inline constexpr auto rowmajor_matrix(
-        T* A, 
-        std::experimental::dextents<2>::size_type m, 
-        std::experimental::dextents<2>::size_type n ) noexcept
+        T* A,
+        std::experimental::dextents<2>::size_type m,
+        std::experimental::dextents<2>::size_type n) noexcept
     {
         using std::experimental::dextents;
         using extents_t = dextents<2>;
         using std::experimental::layout_right;
-        using mapping = typename layout_right::template mapping< extents_t >;
+        using mapping = typename layout_right::template mapping<extents_t>;
 
-        return mdspan< T, extents_t, layout_right > (
-            A, mapping( extents_t(m,n) )
-        );
+        return mdspan<T, extents_t, layout_right>(A, mapping(extents_t(m, n)));
     }
 
-    template< typename T, typename integral_type >
-    inline constexpr auto vector(
-        T* x,
-        std::experimental::dextents<1>::size_type n,
-        integral_type ldim ) noexcept
+    template <typename T, typename integral_type>
+    inline constexpr auto vector(T* x,
+                                 std::experimental::dextents<1>::size_type n,
+                                 integral_type ldim) noexcept
     {
         using std::array;
         using std::experimental::dextents;
         using extents_t = dextents<1>;
         using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping< extents_t >;
+        using mapping = typename layout_stride::template mapping<extents_t>;
 
-        return mdspan< T, extents_t, layout_stride > (
-            x, mapping( extents_t(n), array<integral_type, 1>{ldim} )
-        );
+        return mdspan<T, extents_t, layout_stride>(
+            x, mapping(extents_t(n), array<integral_type, 1>{ldim}));
     }
 
-    template< typename T >
+    template <typename T>
     inline constexpr auto vector(
-        T* x,
-        std::experimental::dextents<1>::size_type n ) noexcept
+        T* x, std::experimental::dextents<1>::size_type n) noexcept
     {
         using std::experimental::dextents;
         using extents_t = dextents<1>;
         using std::experimental::layout_left;
-        using mapping = typename layout_left::template mapping< extents_t >;
+        using mapping = typename layout_left::template mapping<extents_t>;
 
-        return mdspan< T, extents_t, layout_left > (
-            x, mapping( extents_t(n) )
-        );
+        return mdspan<T, extents_t, layout_left>(x, mapping(extents_t(n)));
     }
 
     // Transpose
-    template< class ET, class Exts, class AP >
+    template <class ET, class Exts, class AP>
     inline constexpr auto transpose(
-        const mdspan<ET,Exts,std::experimental::layout_stride,AP>& A ) noexcept
+        const mdspan<ET, Exts, std::experimental::layout_stride, AP>&
+            A) noexcept
     {
         using std::array;
         using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping< Exts >;
+        using mapping = typename layout_stride::template mapping<Exts>;
         using size_type = typename Exts::size_type;
-        
+
         // constants
-        const size_type m  = A.extent(0);
-        const size_type n  = A.extent(1);
+        const size_type m = A.extent(0);
+        const size_type n = A.extent(1);
         const size_type s0 = A.stride(0);
         const size_type s1 = A.stride(1);
 
         // return
-        return mdspan<ET,Exts,layout_stride,AP>(
-            A.data(),
-            mapping(
-                Exts(n,m),
-                array<size_type, 2>{s1,s0}
-            ),
-            typename AP::offset_policy(A.accessor())
-        );
+        return mdspan<ET, Exts, layout_stride, AP>(
+            A.data(), mapping(Exts(n, m), array<size_type, 2>{s1, s0}),
+            typename AP::offset_policy(A.accessor()));
     }
 
     // Transpose
-    template< class ET, class Exts, class AP >
+    template <class ET, class Exts, class AP>
     inline constexpr auto transpose(
-        const mdspan<ET,Exts,std::experimental::layout_left,AP>& A ) noexcept
+        const mdspan<ET, Exts, std::experimental::layout_left, AP>& A) noexcept
     {
         using std::experimental::layout_right;
-        using mapping = typename layout_right::template mapping< Exts >;
+        using mapping = typename layout_right::template mapping<Exts>;
         using size_type = typename Exts::size_type;
-        
+
         // constants
-        const size_type m  = A.extent(0);
-        const size_type n  = A.extent(1);
+        const size_type m = A.extent(0);
+        const size_type n = A.extent(1);
 
         // return
-        return mdspan<ET,Exts,layout_right,AP>(
-            A.data(),
-            mapping( Exts(n,m) ),
-            typename AP::offset_policy(A.accessor())
-        );
+        return mdspan<ET, Exts, layout_right, AP>(
+            A.data(), mapping(Exts(n, m)),
+            typename AP::offset_policy(A.accessor()));
     }
 
     // Transpose
-    template< class ET, class Exts, class AP >
+    template <class ET, class Exts, class AP>
     inline constexpr auto transpose(
-        const mdspan<ET,Exts,std::experimental::layout_right,AP>& A ) noexcept
+        const mdspan<ET, Exts, std::experimental::layout_right, AP>& A) noexcept
     {
         using std::experimental::layout_left;
-        using mapping = typename layout_left::template mapping< Exts >;
+        using mapping = typename layout_left::template mapping<Exts>;
         using size_type = typename Exts::size_type;
-        
+
         // constants
-        const size_type m  = A.extent(0);
-        const size_type n  = A.extent(1);
+        const size_type m = A.extent(0);
+        const size_type n = A.extent(1);
 
         // return
-        return mdspan<ET,Exts,layout_left,AP>(
-            A.data(),
-            mapping( Exts(n,m) ),
-            typename AP::offset_policy(A.accessor())
-        );
+        return mdspan<ET, Exts, layout_left, AP>(
+            A.data(), mapping(Exts(n, m)),
+            typename AP::offset_policy(A.accessor()));
     }
 
-} // namespace internal
+}  // namespace internal
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_MDSPAN_HH
+#endif  // TLAPACK_LEGACY_MDSPAN_HH

--- a/include/tlapack/legacy_api/base/types.hpp
+++ b/include/tlapack/legacy_api/base/types.hpp
@@ -15,8 +15,8 @@
 // -----------------------------------------------------------------------------
 // Integer types TLAPACK_SIZE_T and TLAPACK_INT_T
 
-#include <cstdint> // Defines std::int64_t
-#include <cstddef> // Defines std::size_t
+#include <cstddef>  // Defines std::size_t
+#include <cstdint>  // Defines std::int64_t
 
 #ifdef USE_LAPACKPP_WRAPPERS
     #ifndef TLAPACK_SIZE_T
@@ -34,101 +34,105 @@
 // -----------------------------------------------------------------------------
 
 namespace tlapack {
-    
+
 using idx_t = TLAPACK_SIZE_T;
 using int_t = TLAPACK_INT_T;
 
 // -----------------------------------------------------------------------------
 enum class Sides {
-    Left  = 'L',  L = 'L',
-    Right = 'R',  R = 'R',
-    Both  = 'B',  B = 'B'
+    Left = 'L',
+    L = 'L',
+    Right = 'R',
+    R = 'R',
+    Both = 'B',
+    B = 'B'
 };
 
 // -----------------------------------------------------------------------------
 // Job for computing eigenvectors and singular vectors
 // # needs custom map
 enum class Job {
-    NoVec        = 'N',
-    Vec          = 'V',  // geev, syev, ...
-    UpdateVec    = 'U',  // gghrd#, hbtrd, hgeqz#, hseqr#, ... (many compq or compz)
+    NoVec = 'N',
+    Vec = 'V',  // geev, syev, ...
+    UpdateVec =
+        'U',  // gghrd#, hbtrd, hgeqz#, hseqr#, ... (many compq or compz)
 
-    AllVec       = 'A',  // gesvd, gesdd, gejsv#
-    SomeVec      = 'S',  // gesvd, gesdd, gejsv#, gesvj#
+    AllVec = 'A',        // gesvd, gesdd, gejsv#
+    SomeVec = 'S',       // gesvd, gesdd, gejsv#, gesvj#
     OverwriteVec = 'O',  // gesvd, gesdd
 
-    CompactVec   = 'P',  // bdsdc
-    SomeVecTol   = 'C',  // gesvj
-    VecJacobi    = 'J',  // gejsv
-    Workspace    = 'W',  // gejsv
+    CompactVec = 'P',  // bdsdc
+    SomeVecTol = 'C',  // gesvj
+    VecJacobi = 'J',   // gejsv
+    Workspace = 'W',   // gejsv
 };
 
 // -----------------------------------------------------------------------------
 // hseqr
 enum class JobSchur {
-    Eigenvalues  = 'E',
-    Schur        = 'S',
+    Eigenvalues = 'E',
+    Schur = 'S',
 };
 
 // -----------------------------------------------------------------------------
 // gees
 // todo: generic yes/no
 enum class Sort {
-    NotSorted   = 'N',
-    Sorted      = 'S',
+    NotSorted = 'N',
+    Sorted = 'S',
 };
 
 // -----------------------------------------------------------------------------
 // syevx
 enum class Range {
-    All         = 'A',
-    Value       = 'V',
-    Index       = 'I',
+    All = 'A',
+    Value = 'V',
+    Index = 'I',
 };
 
 // -----------------------------------------------------------------------------
 enum class Vect {
-    Q           = 'Q',  // orgbr, ormbr
-    P           = 'P',  // orgbr, ormbr
-    None        = 'N',  // orgbr, ormbr, gbbrd
-    Both        = 'B',  // orgbr, ormbr, gbbrd
+    Q = 'Q',     // orgbr, ormbr
+    P = 'P',     // orgbr, ormbr
+    None = 'N',  // orgbr, ormbr, gbbrd
+    Both = 'B',  // orgbr, ormbr, gbbrd
 };
 
 // -----------------------------------------------------------------------------
 // lascl
 enum class MatrixType {
-    General     = 'G',
-    Lower       = 'L',
-    Upper       = 'U',
-    Hessenberg  = 'H',
-    LowerBand   = 'B',
-    UpperBand   = 'Q',
-    Band        = 'Z',
+    General = 'G',
+    Lower = 'L',
+    Upper = 'U',
+    Hessenberg = 'H',
+    LowerBand = 'B',
+    UpperBand = 'Q',
+    Band = 'Z',
 };
 
 // -----------------------------------------------------------------------------
 // trevc
 enum class HowMany {
-    All           = 'A',
+    All = 'A',
     Backtransform = 'B',
-    Select        = 'S',
+    Select = 'S',
 };
 
 // -----------------------------------------------------------------------------
 // *svx, *rfsx
 enum class Equed {
-    None        = 'N',
-    Row         = 'R',
-    Col         = 'C',
-    Both        = 'B',
-    Yes         = 'Y',  // porfsx
+    None = 'N',
+    Row = 'R',
+    Col = 'C',
+    Both = 'B',
+    Yes = 'Y',  // porfsx
 };
 
 // -----------------------------------------------------------------------------
 // *svx
 // todo: what's good name for this?
 enum class Factored {
-    Factored    = 'F',
+    Factored = 'F',
     NotFactored = 'N',
     Equilibrate = 'E',
 };
@@ -136,34 +140,34 @@ enum class Factored {
 // -----------------------------------------------------------------------------
 // geesx, trsen
 enum class Sense {
-    None        = 'N',
+    None = 'N',
     Eigenvalues = 'E',
-    Subspace    = 'V',
-    Both        = 'B',
+    Subspace = 'V',
+    Both = 'B',
 };
 
 // -----------------------------------------------------------------------------
 // disna
 enum class JobCond {
-    EigenVec         = 'E',
-    LeftSingularVec  = 'L',
+    EigenVec = 'E',
+    LeftSingularVec = 'L',
     RightSingularVec = 'R',
 };
 
 // -----------------------------------------------------------------------------
 // {ge,gg}{bak,bal}
 enum class Balance {
-    None        = 'N',
-    Permute     = 'P',
-    Scale       = 'S',
-    Both        = 'B',
+    None = 'N',
+    Permute = 'P',
+    Scale = 'S',
+    Both = 'B',
 };
 
 // -----------------------------------------------------------------------------
 // stebz, larrd, stein docs
 enum class Order {
-    Block       = 'B',
-    Entire      = 'E',
+    Block = 'B',
+    Entire = 'E',
 };
 
 // -----------------------------------------------------------------------------
@@ -173,6 +177,6 @@ enum class RowCol {
     Row = 'R',
 };
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_TYPES_HH
+#endif  // TLAPACK_LEGACY_TYPES_HH

--- a/include/tlapack/legacy_api/base/utils.hpp
+++ b/include/tlapack/legacy_api/base/utils.hpp
@@ -14,107 +14,113 @@
 
     #include "tlapack/legacy_api/base/legacyArray.hpp"
 
-    #define tlapack_expr_with_2vectors( x, TX, n, X, incx, ... ) do { \
-        using tlapack::internal::vector; \
-        using tlapack::internal::backward_vector; \
-        if( incx == 1 ) { \
-            auto x = vector( (TX*) X, n ); \
-            tlapack_expr_with_vector( __VA_ARGS__ ); \
-        } \
-        else if( incx == -1 ) { \
-            auto x = backward_vector( (TX*) X, n ); \
-            tlapack_expr_with_vector( __VA_ARGS__ ); \
-        } \
-        else if( incx > 1 ) { \
-            auto x = vector( (TX*) X, n, incx ); \
-            tlapack_expr_with_vector( __VA_ARGS__ ); \
-        } \
-        else { \
-            auto x = backward_vector( (TX*) X, n, -incx ); \
-            tlapack_expr_with_vector( __VA_ARGS__ ); \
-        } \
-    } while(false)
+    #define tlapack_expr_with_2vectors(x, TX, n, X, incx, ...) \
+        do {                                                   \
+            using tlapack::internal::vector;                   \
+            using tlapack::internal::backward_vector;          \
+            if (incx == 1) {                                   \
+                auto x = vector((TX*)X, n);                    \
+                tlapack_expr_with_vector(__VA_ARGS__);         \
+            }                                                  \
+            else if (incx == -1) {                             \
+                auto x = backward_vector((TX*)X, n);           \
+                tlapack_expr_with_vector(__VA_ARGS__);         \
+            }                                                  \
+            else if (incx > 1) {                               \
+                auto x = vector((TX*)X, n, incx);              \
+                tlapack_expr_with_vector(__VA_ARGS__);         \
+            }                                                  \
+            else {                                             \
+                auto x = backward_vector((TX*)X, n, -incx);    \
+                tlapack_expr_with_vector(__VA_ARGS__);         \
+            }                                                  \
+        } while (false)
 
-    #define tlapack_expr_with_vector( x, TX, n, X, incx, expr ) do { \
-        using tlapack::internal::vector; \
-        using tlapack::internal::backward_vector; \
-        if( incx == 1 ) { \
-            auto x = vector( (TX*) X, n ); \
-            expr; \
-        } \
-        else if( incx == -1 ) { \
-            auto x = backward_vector( (TX*) X, n ); \
-            expr; \
-        } \
-        else if( incx > 1 ) { \
-            auto x = vector( (TX*) X, n, incx ); \
-            expr; \
-        } \
-        else { \
-            auto x = backward_vector( (TX*) X, n, -incx ); \
-            expr; \
-        } \
-    } while(false)
+    #define tlapack_expr_with_vector(x, TX, n, X, incx, expr) \
+        do {                                                  \
+            using tlapack::internal::vector;                  \
+            using tlapack::internal::backward_vector;         \
+            if (incx == 1) {                                  \
+                auto x = vector((TX*)X, n);                   \
+                expr;                                         \
+            }                                                 \
+            else if (incx == -1) {                            \
+                auto x = backward_vector((TX*)X, n);          \
+                expr;                                         \
+            }                                                 \
+            else if (incx > 1) {                              \
+                auto x = vector((TX*)X, n, incx);             \
+                expr;                                         \
+            }                                                 \
+            else {                                            \
+                auto x = backward_vector((TX*)X, n, -incx);   \
+                expr;                                         \
+            }                                                 \
+        } while (false)
 
-    #define tlapack_expr_with_vector_positiveInc( x, TX, n, X, incx, expr ) do { \
-        using tlapack::internal::vector; \
-        if( incx == 1 ) { \
-            auto x = vector( (TX*) X, n ); \
-            expr; \
-        } \
-        else { \
-            auto x = vector( (TX*) X, n, incx ); \
-            expr; \
-        } \
-    } while(false)
+    #define tlapack_expr_with_vector_positiveInc(x, TX, n, X, incx, expr) \
+        do {                                                              \
+            using tlapack::internal::vector;                              \
+            if (incx == 1) {                                              \
+                auto x = vector((TX*)X, n);                               \
+                expr;                                                     \
+            }                                                             \
+            else {                                                        \
+                auto x = vector((TX*)X, n, incx);                         \
+                expr;                                                     \
+            }                                                             \
+        } while (false)
 
 #else
     #include "tlapack/legacy_api/base/mdspan.hpp"
-    #include "tlapack/plugins/mdspan.hpp" // Loads mdspan plugin
+    #include "tlapack/plugins/mdspan.hpp"  // Loads mdspan plugin
 
-    #define tlapack_expr_with_2vectors( x, TX, n, X, incx, ... ) do { \
-        using tlapack::internal::vector; \
-        if( incx == 1 ) { \
-            auto x = vector( (TX*) X, n ); \
-            tlapack_expr_with_vector( __VA_ARGS__ ); \
-        } \
-        else if( incx > 1 ) { \
-            auto x = vector( (TX*) X, n, incx ); \
-            tlapack_expr_with_vector( __VA_ARGS__ ); \
-        } \
-        else { \
-            auto x = vector( (TX*) &X[(1-n)*incx], n, incx ); \
-            tlapack_expr_with_vector( __VA_ARGS__ ); \
-        } \
-    } while(false)
+    #define tlapack_expr_with_2vectors(x, TX, n, X, incx, ...)     \
+        do {                                                       \
+            using tlapack::internal::vector;                       \
+            if (incx == 1) {                                       \
+                auto x = vector((TX*)X, n);                        \
+                tlapack_expr_with_vector(__VA_ARGS__);             \
+            }                                                      \
+            else if (incx > 1) {                                   \
+                auto x = vector((TX*)X, n, incx);                  \
+                tlapack_expr_with_vector(__VA_ARGS__);             \
+            }                                                      \
+            else {                                                 \
+                auto x = vector((TX*)&X[(1 - n) * incx], n, incx); \
+                tlapack_expr_with_vector(__VA_ARGS__);             \
+            }                                                      \
+        } while (false)
 
-    #define tlapack_expr_with_vector( x, TX, n, X, incx, expr ) do { \
-        using tlapack::internal::vector; \
-        if( incx == 1 ) { \
-            auto x = vector( (TX*) X, n ); \
-            expr; \
-        } \
-        else if( incx > 1 ) { \
-            auto x = vector( (TX*) X, n, incx ); \
-            expr; \
-        } \
-        else { \
-            auto x = vector( (TX*) &X[(1-n)*incx], n, incx ); \
-            expr; \
-        } \
-    } while(false)
+    #define tlapack_expr_with_vector(x, TX, n, X, incx, expr)      \
+        do {                                                       \
+            using tlapack::internal::vector;                       \
+            if (incx == 1) {                                       \
+                auto x = vector((TX*)X, n);                        \
+                expr;                                              \
+            }                                                      \
+            else if (incx > 1) {                                   \
+                auto x = vector((TX*)X, n, incx);                  \
+                expr;                                              \
+            }                                                      \
+            else {                                                 \
+                auto x = vector((TX*)&X[(1 - n) * incx], n, incx); \
+                expr;                                              \
+            }                                                      \
+        } while (false)
 
-    #define tlapack_expr_with_vector_positiveInc( x, TX, n, X, incx, expr ) do { \
-        using tlapack::internal::vector; \
-        if( incx == 1 ) { \
-            auto x = vector( (TX*) X, n ); \
-            expr; \
-        } \
-        else { \
-            auto x = vector( (TX*) X, n, incx ); \
-            expr; \
-        } \
-    } while(false)
+    #define tlapack_expr_with_vector_positiveInc(x, TX, n, X, incx, expr) \
+        do {                                                              \
+            using tlapack::internal::vector;                              \
+            if (incx == 1) {                                              \
+                auto x = vector((TX*)X, n);                               \
+                expr;                                                     \
+            }                                                             \
+            else {                                                        \
+                auto x = vector((TX*)X, n, incx);                         \
+                expr;                                                     \
+            }                                                             \
+        } while (false)
 #endif
 
-#endif // TLAPACK_LEGACY_UTILS_HH
+#endif  // TLAPACK_LEGACY_UTILS_HH

--- a/include/tlapack/legacy_api/blas.hpp
+++ b/include/tlapack/legacy_api/blas.hpp
@@ -54,12 +54,12 @@
 
 #include "tlapack/legacy_api/blas/gemm.hpp"
 #include "tlapack/legacy_api/blas/hemm.hpp"
-#include "tlapack/legacy_api/blas/herk.hpp"
 #include "tlapack/legacy_api/blas/her2k.hpp"
+#include "tlapack/legacy_api/blas/herk.hpp"
 #include "tlapack/legacy_api/blas/symm.hpp"
-#include "tlapack/legacy_api/blas/syrk.hpp"
 #include "tlapack/legacy_api/blas/syr2k.hpp"
+#include "tlapack/legacy_api/blas/syrk.hpp"
 #include "tlapack/legacy_api/blas/trmm.hpp"
 #include "tlapack/legacy_api/blas/trsm.hpp"
 
-#endif // TLAPACK_BLAS_HH
+#endif  // TLAPACK_BLAS_HH

--- a/include/tlapack/legacy_api/blas/asum.hpp
+++ b/include/tlapack/legacy_api/blas/asum.hpp
@@ -11,15 +11,15 @@
 #ifndef TLAPACK_LEGACY_ASUM_HH
 #define TLAPACK_LEGACY_ASUM_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/asum.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
 /**
  * Wrapper to asum( vector_t const& x ).
- * 
+ *
  * @return 1-norm of vector,
  *     $|| Re(x) ||_1 + || Im(x) ||_1
  *         = \sum_{i=0}^{n-1} |Re(x_i)| + |Im(x_i)|$.
@@ -35,21 +35,17 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename T >
-inline
-real_type<T> asum( idx_t n, T const *x, int_t incx )
+template <typename T>
+inline real_type<T> asum(idx_t n, T const* x, int_t incx)
 {
-    tlapack_check_false( incx <= 0 );
+    tlapack_check_false(incx <= 0);
 
     // quick return
-    if( n <= 0 ) return 0;
-    
-    tlapack_expr_with_vector_positiveInc(
-        x_, T, n, x, incx,
-        return asum( x_ )
-    );
+    if (n <= 0) return 0;
+
+    tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx, return asum(x_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_ASUM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_ASUM_HH

--- a/include/tlapack/legacy_api/blas/axpy.hpp
+++ b/include/tlapack/legacy_api/blas/axpy.hpp
@@ -11,15 +11,15 @@
 #ifndef TLAPACK_LEGACY_AXPY_HH
 #define TLAPACK_LEGACY_AXPY_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/axpy.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
 /**
  * Add scaled vector, $y = \alpha x + y$.
- * 
+ *
  * Wrapper to axpy(
     const alpha_t& alpha,
     const vectorX_t& x, vectorY_t& y ).
@@ -46,27 +46,25 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TX, typename TY >
-void axpy(
-    idx_t n,
-    scalar_type<TX, TY> alpha,
-    TX const *x, int_t incx,
-    TY       *y, int_t incy )
+template <typename TX, typename TY>
+void axpy(idx_t n,
+          scalar_type<TX, TY> alpha,
+          TX const* x,
+          int_t incx,
+          TY* y,
+          int_t incy)
 {
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
     using scalar_t = scalar_type<TX, TY>;
 
     // quick return
-    if( n <= 0 || alpha == scalar_t(0) ) return;
-    
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return axpy( alpha, x_, y_ )
-    );
+    if (n <= 0 || alpha == scalar_t(0)) return;
+
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return axpy(alpha, x_, y_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_AXPY_HH
+#endif  //  #ifndef TLAPACK_LEGACY_AXPY_HH

--- a/include/tlapack/legacy_api/blas/copy.hpp
+++ b/include/tlapack/legacy_api/blas/copy.hpp
@@ -11,15 +11,15 @@
 #ifndef TLAPACK_LEGACY_COPY_HH
 #define TLAPACK_LEGACY_COPY_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/copy.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
 /**
  * Copy vector, $y = x$.
- * 
+ *
  * Wrapper to copy( const vectorX_t& x, vectorY_t& y ).
  *
  * @param[in] n
@@ -41,25 +41,19 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TX, typename TY >
-void copy(
-    idx_t n,
-    TX const *x, int_t incx,
-    TY       *y, int_t incy )
-{    
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+template <typename TX, typename TY>
+void copy(idx_t n, TX const* x, int_t incx, TY* y, int_t incy)
+{
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if( n <= 0 ) return;
-    
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return copy( x_, y_ )
-    );
+    if (n <= 0) return;
+
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return copy(x_, y_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_COPY_HH
+#endif  //  #ifndef TLAPACK_LEGACY_COPY_HH

--- a/include/tlapack/legacy_api/blas/dot.hpp
+++ b/include/tlapack/legacy_api/blas/dot.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_DOT_HH
 #define TLAPACK_LEGACY_DOT_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/dot.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -42,25 +42,20 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TX, typename TY >
-scalar_type<TX,TY> dot(
-    idx_t n,
-    TX const *x, int_t incx,
-    TY const *y, int_t incy )
+template <typename TX, typename TY>
+scalar_type<TX, TY> dot(
+    idx_t n, TX const* x, int_t incx, TY const* y, int_t incy)
 {
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if( n <= 0 ) return scalar_type<TX,TY>(0);
-    
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return dot( x_, y_ )
-    );
+    if (n <= 0) return scalar_type<TX, TY>(0);
+
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return dot(x_, y_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_DOT_HH
+#endif  //  #ifndef TLAPACK_LEGACY_DOT_HH

--- a/include/tlapack/legacy_api/blas/dotu.hpp
+++ b/include/tlapack/legacy_api/blas/dotu.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_DOTU_HH
 #define TLAPACK_LEGACY_DOTU_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/dotu.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -42,25 +42,20 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 scalar_type<TX, TY> dotu(
-    idx_t n,
-    TX const *x, int_t incx,
-    TY const *y, int_t incy )
+    idx_t n, TX const* x, int_t incx, TY const* y, int_t incy)
 {
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if( n <= 0 ) return scalar_type<TX,TY>(0);
-    
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return dotu( x_, y_ )
-    );
+    if (n <= 0) return scalar_type<TX, TY>(0);
+
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return dotu(x_, y_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_DOTU_HH
+#endif  //  #ifndef TLAPACK_LEGACY_DOTU_HH

--- a/include/tlapack/legacy_api/blas/gemm.hpp
+++ b/include/tlapack/legacy_api/blas/gemm.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_GEMM_HH
 #define TLAPACK_LEGACY_GEMM_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/gemm.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -91,84 +91,79 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TB, typename TC >
-void gemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    idx_t m, idx_t n, idx_t k,
-    scalar_type<TA, TB, TC> alpha,
-    TA const *A, idx_t lda,
-    TB const *B, idx_t ldb,
-    scalar_type<TA, TB, TC> beta,
-    TC       *C, idx_t ldc )
+template <typename TA, typename TB, typename TC>
+void gemm(Layout layout,
+          Op transA,
+          Op transB,
+          idx_t m,
+          idx_t n,
+          idx_t k,
+          scalar_type<TA, TB, TC> alpha,
+          TA const* A,
+          idx_t lda,
+          TB const* B,
+          idx_t ldb,
+          scalar_type<TA, TB, TC> beta,
+          TC* C,
+          idx_t ldc)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TB, TC>;
 
     // redirect if row major
     if (layout == Layout::RowMajor) {
-        return gemm(
-            Layout::ColMajor,
-            transB,
-            transA,
-            n, m, k,
-            alpha,
-            B, ldb,
-            A, lda,
-            beta,
-            C, ldc );
+        return gemm(Layout::ColMajor, transB, transA, n, m, k, alpha, B, ldb, A,
+                    lda, beta, C, ldc);
     }
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                      layout != Layout::RowMajor );
-    tlapack_check_false( transA != Op::NoTrans &&
-                   transA != Op::Trans &&
-                   transA != Op::ConjTrans );
-    tlapack_check_false( transB != Op::NoTrans &&
-                   transB != Op::Trans &&
-                   transB != Op::ConjTrans );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( k < 0 );
-    tlapack_check_false( lda < ((transA != Op::NoTrans) ? k : m) );
-    tlapack_check_false( ldb < ((transB != Op::NoTrans) ? n : k) );
-    tlapack_check_false( ldc < m );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(transA != Op::NoTrans && transA != Op::Trans &&
+                        transA != Op::ConjTrans);
+    tlapack_check_false(transB != Op::NoTrans && transB != Op::Trans &&
+                        transB != Op::ConjTrans);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(k < 0);
+    tlapack_check_false(lda < ((transA != Op::NoTrans) ? k : m));
+    tlapack_check_false(ldb < ((transB != Op::NoTrans) ? n : k));
+    tlapack_check_false(ldc < m);
 
     // quick return
-    if ( m == 0 || n == 0 || 
-        ((alpha == scalar_t(0) || k == 0 ) && (beta == scalar_t(1))) ) return;
+    if (m == 0 || n == 0 ||
+        ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
+        return;
 
     // Matrix views
     const auto A_ = (transA == Op::NoTrans)
-            ? colmajor_matrix<TA>( (TA*)A, m, k, lda )
-            : colmajor_matrix<TA>( (TA*)A, k, m, lda );
+                        ? colmajor_matrix<TA>((TA*)A, m, k, lda)
+                        : colmajor_matrix<TA>((TA*)A, k, m, lda);
     const auto B_ = (transB == Op::NoTrans)
-            ? colmajor_matrix<TB>( (TB*)B, k, n, ldb )
-            : colmajor_matrix<TB>( (TB*)B, n, k, ldb );
-    auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
+                        ? colmajor_matrix<TB>((TB*)B, k, n, ldb)
+                        : colmajor_matrix<TB>((TB*)B, n, k, ldb);
+    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
 
-    if( alpha == scalar_t(0) ) {
-        if( beta == scalar_t(0) ) {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < m; ++i)
-                    C_(i,j) = TC(0);
+    if (alpha == scalar_t(0)) {
+        if (beta == scalar_t(0)) {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    C_(i, j) = TC(0);
         }
         else {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < m; ++i)
-                    C_(i,j) *= beta;
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    C_(i, j) *= beta;
         }
     }
     else {
-        if( beta == scalar_t(0) )
-            gemm( transA, transB, alpha, A_, B_, C_ );
+        if (beta == scalar_t(0))
+            gemm(transA, transB, alpha, A_, B_, C_);
         else
-            gemm( transA, transB, alpha, A_, B_, beta, C_ );
+            gemm(transA, transB, alpha, A_, B_, beta, C_);
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_GEMM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_GEMM_HH

--- a/include/tlapack/legacy_api/blas/gemv.hpp
+++ b/include/tlapack/legacy_api/blas/gemv.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_GEMV_HH
 #define TLAPACK_LEGACY_GEMV_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/gemv.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -80,74 +80,69 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX, typename TY >
-void gemv(
-    Layout layout,
-    Op trans,
-    idx_t m, idx_t n,
-    scalar_type<TA, TX, TY> alpha,
-    TA const *A, idx_t lda,
-    TX const *x, int_t incx,
-    scalar_type<TA, TX, TY> beta,
-    TY *y, int_t incy )
+template <typename TA, typename TX, typename TY>
+void gemv(Layout layout,
+          Op trans,
+          idx_t m,
+          idx_t n,
+          scalar_type<TA, TX, TY> alpha,
+          TA const* A,
+          idx_t lda,
+          TX const* x,
+          int_t incx,
+          scalar_type<TA, TX, TY> beta,
+          TY* y,
+          int_t incy)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TX, TY>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < ((layout == Layout::ColMajor) ? m : n) );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if ( m == 0 || n == 0 ||
-        ((alpha == scalar_t(0)) && (beta == scalar_t(1))) ) return;
+    if (m == 0 || n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
+        return;
 
     // Transpose if Row Major
     if (layout == Layout::RowMajor) {
         // A => A^T; A^T => A; A^H => conj(A)
-        std::swap( m, n );
+        std::swap(m, n);
         trans = (trans == Op::NoTrans)
-              ? Op::Trans
-              : ((trans == Op::Trans) ? Op::NoTrans : Op::Conj);
+                    ? Op::Trans
+                    : ((trans == Op::Trans) ? Op::NoTrans : Op::Conj);
     }
 
     // Initialize indexes
     idx_t lenx = ((trans == Op::NoTrans || trans == Op::Conj) ? n : m);
     idx_t leny = ((trans == Op::NoTrans || trans == Op::Conj) ? m : n);
-    
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>( (TA*)A, m, n, lda );
 
-    if( alpha == scalar_t(0) ) {
-        tlapack_expr_with_vector( y_, TY, leny, y, incy,
-            if( beta == scalar_t(0) )
-                for(idx_t i = 0; i < leny; ++i)
-                    y_[i] = TY(0);
-            else
-                for(idx_t i = 0; i < leny; ++i)
-                    y_[i] *= beta
-        );
+    // Matrix views
+    const auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
+
+    if (alpha == scalar_t(0)) {
+        tlapack_expr_with_vector(
+            y_, TY, leny, y, incy,
+            if (beta == scalar_t(0)) for (idx_t i = 0; i < leny; ++i) y_[i] =
+                TY(0);
+            else for (idx_t i = 0; i < leny; ++i) y_[i] *= beta);
     }
     else {
         tlapack_expr_with_2vectors(
-            x_, TX, lenx, x, incx,
-            y_, TY, leny, y, incy,
-            if( beta == scalar_t(0) )
-                return gemv( trans, alpha, A_, x_, y_ );
-            else
-                return gemv( trans, alpha, A_, x_, beta, y_ )
-        );
+            x_, TX, lenx, x, incx, y_, TY, leny, y, incy,
+            if (beta == scalar_t(0)) return gemv(trans, alpha, A_, x_, y_);
+            else return gemv(trans, alpha, A_, x_, beta, y_));
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_GEMV_HH
+#endif  //  #ifndef TLAPACK_LEGACY_GEMV_HH

--- a/include/tlapack/legacy_api/blas/ger.hpp
+++ b/include/tlapack/legacy_api/blas/ger.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_GER_HH
 #define TLAPACK_LEGACY_GER_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/ger.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -61,56 +61,50 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX, typename TY >
-void ger(
-    Layout layout,
-    idx_t m, idx_t n,
-    scalar_type<TA, TX, TY> alpha,
-    TX const *x, int_t incx,
-    TY const *y, int_t incy,
-    TA *A, idx_t lda )
+template <typename TA, typename TX, typename TY>
+void ger(Layout layout,
+         idx_t m,
+         idx_t n,
+         scalar_type<TA, TX, TY> alpha,
+         TX const* x,
+         int_t incx,
+         TY const* y,
+         int_t incy,
+         TA* A,
+         idx_t lda)
 {
     using internal::colmajor_matrix;
     using internal::rowmajor_matrix;
     using scalar_t = scalar_type<TA, TX, TY>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
-    tlapack_check_false( lda < ((layout == Layout::ColMajor) ? m : n) );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
+    tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
 
     // quick return
-    if (m == 0 || n == 0 || alpha == scalar_t(0))
-        return;
+    if (m == 0 || n == 0 || alpha == scalar_t(0)) return;
 
-    if( layout == Layout::ColMajor )
-    {
+    if (layout == Layout::ColMajor) {
         // Matrix views
-        auto A_ = colmajor_matrix<TA>( A, m, n, lda );
+        auto A_ = colmajor_matrix<TA>(A, m, n, lda);
 
-        tlapack_expr_with_2vectors(
-            x_, TX, m, x, incx,
-            y_, TY, n, y, incy,
-            return ger( alpha, x_, y_, A_ )
-        );
+        tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
+                                   return ger(alpha, x_, y_, A_));
     }
-    else
-    {
+    else {
         // Matrix views
-        auto A_ = rowmajor_matrix<TA>( A, m, n, lda );
+        auto A_ = rowmajor_matrix<TA>(A, m, n, lda);
 
-        tlapack_expr_with_2vectors(
-            x_, TX, m, x, incx,
-            y_, TY, n, y, incy,
-            return ger( alpha, x_, y_, A_ )
-        );
+        tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
+                                   return ger(alpha, x_, y_, A_));
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_GER_HH
+#endif  //  #ifndef TLAPACK_LEGACY_GER_HH

--- a/include/tlapack/legacy_api/blas/geru.hpp
+++ b/include/tlapack/legacy_api/blas/geru.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_GERU_HH
 #define TLAPACK_LEGACY_GERU_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/geru.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -61,56 +61,49 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX, typename TY >
-void geru(
-    Layout layout,
-    idx_t m, idx_t n,
-    scalar_type<TA, TX, TY> alpha,
-    TX const *x, int_t incx,
-    TY const *y, int_t incy,
-    TA *A, idx_t lda )
+template <typename TA, typename TX, typename TY>
+void geru(Layout layout,
+          idx_t m,
+          idx_t n,
+          scalar_type<TA, TX, TY> alpha,
+          TX const* x,
+          int_t incx,
+          TY const* y,
+          int_t incy,
+          TA* A,
+          idx_t lda)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TX, TY>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
-    tlapack_check_false( lda < ((layout == Layout::ColMajor) ? m : n) );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
+    tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
 
     // quick return
-    if (m == 0 || n == 0 || alpha == scalar_t(0))
-        return;
+    if (m == 0 || n == 0 || alpha == scalar_t(0)) return;
 
-    if( layout == Layout::ColMajor )
-    {
+    if (layout == Layout::ColMajor) {
         // Matrix views
-        auto A_ = colmajor_matrix<TA>( A, m, n, lda );
+        auto A_ = colmajor_matrix<TA>(A, m, n, lda);
 
-        tlapack_expr_with_2vectors(
-            x_, TX, m, x, incx,
-            y_, TY, n, y, incy,
-            return geru( alpha, x_, y_, A_ )
-        );
+        tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
+                                   return geru(alpha, x_, y_, A_));
     }
-    else
-    {
+    else {
         // Matrix views
-        auto A_ = colmajor_matrix<TA>( A, n, m, lda );
+        auto A_ = colmajor_matrix<TA>(A, n, m, lda);
 
-        tlapack_expr_with_2vectors(
-            y_, TY, n, y, incy,
-            x_, TX, m, x, incx,
-            return geru( alpha, y_, x_, A_ )
-        );
+        tlapack_expr_with_2vectors(y_, TY, n, y, incy, x_, TX, m, x, incx,
+                                   return geru(alpha, y_, x_, A_));
     }
-
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_GER_HH
+#endif  //  #ifndef TLAPACK_LEGACY_GER_HH

--- a/include/tlapack/legacy_api/blas/hemm.hpp
+++ b/include/tlapack/legacy_api/blas/hemm.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_HEMM_HH
 #define TLAPACK_LEGACY_HEMM_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/hemm.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -85,78 +85,77 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TB, typename TC >
-void hemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    idx_t m, idx_t n,
-    scalar_type<TA, TB, TC> alpha,
-    TA const *A, idx_t lda,
-    TB const *B, idx_t ldb,
-    scalar_type<TA, TB, TC> beta,
-    TC       *C, idx_t ldc )
-{    
+template <typename TA, typename TB, typename TC>
+void hemm(Layout layout,
+          Side side,
+          Uplo uplo,
+          idx_t m,
+          idx_t n,
+          scalar_type<TA, TB, TC> alpha,
+          TA const* A,
+          idx_t lda,
+          TB const* B,
+          idx_t ldb,
+          scalar_type<TA, TB, TC> beta,
+          TC* C,
+          idx_t ldc)
+{
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TB, TC>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( side != Side::Left &&
-                   side != Side::Right );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < ((side == Side::Left) ? m : n) );
-    tlapack_check_false( ldb < ((layout == Layout::RowMajor) ? n : m) );
-    tlapack_check_false( ldc < ((layout == Layout::RowMajor) ? n : m) );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
+    tlapack_check_false(ldc < ((layout == Layout::RowMajor) ? n : m));
 
     // quick return
-    if ( m == 0 || n == 0 ||
-        ((alpha == scalar_t(0)) && (beta == scalar_t(1))) ) return;
+    if (m == 0 || n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
+        return;
 
     // adapt if row major
     if (layout == Layout::RowMajor) {
-        side = (side == Side::Left)
-            ? Side::Right
-            : Side::Left;
+        side = (side == Side::Left) ? Side::Right : Side::Left;
         if (uplo == Uplo::Lower)
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m , n );
+        std::swap(m, n);
     }
-    
+
     // Matrix views
     const auto A_ = (side == Side::Left)
-                  ? colmajor_matrix<TA>( (TA*)A, m, m, lda )
-                  : colmajor_matrix<TA>( (TA*)A, n, n, lda );
-    const auto B_ = colmajor_matrix<TB>( (TB*)B, m, n, ldb );
-    auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
+                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
+                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
+    const auto B_ = colmajor_matrix<TB>((TB*)B, m, n, ldb);
+    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
 
-    if( alpha == scalar_t(0) ) {
-        if( beta == scalar_t(0) ) {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < m; ++i)
-                    C_(i,j) = TC(0);
+    if (alpha == scalar_t(0)) {
+        if (beta == scalar_t(0)) {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    C_(i, j) = TC(0);
         }
         else {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < m; ++i)
-                    C_(i,j) *= beta;
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    C_(i, j) *= beta;
         }
     }
     else {
-        if( beta == scalar_t(0) )
-            hemm( side, uplo, alpha, A_, B_, C_ );
+        if (beta == scalar_t(0))
+            hemm(side, uplo, alpha, A_, B_, C_);
         else
-            hemm( side, uplo, alpha, A_, B_, beta, C_ );
+            hemm(side, uplo, alpha, A_, B_, beta, C_);
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_HEMM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_HEMM_HH

--- a/include/tlapack/legacy_api/blas/hemv.hpp
+++ b/include/tlapack/legacy_api/blas/hemv.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_HEMV_HH
 #define TLAPACK_LEGACY_HEMV_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/hemv.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -69,63 +69,64 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX, typename TY >
-void hemv(
-    Layout layout,
-    Uplo uplo,
-    idx_t n,
-    scalar_type<TA, TX, TY> alpha,
-    TA const *A, idx_t lda,
-    TX const *x, int_t incx,
-    scalar_type<TA, TX, TY> beta,
-    TY *y, int_t incy )
+template <typename TA, typename TX, typename TY>
+void hemv(Layout layout,
+          Uplo uplo,
+          idx_t n,
+          scalar_type<TA, TX, TY> alpha,
+          TA const* A,
+          idx_t lda,
+          TX const* x,
+          int_t incx,
+          scalar_type<TA, TX, TY> beta,
+          TY* y,
+          int_t incy)
 {
     using internal::colmajor_matrix;
     using internal::rowmajor_matrix;
     using scalar_t = scalar_type<TA, TX, TY>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < n );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < n);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if ( n == 0 ||
-        ((alpha == scalar_t(0)) && (beta == scalar_t(1))) ) return;
+    if (n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1)))) return;
 
-    if( alpha == scalar_t(0) ) {
-        tlapack_expr_with_vector( y_, TY, n, y, incy,
-            if( beta == scalar_t(0) )
-                for(idx_t i = 0; i < n; ++i)
-                    y_[i] = TY(0);
-            else
-                for(idx_t i = 0; i < n; ++i)
-                    y_[i] *= beta
-        );
+    if (alpha == scalar_t(0)) {
+        tlapack_expr_with_vector(
+            y_, TY, n, y, incy,
+            if (beta == scalar_t(0)) for (idx_t i = 0; i < n; ++i) y_[i] =
+                TY(0);
+            else for (idx_t i = 0; i < n; ++i) y_[i] *= beta);
     }
     else {
         tlapack_expr_with_2vectors(
-            x_, TX, n, x, incx,
-            y_, TY, n, y, incy,
-            if( beta == scalar_t(0) )
-                if(layout == Layout::ColMajor)
-                    return hemv( uplo, alpha, colmajor_matrix<TA>( (TA*)A, n, n, lda ), x_, y_ );
-                else
-                    return hemv( uplo, alpha, rowmajor_matrix<TA>( (TA*)A, n, n, lda ), x_, y_ );
-            else
-                if(layout == Layout::ColMajor)
-                    return hemv( uplo, alpha, colmajor_matrix<TA>( (TA*)A, n, n, lda ), x_, beta, y_ );
-                else
-                    return hemv( uplo, alpha, rowmajor_matrix<TA>( (TA*)A, n, n, lda ), x_, beta, y_ )
-        );
+            x_, TX, n, x, incx, y_, TY, n, y, incy,
+            if (beta ==
+                scalar_t(
+                    0)) if (layout ==
+                            Layout::ColMajor) return hemv(uplo, alpha,
+                                                          colmajor_matrix<TA>(
+                                                              (TA*)A, n, n,
+                                                              lda),
+                                                          x_, y_);
+            else return hemv(uplo, alpha,
+                             rowmajor_matrix<TA>((TA*)A, n, n, lda), x_, y_);
+            else if (layout == Layout::ColMajor) return hemv(
+                uplo, alpha, colmajor_matrix<TA>((TA*)A, n, n, lda), x_, beta,
+                y_);
+            else return hemv(uplo, alpha,
+                             rowmajor_matrix<TA>((TA*)A, n, n, lda), x_, beta,
+                             y_));
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_HEMV_HH
+#endif  //  #ifndef TLAPACK_LEGACY_HEMV_HH

--- a/include/tlapack/legacy_api/blas/her.hpp
+++ b/include/tlapack/legacy_api/blas/her.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_HER_HH
 #define TLAPACK_LEGACY_HER_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/her.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -59,42 +59,41 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX >
-void her(
-    Layout layout,
-    Uplo uplo,
-    idx_t n,
-    real_type<TA, TX> alpha,  // zher takes double alpha; use real
-    TX const *x, int_t incx,
-    TA       *A, idx_t lda )
+template <typename TA, typename TX>
+void her(Layout layout,
+         Uplo uplo,
+         idx_t n,
+         real_type<TA, TX> alpha,  // zher takes double alpha; use real
+         TX const* x,
+         int_t incx,
+         TA* A,
+         idx_t lda)
 {
     using internal::colmajor_matrix;
-    using real_t = real_type<TA,TX>;
+    using real_t = real_type<TA, TX>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( lda < n );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(lda < n);
 
     // quick return
-    if (n == 0 || alpha == real_t(0))
-        return;
+    if (n == 0 || alpha == real_t(0)) return;
 
     // for row major, swap lower <=> upper
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
-    
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
-    tlapack_expr_with_vector( x_, TX, n, x, incx, her( uplo, alpha, x_, A_ ) );
+    // Matrix views
+    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
+
+    tlapack_expr_with_vector(x_, TX, n, x, incx, her(uplo, alpha, x_, A_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_HER_HH
+#endif  //  #ifndef TLAPACK_LEGACY_HER_HH

--- a/include/tlapack/legacy_api/blas/her2.hpp
+++ b/include/tlapack/legacy_api/blas/her2.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_HER2_HH
 #define TLAPACK_LEGACY_HER2_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/her2.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -66,48 +66,45 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX, typename TY >
-void her2(
-    Layout layout,
-    Uplo  uplo,
-    idx_t n,
-    scalar_type<TA, TX, TY> alpha,
-    TX const *x, int_t incx,
-    TY const *y, int_t incy,
-    TA *A, idx_t lda )
+template <typename TA, typename TX, typename TY>
+void her2(Layout layout,
+          Uplo uplo,
+          idx_t n,
+          scalar_type<TA, TX, TY> alpha,
+          TX const* x,
+          int_t incx,
+          TY const* y,
+          int_t incy,
+          TA* A,
+          idx_t lda)
 {
     using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA,TX>;
+    using scalar_t = scalar_type<TA, TX>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
-    tlapack_check_false( lda < n );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
+    tlapack_check_false(lda < n);
 
     // quick return
-    if (n == 0 || alpha == scalar_t(0))
-        return;
+    if (n == 0 || alpha == scalar_t(0)) return;
 
     // for row major, swap lower <=> upper
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
-    
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return her2( uplo, alpha, x_, y_, A_ )
-    );
+    // Matrix views
+    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
+
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return her2(uplo, alpha, x_, y_, A_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_HER2_HH
+#endif  //  #ifndef TLAPACK_LEGACY_HER2_HH

--- a/include/tlapack/legacy_api/blas/her2k.hpp
+++ b/include/tlapack/legacy_api/blas/her2k.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_HER2K_HH
 #define TLAPACK_LEGACY_HER2K_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/her2k.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -91,54 +91,49 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TB, typename TC >
-void her2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    idx_t n, idx_t k,
-    scalar_type<TA, TB, TC> alpha,  // note: complex
-    TA const *A, idx_t lda,
-    TB const *B, idx_t ldb,
-    real_type<TA, TB, TC> beta,  // note: real
-    TC       *C, idx_t ldc )
+template <typename TA, typename TB, typename TC>
+void her2k(Layout layout,
+           Uplo uplo,
+           Op trans,
+           idx_t n,
+           idx_t k,
+           scalar_type<TA, TB, TC> alpha,  // note: complex
+           TA const* A,
+           idx_t lda,
+           TB const* B,
+           idx_t ldb,
+           real_type<TA, TB, TC> beta,  // note: real
+           TC* C,
+           idx_t ldc)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TB, TC>;
     using real_t = real_type<TA, TB, TC>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( is_complex<TA>::value && trans == Op::Trans );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( k < 0 );
-    tlapack_check_false( lda < (
-        (layout == Layout::RowMajor)
-            ? ((trans == Op::NoTrans) ? k : n)
-            : ((trans == Op::NoTrans) ? n : k)
-        )
-    );
-    tlapack_check_false( ldb < (
-        (layout == Layout::RowMajor)
-            ? ((trans == Op::NoTrans) ? k : n)
-            : ((trans == Op::NoTrans) ? n : k)
-        )
-    );
-    tlapack_check_false( ldc < n );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(k < 0);
+    tlapack_check_false(lda < ((layout == Layout::RowMajor)
+                                   ? ((trans == Op::NoTrans) ? k : n)
+                                   : ((trans == Op::NoTrans) ? n : k)));
+    tlapack_check_false(ldb < ((layout == Layout::RowMajor)
+                                   ? ((trans == Op::NoTrans) ? k : n)
+                                   : ((trans == Op::NoTrans) ? n : k)));
+    tlapack_check_false(ldc < n);
 
     // quick return
-    if ( n == 0 ||
-        ((alpha == scalar_t(0) || k == 0 ) && (beta == real_t(1))) ) return;
+    if (n == 0 || ((alpha == scalar_t(0) || k == 0) && (beta == real_t(1))))
+        return;
 
     // This algorithm only works with Op::NoTrans or Op::ConjTrans
-    if(trans == Op::Trans) trans = Op::ConjTrans;
+    if (trans == Op::Trans) trans = Op::ConjTrans;
 
     // adapt if row major
     if (layout == Layout::RowMajor) {
@@ -146,41 +141,39 @@ void her2k(
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        trans = (trans == Op::NoTrans)
-            ? Op::ConjTrans
-            : Op::NoTrans;
+        trans = (trans == Op::NoTrans) ? Op::ConjTrans : Op::NoTrans;
         alpha = conj(alpha);
     }
 
     // Matrix views
     const auto A_ = (trans == Op::NoTrans)
-                  ? colmajor_matrix<TA>( (TA*)A, n, k, lda )
-                  : colmajor_matrix<TA>( (TA*)A, k, n, lda );
+                        ? colmajor_matrix<TA>((TA*)A, n, k, lda)
+                        : colmajor_matrix<TA>((TA*)A, k, n, lda);
     const auto B_ = (trans == Op::NoTrans)
-                  ? colmajor_matrix<TB>( (TB*)B, n, k, ldb )
-                  : colmajor_matrix<TB>( (TB*)B, k, n, ldb );
-    auto C_ = colmajor_matrix<TC>( C, n, n, ldc );
+                        ? colmajor_matrix<TB>((TB*)B, n, k, ldb)
+                        : colmajor_matrix<TB>((TB*)B, k, n, ldb);
+    auto C_ = colmajor_matrix<TC>(C, n, n, ldc);
 
-    if( alpha == scalar_t(0) ) {
-        if( beta == real_t(0) ) {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < n; ++i)
-                    C_(i,j) = TC(0);
+    if (alpha == scalar_t(0)) {
+        if (beta == real_t(0)) {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < n; ++i)
+                    C_(i, j) = TC(0);
         }
         else {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < n; ++i)
-                    C_(i,j) *= beta;
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < n; ++i)
+                    C_(i, j) *= beta;
         }
     }
     else {
-        if( beta == real_t(0) )
-            her2k( uplo, trans, alpha, A_, B_, C_ );
+        if (beta == real_t(0))
+            her2k(uplo, trans, alpha, A_, B_, C_);
         else
-            her2k( uplo, trans, alpha, A_, B_, beta, C_ );
+            her2k(uplo, trans, alpha, A_, B_, beta, C_);
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_HER2K_HH
+#endif  //  #ifndef TLAPACK_LEGACY_HER2K_HH

--- a/include/tlapack/legacy_api/blas/herk.hpp
+++ b/include/tlapack/legacy_api/blas/herk.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_HERK_HH
 #define TLAPACK_LEGACY_HERK_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/herk.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -80,46 +80,43 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TC >
-void herk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    idx_t n, idx_t k,
-    real_type<TA, TC> alpha,  // note: real
-    TA const *A, idx_t lda,
-    real_type<TA, TC> beta,  // note: real
-    TC       *C, idx_t ldc )
+template <typename TA, typename TC>
+void herk(Layout layout,
+          Uplo uplo,
+          Op trans,
+          idx_t n,
+          idx_t k,
+          real_type<TA, TC> alpha,  // note: real
+          TA const* A,
+          idx_t lda,
+          real_type<TA, TC> beta,  // note: real
+          TC* C,
+          idx_t ldc)
 {
     using internal::colmajor_matrix;
     using real_t = real_type<TA, TC>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( is_complex<TA>::value && trans == Op::Trans );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( k < 0 );
-    tlapack_check_false( lda < (
-        (layout == Layout::RowMajor)
-            ? ((trans == Op::NoTrans) ? k : n)
-            : ((trans == Op::NoTrans) ? n : k)
-        )
-    );
-    tlapack_check_false( ldc < n );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(k < 0);
+    tlapack_check_false(lda < ((layout == Layout::RowMajor)
+                                   ? ((trans == Op::NoTrans) ? k : n)
+                                   : ((trans == Op::NoTrans) ? n : k)));
+    tlapack_check_false(ldc < n);
 
     // quick return
-    if ( n == 0 || 
-        ((alpha == real_t(0) || k == 0 ) && (beta == real_t(1))) ) return;
+    if (n == 0 || ((alpha == real_t(0) || k == 0) && (beta == real_t(1))))
+        return;
 
     // This algorithm only works with Op::NoTrans or Op::ConjTrans
-    if(trans == Op::Trans) trans = Op::ConjTrans;
+    if (trans == Op::Trans) trans = Op::ConjTrans;
 
     // adapt if row major
     if (layout == Layout::RowMajor) {
@@ -127,38 +124,36 @@ void herk(
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        trans = (trans == Op::NoTrans)
-            ? Op::ConjTrans
-            : Op::NoTrans;
+        trans = (trans == Op::NoTrans) ? Op::ConjTrans : Op::NoTrans;
         alpha = conj(alpha);
     }
 
     // Matrix views
     const auto A_ = (trans == Op::NoTrans)
-                 ? colmajor_matrix<TA>( (TA*)A, n, k, lda )
-                 : colmajor_matrix<TA>( (TA*)A, k, n, lda );
-    auto C_ = colmajor_matrix<TC>( C, n, n, ldc );
+                        ? colmajor_matrix<TA>((TA*)A, n, k, lda)
+                        : colmajor_matrix<TA>((TA*)A, k, n, lda);
+    auto C_ = colmajor_matrix<TC>(C, n, n, ldc);
 
-    if( alpha == real_t(0) ) {
-        if( beta == real_t(0) ) {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < n; ++i)
-                    C_(i,j) = TC(0);
+    if (alpha == real_t(0)) {
+        if (beta == real_t(0)) {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < n; ++i)
+                    C_(i, j) = TC(0);
         }
         else {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < n; ++i)
-                    C_(i,j) *= beta;
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < n; ++i)
+                    C_(i, j) *= beta;
         }
     }
     else {
-        if( beta == real_t(0) )
-            herk( uplo, trans, alpha, A_, C_ );
+        if (beta == real_t(0))
+            herk(uplo, trans, alpha, A_, C_);
         else
-            herk( uplo, trans, alpha, A_, beta, C_ );
+            herk(uplo, trans, alpha, A_, beta, C_);
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_HERK_HH
+#endif  //  #ifndef TLAPACK_LEGACY_HERK_HH

--- a/include/tlapack/legacy_api/blas/iamax.hpp
+++ b/include/tlapack/legacy_api/blas/iamax.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_IAMAX_HH
 #define TLAPACK_LEGACY_IAMAX_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/iamax.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -28,32 +28,30 @@ namespace tlapack {
  *
  * @param[in] incx
  *     Stride between elements of x. incx > 0.
- * 
+ *
  * @return In priority order:
  * 1. 0 if n <= 0,
- * 2. the index of the first `NAN` in $x$ if it exists and if `checkNAN == true`,
+ * 2. the index of the first `NAN` in $x$ if it exists and if `checkNAN ==
+ * true`,
  * 3. the index of the first `Infinity` in $x$ if it exists,
  * 4. the Index of the infinity-norm of $x$, $|| x ||_{inf}$,
  *     $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$.
- * 
+ *
  * @see iamax( const vector_t& x, const ec_opts_t& opts = {} )
  *
  * @ingroup legacy_blas
  */
-template< typename T >
-idx_t iamax( idx_t n, T const *x, int_t incx )
+template <typename T>
+idx_t iamax(idx_t n, T const* x, int_t incx)
 {
-    tlapack_check_false( incx <= 0 );
+    tlapack_check_false(incx <= 0);
 
     // quick return
-    if( n <= 0 ) return 0;
+    if (n <= 0) return 0;
 
-    tlapack_expr_with_vector_positiveInc(
-        x_, T, n, x, incx,
-        return iamax( x_ )
-    );
+    tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx, return iamax(x_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_IAMAX_HH
+#endif  //  #ifndef TLAPACK_LEGACY_IAMAX_HH

--- a/include/tlapack/legacy_api/blas/nrm2.hpp
+++ b/include/tlapack/legacy_api/blas/nrm2.hpp
@@ -16,9 +16,9 @@
 #ifndef TLAPACK_LEGACY_NRM2_HH
 #define TLAPACK_LEGACY_NRM2_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/nrm2.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -39,20 +39,17 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename T >
-real_type<T> nrm2( idx_t n, T const * x, int_t incx )
+template <typename T>
+real_type<T> nrm2(idx_t n, T const* x, int_t incx)
 {
-    tlapack_check_false( incx <= 0 );
+    tlapack_check_false(incx <= 0);
 
     // quick return
-    if( n <= 0 ) return 0;
+    if (n <= 0) return 0;
 
-    tlapack_expr_with_vector_positiveInc(
-        x_, T, n, x, incx,
-        return nrm2( x_ )
-    );
+    tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx, return nrm2(x_));
 }
 
 }  // namespace tlapack
 
-#endif        // #ifndef TLAPACK_LEGACY_NRM2_HH
+#endif  // #ifndef TLAPACK_LEGACY_NRM2_HH

--- a/include/tlapack/legacy_api/blas/rot.hpp
+++ b/include/tlapack/legacy_api/blas/rot.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_ROT_HH
 #define TLAPACK_LEGACY_ROT_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/rot.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -54,28 +54,26 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TX, typename TY >
-void rot(
-    idx_t n,
-    TX *x, int_t incx,
-    TY *y, int_t incy,
-    const real_type<TX, TY>&   c,
-    const scalar_type<TX, TY>& s )
+template <typename TX, typename TY>
+void rot(idx_t n,
+         TX* x,
+         int_t incx,
+         TY* y,
+         int_t incy,
+         const real_type<TX, TY>& c,
+         const scalar_type<TX, TY>& s)
 {
     // check arguments
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if( n <= 0 ) return;
+    if (n <= 0) return;
 
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return rot( x_, y_, c, s )
-    );
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return rot(x_, y_, c, s));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_ROT_HH
+#endif  //  #ifndef TLAPACK_LEGACY_ROT_HH

--- a/include/tlapack/legacy_api/blas/rotg.hpp
+++ b/include/tlapack/legacy_api/blas/rotg.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_ROTG_HH
 #define TLAPACK_LEGACY_ROTG_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/rotg.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -49,12 +49,11 @@ namespace tlapack {
  * @ingroup legacy_blas
  */
 template <typename T>
-inline void
-rotg ( T* a, T* b, real_type<T>* c, T* s )
+inline void rotg(T* a, T* b, real_type<T>* c, T* s)
 {
-    return rotg(*a,*b,*c,*s);
+    return rotg(*a, *b, *c, *s);
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_ROTG_HH
+#endif  //  #ifndef TLAPACK_LEGACY_ROTG_HH

--- a/include/tlapack/legacy_api/blas/rotm.hpp
+++ b/include/tlapack/legacy_api/blas/rotm.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_ROTM_HH
 #define TLAPACK_LEGACY_ROTM_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/rotm.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -51,35 +51,33 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TX, typename TY >
-void rotm(
-    idx_t n,
-    TX *x, int_t incx,
-    TY *y, int_t incy,
-    scalar_type<TX, TY> const param[5] )
+template <typename TX, typename TY>
+void rotm(idx_t n,
+          TX* x,
+          int_t incx,
+          TY* y,
+          int_t incy,
+          scalar_type<TX, TY> const param[5])
 {
     // constants
-    const int flag = (int) param[0];
+    const int flag = (int)param[0];
     const scalar_type<TX, TY>* h = &param[1];
 
     // check arguments
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
-    tlapack_check_false( flag < -2 && flag > 1 );
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
+    tlapack_check_false(flag < -2 && flag > 1);
 
     // quick return
-    if( n <= 0 ) return;
-    
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        if      ( flag == -2 ) return rotm<-2>(x_,y_,h);
-        else if ( flag == -1 ) return rotm<-1>(x_,y_,h);
-        else if ( flag ==  0 ) return rotm< 0>(x_,y_,h);
-        else                   return rotm< 1>(x_,y_,h);
-    );
+    if (n <= 0) return;
+
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               if (flag == -2) return rotm<-2>(x_, y_, h);
+                               else if (flag == -1) return rotm<-1>(x_, y_, h);
+                               else if (flag == 0) return rotm<0>(x_, y_, h);
+                               else return rotm<1>(x_, y_, h););
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_ROTM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_ROTM_HH

--- a/include/tlapack/legacy_api/blas/rotmg.hpp
+++ b/include/tlapack/legacy_api/blas/rotmg.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_ROTMG_HH
 #define TLAPACK_LEGACY_ROTMG_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/rotmg.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -100,20 +100,15 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename real_t >
-void rotmg(
-    real_t *d1,
-    real_t *d2,
-    real_t *a,
-    real_t  b,
-    real_t param[5] )
+template <typename real_t>
+void rotmg(real_t* d1, real_t* d2, real_t* a, real_t b, real_t param[5])
 {
     // check arguments
-    tlapack_check_false( *d1 <= 0 );
+    tlapack_check_false(*d1 <= 0);
 
-    param[0] = rotmg(*d1,*d2,*a,b,&param[1]);
+    param[0] = rotmg(*d1, *d2, *a, b, &param[1]);
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_ROTMG_HH
+#endif  //  #ifndef TLAPACK_LEGACY_ROTMG_HH

--- a/include/tlapack/legacy_api/blas/scal.hpp
+++ b/include/tlapack/legacy_api/blas/scal.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_SCAL_HH
 #define TLAPACK_LEGACY_SCAL_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/scal.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -36,23 +36,18 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX >
-void scal(
-    idx_t n,
-    const TA& alpha,
-    TX* x, int_t incx )
+template <typename TA, typename TX>
+void scal(idx_t n, const TA& alpha, TX* x, int_t incx)
 {
-    tlapack_check_false( incx <= 0 );
+    tlapack_check_false(incx <= 0);
 
     // quick return
-    if( n <= 0 ) return;
-    
-    tlapack_expr_with_vector_positiveInc(
-        x_, TX, n, x, incx,
-        return scal( alpha, x_ )
-    );
+    if (n <= 0) return;
+
+    tlapack_expr_with_vector_positiveInc(x_, TX, n, x, incx,
+                                         return scal(alpha, x_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_SCAL_HH
+#endif  //  #ifndef TLAPACK_LEGACY_SCAL_HH

--- a/include/tlapack/legacy_api/blas/swap.hpp
+++ b/include/tlapack/legacy_api/blas/swap.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_SWAP_HH
 #define TLAPACK_LEGACY_SWAP_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/swap.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -41,26 +41,20 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TX, typename TY >
-void swap(
-    idx_t n,
-    TX *x, int_t incx,
-    TY *y, int_t incy )
+template <typename TX, typename TY>
+void swap(idx_t n, TX* x, int_t incx, TY* y, int_t incy)
 {
     // check arguments
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if( n <= 0 ) return;
+    if (n <= 0) return;
 
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return tlapack::swap( x_, y_ );
-    );
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return tlapack::swap(x_, y_););
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_SWAP_HH
+#endif  //  #ifndef TLAPACK_LEGACY_SWAP_HH

--- a/include/tlapack/legacy_api/blas/symm.hpp
+++ b/include/tlapack/legacy_api/blas/symm.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_SYMM_HH
 #define TLAPACK_LEGACY_SYMM_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/symm.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -79,78 +79,77 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TB, typename TC >
-void symm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    idx_t m, idx_t n,
-    scalar_type<TA, TB, TC> alpha,
-    TA const *A, idx_t lda,
-    TB const *B, idx_t ldb,
-    scalar_type<TA, TB, TC> beta,
-    TC       *C, idx_t ldc )
-{    
+template <typename TA, typename TB, typename TC>
+void symm(Layout layout,
+          Side side,
+          Uplo uplo,
+          idx_t m,
+          idx_t n,
+          scalar_type<TA, TB, TC> alpha,
+          TA const* A,
+          idx_t lda,
+          TB const* B,
+          idx_t ldb,
+          scalar_type<TA, TB, TC> beta,
+          TC* C,
+          idx_t ldc)
+{
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TB, TC>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( side != Side::Left &&
-                   side != Side::Right );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < ((side == Side::Left) ? m : n) );
-    tlapack_check_false( ldb < ((layout == Layout::RowMajor) ? n : m) );
-    tlapack_check_false( ldc < ((layout == Layout::RowMajor) ? n : m) );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
+    tlapack_check_false(ldc < ((layout == Layout::RowMajor) ? n : m));
 
     // quick return
-    if ( m == 0 || n == 0 ||
-        ((alpha == scalar_t(0)) && (beta == scalar_t(1))) ) return;
+    if (m == 0 || n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
+        return;
 
     // adapt if row major
     if (layout == Layout::RowMajor) {
-        side = (side == Side::Left)
-            ? Side::Right
-            : Side::Left;
+        side = (side == Side::Left) ? Side::Right : Side::Left;
         if (uplo == Uplo::Lower)
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m , n );
+        std::swap(m, n);
     }
-    
+
     // Matrix views
     const auto A_ = (side == Side::Left)
-                  ? colmajor_matrix<TA>( (TA*)A, m, m, lda )
-                  : colmajor_matrix<TA>( (TA*)A, n, n, lda );
-    const auto B_ = colmajor_matrix<TB>( (TB*)B, m, n, ldb );
-    auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
+                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
+                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
+    const auto B_ = colmajor_matrix<TB>((TB*)B, m, n, ldb);
+    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
 
-    if( alpha == scalar_t(0) ) {
-        if( beta == scalar_t(0) ) {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < m; ++i)
-                    C_(i,j) = TC(0);
+    if (alpha == scalar_t(0)) {
+        if (beta == scalar_t(0)) {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    C_(i, j) = TC(0);
         }
         else {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < m; ++i)
-                    C_(i,j) *= beta;
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    C_(i, j) *= beta;
         }
     }
     else {
-        if( beta == scalar_t(0) )
-            symm( side, uplo, alpha, A_, B_, C_ );
+        if (beta == scalar_t(0))
+            symm(side, uplo, alpha, A_, B_, C_);
         else
-            symm( side, uplo, alpha, A_, B_, beta, C_ );
+            symm(side, uplo, alpha, A_, B_, beta, C_);
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_SYMM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/tlapack/legacy_api/blas/symv.hpp
+++ b/include/tlapack/legacy_api/blas/symv.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_SYMV_HH
 #define TLAPACK_LEGACY_SYMV_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/symv.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -67,33 +67,33 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX, typename TY >
-void symv(
-    Layout layout,
-    Uplo uplo,
-    idx_t n,
-    scalar_type<TA, TX, TY> alpha,
-    TA const *A, idx_t lda,
-    TX const *x, int_t incx,
-    scalar_type<TA, TX, TY> beta,
-    TY *y, int_t incy )
+template <typename TA, typename TX, typename TY>
+void symv(Layout layout,
+          Uplo uplo,
+          idx_t n,
+          scalar_type<TA, TX, TY> alpha,
+          TA const* A,
+          idx_t lda,
+          TX const* x,
+          int_t incx,
+          scalar_type<TA, TX, TY> beta,
+          TY* y,
+          int_t incy)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TX, TY>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < n );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < n);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
 
     // quick return
-    if ( n == 0 ||
-        ((alpha == scalar_t(0)) && (beta == scalar_t(1))) ) return;
+    if (n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1)))) return;
 
     // for row major, swap lower <=> upper
     if (layout == Layout::RowMajor) {
@@ -101,30 +101,23 @@ void symv(
     }
 
     // Views
-    const auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
+    const auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
 
-    if( alpha == scalar_t(0) ) {
-        tlapack_expr_with_vector( y_, TY, n, y, incy,
-            if( beta == scalar_t(0) )
-                for(idx_t i = 0; i < n; ++i)
-                    y_[i] = TY(0);
-            else
-                for(idx_t i = 0; i < n; ++i)
-                    y_[i] *= beta
-        );
+    if (alpha == scalar_t(0)) {
+        tlapack_expr_with_vector(
+            y_, TY, n, y, incy,
+            if (beta == scalar_t(0)) for (idx_t i = 0; i < n; ++i) y_[i] =
+                TY(0);
+            else for (idx_t i = 0; i < n; ++i) y_[i] *= beta);
     }
     else {
         tlapack_expr_with_2vectors(
-            x_, TX, n, x, incx,
-            y_, TY, n, y, incy,
-            if( beta == scalar_t(0) )
-                return symv( uplo, alpha, A_, x_, y_ );
-            else
-                return symv( uplo, alpha, A_, x_, beta, y_ )
-        );
+            x_, TX, n, x, incx, y_, TY, n, y, incy,
+            if (beta == scalar_t(0)) return symv(uplo, alpha, A_, x_, y_);
+            else return symv(uplo, alpha, A_, x_, beta, y_));
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_SYMV_HH
+#endif  //  #ifndef TLAPACK_LEGACY_SYMV_HH

--- a/include/tlapack/legacy_api/blas/syr.hpp
+++ b/include/tlapack/legacy_api/blas/syr.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_SYR_HH
 #define TLAPACK_LEGACY_SYR_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/syr.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -57,42 +57,41 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX >
-void syr(
-    Layout layout,
-    Uplo uplo,
-    idx_t n,
-    scalar_type<TA, TX> alpha,
-    TX const *x, int_t incx,
-    TA       *A, idx_t lda )
+template <typename TA, typename TX>
+void syr(Layout layout,
+         Uplo uplo,
+         idx_t n,
+         scalar_type<TA, TX> alpha,
+         TX const* x,
+         int_t incx,
+         TA* A,
+         idx_t lda)
 {
     using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA,TX>;
+    using scalar_t = scalar_type<TA, TX>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( lda < n );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(lda < n);
 
     // quick return
-    if (n == 0 || alpha == scalar_t(0))
-        return;
+    if (n == 0 || alpha == scalar_t(0)) return;
 
     // for row major, swap lower <=> upper
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
-    
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
-    tlapack_expr_with_vector( x_, TX, n, x, incx, syr( uplo, alpha, x_, A_ ) );
+    // Matrix views
+    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
+
+    tlapack_expr_with_vector(x_, TX, n, x, incx, syr(uplo, alpha, x_, A_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_SYR_HH
+#endif  //  #ifndef TLAPACK_LEGACY_SYR_HH

--- a/include/tlapack/legacy_api/blas/syr2.hpp
+++ b/include/tlapack/legacy_api/blas/syr2.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_SYR2_HH
 #define TLAPACK_LEGACY_SYR2_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/syr2.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -64,48 +64,45 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX, typename TY >
-void syr2(
-    Layout layout,
-    Uplo  uplo,
-    idx_t n,
-    scalar_type<TA, TX, TY> alpha,
-    TX const *x, int_t incx,
-    TY const *y, int_t incy,
-    TA *A, idx_t lda )
+template <typename TA, typename TX, typename TY>
+void syr2(Layout layout,
+          Uplo uplo,
+          idx_t n,
+          scalar_type<TA, TX, TY> alpha,
+          TX const* x,
+          int_t incx,
+          TY const* y,
+          int_t incy,
+          TA* A,
+          idx_t lda)
 {
     using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA,TX>;
+    using scalar_t = scalar_type<TA, TX>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( incx == 0 );
-    tlapack_check_false( incy == 0 );
-    tlapack_check_false( lda < n );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(incx == 0);
+    tlapack_check_false(incy == 0);
+    tlapack_check_false(lda < n);
 
     // quick return
-    if (n == 0 || alpha == scalar_t(0))
-        return;
+    if (n == 0 || alpha == scalar_t(0)) return;
 
     // for row major, swap lower <=> upper
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
-    
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>( A, n, n, lda );
 
-    tlapack_expr_with_2vectors(
-        x_, TX, n, x, incx,
-        y_, TY, n, y, incy,
-        return syr2( uplo, alpha, x_, y_, A_ )
-    );
+    // Matrix views
+    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
+
+    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                               return syr2(uplo, alpha, x_, y_, A_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_SYR2_HH
+#endif  //  #ifndef TLAPACK_LEGACY_SYR2_HH

--- a/include/tlapack/legacy_api/blas/syrk.hpp
+++ b/include/tlapack/legacy_api/blas/syrk.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_SYRK_HH
 #define TLAPACK_LEGACY_SYRK_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/syrk.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -45,7 +45,8 @@ namespace tlapack {
  *     - Op::NoTrans: $C = \alpha A A^T + \beta C$.
  *     - Op::Trans:   $C = \alpha A^T A + \beta C$.
  *     - In the real    case, Op::ConjTrans is interpreted as Op::Trans.
- *       In the complex case, Op::ConjTrans is illegal (see @ref herk() instead).
+ *       In the complex case, Op::ConjTrans is illegal (see @ref herk()
+ * instead).
  *
  * @param[in] n
  *     Number of rows and columns of the matrix C. n >= 0.
@@ -80,84 +81,79 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TC >
-void syrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    idx_t n, idx_t k,
-    scalar_type<TA, TC> alpha,
-    TA const *A, idx_t lda,
-    scalar_type<TA, TC> beta,
-    TC       *C, idx_t ldc )
+template <typename TA, typename TC>
+void syrk(Layout layout,
+          Uplo uplo,
+          Op trans,
+          idx_t n,
+          idx_t k,
+          scalar_type<TA, TC> alpha,
+          TA const* A,
+          idx_t lda,
+          scalar_type<TA, TC> beta,
+          TC* C,
+          idx_t ldc)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TC>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper &&
-                   uplo != Uplo::General );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( is_complex<TA>::value && trans == Op::ConjTrans );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( k < 0 );
-    tlapack_check_false( lda < (
-        (layout == Layout::RowMajor)
-            ? ((trans == Op::NoTrans) ? k : n)
-            : ((trans == Op::NoTrans) ? n : k)
-        )
-    );
-    tlapack_check_false( ldc < n );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(is_complex<TA>::value && trans == Op::ConjTrans);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(k < 0);
+    tlapack_check_false(lda < ((layout == Layout::RowMajor)
+                                   ? ((trans == Op::NoTrans) ? k : n)
+                                   : ((trans == Op::NoTrans) ? n : k)));
+    tlapack_check_false(ldc < n);
 
     // quick return
-    if ( n == 0 ||
-        ((alpha == scalar_t(0) || k == 0 ) && (beta == scalar_t(1))) ) return;
+    if (n == 0 || ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
+        return;
 
     // This algorithm only works with Op::NoTrans or Op::Trans
-    if(trans == Op::ConjTrans) trans = Op::Trans;
+    if (trans == Op::ConjTrans) trans = Op::Trans;
 
     // adapt if row major
-    if (layout == Layout::RowMajor) {       
+    if (layout == Layout::RowMajor) {
         if (uplo == Uplo::Lower)
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        trans = (trans == Op::NoTrans)
-            ? Op::Trans
-            : Op::NoTrans;
+        trans = (trans == Op::NoTrans) ? Op::Trans : Op::NoTrans;
     }
 
     // Matrix views
     const auto A_ = (trans == Op::NoTrans)
-                  ? colmajor_matrix<TA>( (TA*)A, n, k, lda )
-                  : colmajor_matrix<TA>( (TA*)A, k, n, lda );
-    auto C_ = colmajor_matrix<TC>( C, n, n, ldc );
+                        ? colmajor_matrix<TA>((TA*)A, n, k, lda)
+                        : colmajor_matrix<TA>((TA*)A, k, n, lda);
+    auto C_ = colmajor_matrix<TC>(C, n, n, ldc);
 
-    if( alpha == scalar_t(0) ) {
-        if( beta == scalar_t(0) ) {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < n; ++i)
-                    C_(i,j) = TC(0);
+    if (alpha == scalar_t(0)) {
+        if (beta == scalar_t(0)) {
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < n; ++i)
+                    C_(i, j) = TC(0);
         }
         else {
-            for(idx_t j = 0; j < n; ++j)
-                for(idx_t i = 0; i < n; ++i)
-                    C_(i,j) *= beta;
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < n; ++i)
+                    C_(i, j) *= beta;
         }
     }
     else {
-        if( beta == scalar_t(0) )
-            syrk( uplo, trans, alpha, A_, C_ );
+        if (beta == scalar_t(0))
+            syrk(uplo, trans, alpha, A_, C_);
         else
-            syrk( uplo, trans, alpha, A_, beta, C_ );
+            syrk(uplo, trans, alpha, A_, beta, C_);
     }
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_SYMM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/tlapack/legacy_api/blas/trmm.hpp
+++ b/include/tlapack/legacy_api/blas/trmm.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_TRMM_HH
 #define TLAPACK_LEGACY_TRMM_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/trmm.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -89,69 +89,63 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TB >
-void trmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    idx_t m,
-    idx_t n,
-    scalar_type<TA, TB> alpha,
-    TA const *A, idx_t lda,
-    TB       *B, idx_t ldb )
+template <typename TA, typename TB>
+void trmm(Layout layout,
+          Side side,
+          Uplo uplo,
+          Op trans,
+          Diag diag,
+          idx_t m,
+          idx_t n,
+          scalar_type<TA, TB> alpha,
+          TA const* A,
+          idx_t lda,
+          TB* B,
+          idx_t ldb)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TB>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( side != Side::Left &&
-                   side != Side::Right );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                   diag != Diag::Unit );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < ((side == Side::Left) ? m : n) );
-    tlapack_check_false( ldb < ((layout == Layout::RowMajor) ? n : m) );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
 
     // quick return
-    if (m == 0 || n == 0)
-        return;
+    if (m == 0 || n == 0) return;
 
     // adapt if row major
     if (layout == Layout::RowMajor) {
-        side = (side == Side::Left)
-            ? Side::Right
-            : Side::Left;
+        side = (side == Side::Left) ? Side::Right : Side::Left;
         if (uplo == Uplo::Lower)
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m , n );
+        std::swap(m, n);
     }
 
     // Matrix views
     const auto A_ = (side == Side::Left)
-                  ? colmajor_matrix<TA>( (TA*)A, m, m, lda )
-                  : colmajor_matrix<TA>( (TA*)A, n, n, lda );
-    auto B_ = colmajor_matrix<TB>( B, m, n, ldb );
+                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
+                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
+    auto B_ = colmajor_matrix<TB>(B, m, n, ldb);
 
-    if( alpha == scalar_t(0) )
-        for(idx_t j = 0; j < n; ++j)
-            for(idx_t i = 0; i < m; ++i)
-                B_(i,j) = TB(0);
+    if (alpha == scalar_t(0))
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < m; ++i)
+                B_(i, j) = TB(0);
     else
-        trmm( side, uplo, trans, diag, alpha, A_, B_ );
+        trmm(side, uplo, trans, diag, alpha, A_, B_);
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_TRMM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_TRMM_HH

--- a/include/tlapack/legacy_api/blas/trmv.hpp
+++ b/include/tlapack/legacy_api/blas/trmv.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_TRMV_HH
 #define TLAPACK_LEGACY_TRMV_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/trmv.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -70,51 +70,49 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX >
-void trmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    idx_t n,
-    TA const *A, idx_t lda,
-    TX       *x, int_t incx )
+template <typename TA, typename TX>
+void trmv(Layout layout,
+          Uplo uplo,
+          Op trans,
+          Diag diag,
+          idx_t n,
+          TA const* A,
+          idx_t lda,
+          TX* x,
+          int_t incx)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                   diag != Diag::Unit );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < n );
-    tlapack_check_false( incx == 0 );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < n);
+    tlapack_check_false(incx == 0);
 
     // quick return
-    if (n == 0)
-        return;
+    if (n == 0) return;
 
     // for row major, swap lower <=> upper and
     // A => A^T; A^T => A; A^H => conj(A)
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
         trans = (trans == Op::NoTrans)
-              ? Op::Trans
-              : ((trans == Op::Trans) ? Op::NoTrans : Op::Conj);
+                    ? Op::Trans
+                    : ((trans == Op::Trans) ? Op::NoTrans : Op::Conj);
     }
-        
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
 
-    tlapack_expr_with_vector( x_, TX, n, x, incx, return trmv( uplo, trans, diag, A_, x_ ) );
+    // Matrix views
+    const auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
+
+    tlapack_expr_with_vector(x_, TX, n, x, incx,
+                             return trmv(uplo, trans, diag, A_, x_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_TRMV_HH
+#endif  //  #ifndef TLAPACK_LEGACY_TRMV_HH

--- a/include/tlapack/legacy_api/blas/trsm.hpp
+++ b/include/tlapack/legacy_api/blas/trsm.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_TRSM_HH
 #define TLAPACK_LEGACY_TRSM_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/trsm.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -94,69 +94,63 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TB >
-void trsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    idx_t m,
-    idx_t n,
-    scalar_type<TA, TB> alpha,
-    TA const *A, idx_t lda,
-    TB       *B, idx_t ldb )
+template <typename TA, typename TB>
+void trsm(Layout layout,
+          Side side,
+          Uplo uplo,
+          Op trans,
+          Diag diag,
+          idx_t m,
+          idx_t n,
+          scalar_type<TA, TB> alpha,
+          TA const* A,
+          idx_t lda,
+          TB* B,
+          idx_t ldb)
 {
     using internal::colmajor_matrix;
     using scalar_t = scalar_type<TA, TB>;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( side != Side::Left &&
-                   side != Side::Right );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                   diag != Diag::Unit );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < ((side == Side::Left) ? m : n) );
-    tlapack_check_false( ldb < ((layout == Layout::RowMajor) ? n : m) );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
 
     // quick return
-    if (m == 0 || n == 0)
-        return;
+    if (m == 0 || n == 0) return;
 
     // adapt if row major
     if (layout == Layout::RowMajor) {
-        side = (side == Side::Left)
-            ? Side::Right
-            : Side::Left;
+        side = (side == Side::Left) ? Side::Right : Side::Left;
         if (uplo == Uplo::Lower)
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m , n );
+        std::swap(m, n);
     }
 
     // Matrix views
     const auto A_ = (side == Side::Left)
-                  ? colmajor_matrix<TA>( (TA*)A, m, m, lda )
-                  : colmajor_matrix<TA>( (TA*)A, n, n, lda );
-    auto B_ = colmajor_matrix<TB>( B, m, n, ldb );
+                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
+                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
+    auto B_ = colmajor_matrix<TB>(B, m, n, ldb);
 
-    if( alpha == scalar_t(0) )
-        for(idx_t j = 0; j < n; ++j)
-            for(idx_t i = 0; i < m; ++i)
-                B_(i,j) = TB(0);
+    if (alpha == scalar_t(0))
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < m; ++i)
+                B_(i, j) = TB(0);
     else
-        trsm( side, uplo, trans, diag, alpha, A_, B_ );
+        trsm(side, uplo, trans, diag, alpha, A_, B_);
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_TRSM_HH
+#endif  //  #ifndef TLAPACK_LEGACY_TRSM_HH

--- a/include/tlapack/legacy_api/blas/trsv.hpp
+++ b/include/tlapack/legacy_api/blas/trsv.hpp
@@ -11,9 +11,9 @@
 #ifndef TLAPACK_LEGACY_TRSV_HH
 #define TLAPACK_LEGACY_TRSV_HH
 
-#include "tlapack/legacy_api/base/utils.hpp"
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/blas/trsv.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
+#include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
 
@@ -74,51 +74,49 @@ namespace tlapack {
  *
  * @ingroup legacy_blas
  */
-template< typename TA, typename TX >
-void trsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    idx_t n,
-    TA const *A, idx_t lda,
-    TX       *x, int_t incx )
+template <typename TA, typename TX>
+void trsv(Layout layout,
+          Uplo uplo,
+          Op trans,
+          Diag diag,
+          idx_t n,
+          TA const* A,
+          idx_t lda,
+          TX* x,
+          int_t incx)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false( layout != Layout::ColMajor &&
-                   layout != Layout::RowMajor );
-    tlapack_check_false( uplo != Uplo::Lower &&
-                   uplo != Uplo::Upper );
-    tlapack_check_false( trans != Op::NoTrans &&
-                   trans != Op::Trans &&
-                   trans != Op::ConjTrans );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                   diag != Diag::Unit );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < n );
-    tlapack_check_false( incx == 0 );
+    tlapack_check_false(layout != Layout::ColMajor &&
+                        layout != Layout::RowMajor);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < n);
+    tlapack_check_false(incx == 0);
 
     // quick return
-    if (n == 0)
-        return;
+    if (n == 0) return;
 
     // for row major, swap lower <=> upper and
     // A => A^T; A^T => A; A^H => A & conj
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
         trans = (trans == Op::NoTrans)
-              ? Op::Trans
-              : ((trans == Op::Trans) ? Op::NoTrans : Op::Conj);
+                    ? Op::Trans
+                    : ((trans == Op::Trans) ? Op::NoTrans : Op::Conj);
     }
-        
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
 
-    tlapack_expr_with_vector( x_, TX, n, x, incx, return trsv( uplo, trans, diag, A_, x_ ) );
+    // Matrix views
+    const auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
+
+    tlapack_expr_with_vector(x_, TX, n, x, incx,
+                             return trsv(uplo, trans, diag, A_, x_));
 }
 
 }  // namespace tlapack
 
-#endif        //  #ifndef TLAPACK_LEGACY_TRSV_HH
+#endif  //  #ifndef TLAPACK_LEGACY_TRSV_HH

--- a/include/tlapack/legacy_api/lapack.hpp
+++ b/include/tlapack/legacy_api/lapack.hpp
@@ -13,31 +13,31 @@
 // Auxiliary routines
 // ------------------
 
-#include "tlapack/legacy_api/lapack/larf.hpp"
-#include "tlapack/legacy_api/lapack/larfg.hpp"
-#include "tlapack/legacy_api/lapack/larft.hpp"
-#include "tlapack/legacy_api/lapack/larfb.hpp"
+#include "tlapack/lapack/ladiv.hpp"
 #include "tlapack/lapack/lapy2.hpp"
 #include "tlapack/lapack/lapy3.hpp"
-#include "tlapack/lapack/ladiv.hpp"
-#include "tlapack/legacy_api/lapack/laset.hpp"
 #include "tlapack/legacy_api/lapack/lacpy.hpp"
 #include "tlapack/legacy_api/lapack/lange.hpp"
 #include "tlapack/legacy_api/lapack/lanhe.hpp"
-#include "tlapack/legacy_api/lapack/lantr.hpp"
 #include "tlapack/legacy_api/lapack/lansy.hpp"
+#include "tlapack/legacy_api/lapack/lantr.hpp"
+#include "tlapack/legacy_api/lapack/larf.hpp"
+#include "tlapack/legacy_api/lapack/larfb.hpp"
+#include "tlapack/legacy_api/lapack/larfg.hpp"
+#include "tlapack/legacy_api/lapack/larft.hpp"
 #include "tlapack/legacy_api/lapack/larnv.hpp"
 #include "tlapack/legacy_api/lapack/lascl.hpp"
+#include "tlapack/legacy_api/lapack/laset.hpp"
 #include "tlapack/legacy_api/lapack/lassq.hpp"
 
 // QR factorization
 // ----------------
 
 #include "tlapack/legacy_api/lapack/geqr2.hpp"
+#include "tlapack/legacy_api/lapack/potrf.hpp"
+#include "tlapack/legacy_api/lapack/potrs.hpp"
 #include "tlapack/legacy_api/lapack/ung2r.hpp"
 #include "tlapack/legacy_api/lapack/unm2r.hpp"
 #include "tlapack/legacy_api/lapack/unmqr.hpp"
-#include "tlapack/legacy_api/lapack/potrf.hpp"
-#include "tlapack/legacy_api/lapack/potrs.hpp"
 
-#endif // TLAPACK_LEGACY_HH
+#endif  // TLAPACK_LEGACY_HH

--- a/include/tlapack/legacy_api/lapack/geqr2.hpp
+++ b/include/tlapack/legacy_api/lapack/geqr2.hpp
@@ -1,6 +1,7 @@
 /// @file geqr2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/geqr2.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/geqr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/geqr2.hpp
+++ b/include/tlapack/legacy_api/lapack/geqr2.hpp
@@ -16,7 +16,7 @@
 namespace tlapack {
 
 /** Computes a QR factorization of a matrix A.
- * 
+ *
  * @param[in] m The number of rows of the matrix A.
  * @param[in] n The number of columns of the matrix A.
  * @param[in,out] A m-by-n matrix.
@@ -29,35 +29,32 @@ namespace tlapack {
  * @param[out] tau Real vector of length min(m,n).
  *      The scalar factors of the elementary reflectors.
  *      The subarray tau[1:n-1] is used as the workspace.
- * 
+ *
  * @see geqr2( matrix_t& A, vector_t &tau, vector_t &work )
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< typename TA, typename Ttau >
-inline int geqr2(
-    idx_t m, idx_t n,
-    TA*   A, idx_t lda,
-    Ttau* tau )
+template <typename TA, typename Ttau>
+inline int geqr2(idx_t m, idx_t n, TA* A, idx_t lda, Ttau* tau)
 {
     using internal::colmajor_matrix;
     using internal::vector;
 
     // check arguments
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( lda < m );
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(lda < m);
 
     // quick return
     if (n <= 0) return 0;
 
     // Matrix views
-    auto A_    = colmajor_matrix( A, m, n, lda );
-    auto tau_  = vector         ( tau, std::min( m, n ) );
-    
-    return geqr2( A_, tau_ );
+    auto A_ = colmajor_matrix(A, m, n, lda);
+    auto tau_ = vector(tau, std::min(m, n));
+
+    return geqr2(A_, tau_);
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_GEQR2_HH
+#endif  // TLAPACK_LEGACY_GEQR2_HH

--- a/include/tlapack/legacy_api/lapack/lacpy.hpp
+++ b/include/tlapack/legacy_api/lapack/lacpy.hpp
@@ -1,6 +1,7 @@
 /// @file lacpy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lacpy.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lacpy.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/lacpy.hpp
+++ b/include/tlapack/legacy_api/lapack/lacpy.hpp
@@ -17,10 +17,10 @@ namespace tlapack {
 
 /**
  * @brief Copies a matrix from A to B.
- * 
+ *
  * @tparam uplo_t
  *      Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper:   Upper triangle of A and B are referenced;
  *      - Uplo::Lower:   Lower triangle of A and B are referenced;
@@ -33,60 +33,63 @@ namespace tlapack {
  * @param[out] B Matrix with at least m rows and at least n columns.
  * @param[in] ldb Leading dimension of B.
  */
-template< class uplo_t, typename TA, typename TB >
+template <class uplo_t, typename TA, typename TB>
 void lacpy(
-    uplo_t uplo, idx_t m, idx_t n,
-    const TA* A, idx_t lda,
-    TB* B, idx_t ldb )
+    uplo_t uplo, idx_t m, idx_t n, const TA* A, idx_t lda, TB* B, idx_t ldb)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper &&
-                    uplo != Uplo::General );
-    
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>( (TA*)A, m, n, lda );
-    auto B_ = colmajor_matrix<TB>( B, m, n, ldb );
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
 
-    lacpy( uplo, A_, B_ );
+    // Matrix views
+    const auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
+    auto B_ = colmajor_matrix<TB>(B, m, n, ldb);
+
+    lacpy(uplo, A_, B_);
 }
 
-/** Copies a real matrix from A to B where A is either a full, upper triangular or lower triangular matrix.
+/** Copies a real matrix from A to B where A is either a full, upper triangular
+ * or lower triangular matrix.
  *
  * @param[in] matrixtype :
  *
- *        'U': A is assumed to be upper triangular; elements below the diagonal are not referenced.
- *        'L': A is assumed to be lower triangular; elements above the diagonal are not referenced.
- *        otherwise, A is assumed to be a full matrix.
- * 
+ *        'U': A is assumed to be upper triangular; elements below the diagonal
+ * are not referenced. 'L': A is assumed to be lower triangular; elements above
+ * the diagonal are not referenced. otherwise, A is assumed to be a full matrix.
+ *
  * @param[in] m Number of rows of A.
  * @param[in] n Number of columns of A.
  * @param[in] A m-by-n matrix.
  * @param[in] lda Leading dimension of A.
  * @param[out] B Matrix with at least m rows and at least n columns.
  * @param[in] ldb Leading dimension of B.
- * 
+ *
  * @see lacpy( uplo_t, idx_t, idx_t, const TA*, idx_t, TB* B, idx_t )
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< typename TA, typename TB >
-void inline lacpy(
-    MatrixType matrixtype, idx_t m, idx_t n,
-    const TA* A, idx_t lda,
-    TB* B, idx_t ldb )
+template <typename TA, typename TB>
+void inline lacpy(MatrixType matrixtype,
+                  idx_t m,
+                  idx_t n,
+                  const TA* A,
+                  idx_t lda,
+                  TB* B,
+                  idx_t ldb)
 {
     if (matrixtype == MatrixType::Upper) {
         lacpy(Uplo::Upper, m, n, A, lda, B, ldb);
-    } else if (matrixtype == MatrixType::Lower) {
+    }
+    else if (matrixtype == MatrixType::Lower) {
         lacpy(Uplo::Lower, m, n, A, lda, B, ldb);
-    } else {
+    }
+    else {
         lacpy(Uplo::General, m, n, A, lda, B, ldb);
     }
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LACPY_HH
+#endif  // TLAPACK_LEGACY_LACPY_HH

--- a/include/tlapack/legacy_api/lapack/lange.hpp
+++ b/include/tlapack/legacy_api/lapack/lange.hpp
@@ -1,6 +1,7 @@
 /// @file lange.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lange.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/lange.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/lange.hpp
+++ b/include/tlapack/legacy_api/lapack/lange.hpp
@@ -15,49 +15,46 @@
 
 namespace tlapack {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or element of largest absolute value
+/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+ *element of largest absolute value
  *
  * @return Calculated norm value for the specified type.
- * 
+ *
  * @param normType Type should be specified as follows:
  *
  *     Norm::Max = maximum absolute value over all elements in A.
  *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of each column.
- *     Norm::Inf = the infinity norm of the matrix A, the maximum value of the sum of each row.
- *     Norm::Fro = the Frobenius norm of the matrix A.
- *         This the square root of the sum of the squares of each element in A.
+ *     Norm::One = one norm of the matrix A, the maximum value of the sums of
+ *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
+ *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
+ *the square root of the sum of the squares of each element in A.
  *
  * @param m Number of rows to be included in the norm. m >= 0
  * @param n Number of columns to be included in the norm. n >= 0
  * @param A matrix size m-by-n.
  * @param lda Column length of the matrix A.  ldA >= m
- * 
+ *
  * @ingroup legacy_lapack
-**/
+ **/
 template <class norm_t, typename TA>
 inline real_type<TA> lange(
-    norm_t normType, idx_t m, idx_t n,
-    const TA *A, idx_t lda )
+    norm_t normType, idx_t m, idx_t n, const TA* A, idx_t lda)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
 
     // quick return
-    if (m == 0 || n == 0)
-        return 0;
+    if (m == 0 || n == 0) return 0;
 
     // Views
-    auto A_ = colmajor_matrix<TA>( (TA*)A, m, n, lda );
+    auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
 
-    return lange( normType, A_ );
+    return lange(normType, A_);
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LANGE_HH
+#endif  // TLAPACK_LEGACY_LANGE_HH

--- a/include/tlapack/legacy_api/lapack/lanhe.hpp
+++ b/include/tlapack/legacy_api/lapack/lanhe.hpp
@@ -15,51 +15,48 @@
 
 namespace tlapack {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or element of largest absolute value of a symmetric matrix
+/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+ *element of largest absolute value of a symmetric matrix
  *
  * @return Calculated norm value for the specified type.
- * 
+ *
  * @param normType Type should be specified as follows:
  *
  *     Norm::Max = maximum absolute value over all elements in A.
  *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of each column.
- *     Norm::Inf = the infinity norm of the matrix A, the maximum value of the sum of each row.
- *     Norm::Fro = the Frobenius norm of the matrix A.
- *         This the square root of the sum of the squares of each element in A.
- * 
- * @param uplo Indicates whether the symmetric matrix A is stored as upper triangular or lower triangular.
- *      The other strict triangular part of A is not referenced.
+ *     Norm::One = one norm of the matrix A, the maximum value of the sums of
+ *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
+ *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
+ *the square root of the sum of the squares of each element in A.
+ *
+ * @param uplo Indicates whether the symmetric matrix A is stored as upper
+ *triangular or lower triangular. The other strict triangular part of A is not
+ *referenced.
  * @param n Number of columns to be included in the norm. n >= 0
  * @param A symmetric matrix size lda-by-n.
  * @param lda Leading dimension of matrix A.  ldA >= m
- * 
+ *
  * @ingroup legacy_lapack
-**/
+ **/
 template <class norm_t, typename TA>
-real_type<TA> lanhe(
-    norm_t normType, Uplo uplo, idx_t n,
-    const TA *A, idx_t lda )
+real_type<TA> lanhe(norm_t normType, Uplo uplo, idx_t n, const TA* A, idx_t lda)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                          uplo != Uplo::Upper );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // quick return
-    if ( n == 0 ) return 0;
+    if (n == 0) return 0;
 
     // Matrix views
-    auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
+    auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
 
-    return lanhe( normType, uplo, A_ );
+    return lanhe(normType, uplo, A_);
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LANHE_HH
+#endif  // TLAPACK_LEGACY_LANHE_HH

--- a/include/tlapack/legacy_api/lapack/lansy.hpp
+++ b/include/tlapack/legacy_api/lapack/lansy.hpp
@@ -15,51 +15,48 @@
 
 namespace tlapack {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or element of largest absolute value of a symmetric matrix
+/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+ *element of largest absolute value of a symmetric matrix
  *
  * @return Calculated norm value for the specified type.
- * 
+ *
  * @param normType Type should be specified as follows:
  *
  *     Norm::Max = maximum absolute value over all elements in A.
  *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of each column.
- *     Norm::Inf = the infinity norm of the matrix A, the maximum value of the sum of each row.
- *     Norm::Fro = the Frobenius norm of the matrix A.
- *         This the square root of the sum of the squares of each element in A.
- * 
- * @param uplo Indicates whether the symmetric matrix A is stored as upper triangular or lower triangular.
- *      The other triangular part of A is not referenced.
+ *     Norm::One = one norm of the matrix A, the maximum value of the sums of
+ *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
+ *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
+ *the square root of the sum of the squares of each element in A.
+ *
+ * @param uplo Indicates whether the symmetric matrix A is stored as upper
+ *triangular or lower triangular. The other triangular part of A is not
+ *referenced.
  * @param n Number of columns to be included in the norm. n >= 0
  * @param A symmetric matrix size lda-by-n.
  * @param lda Leading dimension of matrix A.  ldA >= m
- * 
+ *
  * @ingroup legacy_lapack
-**/
+ **/
 template <class norm_t, typename TA>
-real_type<TA> lansy(
-    norm_t normType, Uplo uplo, idx_t n,
-    const TA *A, idx_t lda )
+real_type<TA> lansy(norm_t normType, Uplo uplo, idx_t n, const TA* A, idx_t lda)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                          uplo != Uplo::Upper );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // quick return
-    if ( n == 0 ) return 0;
+    if (n == 0) return 0;
 
     // Matrix views
-    auto A_ = colmajor_matrix<TA>( (TA*)A, n, n, lda );
+    auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
 
-    return lansy( normType, uplo, A_ );
+    return lansy(normType, uplo, A_);
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LANSY_HH
+#endif  // TLAPACK_LEGACY_LANSY_HH

--- a/include/tlapack/legacy_api/lapack/lantr.hpp
+++ b/include/tlapack/legacy_api/lapack/lantr.hpp
@@ -15,19 +15,20 @@
 
 namespace tlapack {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or element of largest absolute value of a triangular matrix
+/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+ *element of largest absolute value of a triangular matrix
  *
  * @return Calculated norm value for the specified type.
- * 
+ *
  * @param normType Type should be specified as follows:
  *
  *     Norm::Max = maximum absolute value over all elements in A.
  *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of each column.
- *     Norm::Inf = the infinity norm of the matrix A, the maximum value of the sum of each row.
- *     Norm::Fro = the Frobenius norm of the matrix A.
- *         This the square root of the sum of the squares of each element in A.
- * 
+ *     Norm::One = one norm of the matrix A, the maximum value of the sums of
+ *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
+ *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
+ *the square root of the sum of the squares of each element in A.
+ *
  * @param uplo Indicates whether A is upper or lower triangular.
  *      The other strict triangular part of A is not referenced.
  *
@@ -35,40 +36,40 @@ namespace tlapack {
  *     Whether A has a unit or non-unit diagonal:
  *     - Diag::Unit:    A is assumed to be unit triangular.
  *     - Diag::NonUnit: A is not assumed to be unit triangular.
- * 
+ *
  * @param m Number of rows to be included in the norm. m >= 0
  * @param n Number of columns to be included in the norm. n >= 0
  * @param A symmetric matrix size lda-by-n.
  * @param lda Leading dimension of matrix A.  ldA >= m
- * 
+ *
  * @ingroup legacy_lapack
-**/
+ **/
 template <typename TA>
-real_type<TA> lantr(
-    Norm normType, Uplo uplo, Diag diag, idx_t m, idx_t n,
-    const TA *A, idx_t lda )
+real_type<TA> lantr(Norm normType,
+                    Uplo uplo,
+                    Diag diag,
+                    idx_t m,
+                    idx_t n,
+                    const TA* A,
+                    idx_t lda)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(  normType != Norm::Fro &&
-                    normType != Norm::Inf &&
-                    normType != Norm::Max &&
-                    normType != Norm::One );
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                          uplo != Uplo::Upper );
-    tlapack_check_false( diag != Diag::NonUnit &&
-                         diag != Diag::Unit );
+    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                        normType != Norm::Max && normType != Norm::One);
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
 
     // quick return
     if (m == 0 || n == 0) return 0;
 
     // Matrix views
-    auto A_ = colmajor_matrix<TA>( (TA*)A, m, n, lda );
+    auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
 
-    return lantr( normType, uplo, diag, A_ );
+    return lantr(normType, uplo, diag, A_);
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LANTR_HH
+#endif  // TLAPACK_LEGACY_LANTR_HH

--- a/include/tlapack/legacy_api/lapack/larf.hpp
+++ b/include/tlapack/legacy_api/lapack/larf.hpp
@@ -16,41 +16,41 @@
 namespace tlapack {
 
 /** Applies an elementary reflector H to a m-by-n matrix C.
- * 
- * @see larf( Side side, idx_t m, idx_t n, TV const *v, int_t incv, scalar_type< TV, TC , TW > tau, TC *C, idx_t ldC, TW *work )
- * 
+ *
+ * @see larf( Side side, idx_t m, idx_t n, TV const *v, int_t incv, scalar_type<
+ * TV, TC , TW > tau, TC *C, idx_t ldC, TW *work )
+ *
  * @ingroup legacy_lapack
  */
-template< class side_t, typename TV, typename TC >
-inline void larf(
-    side_t side,
-    idx_t m, idx_t n,
-    TV const *v, int_t incv,
-    scalar_type< TV, TC > tau,
-    TC *C, idx_t ldC )
+template <class side_t, typename TV, typename TC>
+inline void larf(side_t side,
+                 idx_t m,
+                 idx_t n,
+                 TV const* v,
+                 int_t incv,
+                 scalar_type<TV, TC> tau,
+                 TC* C,
+                 idx_t ldC)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false( side != Side::Left &&
-                   side != Side::Right );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( incv == 0 );
-    tlapack_check_false( ldC < m );
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(incv == 0);
+    tlapack_check_false(ldC < m);
 
     // Initialize indexes
-    idx_t lenv  = (( side == Side::Left ) ? m : n);
-    
-    // Matrix views
-    auto C_ = colmajor_matrix<TC>( C, m, n, ldC );
+    idx_t lenv = ((side == Side::Left) ? m : n);
 
-    tlapack_expr_with_vector(
-        v_, TV, lenv, v, incv,
-        return larf( side, v_, tau, C_)
-    );
+    // Matrix views
+    auto C_ = colmajor_matrix<TC>(C, m, n, ldC);
+
+    tlapack_expr_with_vector(v_, TV, lenv, v, incv,
+                             return larf(side, v_, tau, C_));
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LARF_HH
+#endif  // TLAPACK_LEGACY_LARF_HH

--- a/include/tlapack/legacy_api/lapack/larf.hpp
+++ b/include/tlapack/legacy_api/lapack/larf.hpp
@@ -1,6 +1,7 @@
 /// @file larf.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larf.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larf.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larfb.hpp
+++ b/include/tlapack/legacy_api/lapack/larfb.hpp
@@ -1,6 +1,7 @@
 /// @file larfb.hpp Applies a Householder block reflector to a matrix.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfb.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larfb.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larfb.hpp
+++ b/include/tlapack/legacy_api/lapack/larfb.hpp
@@ -24,7 +24,8 @@ namespace tlapack {
  *
  * @param[in] trans
  *     - Op::NoTrans:   apply $H  $ (No transpose)
- *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of H is Real)
+ *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of H is
+ * Real)
  *     - Op::ConjTrans: apply $H^H$ (Conjugate transpose)
  *
  * @param[in] direction
@@ -107,49 +108,55 @@ namespace tlapack {
  *         (  1 v2 v3 )                     ( v3 v3 v3 v3  1 )
  *         (     1 v3 )
  *         (        1 )
- * 
+ *
  * @ingroup legacy_lapack
  */
 
-template <class side_t, class trans_t, class direction_t, class storeV_t,
-    typename TV, typename TC>
-int larfb(
-    side_t side, trans_t trans,
-    direction_t direction, storeV_t storev,
-    idx_t m, idx_t n, idx_t k,
-    TV const* V, idx_t ldv,
-    TV const* T, idx_t ldt,
-    TC* C, idx_t ldc )
+template <class side_t,
+          class trans_t,
+          class direction_t,
+          class storeV_t,
+          typename TV,
+          typename TC>
+int larfb(side_t side,
+          trans_t trans,
+          direction_t direction,
+          storeV_t storev,
+          idx_t m,
+          idx_t n,
+          idx_t k,
+          TV const* V,
+          idx_t ldv,
+          TV const* T,
+          idx_t ldt,
+          TC* C,
+          idx_t ldc)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(    side != Side::Left &&
-                        side != Side::Right );
-    tlapack_check_false(    trans != Op::NoTrans &&
-                        trans != Op::ConjTrans &&
-                        (
-                            (trans != Op::Trans) ||
-                            is_complex< TV >::value
-                        ) );
-    tlapack_check_false(    direction != Direction::Backward &&
-                        direction != Direction::Forward );
-    tlapack_check_false(    storev != StoreV::Columnwise &&
-                        storev != StoreV::Rowwise );
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::ConjTrans &&
+                        ((trans != Op::Trans) || is_complex<TV>::value));
+    tlapack_check_false(direction != Direction::Backward &&
+                        direction != Direction::Forward);
+    tlapack_check_false(storev != StoreV::Columnwise &&
+                        storev != StoreV::Rowwise);
 
     // Quick return
     if (m <= 0 || n <= 0) return 0;
 
     // Views
-    const auto V_ = (storev == StoreV::Columnwise)
-                  ? colmajor_matrix<TV>( (TV*) V, (side == Side::Left) ? m : n, k, ldv )
-                  : colmajor_matrix<TV>( (TV*) V, k, (side == Side::Left) ? m : n, ldv );
-    const auto T_ = colmajor_matrix<TV>( (TV*) T, k, k, ldt );
-    auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
+    const auto V_ =
+        (storev == StoreV::Columnwise)
+            ? colmajor_matrix<TV>((TV*)V, (side == Side::Left) ? m : n, k, ldv)
+            : colmajor_matrix<TV>((TV*)V, k, (side == Side::Left) ? m : n, ldv);
+    const auto T_ = colmajor_matrix<TV>((TV*)T, k, k, ldt);
+    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
 
-    return larfb( side, trans, direction, storev, V_, T_, C_ );
+    return larfb(side, trans, direction, storev, V_, T_, C_);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LARFB_HH
+#endif  // TLAPACK_LEGACY_LARFB_HH

--- a/include/tlapack/legacy_api/lapack/larfg.hpp
+++ b/include/tlapack/legacy_api/lapack/larfg.hpp
@@ -15,26 +15,25 @@
 
 namespace tlapack {
 
-template< typename T >
-void larfg(
-    idx_t n, T &alpha, T *x, int_t incx, T &tau )
-{    
-    tlapack_expr_with_vector( x_, T, n-1, x, incx, return larfg( alpha, x_, tau ) );
+template <typename T>
+void larfg(idx_t n, T& alpha, T* x, int_t incx, T& tau)
+{
+    tlapack_expr_with_vector(x_, T, n - 1, x, incx,
+                             return larfg(alpha, x_, tau));
 }
 
 /** Generates a elementary Householder reflection.
- * 
+ *
  * @see larfg( idx_t, T &, T *, int_t, T & )
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< typename T >
-void inline larfg(
-    idx_t n, T *alpha, T *x, int_t incx, T *tau )
+template <typename T>
+void inline larfg(idx_t n, T* alpha, T* x, int_t incx, T* tau)
 {
     larfg(n, *alpha, x, incx, *tau);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LARFG_HH
+#endif  // TLAPACK_LEGACY_LARFG_HH

--- a/include/tlapack/legacy_api/lapack/larfg.hpp
+++ b/include/tlapack/legacy_api/lapack/larfg.hpp
@@ -1,6 +1,7 @@
 /// @file larfg.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfg.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larfg.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larft.hpp
+++ b/include/tlapack/legacy_api/lapack/larft.hpp
@@ -18,16 +18,17 @@ namespace tlapack {
 /** Forms the triangular factor T of a block reflector H of order n,
  * which is defined as a product of k elementary reflectors.
  *
- *               If direction = Direction::Forward, H = H_1 H_2 . . . H_k and T is upper triangular.
- *               If direction = Direction::Backward, H = H_k . . . H_2 H_1 and T is lower triangular.
+ *               If direction = Direction::Forward, H = H_1 H_2 . . . H_k and T
+ * is upper triangular. If direction = Direction::Backward, H = H_k . . . H_2
+ * H_1 and T is lower triangular.
  *
- *  If storev = StoreV::Columnwise, the vector which defines the elementary reflector
- *  H(i) is stored in the i-th column of the array V, and
+ *  If storev = StoreV::Columnwise, the vector which defines the elementary
+ * reflector H(i) is stored in the i-th column of the array V, and
  *
  *               H  =  I - V * T * V'
  *
- *  If storev = StoreV::Rowwise, the vector which defines the elementary reflector
- *  H(i) is stored in the i-th row of the array V, and
+ *  If storev = StoreV::Rowwise, the vector which defines the elementary
+ * reflector H(i) is stored in the i-th row of the array V, and
  *
  *               H  =  I - V' * T * V
  *
@@ -35,7 +36,8 @@ namespace tlapack {
  *  the H(i) is best illustrated by the following example with n = 5 and
  *  k = 3. The elements equal to 1 are not stored.
  *
- *               direction=Direction::Forward & storev=StoreV::Columnwise          direction=Direction::Forward & storev=StoreV::Rowwise
+ *               direction=Direction::Forward & storev=StoreV::Columnwise
+ * direction=Direction::Forward & storev=StoreV::Rowwise
  *               -----------------------          -----------------------
  *               V = (  1       )                 V = (  1 v1 v1 v1 v1 )
  *                   ( v1  1    )                     (     1 v2 v2 v2 )
@@ -43,7 +45,8 @@ namespace tlapack {
  *                   ( v1 v2 v3 )
  *                   ( v1 v2 v3 )
  *
- *               direction=Direction::Backward & storev=StoreV::Columnwise          direction=Direction::Backward & storev=StoreV::Rowwise
+ *               direction=Direction::Backward & storev=StoreV::Columnwise
+ * direction=Direction::Backward & storev=StoreV::Rowwise
  *               -----------------------          -----------------------
  *               V = ( v1 v2 v3 )                 V = ( v1 v1  1       )
  *                   ( v1 v2 v3 )                     ( v2 v2 v2  1    )
@@ -53,66 +56,74 @@ namespace tlapack {
  *
  * @return 0 if success.
  * @return -i if the ith argument is invalid.
- * 
- * @param direction Specifies the direction in which the elementary reflectors are multiplied to form the block reflector.
+ *
+ * @param direction Specifies the direction in which the elementary reflectors
+ * are multiplied to form the block reflector.
  *
  *               Direction::Forward
  *               Direction::Backward
  *
- * @param storev Specifies how the vectors which define the elementary reflectors are stored.
+ * @param storev Specifies how the vectors which define the elementary
+ * reflectors are stored.
  *
  *               StoreV::Columnwise
  *               StoreV::Rowwise
  *
  * @param n The order of the block reflector H. n >= 0.
- * @param k The order of the triangular factor T, or the number of elementary reflectors. k >= 1.
- * @param[in] V Real matrix containing the vectors defining the elementary reflector H.
- * If stored columnwise, V is n-by-k.  If stored rowwise, V is k-by-n.
+ * @param k The order of the triangular factor T, or the number of elementary
+ * reflectors. k >= 1.
+ * @param[in] V Real matrix containing the vectors defining the elementary
+ * reflector H. If stored columnwise, V is n-by-k.  If stored rowwise, V is
+ * k-by-n.
  * @param ldV Column length of the matrix V.  If stored columnwise, ldV >= n.
  * If stored rowwise, ldV >= k.
- * @param[in] tau Real vector of length k containing the scalar factors of the elementary reflectors H.
- * @param[out] T Real matrix of size k-by-k containing the triangular factor of the block reflector.
- * If the direction of the elementary reflectors is forward, T is upper triangular;
- * if the direction of the elementary reflectors is backward, T is lower triangular.
+ * @param[in] tau Real vector of length k containing the scalar factors of the
+ * elementary reflectors H.
+ * @param[out] T Real matrix of size k-by-k containing the triangular factor of
+ * the block reflector. If the direction of the elementary reflectors is
+ * forward, T is upper triangular; if the direction of the elementary reflectors
+ * is backward, T is lower triangular.
  * @param ldT Column length of the matrix T.  ldT >= k.
- * 
+ *
  * @ingroup legacy_lapack
  */
 template <class direction_t, class storeV_t, typename scalar_t>
-int larft(
-    direction_t direction, storeV_t storev,
-    idx_t n, idx_t k,
-    const scalar_t *V, idx_t ldV,
-    const scalar_t *tau,
-    scalar_t *T, idx_t ldT)
+int larft(direction_t direction,
+          storeV_t storev,
+          idx_t n,
+          idx_t k,
+          const scalar_t* V,
+          idx_t ldV,
+          const scalar_t* tau,
+          scalar_t* T,
+          idx_t ldT)
 {
     using internal::colmajor_matrix;
     using internal::vector;
 
     // check arguments
-    tlapack_check_false( direction != Direction::Forward &&
-                     direction != Direction::Backward );
-    tlapack_check_false( storev != StoreV::Columnwise &&
-                     storev != StoreV::Rowwise );
-    tlapack_check_false( n < 0 );
-    tlapack_check_false( k < 1 );
-    tlapack_check_false( ldV < ((storev == StoreV::Columnwise) ? n : k) );
-    tlapack_check_false( ldT < k );
+    tlapack_check_false(direction != Direction::Forward &&
+                        direction != Direction::Backward);
+    tlapack_check_false(storev != StoreV::Columnwise &&
+                        storev != StoreV::Rowwise);
+    tlapack_check_false(n < 0);
+    tlapack_check_false(k < 1);
+    tlapack_check_false(ldV < ((storev == StoreV::Columnwise) ? n : k));
+    tlapack_check_false(ldT < k);
 
     // Quick return
-    if (n == 0 || k == 0)
-        return 0;
+    if (n == 0 || k == 0) return 0;
 
     // Matrix views
     auto V_ = (storev == StoreV::Columnwise)
-            ? colmajor_matrix<scalar_t>( (scalar_t*)V, n, k, ldV )
-            : colmajor_matrix<scalar_t>( (scalar_t*)V, k, n, ldV );
-    auto tau_ = vector( (scalar_t*)tau, k );
-    auto T_ = colmajor_matrix<scalar_t>( T, k, k, ldT );
+                  ? colmajor_matrix<scalar_t>((scalar_t*)V, n, k, ldV)
+                  : colmajor_matrix<scalar_t>((scalar_t*)V, k, n, ldV);
+    auto tau_ = vector((scalar_t*)tau, k);
+    auto T_ = colmajor_matrix<scalar_t>(T, k, k, ldT);
 
-    return larft( direction, storev, V_, tau_, T_);
+    return larft(direction, storev, V_, tau_, T_);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LARFT_HH
+#endif  // TLAPACK_LEGACY_LARFT_HH

--- a/include/tlapack/legacy_api/lapack/larft.hpp
+++ b/include/tlapack/legacy_api/lapack/larft.hpp
@@ -1,6 +1,7 @@
 /// @file larft.hpp Forms the triangular factor T of a block reflector.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larft.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/larft.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larnv.hpp
+++ b/include/tlapack/legacy_api/lapack/larnv.hpp
@@ -1,4 +1,5 @@
-/// @file larnv.hpp Returns a vector of random numbers from a uniform or normal distribution.
+/// @file larnv.hpp Returns a vector of random numbers from a uniform or normal
+/// distribution.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// Adapted from @see https://github.com/langou/latl/blob/mastUSA
 /// @note Adapted
@@ -11,19 +12,21 @@
 #ifndef TLAPACK_LEGACY_LARNV_HH
 #define TLAPACK_LEGACY_LARNV_HH
 
-#include "tlapack/legacy_api/base/types.hpp"
 #include "tlapack/lapack/larnv.hpp"
+#include "tlapack/legacy_api/base/types.hpp"
 
 namespace tlapack {
 
 /**
- * @brief Returns a vector of n random numbers from a uniform or normal distribution.
- * 
- * This implementation uses the Mersenne Twister 19937 generator (class std::mt19937),
- * which is a Mersenne Twister pseudo-random generator of 32-bit numbers with a state size of 19937 bits.
- * 
+ * @brief Returns a vector of n random numbers from a uniform or normal
+ * distribution.
+ *
+ * This implementation uses the Mersenne Twister 19937 generator (class
+ * std::mt19937), which is a Mersenne Twister pseudo-random generator of 32-bit
+ * numbers with a state size of 19937 bits.
+ *
  * Requires ISO C++ 2011 random number generators.
- * 
+ *
  * @param[in] idist Specifies the distribution:
  *
  *        1:  real and imaginary parts each uniform (0,1)
@@ -31,29 +34,33 @@ namespace tlapack {
  *        3:  real and imaginary parts each normal (0,1)
  *        4:  uniformly distributed on the disc abs(z) < 1
  *        5:  uniformly distributed on the circle abs(z) = 1
- * 
+ *
  * @param[in,out] iseed Seed for the random number generator.
- *      The seed is updated inside the routine ( Currently: seed_out := seed_in + 1 )
+ *      The seed is updated inside the routine ( Currently: seed_out := seed_in
+ * + 1 )
  * @param[in] n Length of vector x.
  * @param[out] x Pointer to real vector of length n.
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< typename T >
-inline void larnv(
-    idx_t idist, idx_t* iseed,
-    idx_t n, T* x )
+template <typename T>
+inline void larnv(idx_t idist, idx_t* iseed, idx_t n, T* x)
 {
     using internal::vector;
-    auto x_ = vector( x, n );
+    auto x_ = vector(x, n);
 
-    if (idist == 1) return larnv<1>( *iseed, x_ );
-    else if (idist == 2) return larnv<2>( *iseed, x_ );
-    else if (idist == 3) return larnv<3>( *iseed, x_ );
-    else if (idist == 4) return larnv<4>( *iseed, x_ );
-    else if (idist == 5) return larnv<5>( *iseed, x_ );
+    if (idist == 1)
+        return larnv<1>(*iseed, x_);
+    else if (idist == 2)
+        return larnv<2>(*iseed, x_);
+    else if (idist == 3)
+        return larnv<3>(*iseed, x_);
+    else if (idist == 4)
+        return larnv<4>(*iseed, x_);
+    else if (idist == 5)
+        return larnv<5>(*iseed, x_);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LARNV_HH
+#endif  // TLAPACK_LEGACY_LARNV_HH

--- a/include/tlapack/legacy_api/lapack/lascl.hpp
+++ b/include/tlapack/legacy_api/lapack/lascl.hpp
@@ -17,16 +17,17 @@ namespace tlapack {
 
 /** @brief  Multiplies a matrix A by the real scalar a/b.
  *
- * Multiplication of a matrix A by scalar a/b is done without over/underflow as long as the final
- * result $a A/b$ does not over/underflow. The parameter type specifies that
- * A may be full, upper triangular, lower triangular, upper Hessenberg, or banded.
- * 
+ * Multiplication of a matrix A by scalar a/b is done without over/underflow as
+ * long as the final result $a A/b$ does not over/underflow. The parameter type
+ * specifies that A may be full, upper triangular, lower triangular, upper
+ * Hessenberg, or banded.
+ *
  * @return 0 if success.
  * @return -i if the ith argument is invalid.
- * 
+ *
  * @param[in] matrixtype Specifies the type of matrix A.
  *
- *        MatrixType::General: 
+ *        MatrixType::General:
  *          A is a full matrix.
  *        MatrixType::Lower:
  *          A is a lower triangular matrix.
@@ -35,113 +36,102 @@ namespace tlapack {
  *        MatrixType::Hessenberg:
  *          A is an upper Hessenberg matrix.
  *        MatrixType::LowerBand:
- *          A is a symmetric band matrix with lower bandwidth kl and upper bandwidth ku
- *          and with the only the lower half stored.
- *        MatrixType::UpperBand: 
- *          A is a symmetric band matrix with lower bandwidth kl and upper bandwidth ku
- *          and with the only the upper half stored.
- *        MatrixType::Band:
- *          A is a band matrix with lower bandwidth kl and upper bandwidth ku.
- * 
- * @param[in] kl The lower bandwidth of A, used only for banded matrix types B, Q and Z.
- * @param[in] ku The upper bandwidth of A, used only for banded matrix types B, Q and Z.
+ *          A is a symmetric band matrix with lower bandwidth kl and upper
+ * bandwidth ku and with the only the lower half stored. MatrixType::UpperBand:
+ *          A is a symmetric band matrix with lower bandwidth kl and upper
+ * bandwidth ku and with the only the upper half stored. MatrixType::Band: A is
+ * a band matrix with lower bandwidth kl and upper bandwidth ku.
+ *
+ * @param[in] kl The lower bandwidth of A, used only for banded matrix types B,
+ * Q and Z.
+ * @param[in] ku The upper bandwidth of A, used only for banded matrix types B,
+ * Q and Z.
  * @param[in] b The denominator of the scalar a/b.
  * @param[in] a The numerator of the scalar a/b.
  * @param[in] m The number of rows of the matrix A. m>=0
  * @param[in] n The number of columns of the matrix A. n>=0
  * @param[in,out] A Pointer to the matrix A [in/out].
  * @param[in] lda The column length of the matrix A.
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< class matrixType_t, typename T >
-int lascl(
-    matrixType_t matrixtype,
-    idx_t kl, idx_t ku,
-    const real_type<T>& b, const real_type<T>& a,
-    idx_t m, idx_t n,
-    T* A, idx_t lda )
+template <class matrixType_t, typename T>
+int lascl(matrixType_t matrixtype,
+          idx_t kl,
+          idx_t ku,
+          const real_type<T>& b,
+          const real_type<T>& a,
+          idx_t m,
+          idx_t n,
+          T* A,
+          idx_t lda)
 {
-    using internal::colmajor_matrix;
     using internal::banded_matrix;
+    using internal::colmajor_matrix;
     using std::max;
-    
-    // check arguments
-    tlapack_check_false(
-        (matrixtype != MatrixType::General) && 
-        (matrixtype != MatrixType::Lower) && 
-        (matrixtype != MatrixType::Upper) && 
-        (matrixtype != MatrixType::Hessenberg) && 
-        (matrixtype != MatrixType::LowerBand) && 
-        (matrixtype != MatrixType::UpperBand) && 
-        (matrixtype != MatrixType::Band) );
-    tlapack_check_false( (
-            (matrixtype == MatrixType::LowerBand) ||
-            (matrixtype == MatrixType::UpperBand) || 
-            (matrixtype == MatrixType::Band)
-        ) && (
-            (kl < 0) ||
-            (kl > max(m-1, idx_t(0)))
-        ) );
-    tlapack_check_false( (
-            (matrixtype == MatrixType::LowerBand) ||
-            (matrixtype == MatrixType::UpperBand) || 
-            (matrixtype == MatrixType::Band)
-        ) && (
-            (ku < 0) ||
-            (ku > max(n-1, idx_t(0)))
-        ) );
-    tlapack_check_false( (
-            (matrixtype == MatrixType::LowerBand) ||
-            (matrixtype == MatrixType::UpperBand)
-        ) && ( kl != ku ) );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( (lda < m) && (
-        (matrixtype == MatrixType::General) || 
-        (matrixtype == MatrixType::Lower) ||
-        (matrixtype == MatrixType::Upper) ||
-        (matrixtype == MatrixType::Hessenberg) ) );
-    tlapack_check_false( (matrixtype == MatrixType::LowerBand) && (lda < kl + 1) );
-    tlapack_check_false( (matrixtype == MatrixType::UpperBand) && (lda < ku + 1) );
-    tlapack_check_false( (matrixtype == MatrixType::Band) && (lda < 2 * kl + ku + 1) );
 
-    if (matrixtype == MatrixType::LowerBand)
-    {
-        auto A_ = banded_matrix<T>( A, m, n, kl, 0 );
-        return lascl( band_t(kl,0), b, a, A_ );
+    // check arguments
+    tlapack_check_false((matrixtype != MatrixType::General) &&
+                        (matrixtype != MatrixType::Lower) &&
+                        (matrixtype != MatrixType::Upper) &&
+                        (matrixtype != MatrixType::Hessenberg) &&
+                        (matrixtype != MatrixType::LowerBand) &&
+                        (matrixtype != MatrixType::UpperBand) &&
+                        (matrixtype != MatrixType::Band));
+    tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
+                         (matrixtype == MatrixType::UpperBand) ||
+                         (matrixtype == MatrixType::Band)) &&
+                        ((kl < 0) || (kl > max(m - 1, idx_t(0)))));
+    tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
+                         (matrixtype == MatrixType::UpperBand) ||
+                         (matrixtype == MatrixType::Band)) &&
+                        ((ku < 0) || (ku > max(n - 1, idx_t(0)))));
+    tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
+                         (matrixtype == MatrixType::UpperBand)) &&
+                        (kl != ku));
+    tlapack_check_false(m < 0);
+    tlapack_check_false((lda < m) && ((matrixtype == MatrixType::General) ||
+                                      (matrixtype == MatrixType::Lower) ||
+                                      (matrixtype == MatrixType::Upper) ||
+                                      (matrixtype == MatrixType::Hessenberg)));
+    tlapack_check_false((matrixtype == MatrixType::LowerBand) &&
+                        (lda < kl + 1));
+    tlapack_check_false((matrixtype == MatrixType::UpperBand) &&
+                        (lda < ku + 1));
+    tlapack_check_false((matrixtype == MatrixType::Band) &&
+                        (lda < 2 * kl + ku + 1));
+
+    if (matrixtype == MatrixType::LowerBand) {
+        auto A_ = banded_matrix<T>(A, m, n, kl, 0);
+        return lascl(band_t(kl, 0), b, a, A_);
     }
-    else if (matrixtype == MatrixType::UpperBand)
-    {
-        auto A_ = banded_matrix<T>( A, m, n, 0, ku );
-        return lascl( band_t(0,ku), b, a, A_ );
+    else if (matrixtype == MatrixType::UpperBand) {
+        auto A_ = banded_matrix<T>(A, m, n, 0, ku);
+        return lascl(band_t(0, ku), b, a, A_);
     }
-    else if (matrixtype == MatrixType::Band)
-    {
-        auto A_ = banded_matrix<T>( A, m, n, kl, ku );
-        return lascl( band_t(kl,ku), b, a, A_ );
+    else if (matrixtype == MatrixType::Band) {
+        auto A_ = banded_matrix<T>(A, m, n, kl, ku);
+        return lascl(band_t(kl, ku), b, a, A_);
     }
     else {
-        auto A_ = colmajor_matrix<T>( A, m, n, lda );
-        
-        if (matrixtype == MatrixType::General)
-        {
-            return lascl( MatrixAccessPolicy::Dense, b, a, A_ );
+        auto A_ = colmajor_matrix<T>(A, m, n, lda);
+
+        if (matrixtype == MatrixType::General) {
+            return lascl(MatrixAccessPolicy::Dense, b, a, A_);
         }
-        else if (matrixtype == MatrixType::Lower)
-        {
-            return lascl( MatrixAccessPolicy::LowerTriangle, b, a, A_ );
+        else if (matrixtype == MatrixType::Lower) {
+            return lascl(MatrixAccessPolicy::LowerTriangle, b, a, A_);
         }
-        else if (matrixtype == MatrixType::Upper)
-        {
-            return lascl( MatrixAccessPolicy::UpperTriangle, b, a, A_ );
+        else if (matrixtype == MatrixType::Upper) {
+            return lascl(MatrixAccessPolicy::UpperTriangle, b, a, A_);
         }
-        else // if (matrixtype == MatrixType::Hessenberg)
+        else  // if (matrixtype == MatrixType::Hessenberg)
         {
-            return lascl( MatrixAccessPolicy::UpperHessenberg, b, a, A_ );
+            return lascl(MatrixAccessPolicy::UpperHessenberg, b, a, A_);
         }
     }
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LASCL_HH
+#endif  // TLAPACK_LEGACY_LASCL_HH

--- a/include/tlapack/legacy_api/lapack/laset.hpp
+++ b/include/tlapack/legacy_api/lapack/laset.hpp
@@ -1,6 +1,7 @@
 /// @file laset.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/laset.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/laset.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/laset.hpp
+++ b/include/tlapack/legacy_api/lapack/laset.hpp
@@ -17,10 +17,10 @@ namespace tlapack {
 
 /**
  * @brief Initializes a matrix to diagonal and off-diagonal values
- * 
+ *
  * @tparam uplo_t
  *      Either Uplo or any class that implements `operator Uplo()`.
- * 
+ *
  * @param[in] uplo
  *      - Uplo::Upper:   Upper triangle of A and B are referenced;
  *      - Uplo::Lower:   Lower triangle of A and B are referenced;
@@ -33,36 +33,31 @@ namespace tlapack {
  * @param[in] A m-by-n matrix.
  * @param[in] lda Leading dimension of A.
  */
-template< class uplo_t, typename TA >
-void laset(
-    uplo_t uplo, idx_t m, idx_t n,
-    TA alpha, TA beta,
-    TA* A, idx_t lda )
+template <class uplo_t, typename TA>
+void laset(uplo_t uplo, idx_t m, idx_t n, TA alpha, TA beta, TA* A, idx_t lda)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(  uplo != Uplo::Lower &&
-                    uplo != Uplo::Upper &&
-                    uplo != Uplo::General );
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                        uplo != Uplo::General);
 
     // quick return
-    if( m <= 0 || n <= 0 )
-        return;
-    
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>( A, m, n, lda );
+    if (m <= 0 || n <= 0) return;
 
-    return laset( uplo, alpha, beta, A_ );
+    // Matrix views
+    auto A_ = colmajor_matrix<TA>(A, m, n, lda);
+
+    return laset(uplo, alpha, beta, A_);
 }
 
 /** Initializes a matrix to diagonal and off-diagonal values
- * 
+ *
  * @param[in] matrixtype :
  *
- *        'U': A is assumed to be upper triangular; elements below the diagonal are not referenced.
- *        'L': A is assumed to be lower triangular; elements above the diagonal are not referenced.
- *        otherwise, A is assumed to be a full matrix.
+ *        'U': A is assumed to be upper triangular; elements below the diagonal
+ * are not referenced. 'L': A is assumed to be lower triangular; elements above
+ * the diagonal are not referenced. otherwise, A is assumed to be a full matrix.
  * @param[in] m Number of rows of A.
  * @param[in] n Number of columns of A.
  * @param[in] alpha Value to be assigned to the off-diagonal elements of A.
@@ -71,24 +66,29 @@ void laset(
  * @param[in] lda Leading dimension of A.
  *
  * @see laset( Uplo, idx_t, idx_t, TA, TA, TA*, idx_t )
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< typename TA >
-void inline laset(
-    MatrixType matrixtype, idx_t m, idx_t n,
-    TA alpha, TA beta,
-    TA* A, idx_t lda )
+template <typename TA>
+void inline laset(MatrixType matrixtype,
+                  idx_t m,
+                  idx_t n,
+                  TA alpha,
+                  TA beta,
+                  TA* A,
+                  idx_t lda)
 {
     if (matrixtype == MatrixType::Upper) {
         laset(Uplo::Upper, m, n, alpha, beta, A, lda);
-    } else if (matrixtype == MatrixType::Lower) {
+    }
+    else if (matrixtype == MatrixType::Lower) {
         laset(Uplo::Lower, m, n, alpha, beta, A, lda);
-    } else {
+    }
+    else {
         laset(Uplo::General, m, n, alpha, beta, A, lda);
     }
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LASET_HH
+#endif  // TLAPACK_LEGACY_LASET_HH

--- a/include/tlapack/legacy_api/lapack/lassq.hpp
+++ b/include/tlapack/legacy_api/lapack/lassq.hpp
@@ -1,6 +1,6 @@
 /// @file lassq.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// 
+///
 /// Anderson E. (2017)
 /// Algorithm 978: Safe Scaling in the Level 1 BLAS
 /// ACM Trans Math Softw 44:1--28
@@ -21,10 +21,11 @@ namespace tlapack {
 
 /** Updates a sum of squares represented in scaled form.
  * \[
- *      scl_{[OUT]}^2 sumsq_{[OUT]} = \sum_{i = 0}^n x_i^2 + scl_{[IN]}^2 sumsq_{[IN]},
+ *      scl_{[OUT]}^2 sumsq_{[OUT]} = \sum_{i = 0}^n x_i^2 + scl_{[IN]}^2
+ * sumsq_{[IN]},
  * \]
  * The value of  sumsq  is assumed to be non-negative.
- * 
+ *
  * If (scale * sqrt( sumsq )) > tbig on entry then
  *    we require:   scale >= sqrt( TINY*EPS ) / sbig   on entry,
  * and if 0 < (scale * sqrt( sumsq )) < tsml on entry then
@@ -37,7 +38,7 @@ namespace tlapack {
  * and
  *    TINY*EPS -- tiniest representable number;
  *    HUGE     -- biggest representable number.
- * 
+ *
  * @param[in] n The number of elements to be used from the vector x.
  * @param[in] x Array of dimension $(1+(n-1)*|incx|)$.
  * @param[in] incx The increment between successive values of the vector x.
@@ -48,22 +49,19 @@ namespace tlapack {
  *          in the vector norm n times.
  * @param[in] scl
  * @param[in] sumsq
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< typename TX >
+template <typename TX>
 void lassq(
-    idx_t n,
-    TX const* x, int_t incx,
-    real_type<TX> &scl,
-    real_type<TX> &sumsq)
+    idx_t n, TX const* x, int_t incx, real_type<TX>& scl, real_type<TX>& sumsq)
 {
     // quick return
-    if( isnan(scl) || isnan(sumsq) || n <= 0 ) return;
+    if (isnan(scl) || isnan(sumsq) || n <= 0) return;
 
-    tlapack_expr_with_vector( x_, TX, n, x, incx, return lassq( x_, scl, sumsq ) );
+    tlapack_expr_with_vector(x_, TX, n, x, incx, return lassq(x_, scl, sumsq));
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_LASSQ_HH
+#endif  // TLAPACK_LEGACY_LASSQ_HH

--- a/include/tlapack/legacy_api/lapack/potrf.hpp
+++ b/include/tlapack/legacy_api/lapack/potrf.hpp
@@ -16,26 +16,26 @@ namespace tlapack {
 
 /** Computes the Cholesky factorization of a Hermitian
  * positive definite matrix A using a blocked algorithm.
- * 
- * @see potrf( uplo_t uplo, matrix_t& A, const potrf_opts_t< size_type<matrix_t> >& opts = {} )
- * 
+ *
+ * @see potrf( uplo_t uplo, matrix_t& A, const potrf_opts_t< size_type<matrix_t>
+ * >& opts = {} )
+ *
  * @ingroup legacy_lapack
  */
-template< class uplo_t, typename T >
-inline int potrf( uplo_t uplo, idx_t n, T* A, idx_t lda )
+template <class uplo_t, typename T>
+inline int potrf(uplo_t uplo, idx_t n, T* A, idx_t lda)
 {
     using internal::colmajor_matrix;
 
     // check arguments
-    tlapack_check_false(    uplo != Uplo::Lower &&
-                        uplo != Uplo::Upper );
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // Matrix views
-    auto A_ = colmajor_matrix( A, n, n, lda );
+    auto A_ = colmajor_matrix(A, n, n, lda);
 
-    return potrf_blocked( uplo, A_ );
+    return potrf_blocked(uplo, A_);
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_POTRF_HH
+#endif  // TLAPACK_LEGACY_POTRF_HH

--- a/include/tlapack/legacy_api/lapack/potrs.hpp
+++ b/include/tlapack/legacy_api/lapack/potrs.hpp
@@ -15,30 +15,27 @@
 namespace tlapack {
 
 /** Apply the Cholesky factorization to solve a linear system.
- * 
+ *
  * @see potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< class uplo_t, typename T >
+template <class uplo_t, typename T>
 inline int potrs(
-    uplo_t uplo, idx_t n, idx_t nrhs,
-    const T* A, idx_t lda,
-    T* B, idx_t ldb )
+    uplo_t uplo, idx_t n, idx_t nrhs, const T* A, idx_t lda, T* B, idx_t ldb)
 {
     using internal::colmajor_matrix;
 
     // Check arguments
-    tlapack_check_false(    uplo != Uplo::Lower &&
-                        uplo != Uplo::Upper );
+    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
     // Matrix views
-    const auto A_ = colmajor_matrix<T>( (T*) A, n, n, lda );
-          auto B_ = colmajor_matrix<T>( B, n, nrhs, ldb );
+    const auto A_ = colmajor_matrix<T>((T*)A, n, n, lda);
+    auto B_ = colmajor_matrix<T>(B, n, nrhs, ldb);
 
-    return potrs( uplo, A_, B_ );
+    return potrs(uplo, A_, B_);
 }
 
-} // lapack
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_POTRS_HH
+#endif  // TLAPACK_LEGACY_POTRS_HH

--- a/include/tlapack/legacy_api/lapack/ung2r.hpp
+++ b/include/tlapack/legacy_api/lapack/ung2r.hpp
@@ -1,6 +1,7 @@
 /// @file ung2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/ung2r.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/ung2r.hpp
+++ b/include/tlapack/legacy_api/lapack/ung2r.hpp
@@ -19,49 +19,47 @@ namespace tlapack {
  * \[
  *     Q  =  H_1 H_2 ... H_k
  * \]
- * 
+ *
  * @return  0 if success
  * @return -i if the ith argument is invalid
- * 
+ *
  * @param[in] m The number of rows of the matrix A. m>=0
  * @param[in] n The number of columns of the matrix A. n>=0
- * @param[in] k The number of elementary reflectors whose product defines the matrix Q. n>=k>=0
+ * @param[in] k The number of elementary reflectors whose product defines the
+ * matrix Q. n>=k>=0
  * @param[in,out] A m-by-n matrix.
  *      On entry, the i-th column must contains the vector which defines the
- *      elementary reflector $H_i$, for $i=0,1,...,k-1$, as returned by GEQRF in the
- *      first k columns of its array argument A.
- *      On exit, the m-by-n matrix $Q  =  H_1 H_2 ... H_k$.
+ *      elementary reflector $H_i$, for $i=0,1,...,k-1$, as returned by GEQRF in
+ * the first k columns of its array argument A. On exit, the m-by-n matrix $Q  =
+ * H_1 H_2 ... H_k$.
  * @param[in] lda The leading dimension of A. lda >= max(1,m).
- * @param[in] tau Real vector of length min(m,n).      
+ * @param[in] tau Real vector of length min(m,n).
  *      The scalar factors of the elementary reflectors.
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< typename TA, typename Ttau >
-inline int ung2r(
-    idx_t m, idx_t n, idx_t k,
-    TA* A, idx_t lda,
-    const Ttau* tau )
+template <typename TA, typename Ttau>
+inline int ung2r(idx_t m, idx_t n, idx_t k, TA* A, idx_t lda, const Ttau* tau)
 {
     using internal::colmajor_matrix;
     using internal::vector;
 
     // check arguments
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 || n > m );
-    tlapack_check_false( k < 0 || k > n );
-    tlapack_check_false( lda < m );
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0 || n > m);
+    tlapack_check_false(k < 0 || k > n);
+    tlapack_check_false(lda < m);
 
     // quick return
     if (n <= 0) return 0;
 
     // Matrix views
-    auto A_    = colmajor_matrix<TA>( A, m, n, lda );
-    auto tau_  = vector( (Ttau*)tau, std::min<idx_t>( m, n ) );
-    
-    return ung2r( k, A_, tau_ );
+    auto A_ = colmajor_matrix<TA>(A, m, n, lda);
+    auto tau_ = vector((Ttau*)tau, std::min<idx_t>(m, n));
+
+    return ung2r(k, A_, tau_);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_UNG2R_HH
+#endif  // TLAPACK_LEGACY_UNG2R_HH

--- a/include/tlapack/legacy_api/lapack/unm2r.hpp
+++ b/include/tlapack/legacy_api/lapack/unm2r.hpp
@@ -1,6 +1,7 @@
 /// @file unm2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
+/// @note Adapted from @see
+/// https://github.com/langou/latl/blob/master/include/ormr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/unm2r.hpp
+++ b/include/tlapack/legacy_api/lapack/unm2r.hpp
@@ -16,10 +16,10 @@
 namespace tlapack {
 
 /** Applies unitary matrix Q to a matrix C.
- * 
+ *
  * @return  0 if success
  * @return -i if the ith argument is invalid
- * 
+ *
  * @param[in] side Specifies which side Q is to be applied.
  *                 'L': apply Q or Q' from the Left;
  *                 'R': apply Q or Q' from the Right.
@@ -28,61 +28,61 @@ namespace tlapack {
  *                 'T':  Transpose, apply Q'.
  * @param[in] m The number of rows of the matrix C.
  * @param[in] n The number of columns of the matrix C.
- * @param[in] k The number of elementary reflectors whose product defines the matrix Q.
- *                 If side='L', m>=k>=0;
- *                 if side='R', n>=k>=0.
+ * @param[in] k The number of elementary reflectors whose product defines the
+ * matrix Q. If side='L', m>=k>=0; if side='R', n>=k>=0.
  * @param[in] A Matrix containing the elementary reflectors H.
  *                 If side='L', A is k-by-m;
  *                 if side='R', A is k-by-n.
  * @param[in] lda The column length of the matrix A.  ldA>=k.
  * @param[in] tau Real vector of length k containing the scalar factors of the
  * elementary reflectors.
- * @param[in,out] C m-by-n matrix. 
+ * @param[in,out] C m-by-n matrix.
  *     On exit, C is replaced by one of the following:
  *                 If side='L' & trans='N':  C <- Q * C
  *                 If side='L' & trans='T':  C <- Q'* C
  *                 If side='R' & trans='T':  C <- C * Q'
  *                 If side='R' & trans='N':  C <- C * Q
  * @param ldc The column length the matrix C. ldC>=m.
- * 
+ *
  * @ingroup legacy_lapack
  */
-template< class side_t, class trans_t, typename TA, typename TC>
-inline int unm2r(
-    side_t side, trans_t trans,
-    idx_t m, idx_t n, idx_t k,
-    TA* A, idx_t lda,
-    const real_type<TA,TC>* tau,
-    TC* C, idx_t ldc )
+template <class side_t, class trans_t, typename TA, typename TC>
+inline int unm2r(side_t side,
+                 trans_t trans,
+                 idx_t m,
+                 idx_t n,
+                 idx_t k,
+                 TA* A,
+                 idx_t lda,
+                 const real_type<TA, TC>* tau,
+                 TC* C,
+                 idx_t ldc)
 {
     using internal::colmajor_matrix;
     using internal::vector;
 
     // check arguments
-    tlapack_check_false( side != Side::Left &&
-                     side != Side::Right );
-    tlapack_check_false( trans != Op::NoTrans &&
-                     trans != Op::Trans &&
-                     trans != Op::ConjTrans );
-    tlapack_check_false( m < 0 );
-    tlapack_check_false( n < 0 );
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+    tlapack_check_false(m < 0);
+    tlapack_check_false(n < 0);
     const idx_t q = (side == Side::Left) ? m : n;
-    tlapack_check_false( k < 0 || k > q );
-    tlapack_check_false( lda < q );
-    tlapack_check_false( ldc < m );
+    tlapack_check_false(k < 0 || k > q);
+    tlapack_check_false(lda < q);
+    tlapack_check_false(ldc < m);
 
     // quick return
-    if ((m == 0) || (n == 0) || (k == 0))
-        return 0;
+    if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Matrix views
-    const auto A_ = colmajor_matrix<TA>( (TA*)A, q, k, lda );
-    const auto tau_ = vector( (TA*)tau, k );
-    auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
+    const auto A_ = colmajor_matrix<TA>((TA*)A, q, k, lda);
+    const auto tau_ = vector((TA*)tau, k);
+    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
 
-    return unm2r( side, trans, A, tau_, C_ );
+    return unm2r(side, trans, A, tau_, C_);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_UNM2R_HH
+#endif  // TLAPACK_LEGACY_UNM2R_HH

--- a/include/tlapack/legacy_api/lapack/unmqr.hpp
+++ b/include/tlapack/legacy_api/lapack/unmqr.hpp
@@ -14,7 +14,8 @@
 
 namespace tlapack {
 
-/** Multiplies the general m-by-n matrix C by Q from geqrf() using a blocked code as follows:
+/** Multiplies the general m-by-n matrix C by Q from geqrf() using a blocked
+ code as follows:
  *
  * @param[in] side
  *     - Side::Left:  apply $Q$ or $Q^H$ from the Left;
@@ -62,7 +63,7 @@ namespace tlapack {
  *
  * @param[in] ldc
  *     The leading dimension of the array C. ldc >= max(1,m).
- * 
+ *
  * @see unmqr(
     side_t side, trans_t trans,
     const matrixA_t& A, const tau_t& tau,
@@ -70,34 +71,36 @@ namespace tlapack {
  *
  * @ingroup legacy_lapack
  */
-template< class side_t, class trans_t, typename TA, typename TC >
-inline int unmqr(
-    side_t side, trans_t trans,
-    idx_t m, idx_t n, idx_t k,
-    TA const* A, idx_t lda,
-    TA const* tau,
-    TC* C, idx_t ldc )
+template <class side_t, class trans_t, typename TA, typename TC>
+inline int unmqr(side_t side,
+                 trans_t trans,
+                 idx_t m,
+                 idx_t n,
+                 idx_t k,
+                 TA const* A,
+                 idx_t lda,
+                 TA const* tau,
+                 TC* C,
+                 idx_t ldc)
 {
     using internal::colmajor_matrix;
     using internal::vector;
 
     // check arguments
-    tlapack_check_false( side != Side::Left &&
-                     side != Side::Right );
-    tlapack_check_false( trans != Op::NoTrans &&
-                     trans != Op::Trans &&
-                     trans != Op::ConjTrans );
-                
+    tlapack_check_false(side != Side::Left && side != Side::Right);
+    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                        trans != Op::ConjTrans);
+
     // Matrix views
     const auto A_ = (side == Side::Left)
-            ? colmajor_matrix<TA>( (TA*)A, m, k, lda )
-            : colmajor_matrix<TA>( (TA*)A, n, k, lda );
-    const auto tau_ = vector( (TA*)tau, k );
-    auto C_ = colmajor_matrix<TC>( C, m, n, ldc );
+                        ? colmajor_matrix<TA>((TA*)A, m, k, lda)
+                        : colmajor_matrix<TA>((TA*)A, n, k, lda);
+    const auto tau_ = vector((TA*)tau, k);
+    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
 
-    return unmqr( side, trans, A_, tau_, C_ );
+    return unmqr(side, trans, A_, tau_, C_);
 }
 
-}
+}  // namespace tlapack
 
-#endif // TLAPACK_LEGACY_UNMQR_HH
+#endif  // TLAPACK_LEGACY_UNMQR_HH

--- a/include/tlapack/plugins/abstractArray.hpp
+++ b/include/tlapack/plugins/abstractArray.hpp
@@ -18,248 +18,236 @@
 
 namespace tlapack {
 
-    // -------------------------------------------------------------------------
-    // Data descriptors for matrices in <T>LAPACK
-    
-    /**
-     * @brief Return the number of rows of a given matrix.
-     * 
-     * @tparam idx_t    Index type.
-     * @tparam matrix_t Matrix type.
-     * 
-     * @param A Matrix.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class idx_t, class matrix_t >
-    inline constexpr idx_t
-    nrows( const matrix_t& A );
+// -------------------------------------------------------------------------
+// Data descriptors for matrices in <T>LAPACK
 
-    /**
-     * @brief Return the number of columns of a given matrix.
-     * 
-     * @tparam idx_t    Index type.
-     * @tparam matrix_t Matrix type.
-     * 
-     * @param A Matrix.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class idx_t, class matrix_t >
-    inline constexpr idx_t
-    ncols( const matrix_t& A );
+/**
+ * @brief Return the number of rows of a given matrix.
+ *
+ * @tparam idx_t    Index type.
+ * @tparam matrix_t Matrix type.
+ *
+ * @param A Matrix.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class idx_t, class matrix_t>
+inline constexpr idx_t nrows(const matrix_t& A);
 
-    // -------------------------------------------------------------------------
-    // Data descriptors for vectors in <T>LAPACK
+/**
+ * @brief Return the number of columns of a given matrix.
+ *
+ * @tparam idx_t    Index type.
+ * @tparam matrix_t Matrix type.
+ *
+ * @param A Matrix.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class idx_t, class matrix_t>
+inline constexpr idx_t ncols(const matrix_t& A);
 
-    /**
-     * @brief Return the number of elements of a given vector.
-     * 
-     * @tparam idx_t    Index type.
-     * @tparam vector_t Vector type.
-     * 
-     * @param v Vector.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class idx_t, class vector_t >
-    inline constexpr idx_t
-    size( const vector_t& v );
+// -------------------------------------------------------------------------
+// Data descriptors for vectors in <T>LAPACK
 
-    // -------------------------------------------------------------------------
-    // Block operations with matrices in <T>LAPACK
+/**
+ * @brief Return the number of elements of a given vector.
+ *
+ * @tparam idx_t    Index type.
+ * @tparam vector_t Vector type.
+ *
+ * @param v Vector.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class idx_t, class vector_t>
+inline constexpr idx_t size(const vector_t& v);
 
-    /**
-     * @brief Extracts a slice from a given matrix.
-     * 
-     * @returns a matrix.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam pair_t   Pair of integers.
-     *      Stored in pair::first and pair::second.
-     * 
-     * @param A     Matrix.
-     * @param rows  Pair (i,k).
-     *      i   is the index of the first row, and
-     *      k-1 is the index of the last row.
-     * @param cols  Pair (j,l).
-     *      j   is the index of the first column, and
-     *      l-1 is the index of the last column.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class pair_t >
-    inline constexpr auto
-    slice( const matrix_t& A, pair_t&& rows, pair_t&& cols );
+// -------------------------------------------------------------------------
+// Block operations with matrices in <T>LAPACK
 
-    /**
-     * @brief Extracts a slice from a given matrix.
-     * 
-     * @returns a vector.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam idx_t    Index type.
-     * @tparam pair_t   Pair of integers.
-     *      Stored in pair::first and pair::second.
-     * 
-     * @param A         Matrix.
-     * @param rowIdx    Row index.
-     * @param cols  Pair (j,l).
-     *      j   is the index of the first column, and
-     *      l-1 is the index of the last column.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class idx_t, class pair_t >
-    inline constexpr auto
-    slice( const matrix_t& A, idx_t rowIdx, pair_t&& cols );
+/**
+ * @brief Extracts a slice from a given matrix.
+ *
+ * @returns a matrix.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam pair_t   Pair of integers.
+ *      Stored in pair::first and pair::second.
+ *
+ * @param A     Matrix.
+ * @param rows  Pair (i,k).
+ *      i   is the index of the first row, and
+ *      k-1 is the index of the last row.
+ * @param cols  Pair (j,l).
+ *      j   is the index of the first column, and
+ *      l-1 is the index of the last column.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class pair_t>
+inline constexpr auto slice(const matrix_t& A, pair_t&& rows, pair_t&& cols);
 
-    /**
-     * @brief Extracts a slice from a given matrix.
-     * 
-     * @returns a vector.
-     * 
-     * Default column value is zero. This is useful to obtain vectors from a 
-     * given array since `slice( work, {0,n} )` returns a vector of size `n` no
-     * matter if `work` is a matrix or a vector.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam pair_t   Pair of integers.
-     *      Stored in pair::first and pair::second.
-     * @tparam idx_t    Index type.
-     * 
-     * @param A         Matrix.
-     * @param rows      Pair (i,k).
-     *      i   is the index of the first row, and
-     *      k-1 is the index of the last row.
-     * @param colIdx    Column index.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class pair_t, class idx_t >
-    inline constexpr auto
-    slice( const matrix_t& A, pair_t&& rows, idx_t colIdx );
-    
-    /**
-     * @brief Extracts a set of rows from a given matrix.
-     * 
-     * @returns a matrix.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam pair_t   Pair of integers.
-     *      Stored in pair::first and pair::second.
-     * 
-     * @param A     Matrix.
-     * @param rows  Pair (i,k).
-     *      i   is the index of the first row, and
-     *      k-1 is the index of the last row.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class pair_t >
-    inline constexpr auto
-    rows( const matrix_t& A, pair_t&& rows );
-    
-    /**
-     * @brief Extracts a set of columns from a given matrix.
-     * 
-     * @returns a matrix.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam pair_t   Pair of integers.
-     *      Stored in pair::first and pair::second.
-     * 
-     * @param A     Matrix.
-     * @param cols  Pair (j,l).
-     *      j   is the index of the first column, and
-     *      l-1 is the index of the last column.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class pair_t >
-    inline constexpr auto
-    cols( const matrix_t& A, pair_t&& cols );
-    
-    /**
-     * @brief Extracts a row from a given matrix.
-     * 
-     * @returns a vector.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam idx_t    Index type.
-     * 
-     * @param A         Matrix.
-     * @param rowIdx    Row index.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class idx_t >
-    inline constexpr auto
-    row( const matrix_t& A, idx_t rowIdx );
-    
-    /**
-     * @brief Extracts a column from a given matrix.
-     * 
-     * @returns a vector.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam idx_t    Index type.
-     * 
-     * @param A         Matrix.
-     * @param colIdx    Column index.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class idx_t >
-    inline constexpr auto
-    col( const matrix_t& A, idx_t colIdx );
+/**
+ * @brief Extracts a slice from a given matrix.
+ *
+ * @returns a vector.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam idx_t    Index type.
+ * @tparam pair_t   Pair of integers.
+ *      Stored in pair::first and pair::second.
+ *
+ * @param A         Matrix.
+ * @param rowIdx    Row index.
+ * @param cols  Pair (j,l).
+ *      j   is the index of the first column, and
+ *      l-1 is the index of the last column.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class idx_t, class pair_t>
+inline constexpr auto slice(const matrix_t& A, idx_t rowIdx, pair_t&& cols);
 
-    /**
-     * @brief Extracts a diagonal from a given matrix.
-     * 
-     * @returns a vector.
-     * 
-     * @tparam matrix_t Matrix type.
-     * @tparam idx_t    Index type.
-     * 
-     * @param A         Matrix of size m-by-n. 
-     * @param diagIdx   Diagonal index.
-     *      - diagIdx = 0: main diagonal.
-     *          Vector of size min( m, n ).
-     *      - diagIdx < 0: subdiagonal starting on A( -diagIdx, 0 ).
-     *          Vector of size min( m, n-diagIdx ) + diagIdx.
-     *      - diagIdx > 0: superdiagonal starting on A( 0, diagIdx ).
-     *          Vector of size min( m+diagIdx, n ) - diagIdx.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class matrix_t, class idx_t >
-    inline constexpr auto
-    diag( const matrix_t& A, idx_t diagIdx = 0 );
+/**
+ * @brief Extracts a slice from a given matrix.
+ *
+ * @returns a vector.
+ *
+ * Default column value is zero. This is useful to obtain vectors from a
+ * given array since `slice( work, {0,n} )` returns a vector of size `n` no
+ * matter if `work` is a matrix or a vector.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam pair_t   Pair of integers.
+ *      Stored in pair::first and pair::second.
+ * @tparam idx_t    Index type.
+ *
+ * @param A         Matrix.
+ * @param rows      Pair (i,k).
+ *      i   is the index of the first row, and
+ *      k-1 is the index of the last row.
+ * @param colIdx    Column index.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class pair_t, class idx_t>
+inline constexpr auto slice(const matrix_t& A, pair_t&& rows, idx_t colIdx);
 
-    // -------------------------------------------------------------------------
-    // Block operations with vectors in <T>LAPACK
+/**
+ * @brief Extracts a set of rows from a given matrix.
+ *
+ * @returns a matrix.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam pair_t   Pair of integers.
+ *      Stored in pair::first and pair::second.
+ *
+ * @param A     Matrix.
+ * @param rows  Pair (i,k).
+ *      i   is the index of the first row, and
+ *      k-1 is the index of the last row.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class pair_t>
+inline constexpr auto rows(const matrix_t& A, pair_t&& rows);
 
-    /**
-     * @brief Extracts a slice from a vector.
-     * 
-     * @returns a vector.
-     * 
-     * @tparam vector_t Vector type.
-     * @tparam pair_t   Pair of integers.
-     *      Stored in pair::first and pair::second.
-     * 
-     * @param v     Vector.
-     * @param rows  Pair (i,k).
-     *      i   is the index of the first row, and
-     *      k-1 is the index of the last row.
-     * 
-     * @ingroup abstract_matrix
-     */
-    template< class vector_t, class pair_t >
-    inline constexpr auto
-    slice( const vector_t& v, pair_t&& rows );
+/**
+ * @brief Extracts a set of columns from a given matrix.
+ *
+ * @returns a matrix.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam pair_t   Pair of integers.
+ *      Stored in pair::first and pair::second.
+ *
+ * @param A     Matrix.
+ * @param cols  Pair (j,l).
+ *      j   is the index of the first column, and
+ *      l-1 is the index of the last column.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class pair_t>
+inline constexpr auto cols(const matrix_t& A, pair_t&& cols);
 
-} // namespace tlapack
+/**
+ * @brief Extracts a row from a given matrix.
+ *
+ * @returns a vector.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam idx_t    Index type.
+ *
+ * @param A         Matrix.
+ * @param rowIdx    Row index.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class idx_t>
+inline constexpr auto row(const matrix_t& A, idx_t rowIdx);
 
-#endif // TLAPACK_ABSTRACT_ARRAY_HH
+/**
+ * @brief Extracts a column from a given matrix.
+ *
+ * @returns a vector.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam idx_t    Index type.
+ *
+ * @param A         Matrix.
+ * @param colIdx    Column index.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class idx_t>
+inline constexpr auto col(const matrix_t& A, idx_t colIdx);
+
+/**
+ * @brief Extracts a diagonal from a given matrix.
+ *
+ * @returns a vector.
+ *
+ * @tparam matrix_t Matrix type.
+ * @tparam idx_t    Index type.
+ *
+ * @param A         Matrix of size m-by-n.
+ * @param diagIdx   Diagonal index.
+ *      - diagIdx = 0: main diagonal.
+ *          Vector of size min( m, n ).
+ *      - diagIdx < 0: subdiagonal starting on A( -diagIdx, 0 ).
+ *          Vector of size min( m, n-diagIdx ) + diagIdx.
+ *      - diagIdx > 0: superdiagonal starting on A( 0, diagIdx ).
+ *          Vector of size min( m+diagIdx, n ) - diagIdx.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class matrix_t, class idx_t>
+inline constexpr auto diag(const matrix_t& A, idx_t diagIdx = 0);
+
+// -------------------------------------------------------------------------
+// Block operations with vectors in <T>LAPACK
+
+/**
+ * @brief Extracts a slice from a vector.
+ *
+ * @returns a vector.
+ *
+ * @tparam vector_t Vector type.
+ * @tparam pair_t   Pair of integers.
+ *      Stored in pair::first and pair::second.
+ *
+ * @param v     Vector.
+ * @param rows  Pair (i,k).
+ *      i   is the index of the first row, and
+ *      k-1 is the index of the last row.
+ *
+ * @ingroup abstract_matrix
+ */
+template <class vector_t, class pair_t>
+inline constexpr auto slice(const vector_t& v, pair_t&& rows);
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_ABSTRACT_ARRAY_HH

--- a/include/tlapack/plugins/debugutils.hpp
+++ b/include/tlapack/plugins/debugutils.hpp
@@ -8,219 +8,225 @@
 #ifndef TLAPACK_DEBUG_UTILS_HH
 #define TLAPACK_DEBUG_UTILS_HH
 
-#include <iostream>
-#include <iomanip>
-#include <sstream>
 #include <complex>
 #include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 #include "tlapack/base/utils.hpp"
 
-namespace tlapack
+namespace tlapack {
+
+/**
+ * @brief Prints a matrix a to std::out
+ *
+ * @param A m by n matrix
+ */
+template <typename matrix_t>
+void print_matrix(const matrix_t& A)
 {
+    using idx_t = size_type<matrix_t>;
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
 
-    /**
-     * @brief Prints a matrix a to std::out
-     *
-     * @param A m by n matrix
-     */
-    template <typename matrix_t>
-    void print_matrix(const matrix_t &A)
-    {
-        using idx_t = size_type<matrix_t>;
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-
-        for (idx_t i = 0; i < m; ++i)
-        {
-            std::cout << std::endl;
-            for (idx_t j = 0; j < n; ++j)
-                std::cout << std::setw(16) << A(i, j) << " ";
-        }
-    }
-
-    //
-    // GDB doesn't handle templates well, so we explicitly define some versions of the functions
-    // for common template arguments
-    //
-    void print_matrix_r(const legacyMatrix<float, size_t, Layout::ColMajor> &A)
-    {
-        print_matrix(A);
-    }
-    void print_matrix_d(const legacyMatrix<double, size_t, Layout::ColMajor> &A)
-    {
-        print_matrix(A);
-    }
-    void print_matrix_c(const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor> &A)
-    {
-        print_matrix(A);
-    }
-    void print_matrix_z(const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor> &A)
-    {
-        print_matrix(A);
-    }
-    void print_rowmajormatrix_r(const legacyMatrix<float, size_t, Layout::RowMajor> &A)
-    {
-        print_matrix(A);
-    }
-    void print_rowmajormatrix_d(const legacyMatrix<double, size_t, Layout::RowMajor> &A)
-    {
-        print_matrix(A);
-    }
-    void print_rowmajormatrix_c(const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor> &A)
-    {
-        print_matrix(A);
-    }
-    void print_rowmajormatrix_z(const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor> &A)
-    {
-        print_matrix(A);
-    }
-
-    /**
-     * @brief Constructs a json string representing the matrix
-     *        for use with vscode-debug-visualizer
-     *
-     * @return String containing JSON representation of A
-     *
-     * @param A m by n matrix
-     */
-    template <typename matrix_t>
-    std::string visualize_matrix_text(const matrix_t &A)
-    {
-        using idx_t = size_type<matrix_t>;
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-
-        const int width = is_complex<type_t<matrix_t>>::value ? 25 : 10;
-
-        std::stringstream stream;
-        stream << "{ \"kind\":{ \"text\": true },\"text\": \"";
-
-        // Col indices
+    for (idx_t i = 0; i < m; ++i) {
+        std::cout << std::endl;
         for (idx_t j = 0; j < n; ++j)
-            stream << std::setw(width) << j << " ";
-        stream << "\\n";
-
-        // Add the matrix values
-        for (idx_t i = 0; i < m; ++i)
-        {
-            for (idx_t j = 0; j < n; ++j)
-                stream << std::setw(width) << std::setprecision(3) << A(i, j) << " ";
-            stream << "\\n";
-        }
-
-        stream << "\"}";
-
-        return stream.str();
+            std::cout << std::setw(16) << A(i, j) << " ";
     }
-
-    /**
-     * @brief Constructs a json string representing the matrix
-     *        for use with vscode-debug-visualizer
-     *
-     * @return String containing JSON representation of A
-     *
-     * @param A m by n matrix
-     */
-    template <typename matrix_t>
-    std::string visualize_matrix_table(const matrix_t &A)
-    {
-        using idx_t = size_type<matrix_t>;
-        const idx_t m = nrows(A);
-        const idx_t n = ncols(A);
-
-        std::stringstream stream;
-        stream << "{ \"kind\":{ \"plotly\": true },\"data\":[{";
-
-        // Add the header (matrix index)
-        stream << "\"header\":{\"values\":[";
-        for (idx_t j = 0; j < n; ++j)
-        {
-            stream << j;
-            if (j + 1 < n)
-                stream << ", ";
-        }
-        stream << "]},";
-
-        // Add the matrix values
-        stream << "\"cells\":{\"values\":[";
-        for (idx_t j = 0; j < n; ++j)
-        {
-            stream << "[";
-            for (idx_t i = 0; i < m; ++i)
-            {
-                stream << "\"" << std::setprecision(3) << A(i, j) << "\"";
-                if (i + 1 < m)
-                    stream << ", ";
-            }
-            stream << "]";
-            if (j + 1 < n)
-                stream << ", ";
-        }
-
-        stream << "]},";
-        stream << "\"type\": \"table\"}],\"layout\": {}}";
-
-        return stream.str();
-    }
-
-    /**
-     * @brief Constructs a json string representing the matrix
-     *        for use with vscode-debug-visualizer
-     *
-     * @return String containing JSON representation of A
-     *
-     * @param A m by n matrix
-     */
-    template <typename matrix_t>
-    std::string visualize_matrix(const matrix_t &A)
-    {
-        using idx_t = size_type<matrix_t>;
-        const idx_t n = std::max(ncols(A), nrows(A));
-
-        if (n > 7)
-            return visualize_matrix_text(A);
-        else
-            return visualize_matrix_table(A);
-    }
-
-    //
-    // GDB doesn't handle templates well, so we explicitly define some versions of the functions
-    // for common template arguments
-    //
-    std::string visualize_matrix_r(const legacyMatrix<float, size_t, Layout::ColMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-    std::string visualize_matrix_d(const legacyMatrix<double, size_t, Layout::ColMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-    std::string visualize_matrix_c(const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-    std::string visualize_matrix_z(const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-    std::string visualize_rowmajormatrix_r(const legacyMatrix<float, size_t, Layout::RowMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-    std::string visualize_rowmajormatrix_d(const legacyMatrix<double, size_t, Layout::RowMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-    std::string visualize_rowmajormatrix_c(const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-    std::string visualize_rowmajormatrix_z(const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor> &A)
-    {
-        return visualize_matrix(A);
-    }
-
 }
 
-#endif // TLAPACK_DEBUG_UTILS_HH
+//
+// GDB doesn't handle templates well, so we explicitly define some versions of
+// the functions for common template arguments
+//
+void print_matrix_r(const legacyMatrix<float, size_t, Layout::ColMajor>& A)
+{
+    print_matrix(A);
+}
+void print_matrix_d(const legacyMatrix<double, size_t, Layout::ColMajor>& A)
+{
+    print_matrix(A);
+}
+void print_matrix_c(
+    const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A)
+{
+    print_matrix(A);
+}
+void print_matrix_z(
+    const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A)
+{
+    print_matrix(A);
+}
+void print_rowmajormatrix_r(
+    const legacyMatrix<float, size_t, Layout::RowMajor>& A)
+{
+    print_matrix(A);
+}
+void print_rowmajormatrix_d(
+    const legacyMatrix<double, size_t, Layout::RowMajor>& A)
+{
+    print_matrix(A);
+}
+void print_rowmajormatrix_c(
+    const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A)
+{
+    print_matrix(A);
+}
+void print_rowmajormatrix_z(
+    const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A)
+{
+    print_matrix(A);
+}
+
+/**
+ * @brief Constructs a json string representing the matrix
+ *        for use with vscode-debug-visualizer
+ *
+ * @return String containing JSON representation of A
+ *
+ * @param A m by n matrix
+ */
+template <typename matrix_t>
+std::string visualize_matrix_text(const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+
+    const int width = is_complex<type_t<matrix_t>>::value ? 25 : 10;
+
+    std::stringstream stream;
+    stream << "{ \"kind\":{ \"text\": true },\"text\": \"";
+
+    // Col indices
+    for (idx_t j = 0; j < n; ++j)
+        stream << std::setw(width) << j << " ";
+    stream << "\\n";
+
+    // Add the matrix values
+    for (idx_t i = 0; i < m; ++i) {
+        for (idx_t j = 0; j < n; ++j)
+            stream << std::setw(width) << std::setprecision(3) << A(i, j)
+                   << " ";
+        stream << "\\n";
+    }
+
+    stream << "\"}";
+
+    return stream.str();
+}
+
+/**
+ * @brief Constructs a json string representing the matrix
+ *        for use with vscode-debug-visualizer
+ *
+ * @return String containing JSON representation of A
+ *
+ * @param A m by n matrix
+ */
+template <typename matrix_t>
+std::string visualize_matrix_table(const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+
+    std::stringstream stream;
+    stream << "{ \"kind\":{ \"plotly\": true },\"data\":[{";
+
+    // Add the header (matrix index)
+    stream << "\"header\":{\"values\":[";
+    for (idx_t j = 0; j < n; ++j) {
+        stream << j;
+        if (j + 1 < n) stream << ", ";
+    }
+    stream << "]},";
+
+    // Add the matrix values
+    stream << "\"cells\":{\"values\":[";
+    for (idx_t j = 0; j < n; ++j) {
+        stream << "[";
+        for (idx_t i = 0; i < m; ++i) {
+            stream << "\"" << std::setprecision(3) << A(i, j) << "\"";
+            if (i + 1 < m) stream << ", ";
+        }
+        stream << "]";
+        if (j + 1 < n) stream << ", ";
+    }
+
+    stream << "]},";
+    stream << "\"type\": \"table\"}],\"layout\": {}}";
+
+    return stream.str();
+}
+
+/**
+ * @brief Constructs a json string representing the matrix
+ *        for use with vscode-debug-visualizer
+ *
+ * @return String containing JSON representation of A
+ *
+ * @param A m by n matrix
+ */
+template <typename matrix_t>
+std::string visualize_matrix(const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
+    const idx_t n = std::max(ncols(A), nrows(A));
+
+    if (n > 7)
+        return visualize_matrix_text(A);
+    else
+        return visualize_matrix_table(A);
+}
+
+//
+// GDB doesn't handle templates well, so we explicitly define some versions of
+// the functions for common template arguments
+//
+std::string visualize_matrix_r(
+    const legacyMatrix<float, size_t, Layout::ColMajor>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_matrix_d(
+    const legacyMatrix<double, size_t, Layout::ColMajor>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_matrix_c(
+    const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_matrix_z(
+    const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_rowmajormatrix_r(
+    const legacyMatrix<float, size_t, Layout::RowMajor>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_rowmajormatrix_d(
+    const legacyMatrix<double, size_t, Layout::RowMajor>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_rowmajormatrix_c(
+    const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_rowmajormatrix_z(
+    const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A)
+{
+    return visualize_matrix(A);
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_DEBUG_UTILS_HH

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -10,750 +10,848 @@
 #ifndef TLAPACK_EIGEN_HH
 #define TLAPACK_EIGEN_HH
 
-#include <cassert>
 #include <Eigen/Core>
+#include <cassert>
 
 #include "tlapack/base/arrayTraits.hpp"
 #include "tlapack/base/legacyArray.hpp"
 #include "tlapack/base/workspace.hpp"
 
-namespace tlapack{
+namespace tlapack {
 
-    // Forward declarations
-    template< typename T > T abs ( const T& x );
-    template< typename T > bool isnan( const std::complex<T>& x );
-    template< typename T > bool isinf( const std::complex<T>& x );
+// Forward declarations
+template <typename T>
+T abs(const T& x);
+template <typename T>
+bool isnan(const std::complex<T>& x);
+template <typename T>
+bool isinf(const std::complex<T>& x);
 
-    /// Absolute value
-    template<>
-    inline Eigen::half abs( const Eigen::half& x ) {
-        return Eigen::half_impl::abs( x );
+/// Absolute value
+template <>
+inline Eigen::half abs(const Eigen::half& x)
+{
+    return Eigen::half_impl::abs(x);
+}
+
+inline auto pow(int base, const Eigen::half& exp)
+{
+    return pow(Eigen::half(base), exp);
+}
+
+std::complex<Eigen::half> sqrt(const std::complex<Eigen::half>& z)
+{
+    const Eigen::half x = real(z);
+    const Eigen::half y = imag(z);
+    const Eigen::half zero(0);
+    const Eigen::half two(2);
+    const Eigen::half half(0.5);
+
+    if (isnan(z))
+        return std::numeric_limits<Eigen::half>::quiet_NaN();
+    else if (isinf(z))
+        return std::numeric_limits<Eigen::half>::infinity();
+    else if (x == zero) {
+        Eigen::half t = sqrt(half * abs(y));
+        return std::complex<Eigen::half>(t, (y < zero) ? -t : t);
     }
-
-    inline auto
-    pow( int base, const Eigen::half& exp )
-    {
-        return pow( Eigen::half(base), exp );
+    else {
+        Eigen::half t = sqrt(two * (std::abs(z) + abs(x)));
+        Eigen::half u = half * t;
+        return (x > zero)
+                   ? std::complex<Eigen::half>(u, y / t)
+                   : std::complex<Eigen::half>(abs(y) / t, (y < zero) ? -u : u);
     }
+}
 
-    std::complex<Eigen::half>
-    sqrt( const std::complex<Eigen::half>& z )
-    {
-        const Eigen::half x = real(z);
-        const Eigen::half y = imag(z);
-        const Eigen::half zero(0);
-        const Eigen::half two(2);
-        const Eigen::half half(0.5);
+// -----------------------------------------------------------------------------
+// Helpers
 
-        if( isnan(z) )
-            return std::numeric_limits<Eigen::half>::quiet_NaN();
-        else if( isinf(z) )
-            return std::numeric_limits<Eigen::half>::infinity();
-        else if( x == zero )
-        {
-            Eigen::half t = sqrt(half*abs(y));
-            return std::complex<Eigen::half>(t, (y < zero) ? -t : t);
-        }
-        else
-        {
-            Eigen::half t = sqrt(two*(std::abs(z)+abs(x)));
-            Eigen::half u = half*t;
-            return (x > zero)
-                ? std::complex<Eigen::half>( u, y/t )
-                : std::complex<Eigen::half>( abs(y)/t, (y < zero) ? -u : u );
-        }
-    }
+namespace internal {
+    // Auxiliary constexpr routines
 
-    // -----------------------------------------------------------------------------
-    // Helpers
+    template <class Derived>
+    std::true_type is_eigen_type_f(const Eigen::EigenBase<Derived>*);
+    std::false_type is_eigen_type_f(const void*);
 
-    namespace internal
-    {
-        // Auxiliary constexpr routines
+    template <class Derived>
+    std::true_type is_eigen_dense_f(const Eigen::DenseBase<Derived>*);
+    std::false_type is_eigen_dense_f(const void*);
 
-        template<class Derived>
-        std::true_type is_eigen_type_f(const Eigen::EigenBase<Derived> *);
-        std::false_type is_eigen_type_f(const void *);
+    template <class Derived>
+    std::true_type is_eigen_matrix_f(const Eigen::MatrixBase<Derived>*);
+    std::false_type is_eigen_matrix_f(const void*);
 
-        template<class Derived>
-        std::true_type is_eigen_dense_f(const Eigen::DenseBase<Derived> *);
-        std::false_type is_eigen_dense_f(const void *);
+    template <class XprType, int BlockRows, int BlockCols, bool InnerPanel>
+    std::true_type is_eigen_block_f(
+        const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>*);
+    std::false_type is_eigen_block_f(const void*);
 
-        template<class Derived>
-        std::true_type is_eigen_matrix_f(const Eigen::MatrixBase<Derived> *);
-        std::false_type is_eigen_matrix_f(const void *);
+    template <class PlainObjectType, int MapOptions, class StrideType>
+    std::true_type is_eigen_map_f(
+        const Eigen::Map<PlainObjectType, MapOptions, StrideType>*);
+    std::false_type is_eigen_map_f(const void*);
 
-        template<class XprType, int BlockRows, int BlockCols, bool InnerPanel>
-        std::true_type is_eigen_block_f(const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel> *);
-        std::false_type is_eigen_block_f(const void *);
-
-        template<class PlainObjectType, int MapOptions, class StrideType>
-        std::true_type is_eigen_map_f(const Eigen::Map<PlainObjectType,MapOptions,StrideType> *);
-        std::false_type is_eigen_map_f(const void *);
-
-        /// True if T is derived from Eigen::EigenDense<T>
-        /// @see https://stackoverflow.com/a/25223400/5253097
-        template<class T>
-        constexpr bool is_eigen_dense = decltype(is_eigen_dense_f(std::declval<T*>()))::value;
-
-        /// True if T is derived from Eigen::EigenMatrix<T>
-        /// @see https://stackoverflow.com/a/25223400/5253097
-        template<class T>
-        constexpr bool is_eigen_matrix = decltype(is_eigen_matrix_f(std::declval<T*>()))::value;
-
-        /// True if T is derived from Eigen::EigenBlock
-        /// @see https://stackoverflow.com/a/25223400/5253097
-        template<class T>
-        constexpr bool is_eigen_block = decltype(is_eigen_block_f(std::declval<T*>()))::value;
-
-        /// True if T is derived from Eigen::MapBase
-        /// @see https://stackoverflow.com/a/25223400/5253097
-        template<class T>
-        constexpr bool is_eigen_map = decltype(is_eigen_map_f(std::declval<T*>()))::value;
-    }
-
-    /// True if T is derived from Eigen::EigenBase
+    /// True if T is derived from Eigen::EigenDense<T>
     /// @see https://stackoverflow.com/a/25223400/5253097
-    template<class T>
-    constexpr bool is_eigen_type = decltype(internal::is_eigen_type_f(std::declval<T*>()))::value;
+    template <class T>
+    constexpr bool is_eigen_dense =
+        decltype(is_eigen_dense_f(std::declval<T*>()))::value;
 
-    // -----------------------------------------------------------------------------
-    // Data traits
+    /// True if T is derived from Eigen::EigenMatrix<T>
+    /// @see https://stackoverflow.com/a/25223400/5253097
+    template <class T>
+    constexpr bool is_eigen_matrix =
+        decltype(is_eigen_matrix_f(std::declval<T*>()))::value;
 
-    namespace internal
-    {
-        /// Layout for Eigen::Dense types that are not derived from Eigen::Block
-        /// nor from Eigen::Map
-        template< class matrix_t >
-        struct LayoutImpl< matrix_t, typename std::enable_if<
-            is_eigen_dense<matrix_t> &&
-            !is_eigen_block<matrix_t> &&
-            !is_eigen_map<matrix_t>
-        ,int>::type >
+    /// True if T is derived from Eigen::EigenBlock
+    /// @see https://stackoverflow.com/a/25223400/5253097
+    template <class T>
+    constexpr bool is_eigen_block =
+        decltype(is_eigen_block_f(std::declval<T*>()))::value;
+
+    /// True if T is derived from Eigen::MapBase
+    /// @see https://stackoverflow.com/a/25223400/5253097
+    template <class T>
+    constexpr bool is_eigen_map =
+        decltype(is_eigen_map_f(std::declval<T*>()))::value;
+}  // namespace internal
+
+/// True if T is derived from Eigen::EigenBase
+/// @see https://stackoverflow.com/a/25223400/5253097
+template <class T>
+constexpr bool is_eigen_type =
+    decltype(internal::is_eigen_type_f(std::declval<T*>()))::value;
+
+// -----------------------------------------------------------------------------
+// Data traits
+
+namespace internal {
+    /// Layout for Eigen::Dense types that are not derived from Eigen::Block
+    /// nor from Eigen::Map
+    template <class matrix_t>
+    struct LayoutImpl<matrix_t,
+                      typename std::enable_if<is_eigen_dense<matrix_t> &&
+                                                  !is_eigen_block<matrix_t> &&
+                                                  !is_eigen_map<matrix_t>,
+                                              int>::type> {
+        static constexpr Layout layout =
+            (matrix_t::IsRowMajor) ? Layout::RowMajor : Layout::ColMajor;
+    };
+
+    /// Layout for Eigen::Block
+    template <class XprType, int BlockRows, int BlockCols, bool InnerPanel>
+    struct LayoutImpl<Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>,
+                      int> {
+        static constexpr Layout layout = tlapack::layout<XprType>;
+    };
+
+    /// Layout for const Eigen::Block
+    template <class XprType, int BlockRows, int BlockCols, bool InnerPanel>
+    struct LayoutImpl<
+        const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>,
+        int> {
+        static constexpr Layout layout = tlapack::layout<XprType>;
+    };
+
+    /// Layout for Eigen::Map
+    template <class PlainObjectType, int MapOptions, class StrideType>
+    struct LayoutImpl<Eigen::Map<PlainObjectType, MapOptions, StrideType>,
+                      int> {
+        static constexpr Layout layout = tlapack::layout<PlainObjectType>;
+    };
+
+    /// Layout for const Eigen::Map
+    template <class PlainObjectType, int MapOptions, class StrideType>
+    struct LayoutImpl<const Eigen::Map<PlainObjectType, MapOptions, StrideType>,
+                      int> {
+        static constexpr Layout layout = tlapack::layout<PlainObjectType>;
+    };
+
+    /// Implementation of AllowOptBLASImpl for Eigen datatypes
+    template <class matrix_t>
+    struct AllowOptBLASImpl<
+        matrix_t,
+        typename std::enable_if<is_eigen_dense<matrix_t>, int>::type> {
+        static constexpr bool value = allow_optblas<typename matrix_t::Scalar>;
+    };
+
+    /// Transpose for Eigen::Matrix
+    template <class matrix_t>
+    struct TransposeTypeImpl<
+        matrix_t,
+        typename std::enable_if<is_eigen_matrix<matrix_t>, int>::type> {
+        using type = Eigen::Matrix<typename matrix_t::Scalar,
+                                   matrix_t::ColsAtCompileTime,
+                                   matrix_t::RowsAtCompileTime,
+                                   (matrix_t::IsRowMajor) ? Eigen::RowMajor
+                                                          : Eigen::ColMajor,
+                                   matrix_t::MaxColsAtCompileTime,
+                                   matrix_t::MaxRowsAtCompileTime>;
+    };
+
+    /// Create Eigen::Matrix, @see Create
+    template <typename U>
+    struct CreateImpl<U,
+                      typename std::enable_if<is_eigen_dense<U>, int>::type> {
+        using T = typename U::Scalar;
+        static constexpr int Rows_ =
+            (U::RowsAtCompileTime == 1) ? 1 : Eigen::Dynamic;
+        static constexpr int Cols_ =
+            (U::ColsAtCompileTime == 1) ? 1 : Eigen::Dynamic;
+        static constexpr int Options_ =
+            (U::IsRowMajor) ? Eigen::RowMajor : Eigen::ColMajor;
+
+        using matrix_t = Eigen::Matrix<T, Rows_, Cols_, Options_>;
+        using idx_t = Eigen::Index;
+        using map_t =
+            Eigen::Map<matrix_t, Eigen::Unaligned, Eigen::OuterStride<> >;
+
+        inline constexpr auto operator()(std::vector<T>& v,
+                                         idx_t m,
+                                         idx_t n = 1) const
         {
-            static constexpr Layout layout = (matrix_t::IsRowMajor)
-                ? Layout::RowMajor
-                : Layout::ColMajor;
-        };
+            assert(m >= 0 && n >= 0);
+            v.resize(0);
+            return matrix_t(m, n);
+        }
 
-        /// Layout for Eigen::Block
-        template<class XprType, int BlockRows, int BlockCols, bool InnerPanel>
-        struct LayoutImpl< Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>, int >
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n,
+                                         Workspace& rW) const
         {
-            static constexpr Layout layout = tlapack::layout<XprType>;
-        };
+            assert(m >= 0 && n >= 0);
 
-        /// Layout for const Eigen::Block
-        template<class XprType, int BlockRows, int BlockCols, bool InnerPanel>
-        struct LayoutImpl< const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>, int >
-        {
-            static constexpr Layout layout = tlapack::layout<XprType>;
-        };
-
-        /// Layout for Eigen::Map
-        template<class PlainObjectType, int MapOptions, class StrideType>
-        struct LayoutImpl< Eigen::Map<PlainObjectType,MapOptions,StrideType>, int >
-        {
-            static constexpr Layout layout = tlapack::layout<PlainObjectType>;
-        };
-
-        /// Layout for const Eigen::Map
-        template<class PlainObjectType, int MapOptions, class StrideType>
-        struct LayoutImpl< const Eigen::Map<PlainObjectType,MapOptions,StrideType>, int >
-        {
-            static constexpr Layout layout = tlapack::layout<PlainObjectType>;
-        };
-
-        /// Implementation of AllowOptBLASImpl for Eigen datatypes
-        template< class matrix_t >
-        struct AllowOptBLASImpl< matrix_t, typename std::enable_if< is_eigen_dense<matrix_t>, int >::type >
-        {
-            static constexpr bool value = allow_optblas<typename matrix_t::Scalar>;
-        };
-
-        /// Transpose for Eigen::Matrix
-        template< class matrix_t >
-        struct TransposeTypeImpl< matrix_t, typename std::enable_if<
-            is_eigen_matrix<matrix_t>
-        ,int>::type >
-        {
-            using type = Eigen::Matrix<
-                typename matrix_t::Scalar,
-                matrix_t::ColsAtCompileTime,
-                matrix_t::RowsAtCompileTime, 
-                (matrix_t::IsRowMajor) ? Eigen::RowMajor : Eigen::ColMajor,
-                matrix_t::MaxColsAtCompileTime,
-                matrix_t::MaxRowsAtCompileTime
-            >;
-        };
-
-        /// Create Eigen::Matrix, @see Create
-        template<typename U>
-        struct CreateImpl< U, typename std::enable_if< is_eigen_dense<U> ,int>::type >
-        {
-            using T = typename U::Scalar;
-            static constexpr int Rows_ = (U::RowsAtCompileTime == 1) ? 1 : Eigen::Dynamic;
-            static constexpr int Cols_ = (U::ColsAtCompileTime == 1) ? 1 : Eigen::Dynamic;
-            static constexpr int Options_ = (U::IsRowMajor) ? Eigen::RowMajor : Eigen::ColMajor;
-
-            using matrix_t  = Eigen::Matrix< T, Rows_, Cols_, Options_ >;
-            using idx_t     = Eigen::Index;
-            using map_t     = Eigen::Map< matrix_t, Eigen::Unaligned, Eigen::OuterStride<> >;
-
-            inline constexpr auto
-            operator()( std::vector<T>& v, idx_t m, idx_t n = 1 ) const {
-                assert( m >= 0 && n >= 0 );
-                v.resize(0);
-                return matrix_t( m, n );
+            if (matrix_t::IsRowMajor) {
+                rW = W.extract(n * sizeof(T), m);
+                return map_t(
+                    (T*)W.data(), m, n,
+                    Eigen::OuterStride<>(
+                        (W.isContiguous()) ? n : W.getLdim() / sizeof(T)));
             }
-
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n, Workspace& rW ) const {
-            
-                assert( m >= 0 && n >= 0 );
-
-                if( matrix_t::IsRowMajor )
-                {
-                    rW = W.extract( n*sizeof(T), m );
-                    return map_t( (T*) W.data(), m, n, Eigen::OuterStride<>(
-                                    (W.isContiguous()) ? n : W.getLdim()/sizeof(T)
-                                ) );
-                }
-                else
-                {
-                    rW = W.extract( m*sizeof(T), n );
-                    return map_t( (T*) W.data(), m, n, Eigen::OuterStride<>(
-                                    (W.isContiguous()) ? m : W.getLdim()/sizeof(T)
-                                ) );
-                }
+            else {
+                rW = W.extract(m * sizeof(T), n);
+                return map_t(
+                    (T*)W.data(), m, n,
+                    Eigen::OuterStride<>(
+                        (W.isContiguous()) ? m : W.getLdim() / sizeof(T)));
             }
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, Workspace& rW ) const {
-                return operator()( W, m, 1, rW );
+        }
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         Workspace& rW) const
+        {
+            return operator()(W, m, 1, rW);
+        }
+
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n = 1) const
+        {
+            assert(m >= 0 && n >= 0);
+
+            if (matrix_t::IsRowMajor) {
+                tlapack_check(W.contains(n * sizeof(T), m));
+                return map_t(
+                    (T*)W.data(), m, n,
+                    Eigen::OuterStride<>(
+                        (W.isContiguous()) ? n : W.getLdim() / sizeof(T)));
             }
-
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n = 1 ) const {
-                
-                assert( m >= 0 && n >= 0 );
-
-                if( matrix_t::IsRowMajor )
-                {
-                    tlapack_check( W.contains( n*sizeof(T), m ) );
-                    return map_t( (T*) W.data(), m, n, Eigen::OuterStride<>(
-                                    (W.isContiguous()) ? n : W.getLdim()/sizeof(T)
-                                ) );
-                }
-                else
-                {
-                    tlapack_check( W.contains( m*sizeof(T), n ) );
-                    return map_t( (T*) W.data(), m, n, Eigen::OuterStride<>(
-                                    (W.isContiguous()) ? m : W.getLdim()/sizeof(T)
-                                ) );
-                }
+            else {
+                tlapack_check(W.contains(m * sizeof(T), n));
+                return map_t(
+                    (T*)W.data(), m, n,
+                    Eigen::OuterStride<>(
+                        (W.isContiguous()) ? m : W.getLdim() / sizeof(T)));
             }
-        };
-    }
+        }
+    };
+}  // namespace internal
 
-    // -----------------------------------------------------------------------------
-    // Data descriptors for Eigen datatypes
+// -----------------------------------------------------------------------------
+// Data descriptors for Eigen datatypes
 
-    // Size
-    template< class Derived
-    #if __cplusplus >= 201703L
-        // Avoids conflict with std::size
-        , std::enable_if_t<
-            !std::is_same_v< complex_type<typename Derived::Scalar>, typename Derived::Scalar >
-        ,int> = 0
-    #endif
+// Size
+template <
+    class Derived
+#if __cplusplus >= 201703L
+    // Avoids conflict with std::size
+    ,
+    std::enable_if_t<!std::is_same_v<complex_type<typename Derived::Scalar>,
+                                     typename Derived::Scalar>,
+                     int> = 0
+#endif
     >
-    inline constexpr auto
-    size( const Eigen::EigenBase<Derived>& x ) {
-        return x.size();
-    }
-    // Number of rows
-    template<class T>
-    inline constexpr auto
-    nrows( const Eigen::EigenBase<T>& x ) {
-        return x.rows();
-    }
-    // Number of columns
-    template<class T>
-    inline constexpr auto
-    ncols( const Eigen::EigenBase<T>& x ) {
-        return x.cols();
-    }
+inline constexpr auto size(const Eigen::EigenBase<Derived>& x)
+{
+    return x.size();
+}
+// Number of rows
+template <class T>
+inline constexpr auto nrows(const Eigen::EigenBase<T>& x)
+{
+    return x.rows();
+}
+// Number of columns
+template <class T>
+inline constexpr auto ncols(const Eigen::EigenBase<T>& x)
+{
+    return x.cols();
+}
 
-    // -----------------------------------------------------------------------------
-    /* 
-     * It is important to separate block operations between: 
-     * 1. Data types that do not derive from Eigen::Block
-     * 2. Data types that derive from Eigen::Block
-     * 
-     * This is done to avoid the creation of classes like:
-     * Block< Block< Block< MaxtrixXd > > >
-     * which would increase the number of template specializations in <T>LAPACK.
-     * 
-     * Moreover, recursive algorithms call themselves using blocks of thier
-     * matrices. This creates a dead lock at compile time if the sizes are
-     * given at runtime, and the compiler cannot deduce where to stop the
-     * recursion for the template specialization.
-     */
+// -----------------------------------------------------------------------------
+/*
+ * It is important to separate block operations between:
+ * 1. Data types that do not derive from Eigen::Block
+ * 2. Data types that derive from Eigen::Block
+ *
+ * This is done to avoid the creation of classes like:
+ * Block< Block< Block< MaxtrixXd > > >
+ * which would increase the number of template specializations in <T>LAPACK.
+ *
+ * Moreover, recursive algorithms call themselves using blocks of thier
+ * matrices. This creates a dead lock at compile time if the sizes are
+ * given at runtime, and the compiler cannot deduce where to stop the
+ * recursion for the template specialization.
+ */
 
-    #define isSlice(SliceSpec) !std::is_convertible< SliceSpec, Eigen::Index >::value
+#define isSlice(SliceSpec) !std::is_convertible<SliceSpec, Eigen::Index>::value
 
-    // Block operations for Eigen::Dense that are not derived from Eigen::Block
+// Block operations for Eigen::Dense that are not derived from Eigen::Block
 
-    template< class T, class SliceSpecRow, class SliceSpecCol, typename std::enable_if<
-        isSlice(SliceSpecRow) && isSlice(SliceSpecCol)
-        && internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto
-    slice( T& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept
-    {
-        return A.block( rows.first, cols.first, rows.second-rows.first, cols.second-cols.first );
-    }
+template <class T,
+          class SliceSpecRow,
+          class SliceSpecCol,
+          typename std::enable_if<
+              isSlice(SliceSpecRow) && isSlice(SliceSpecCol) &&
+                  internal::is_eigen_dense<T> && !internal::is_eigen_block<T>,
+              int>::type = 0>
+inline constexpr auto slice(T& A,
+                            SliceSpecRow&& rows,
+                            SliceSpecCol&& cols) noexcept
+{
+    return A.block(rows.first, cols.first, rows.second - rows.first,
+                   cols.second - cols.first);
+}
 
-    template<class T, typename SliceSpecCol, typename std::enable_if<
-        internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto
-    slice( T& A, Eigen::Index rowIdx, SliceSpecCol&& cols ) noexcept
-    {
-        return A.row( rowIdx ).segment( cols.first, cols.second-cols.first );
-    }
+template <class T,
+          typename SliceSpecCol,
+          typename std::enable_if<internal::is_eigen_dense<T> &&
+                                      !internal::is_eigen_block<T>,
+                                  int>::type = 0>
+inline constexpr auto slice(T& A,
+                            Eigen::Index rowIdx,
+                            SliceSpecCol&& cols) noexcept
+{
+    return A.row(rowIdx).segment(cols.first, cols.second - cols.first);
+}
 
-    template<class T, typename SliceSpecRow, typename std::enable_if<
-        internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto
-    slice( T& A, SliceSpecRow&& rows, Eigen::Index colIdx ) noexcept
-    {
-        return A.col( colIdx ).segment( rows.first, rows.second-rows.first );
-    }
+template <class T,
+          typename SliceSpecRow,
+          typename std::enable_if<internal::is_eigen_dense<T> &&
+                                      !internal::is_eigen_block<T>,
+                                  int>::type = 0>
+inline constexpr auto slice(T& A,
+                            SliceSpecRow&& rows,
+                            Eigen::Index colIdx) noexcept
+{
+    return A.col(colIdx).segment(rows.first, rows.second - rows.first);
+}
 
-    template<class T, typename SliceSpec, typename std::enable_if<
-        internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto
-    slice( T& x, SliceSpec&& range ) noexcept
-    {
-        return x.segment( range.first, range.second-range.first );
-    }
+template <class T,
+          typename SliceSpec,
+          typename std::enable_if<internal::is_eigen_dense<T> &&
+                                      !internal::is_eigen_block<T>,
+                                  int>::type = 0>
+inline constexpr auto slice(T& x, SliceSpec&& range) noexcept
+{
+    return x.segment(range.first, range.second - range.first);
+}
 
-    template<class T, typename SliceSpec, typename std::enable_if<
-        internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto
-    rows( T& A, SliceSpec&& rows ) noexcept
-    {
-        return A.middleRows( rows.first, rows.second-rows.first );
-    }
+template <class T,
+          typename SliceSpec,
+          typename std::enable_if<internal::is_eigen_dense<T> &&
+                                      !internal::is_eigen_block<T>,
+                                  int>::type = 0>
+inline constexpr auto rows(T& A, SliceSpec&& rows) noexcept
+{
+    return A.middleRows(rows.first, rows.second - rows.first);
+}
 
-    template<class T, typename std::enable_if<
-        internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto row( T& A, Eigen::Index rowIdx ) noexcept
-    {
-        return A.row( rowIdx );
-    }
+template <class T,
+          typename std::enable_if<internal::is_eigen_dense<T> &&
+                                      !internal::is_eigen_block<T>,
+                                  int>::type = 0>
+inline constexpr auto row(T& A, Eigen::Index rowIdx) noexcept
+{
+    return A.row(rowIdx);
+}
 
-    template<class T, typename SliceSpec, typename std::enable_if<
-        internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto cols( T& A, SliceSpec&& cols ) noexcept
-    {
-        return A.middleCols( cols.first, cols.second-cols.first );
-    }
+template <class T,
+          typename SliceSpec,
+          typename std::enable_if<internal::is_eigen_dense<T> &&
+                                      !internal::is_eigen_block<T>,
+                                  int>::type = 0>
+inline constexpr auto cols(T& A, SliceSpec&& cols) noexcept
+{
+    return A.middleCols(cols.first, cols.second - cols.first);
+}
 
-    template<class T, typename std::enable_if<
-        internal::is_eigen_dense<T> && !internal::is_eigen_block<T>
-    , int >::type = 0 >
-    inline constexpr auto col( T& A, Eigen::Index colIdx ) noexcept
-    {
-        return A.col( colIdx );
-    }
+template <class T,
+          typename std::enable_if<internal::is_eigen_dense<T> &&
+                                      !internal::is_eigen_block<T>,
+                                  int>::type = 0>
+inline constexpr auto col(T& A, Eigen::Index colIdx) noexcept
+{
+    return A.col(colIdx);
+}
 
-    // Block operations for Eigen::Dense that are derived from Eigen::Block
+// Block operations for Eigen::Dense that are derived from Eigen::Block
 
-    template< class XprType, int BlockRows, int BlockCols, bool InnerPanel, class SliceSpecRow, class SliceSpecCol,
-              typename std::enable_if< isSlice(SliceSpecRow) && isSlice(SliceSpecCol), int >::type = 0 >
-    inline constexpr auto
-    slice( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept
-    {
-        assert( rows.second <= A.rows() );
-        assert( cols.second <= A.cols() );
+template <
+    class XprType,
+    int BlockRows,
+    int BlockCols,
+    bool InnerPanel,
+    class SliceSpecRow,
+    class SliceSpecCol,
+    typename std::enable_if<isSlice(SliceSpecRow) && isSlice(SliceSpecCol),
+                            int>::type = 0>
+inline constexpr auto slice(
+    Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpecRow&& rows,
+    SliceSpecCol&& cols) noexcept
+{
+    assert(rows.second <= A.rows());
+    assert(cols.second <= A.cols());
 
-        return Eigen::Block< XprType, Eigen::Dynamic, Eigen::Dynamic, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rows.first, A.startCol() + cols.first,
-            rows.second-rows.first, cols.second-cols.first );
-    }
+    return Eigen::Block<XprType, Eigen::Dynamic, Eigen::Dynamic, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rows.first,
+        A.startCol() + cols.first, rows.second - rows.first,
+        cols.second - cols.first);
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpecCol>
-    inline constexpr auto
-    slice( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, Eigen::Index rowIdx, SliceSpecCol&& cols ) noexcept
-    {
-        assert( rowIdx < A.rows() );
-        assert( cols.second <= A.cols() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpecCol>
+inline constexpr auto slice(
+    Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    Eigen::Index rowIdx,
+    SliceSpecCol&& cols) noexcept
+{
+    assert(rowIdx < A.rows());
+    assert(cols.second <= A.cols());
 
-        return Eigen::Block< XprType, 1, Eigen::Dynamic, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rowIdx, A.startCol() + cols.first,
-            1, cols.second-cols.first );
-    }
+    return Eigen::Block<XprType, 1, Eigen::Dynamic, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rowIdx, A.startCol() + cols.first,
+        1, cols.second - cols.first);
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpecRow>
-    inline constexpr auto
-    slice( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpecRow&& rows, Eigen::Index colIdx ) noexcept
-    {
-        assert( rows.second <= A.rows() );
-        assert( colIdx < A.cols() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpecRow>
+inline constexpr auto slice(
+    Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpecRow&& rows,
+    Eigen::Index colIdx) noexcept
+{
+    assert(rows.second <= A.rows());
+    assert(colIdx < A.cols());
 
-        return Eigen::Block< XprType, Eigen::Dynamic, 1, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rows.first, A.startCol() + colIdx,
-            rows.second-rows.first, 1 );
-    }
+    return Eigen::Block<XprType, Eigen::Dynamic, 1, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rows.first, A.startCol() + colIdx,
+        rows.second - rows.first, 1);
+}
 
-    template<class XprType, int BlockRows, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    slice( Eigen::Block<XprType,BlockRows,1,InnerPanel>& x, SliceSpec&& range ) noexcept
-    {
-        assert( range.second <= x.size() );
+template <class XprType, int BlockRows, bool InnerPanel, typename SliceSpec>
+inline constexpr auto slice(Eigen::Block<XprType, BlockRows, 1, InnerPanel>& x,
+                            SliceSpec&& range) noexcept
+{
+    assert(range.second <= x.size());
 
-        return Eigen::Block< XprType, Eigen::Dynamic, 1, InnerPanel >
-        (   x.nestedExpression(),
-            x.startRow() + range.first, x.startCol(),
-            range.second-range.first, 1 );
-    }
+    return Eigen::Block<XprType, Eigen::Dynamic, 1, InnerPanel>(
+        x.nestedExpression(), x.startRow() + range.first, x.startCol(),
+        range.second - range.first, 1);
+}
 
-    template<class XprType, int BlockCols, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    slice( Eigen::Block<XprType,1,BlockCols,InnerPanel>& x, SliceSpec&& range ) noexcept
-    {
-        assert( range.second <= x.size() );
+template <class XprType, int BlockCols, bool InnerPanel, typename SliceSpec>
+inline constexpr auto slice(Eigen::Block<XprType, 1, BlockCols, InnerPanel>& x,
+                            SliceSpec&& range) noexcept
+{
+    assert(range.second <= x.size());
 
-        return Eigen::Block< XprType, 1, Eigen::Dynamic, InnerPanel >
-        (   x.nestedExpression(),
-            x.startRow(), x.startCol() + range.first,
-            1, range.second-range.first );
-    }
+    return Eigen::Block<XprType, 1, Eigen::Dynamic, InnerPanel>(
+        x.nestedExpression(), x.startRow(), x.startCol() + range.first, 1,
+        range.second - range.first);
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    rows( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpec&& rows ) noexcept
-    {
-        assert( rows.second <= A.rows() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpec>
+inline constexpr auto rows(
+    Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpec&& rows) noexcept
+{
+    assert(rows.second <= A.rows());
 
-        return Eigen::Block< XprType, Eigen::Dynamic, BlockCols, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rows.first, A.startCol(),
-            rows.second-rows.first, A.cols() );
-    }
+    return Eigen::Block<XprType, Eigen::Dynamic, BlockCols, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rows.first, A.startCol(),
+        rows.second - rows.first, A.cols());
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel>
-    inline constexpr auto
-    row( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, Eigen::Index rowIdx ) noexcept
-    {
-        assert( rowIdx < A.rows() );
+template <class XprType, int BlockRows, int BlockCols, bool InnerPanel>
+inline constexpr auto row(
+    Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    Eigen::Index rowIdx) noexcept
+{
+    assert(rowIdx < A.rows());
 
-        return Eigen::Block< XprType, 1, BlockCols, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rowIdx, A.startCol(),
-            1, A.cols() );
-    }
+    return Eigen::Block<XprType, 1, BlockCols, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rowIdx, A.startCol(), 1, A.cols());
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    cols( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpec&& cols ) noexcept
-    {
-        assert( cols.second <= A.cols() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpec>
+inline constexpr auto cols(
+    Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpec&& cols) noexcept
+{
+    assert(cols.second <= A.cols());
 
-        return Eigen::Block< XprType, BlockRows, Eigen::Dynamic, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow(), A.startCol() + cols.first,
-            A.rows(), cols.second-cols.first );
-    }
+    return Eigen::Block<XprType, BlockRows, Eigen::Dynamic, InnerPanel>(
+        A.nestedExpression(), A.startRow(), A.startCol() + cols.first, A.rows(),
+        cols.second - cols.first);
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel>
-    inline constexpr auto
-    col( Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, Eigen::Index colIdx ) noexcept
-    {
-        assert( colIdx < A.cols() );
+template <class XprType, int BlockRows, int BlockCols, bool InnerPanel>
+inline constexpr auto col(
+    Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    Eigen::Index colIdx) noexcept
+{
+    assert(colIdx < A.cols());
 
-        return Eigen::Block< XprType, BlockRows, 1, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow(), A.startCol() + colIdx,
-            A.rows(), 1 );
-    }
+    return Eigen::Block<XprType, BlockRows, 1, InnerPanel>(
+        A.nestedExpression(), A.startRow(), A.startCol() + colIdx, A.rows(), 1);
+}
 
-    template< class XprType, int BlockRows, int BlockCols, bool InnerPanel, class SliceSpecRow, class SliceSpecCol,
-              typename std::enable_if< isSlice(SliceSpecRow) && isSlice(SliceSpecCol), int >::type = 0 >
-    inline constexpr auto
-    slice( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept
-    {
-        assert( rows.second <= A.rows() );
-        assert( cols.second <= A.cols() );
+template <
+    class XprType,
+    int BlockRows,
+    int BlockCols,
+    bool InnerPanel,
+    class SliceSpecRow,
+    class SliceSpecCol,
+    typename std::enable_if<isSlice(SliceSpecRow) && isSlice(SliceSpecCol),
+                            int>::type = 0>
+inline constexpr auto slice(
+    const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpecRow&& rows,
+    SliceSpecCol&& cols) noexcept
+{
+    assert(rows.second <= A.rows());
+    assert(cols.second <= A.cols());
 
-        return Eigen::Block< const XprType, Eigen::Dynamic, Eigen::Dynamic, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rows.first, A.startCol() + cols.first,
-            rows.second-rows.first, cols.second-cols.first );
-    }
+    return Eigen::Block<const XprType, Eigen::Dynamic, Eigen::Dynamic,
+                        InnerPanel>(
+        A.nestedExpression(), A.startRow() + rows.first,
+        A.startCol() + cols.first, rows.second - rows.first,
+        cols.second - cols.first);
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpecCol>
-    inline constexpr auto
-    slice( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, Eigen::Index rowIdx, SliceSpecCol&& cols ) noexcept
-    {
-        assert( rowIdx < A.rows() );
-        assert( cols.second <= A.cols() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpecCol>
+inline constexpr auto slice(
+    const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    Eigen::Index rowIdx,
+    SliceSpecCol&& cols) noexcept
+{
+    assert(rowIdx < A.rows());
+    assert(cols.second <= A.cols());
 
-        return Eigen::Block< const XprType, 1, Eigen::Dynamic, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rowIdx, A.startCol() + cols.first,
-            1, cols.second-cols.first );
-    }
+    return Eigen::Block<const XprType, 1, Eigen::Dynamic, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rowIdx, A.startCol() + cols.first,
+        1, cols.second - cols.first);
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpecRow>
-    inline constexpr auto
-    slice( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpecRow&& rows, Eigen::Index colIdx ) noexcept
-    {
-        assert( rows.second <= A.rows() );
-        assert( colIdx < A.cols() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpecRow>
+inline constexpr auto slice(
+    const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpecRow&& rows,
+    Eigen::Index colIdx) noexcept
+{
+    assert(rows.second <= A.rows());
+    assert(colIdx < A.cols());
 
-        return Eigen::Block< const XprType, Eigen::Dynamic, 1, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rows.first, A.startCol() + colIdx,
-            rows.second-rows.first, 1 );
-    }
+    return Eigen::Block<const XprType, Eigen::Dynamic, 1, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rows.first, A.startCol() + colIdx,
+        rows.second - rows.first, 1);
+}
 
-    template<class XprType, int BlockRows, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    slice( const Eigen::Block<XprType,BlockRows,1,InnerPanel>& x, SliceSpec&& range ) noexcept
-    {
-        assert( range.second <= x.size() );
+template <class XprType, int BlockRows, bool InnerPanel, typename SliceSpec>
+inline constexpr auto slice(
+    const Eigen::Block<XprType, BlockRows, 1, InnerPanel>& x,
+    SliceSpec&& range) noexcept
+{
+    assert(range.second <= x.size());
 
-        return Eigen::Block< const XprType, Eigen::Dynamic, 1, InnerPanel >
-        (   x.nestedExpression(),
-            x.startRow() + range.first, x.startCol(),
-            range.second-range.first, 1 );
-    }
+    return Eigen::Block<const XprType, Eigen::Dynamic, 1, InnerPanel>(
+        x.nestedExpression(), x.startRow() + range.first, x.startCol(),
+        range.second - range.first, 1);
+}
 
-    template<class XprType, int BlockCols, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    slice( const Eigen::Block<XprType,1,BlockCols,InnerPanel>& x, SliceSpec&& range ) noexcept
-    {
-        assert( range.second <= x.size() );
+template <class XprType, int BlockCols, bool InnerPanel, typename SliceSpec>
+inline constexpr auto slice(
+    const Eigen::Block<XprType, 1, BlockCols, InnerPanel>& x,
+    SliceSpec&& range) noexcept
+{
+    assert(range.second <= x.size());
 
-        return Eigen::Block< const XprType, 1, Eigen::Dynamic, InnerPanel >
-        (   x.nestedExpression(),
-            x.startRow(), x.startCol() + range.first,
-            1, range.second-range.first );
-    }
+    return Eigen::Block<const XprType, 1, Eigen::Dynamic, InnerPanel>(
+        x.nestedExpression(), x.startRow(), x.startCol() + range.first, 1,
+        range.second - range.first);
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    rows( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpec&& rows ) noexcept
-    {
-        assert( rows.second <= A.rows() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpec>
+inline constexpr auto rows(
+    const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpec&& rows) noexcept
+{
+    assert(rows.second <= A.rows());
 
-        return Eigen::Block< const XprType, Eigen::Dynamic, BlockCols, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rows.first, A.startCol(),
-            rows.second-rows.first, A.cols() );
-    }
+    return Eigen::Block<const XprType, Eigen::Dynamic, BlockCols, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rows.first, A.startCol(),
+        rows.second - rows.first, A.cols());
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel>
-    inline constexpr auto
-    row( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, Eigen::Index rowIdx ) noexcept
-    {
-        assert( rowIdx < A.rows() );
+template <class XprType, int BlockRows, int BlockCols, bool InnerPanel>
+inline constexpr auto row(
+    const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    Eigen::Index rowIdx) noexcept
+{
+    assert(rowIdx < A.rows());
 
-        return Eigen::Block< const XprType, 1, BlockCols, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow() + rowIdx, A.startCol(),
-            1, A.cols() );
-    }
+    return Eigen::Block<const XprType, 1, BlockCols, InnerPanel>(
+        A.nestedExpression(), A.startRow() + rowIdx, A.startCol(), 1, A.cols());
+}
 
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel, typename SliceSpec>
-    inline constexpr auto
-    cols( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, SliceSpec&& cols ) noexcept
-    {
-        assert( cols.second <= A.cols() );
+template <class XprType,
+          int BlockRows,
+          int BlockCols,
+          bool InnerPanel,
+          typename SliceSpec>
+inline constexpr auto cols(
+    const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    SliceSpec&& cols) noexcept
+{
+    assert(cols.second <= A.cols());
 
-        return Eigen::Block< const XprType, BlockRows, Eigen::Dynamic, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow(), A.startCol() + cols.first,
-            A.rows(), cols.second-cols.first );
-    }
-    
-    template<class XprType, int BlockRows, int BlockCols, bool InnerPanel>
-    inline constexpr auto
-    col( const Eigen::Block<XprType,BlockRows,BlockCols,InnerPanel>& A, Eigen::Index colIdx ) noexcept
-    {
-        assert( colIdx < A.cols() );
+    return Eigen::Block<const XprType, BlockRows, Eigen::Dynamic, InnerPanel>(
+        A.nestedExpression(), A.startRow(), A.startCol() + cols.first, A.rows(),
+        cols.second - cols.first);
+}
 
-        return Eigen::Block< const XprType, BlockRows, 1, InnerPanel >
-        (   A.nestedExpression(),
-            A.startRow(), A.startCol() + colIdx,
-            A.rows(), 1 );
-    }
+template <class XprType, int BlockRows, int BlockCols, bool InnerPanel>
+inline constexpr auto col(
+    const Eigen::Block<XprType, BlockRows, BlockCols, InnerPanel>& A,
+    Eigen::Index colIdx) noexcept
+{
+    assert(colIdx < A.cols());
 
-    #undef isSlice
+    return Eigen::Block<const XprType, BlockRows, 1, InnerPanel>(
+        A.nestedExpression(), A.startRow(), A.startCol() + colIdx, A.rows(), 1);
+}
 
-    /// Get the Diagonal of an Eigen Matrix
-    template<class T, typename std::enable_if< internal::is_eigen_matrix<T> , int >::type = 0 >
-    inline constexpr auto diag( T& A, int diagIdx = 0 ) noexcept
-    {
-        return A.diagonal( diagIdx );
-    }
+#undef isSlice
 
-    // -----------------------------------------------------------------------------
-    // Deduce matrix and vector type from two provided ones
+/// Get the Diagonal of an Eigen Matrix
+template <class T,
+          typename std::enable_if<internal::is_eigen_matrix<T>, int>::type = 0>
+inline constexpr auto diag(T& A, int diagIdx = 0) noexcept
+{
+    return A.diagonal(diagIdx);
+}
 
-    namespace internal {
+// -----------------------------------------------------------------------------
+// Deduce matrix and vector type from two provided ones
 
-        #ifdef TLAPACK_PREFERRED_MATRIX_EIGEN
+namespace internal {
 
-            #ifndef TLAPACK_LEGACY_HH
-                #ifndef TLAPACK_MDSPAN_HH
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) true
-                #else
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_mdspan_type<T>
-                #endif
-            #else
-                #ifndef TLAPACK_MDSPAN_HH
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_legacy_type<T>
-                #else
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) (!is_legacy_type<T> && !is_mdspan_type<T>)
-                #endif
-            #endif
+#ifdef TLAPACK_PREFERRED_MATRIX_EIGEN
 
-            // for two types
-            // should be especialized for every new matrix class
-            template< typename matrixA_t, typename matrixB_t >
-            struct matrix_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixB_t)
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-
-                static constexpr Layout LA = layout<matrixA_t>;
-                static constexpr Layout LB = layout<matrixB_t>;
-                static constexpr int L =
-                    ((LA == Layout::RowMajor) && (LB == Layout::RowMajor))
-                        ? Eigen::RowMajor
-                        : Eigen::ColMajor;
-
-                using type = Eigen::Matrix< T, Eigen::Dynamic, Eigen::Dynamic, L >;
-            };
-
-            // for two types
-            // should be especialized for every new vector class
-            template< typename vecA_t, typename vecB_t >
-            struct vector_type_traits< vecA_t, vecB_t, typename std::enable_if<
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecA_t) ||
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecB_t)
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<vecA_t>, type_t<vecB_t> >;
-                using type = Eigen::Matrix< T, Eigen::Dynamic, 1 >;
-            };
-
+    #ifndef TLAPACK_LEGACY_HH
+        #ifndef TLAPACK_MDSPAN_HH
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) true
         #else
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_mdspan_type<T>
+        #endif
+    #else
+        #ifndef TLAPACK_MDSPAN_HH
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_legacy_type<T>
+        #else
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) \
+                (!is_legacy_type<T> && !is_mdspan_type<T>)
+        #endif
+    #endif
 
-            template< class matrixA_t, class matrixB_t >
-            struct matrix_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                is_eigen_dense<matrixA_t> && is_eigen_dense<matrixB_t>
-            ,int>::type >
-            {
-                using T = scalar_type< typename matrixA_t::Scalar, typename matrixB_t::Scalar >;
-                static constexpr int Options_ = (matrixA_t::IsRowMajor && matrixB_t::IsRowMajor)
-                    ? Eigen::RowMajor
-                    : Eigen::ColMajor;
+    // for two types
+    // should be especialized for every new matrix class
+    template <typename matrixA_t, typename matrixB_t>
+    struct matrix_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
+                                    TLAPACK_USE_PREFERRED_MATRIX_TYPE(
+                                        matrixB_t),
+                                int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t> >;
 
-                using type = Eigen::Matrix< T, Eigen::Dynamic, Eigen::Dynamic, Options_ >;
-            };
-            
-            template< typename vecA_t, typename vecB_t >
-            struct vector_type_traits< vecA_t, vecB_t, typename std::enable_if<
-                is_eigen_dense<vecA_t> && is_eigen_dense<vecB_t>
-            ,int>::type >
-            {
-                using T = scalar_type< typename vecA_t::Scalar, typename vecB_t::Scalar >;
-                using type = Eigen::Matrix< T, Eigen::Dynamic, 1 >;
-            };
+        static constexpr Layout LA = layout<matrixA_t>;
+        static constexpr Layout LB = layout<matrixB_t>;
+        static constexpr int L =
+            ((LA == Layout::RowMajor) && (LB == Layout::RowMajor))
+                ? Eigen::RowMajor
+                : Eigen::ColMajor;
 
-        #endif // TLAPACK_PREFERRED_MATRIX
-    }
+        using type = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, L>;
+    };
 
-    // -----------------------------------------------------------------------------
-    // Cast to Legacy arrays
+    // for two types
+    // should be especialized for every new vector class
+    template <typename vecA_t, typename vecB_t>
+    struct vector_type_traits<
+        vecA_t,
+        vecB_t,
+        typename std::enable_if<TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecA_t) ||
+                                    TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecB_t),
+                                int>::type> {
+        using T = scalar_type<type_t<vecA_t>, type_t<vecB_t> >;
+        using type = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+    };
 
-    template< class T, int Rows, int Cols, int Options, int MaxRows, int MaxCols >
-    inline constexpr auto
-    legacy_matrix( const Eigen::Matrix< T, Rows, Cols, Options, MaxRows, MaxCols >& A ) noexcept
-    {
-        using matrix_t = Eigen::Matrix< T, Rows, Cols, Options, MaxRows, MaxCols >;
-        using idx_t = Eigen::Index;
-        constexpr Layout L = layout<matrix_t>;
+#else
 
-        return legacyMatrix<T,idx_t,L>( A.rows(), A.cols(), (T*) A.data() );
-    }
+    template <class matrixA_t, class matrixB_t>
+    struct matrix_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<is_eigen_dense<matrixA_t> &&
+                                    is_eigen_dense<matrixB_t>,
+                                int>::type> {
+        using T =
+            scalar_type<typename matrixA_t::Scalar, typename matrixB_t::Scalar>;
+        static constexpr int Options_ =
+            (matrixA_t::IsRowMajor && matrixB_t::IsRowMajor) ? Eigen::RowMajor
+                                                             : Eigen::ColMajor;
 
-    template< class Derived >
-    inline constexpr auto
-    legacy_matrix( const Eigen::MapBase<Derived,Eigen::ReadOnlyAccessors>& A ) noexcept
-    {
-        using T = typename Derived::Scalar;
-        using idx_t = Eigen::Index;
-        constexpr Layout L = layout<Derived>;
-        assert( A.innerStride() == 1 || A.innerSize() <= 1 || A.outerStride() == 1 || A.outerSize() <= 1 );
+        using type = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Options_>;
+    };
 
-        return legacyMatrix<T,idx_t,L>( A.rows(), A.cols(), (T*) A.data(), A.outerStride() );
-    }
+    template <typename vecA_t, typename vecB_t>
+    struct vector_type_traits<
+        vecA_t,
+        vecB_t,
+        typename std::enable_if<is_eigen_dense<vecA_t> &&
+                                    is_eigen_dense<vecB_t>,
+                                int>::type> {
+        using T = scalar_type<typename vecA_t::Scalar, typename vecB_t::Scalar>;
+        using type = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+    };
 
-    template< class T, int Rows, int Cols, int Options, int MaxRows, int MaxCols >
-    inline constexpr auto
-    legacy_vector( const Eigen::Matrix< T, Rows, Cols, Options, MaxRows, MaxCols >& A ) noexcept
-    {
-        using idx_t = Eigen::Index;
-        assert( A.innerSize() <= 1 || A.outerSize() <= 1 );
-        
-        return legacyVector<T,idx_t,idx_t>( A.size(), (T*) A.data(),
-            (A.outerSize() == 1) ? A.innerStride() : A.outerStride() );
-    }
+#endif  // TLAPACK_PREFERRED_MATRIX
+}  // namespace internal
 
-    template< class Derived >
-    inline constexpr auto
-    legacy_vector( const Eigen::MapBase<Derived,Eigen::ReadOnlyAccessors>& A ) noexcept
-    {
-        using T = typename Derived::Scalar;
-        using idx_t = Eigen::Index;
-        assert( A.innerSize() <= 1 || A.outerSize() <= 1 );
+// -----------------------------------------------------------------------------
+// Cast to Legacy arrays
 
-        return legacyVector<T,idx_t,idx_t>( A.size(), (T*) A.data(),
-            (A.outerSize() == 1) ? A.innerStride() : A.outerStride() );
-    }
+template <class T, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+inline constexpr auto legacy_matrix(
+    const Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>& A) noexcept
+{
+    using matrix_t = Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>;
+    using idx_t = Eigen::Index;
+    constexpr Layout L = layout<matrix_t>;
 
-    template< class T, int Rows, int MaxRows, int MaxCols >
-    inline constexpr auto
-    legacy_vector( const Eigen::Matrix< T, Rows, 1, Eigen::ColMajor, MaxRows, MaxCols >& A ) noexcept
-    {
-        using idx_t = Eigen::Index;
-        return legacyVector<T,idx_t>( A.innerSize(), (T*) A.data() );
-    }
+    return legacyMatrix<T, idx_t, L>(A.rows(), A.cols(), (T*)A.data());
+}
 
-    template< class T, int Cols, int MaxRows, int MaxCols >
-    inline constexpr auto
-    legacy_vector( const Eigen::Matrix< T, 1, Cols, Eigen::RowMajor, MaxRows, MaxCols >& A ) noexcept
-    {
-        using idx_t = Eigen::Index;
-        return legacyVector<T,idx_t>( A.innerSize(), (T*) A.data() );
-    }
+template <class Derived>
+inline constexpr auto legacy_matrix(
+    const Eigen::MapBase<Derived, Eigen::ReadOnlyAccessors>& A) noexcept
+{
+    using T = typename Derived::Scalar;
+    using idx_t = Eigen::Index;
+    constexpr Layout L = layout<Derived>;
+    assert(A.innerStride() == 1 || A.innerSize() <= 1 || A.outerStride() == 1 ||
+           A.outerSize() <= 1);
 
-} // namespace tlapack
+    return legacyMatrix<T, idx_t, L>(A.rows(), A.cols(), (T*)A.data(),
+                                     A.outerStride());
+}
 
-#endif // TLAPACK_EIGEN_HH
+template <class T, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+inline constexpr auto legacy_vector(
+    const Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>& A) noexcept
+{
+    using idx_t = Eigen::Index;
+    assert(A.innerSize() <= 1 || A.outerSize() <= 1);
+
+    return legacyVector<T, idx_t, idx_t>(
+        A.size(), (T*)A.data(),
+        (A.outerSize() == 1) ? A.innerStride() : A.outerStride());
+}
+
+template <class Derived>
+inline constexpr auto legacy_vector(
+    const Eigen::MapBase<Derived, Eigen::ReadOnlyAccessors>& A) noexcept
+{
+    using T = typename Derived::Scalar;
+    using idx_t = Eigen::Index;
+    assert(A.innerSize() <= 1 || A.outerSize() <= 1);
+
+    return legacyVector<T, idx_t, idx_t>(
+        A.size(), (T*)A.data(),
+        (A.outerSize() == 1) ? A.innerStride() : A.outerStride());
+}
+
+template <class T, int Rows, int MaxRows, int MaxCols>
+inline constexpr auto legacy_vector(
+    const Eigen::Matrix<T, Rows, 1, Eigen::ColMajor, MaxRows, MaxCols>&
+        A) noexcept
+{
+    using idx_t = Eigen::Index;
+    return legacyVector<T, idx_t>(A.innerSize(), (T*)A.data());
+}
+
+template <class T, int Cols, int MaxRows, int MaxCols>
+inline constexpr auto legacy_vector(
+    const Eigen::Matrix<T, 1, Cols, Eigen::RowMajor, MaxRows, MaxCols>&
+        A) noexcept
+{
+    using idx_t = Eigen::Index;
+    return legacyVector<T, idx_t>(A.innerSize(), (T*)A.data());
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_EIGEN_HH

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -12,424 +12,483 @@
 
 #include <cassert>
 
-#include "tlapack/base/legacyArray.hpp"
 #include "tlapack/base/arrayTraits.hpp"
+#include "tlapack/base/legacyArray.hpp"
 #include "tlapack/base/workspace.hpp"
 
 namespace tlapack {
 
-    // -----------------------------------------------------------------------------
-    // Helpers
+// -----------------------------------------------------------------------------
+// Helpers
 
-    namespace internal
-    {
-        template< typename T, class idx_t, Layout L >
-        std::true_type is_legacy_type_f(const legacyMatrix<T,idx_t,L> *);
+namespace internal {
+    template <typename T, class idx_t, Layout L>
+    std::true_type is_legacy_type_f(const legacyMatrix<T, idx_t, L>*);
 
-        template< typename T, class idx_t, class int_t, Direction D >
-        std::true_type is_legacy_type_f(const legacyVector<T,idx_t,int_t,D> *);
+    template <typename T, class idx_t, class int_t, Direction D>
+    std::true_type is_legacy_type_f(const legacyVector<T, idx_t, int_t, D>*);
 
-        std::false_type is_legacy_type_f(const void *);
-    }
+    std::false_type is_legacy_type_f(const void*);
+}  // namespace internal
 
-    /// True if T is a legacy array
-    /// @see https://stackoverflow.com/a/25223400/5253097
-    template<class T>
-    constexpr bool is_legacy_type = decltype(internal::is_legacy_type_f(std::declval<T*>()))::value;
+/// True if T is a legacy array
+/// @see https://stackoverflow.com/a/25223400/5253097
+template <class T>
+constexpr bool is_legacy_type =
+    decltype(internal::is_legacy_type_f(std::declval<T*>()))::value;
 
-    // -----------------------------------------------------------------------------
-    // Data traits
+// -----------------------------------------------------------------------------
+// Data traits
 
-    namespace internal
-    {
-        /// Layout for legacyMatrix
-        template< typename T, class idx_t, Layout L >
-        struct LayoutImpl< legacyMatrix<T,idx_t,L>, int > {
-            static constexpr Layout layout = L;
-        };
+namespace internal {
+    /// Layout for legacyMatrix
+    template <typename T, class idx_t, Layout L>
+    struct LayoutImpl<legacyMatrix<T, idx_t, L>, int> {
+        static constexpr Layout layout = L;
+    };
 
-        /// Layout for legacyBandedMatrix
-        template< typename T, class idx_t >
-        struct LayoutImpl< legacyBandedMatrix<T,idx_t>, int > {
-            static constexpr Layout layout = Layout::BandStorage;
-        };
+    /// Layout for legacyBandedMatrix
+    template <typename T, class idx_t>
+    struct LayoutImpl<legacyBandedMatrix<T, idx_t>, int> {
+        static constexpr Layout layout = Layout::BandStorage;
+    };
 
-        /// Implementation of AllowOptBLASImpl for legacy datatypes
-        template< typename T, class idx_t, Layout L >
-        struct AllowOptBLASImpl< legacyMatrix<T,idx_t,L>, int >
+    /// Implementation of AllowOptBLASImpl for legacy datatypes
+    template <typename T, class idx_t, Layout L>
+    struct AllowOptBLASImpl<legacyMatrix<T, idx_t, L>, int> {
+        static constexpr bool value = allow_optblas<T>;
+    };
+    template <typename T, class idx_t, class int_t, Direction D>
+    struct AllowOptBLASImpl<legacyVector<T, idx_t, int_t, D>, int> {
+        static constexpr bool value = allow_optblas<T>;
+    };
+
+    /// Transpose type for legacyMatrix
+    template <class T, class idx_t>
+    struct TransposeTypeImpl<legacyMatrix<T, idx_t, Layout::ColMajor>, int> {
+        using type = legacyMatrix<T, idx_t, Layout::RowMajor>;
+    };
+    template <class T, class idx_t>
+    struct TransposeTypeImpl<legacyMatrix<T, idx_t, Layout::RowMajor>, int> {
+        using type = legacyMatrix<T, idx_t, Layout::ColMajor>;
+    };
+
+    /// Create legacyMatrix @see Create
+    template <class T, class idx_t, Layout layout>
+    struct CreateImpl<legacyMatrix<T, idx_t, layout>, int> {
+        using matrix_t = legacyMatrix<T, idx_t, layout>;
+
+        inline constexpr auto operator()(std::vector<T>& v,
+                                         idx_t m,
+                                         idx_t n) const
         {
-            static constexpr bool value = allow_optblas<T>;
-        };
-        template< typename T, class idx_t, class int_t, Direction D >
-        struct AllowOptBLASImpl< legacyVector<T,idx_t,int_t,D>, int >
+            assert(m >= 0 && n >= 0);
+            v.resize(m * n);  // Allocates space in memory
+            return matrix_t(m, n, v.data());
+        }
+
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n,
+                                         Workspace& rW) const
         {
-            static constexpr bool value = allow_optblas<T>;
-        };
+            assert(m >= 0 && n >= 0);
+            rW = (layout == Layout::ColMajor) ? W.extract(m * sizeof(T), n)
+                                              : W.extract(n * sizeof(T), m);
+            return (W.isContiguous())
+                       ? matrix_t(m, n,
+                                  (T*)W.data())  // contiguous space in memory
+                       : matrix_t(m, n, (T*)W.data(), W.getLdim() / sizeof(T));
+        }
 
-        /// Transpose type for legacyMatrix
-        template< class T, class idx_t >
-        struct TransposeTypeImpl< legacyMatrix<T,idx_t,Layout::ColMajor>, int > {
-            using type = legacyMatrix<T,idx_t,Layout::RowMajor>;
-        };
-        template< class T, class idx_t >
-        struct TransposeTypeImpl< legacyMatrix<T,idx_t,Layout::RowMajor>, int > {
-            using type = legacyMatrix<T,idx_t,Layout::ColMajor>;
-        };
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n) const
+        {
+            assert(m >= 0 && n >= 0);
+            tlapack_check((layout == Layout::ColMajor)
+                              ? W.contains(m * sizeof(T), n)
+                              : W.contains(n * sizeof(T), m));
+            return (W.isContiguous())
+                       ? matrix_t(m, n,
+                                  (T*)W.data())  // contiguous space in memory
+                       : matrix_t(m, n, (T*)W.data(), W.getLdim() / sizeof(T));
+        }
+    };
 
-        /// Create legacyMatrix @see Create 
-        template< class T, class idx_t, Layout layout >
-        struct CreateImpl< legacyMatrix<T,idx_t,layout>, int > {
+    /// Create legacyVector @see Create
+    template <class T, class idx_t, typename int_t, Direction D>
+    struct CreateImpl<legacyVector<T, idx_t, int_t, D>, int> {
+        using vector_t = legacyVector<T, idx_t, int_t, D>;
 
-            using matrix_t = legacyMatrix<T,idx_t,layout>;
+        inline constexpr auto operator()(std::vector<T>& v, idx_t m) const
+        {
+            assert(m >= 0);
+            v.resize(m);  // Allocates space in memory
+            return vector_t(m, v.data());
+        }
 
-            inline constexpr auto
-            operator()( std::vector<T>& v, idx_t m, idx_t n ) const {
-                assert( m >= 0 && n >= 0 );
-                v.resize( m*n ); // Allocates space in memory
-                return matrix_t( m, n, v.data() );
-            }
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         Workspace& rW) const
+        {
+            assert(m >= 0);
+            rW = W.extract(sizeof(T), m);
+            return (W.isContiguous())
+                       ? vector_t(m,
+                                  (T*)W.data())  // contiguous space in memory
+                       : vector_t(m, (T*)W.data(), W.getLdim() / sizeof(T));
+        }
 
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n, Workspace& rW ) const
-            {
-                assert( m >= 0 && n >= 0 );
-                rW = ( layout == Layout::ColMajor ) ? W.extract( m*sizeof(T), n )
-                                                    : W.extract( n*sizeof(T), m );
-                return ( W.isContiguous() )
-                    ? matrix_t( m, n, (T*) W.data() ) // contiguous space in memory
-                    : matrix_t( m, n, (T*) W.data(), W.getLdim()/sizeof(T) );
-            }
+        inline constexpr auto operator()(const Workspace& W, idx_t m) const
+        {
+            assert(m >= 0);
+            tlapack_check(W.contains(sizeof(T), m));
+            return (W.isContiguous())
+                       ? vector_t(m,
+                                  (T*)W.data())  // contiguous space in memory
+                       : vector_t(m, (T*)W.data(), W.getLdim() / sizeof(T));
+        }
+    };
+}  // namespace internal
 
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n ) const
-            {
-                assert( m >= 0 && n >= 0 );
-                tlapack_check( ( layout == Layout::ColMajor ) ? W.contains( m*sizeof(T), n )
-                                                              : W.contains( n*sizeof(T), m ) );
-                return ( W.isContiguous() )
-                    ? matrix_t( m, n, (T*) W.data() ) // contiguous space in memory
-                    : matrix_t( m, n, (T*) W.data(), W.getLdim()/sizeof(T) );
-            }
-        };
+// -----------------------------------------------------------------------------
+// Data descriptors
 
-        /// Create legacyVector @see Create
-        template< class T, class idx_t, typename int_t, Direction D >
-        struct CreateImpl< legacyVector<T,idx_t,int_t,D>, int > {
+// Number of rows of legacyMatrix
+template <typename T, class idx_t, Layout layout>
+inline constexpr auto nrows(const legacyMatrix<T, idx_t, layout>& A)
+{
+    return A.m;
+}
 
-            using vector_t = legacyVector<T,idx_t,int_t,D>;
+// Number of columns of legacyMatrix
+template <typename T, class idx_t, Layout layout>
+inline constexpr auto ncols(const legacyMatrix<T, idx_t, layout>& A)
+{
+    return A.n;
+}
 
-            inline constexpr auto
-            operator()( std::vector<T>& v, idx_t m ) const {
-                assert( m >= 0 );
-                v.resize( m ); // Allocates space in memory
-                return vector_t( m, v.data() );
-            }
+// Size of legacyVector
+template <typename T, class idx_t, typename int_t, Direction direction>
+inline constexpr auto size(const legacyVector<T, idx_t, int_t, direction>& x)
+{
+    return x.n;
+}
 
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, Workspace& rW ) const
-            {
-                assert( m >= 0 );
-                rW = W.extract( sizeof(T), m );
-                return ( W.isContiguous() )
-                    ? vector_t( m, (T*) W.data() ) // contiguous space in memory
-                    : vector_t( m, (T*) W.data(), W.getLdim()/sizeof(T) );
-            }
+// Number of rows of legacyBandedMatrix
+template <typename T, class idx_t>
+inline constexpr auto nrows(const legacyBandedMatrix<T, idx_t>& A)
+{
+    return A.m;
+}
 
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m ) const
-            {
-                assert( m >= 0 );
-                tlapack_check( W.contains( sizeof(T), m ) );
-                return ( W.isContiguous() )
-                    ? vector_t( m, (T*) W.data() ) // contiguous space in memory
-                    : vector_t( m, (T*) W.data(), W.getLdim()/sizeof(T) );
-            }
-        };
-    }
+// Number of columns of legacyBandedMatrix
+template <typename T, class idx_t>
+inline constexpr auto ncols(const legacyBandedMatrix<T, idx_t>& A)
+{
+    return A.n;
+}
 
-    // -----------------------------------------------------------------------------
-    // Data descriptors
+// Lowerband of legacyBandedMatrix
+template <typename T, class idx_t>
+inline constexpr auto lowerband(const legacyBandedMatrix<T, idx_t>& A)
+{
+    return A.kl;
+}
 
-    // Number of rows of legacyMatrix
-    template< typename T, class idx_t, Layout layout >
-    inline constexpr auto
-    nrows( const legacyMatrix<T,idx_t,layout>& A ){ return A.m; }
+// Upperband of legacyBandedMatrix
+template <typename T, class idx_t>
+inline constexpr auto upperband(const legacyBandedMatrix<T, idx_t>& A)
+{
+    return A.ku;
+}
 
-    // Number of columns of legacyMatrix
-    template< typename T, class idx_t, Layout layout >
-    inline constexpr auto
-    ncols( const legacyMatrix<T,idx_t,layout>& A ){ return A.n; }
+// -----------------------------------------------------------------------------
+// Block operations
 
-    // Size of legacyVector
-    template< typename T, class idx_t, typename int_t, Direction direction >
-    inline constexpr auto
-    size( const legacyVector<T,idx_t,int_t,direction>& x ){ return x.n; }
+#define isSlice(SliceSpec) !std::is_convertible<SliceSpec, idx_t>::value
 
-    // Number of rows of legacyBandedMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    nrows( const legacyBandedMatrix<T,idx_t>& A ){ return A.m; }
+// Slice legacyMatrix
+template <
+    typename T,
+    class idx_t,
+    Layout layout,
+    class SliceSpecRow,
+    class SliceSpecCol,
+    typename std::enable_if<isSlice(SliceSpecRow) && isSlice(SliceSpecCol),
+                            int>::type = 0>
+inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
+                            SliceSpecRow&& rows,
+                            SliceSpecCol&& cols) noexcept
+{
+    assert(rows.first >= 0 and (idx_t) rows.first < nrows(A));
+    assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
+    assert(rows.first <= rows.second);
+    assert(cols.first >= 0 and (idx_t) cols.first < ncols(A));
+    assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
+    assert(cols.first <= cols.second);
+    return legacyMatrix<T, idx_t, layout>(rows.second - rows.first,
+                                          cols.second - cols.first,
+                                          &A(rows.first, cols.first), A.ldim);
+}
 
-    // Number of columns of legacyBandedMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    ncols( const legacyBandedMatrix<T,idx_t>& A ){ return A.n; }
+#undef isSlice
 
-    // Lowerband of legacyBandedMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    lowerband( const legacyBandedMatrix<T,idx_t>& A ){ return A.kl; }
+// Slice legacyMatrix over a single row
+template <typename T, class idx_t, Layout layout, class SliceSpecCol>
+inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
+                            size_type<legacyMatrix<T, idx_t, layout>> rowIdx,
+                            SliceSpecCol&& cols) noexcept
+{
+    assert(cols.first >= 0 and (idx_t) cols.first < ncols(A));
+    assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
+    assert(cols.first <= cols.second);
+    assert(rowIdx >= 0 and rowIdx < nrows(A));
+    return legacyVector<T, idx_t, idx_t>(
+        cols.second - cols.first, &A(rowIdx, cols.first),
+        layout == Layout::ColMajor ? A.ldim : 1);
+}
 
-    // Upperband of legacyBandedMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    upperband( const legacyBandedMatrix<T,idx_t>& A ){ return A.ku; }
+// Slice legacyMatrix over a single column
+template <typename T, class idx_t, Layout layout, class SliceSpecRow>
+inline constexpr auto slice(
+    const legacyMatrix<T, idx_t, layout>& A,
+    SliceSpecRow&& rows,
+    size_type<legacyMatrix<T, idx_t, layout>> colIdx) noexcept
+{
+    assert(rows.first >= 0 and (idx_t) rows.first < nrows(A));
+    assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
+    assert(rows.first <= rows.second);
+    assert(colIdx >= 0 and colIdx < ncols(A));
+    return legacyVector<T, idx_t, idx_t>(
+        rows.second - rows.first, &A(rows.first, colIdx),
+        layout == Layout::RowMajor ? A.ldim : 1);
+}
 
-    // -----------------------------------------------------------------------------
-    // Block operations
+// Get rows of legacyMatrix
+template <typename T, class idx_t, Layout layout, class SliceSpec>
+inline constexpr auto rows(const legacyMatrix<T, idx_t, layout>& A,
+                           SliceSpec&& rows) noexcept
+{
+    assert(rows.first >= 0 and (idx_t) rows.first < nrows(A));
+    assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
+    assert(rows.first <= rows.second);
+    return legacyMatrix<T, idx_t, layout>(rows.second - rows.first, A.n,
+                                          &A(rows.first, 0), A.ldim);
+}
 
-    #define isSlice(SliceSpec) !std::is_convertible< SliceSpec, idx_t >::value
-    
-    // Slice legacyMatrix
-    template< typename T, class idx_t, Layout layout, class SliceSpecRow, class SliceSpecCol,
-        typename std::enable_if< isSlice(SliceSpecRow) && isSlice(SliceSpecCol), int >::type = 0
-    >
-    inline constexpr auto
-    slice( const legacyMatrix<T,idx_t,layout>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept {
-        assert( rows.first >= 0 and (idx_t) rows.first < nrows(A));
-        assert( rows.second >= 0 and (idx_t) rows.second <= nrows(A));
-        assert( rows.first <= rows.second );
-        assert( cols.first >= 0 and (idx_t) cols.first < ncols(A));
-        assert( cols.second >= 0 and (idx_t) cols.second <= ncols(A));
-        assert( cols.first <= cols.second );
-        return legacyMatrix<T,idx_t,layout>(
-            rows.second-rows.first, cols.second-cols.first,
-            &A(rows.first,cols.first), A.ldim
-        );
-    }
+// Get a row of a column-major legacyMatrix
+template <typename T, class idx_t>
+inline constexpr auto row(const legacyMatrix<T, idx_t>& A,
+                          size_type<legacyMatrix<T, idx_t>> rowIdx) noexcept
+{
+    assert(rowIdx >= 0 and rowIdx < nrows(A));
+    return legacyVector<T, idx_t, idx_t>(A.n, &A(rowIdx, 0), A.ldim);
+}
 
-    #undef isSlice
-    
-    // Slice legacyMatrix over a single row
-    template< typename T, class idx_t, Layout layout, class SliceSpecCol >
-    inline constexpr auto
-    slice( const legacyMatrix<T,idx_t,layout>& A, size_type<legacyMatrix<T,idx_t,layout>> rowIdx, SliceSpecCol&& cols ) noexcept {
-        assert( cols.first >= 0 and (idx_t) cols.first < ncols(A));
-        assert( cols.second >= 0 and (idx_t) cols.second <= ncols(A));
-        assert( cols.first <= cols.second );
-        assert( rowIdx >= 0 and rowIdx < nrows(A));
-        return legacyVector<T,idx_t,idx_t>( cols.second-cols.first, &A(rowIdx,cols.first), layout == Layout::ColMajor ? A.ldim : 1 );
-    }
-    
-    // Slice legacyMatrix over a single column
-    template< typename T, class idx_t, Layout layout, class SliceSpecRow >
-    inline constexpr auto
-    slice( const legacyMatrix<T,idx_t,layout>& A, SliceSpecRow&& rows, size_type<legacyMatrix<T,idx_t,layout>> colIdx ) noexcept {
-        assert( rows.first >= 0 and (idx_t) rows.first < nrows(A));
-        assert( rows.second >= 0 and (idx_t) rows.second <= nrows(A));
-        assert( rows.first <= rows.second );
-        assert( colIdx >= 0 and colIdx < ncols(A));
-        return legacyVector<T,idx_t,idx_t>( rows.second-rows.first, &A(rows.first,colIdx), layout == Layout::RowMajor ? A.ldim : 1 );
-    }
-    
-    // Get rows of legacyMatrix
-    template< typename T, class idx_t, Layout layout, class SliceSpec >
-    inline constexpr auto
-    rows( const legacyMatrix<T,idx_t,layout>& A, SliceSpec&& rows ) noexcept {
-        assert( rows.first >= 0 and (idx_t) rows.first < nrows(A));
-        assert( rows.second >= 0 and (idx_t) rows.second <= nrows(A));
-        assert( rows.first <= rows.second );
-        return legacyMatrix<T,idx_t,layout>(
-            rows.second-rows.first, A.n,
-            &A(rows.first,0), A.ldim
-        );
-    }
-    
-    // Get a row of a column-major legacyMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    row( const legacyMatrix<T,idx_t>& A, size_type<legacyMatrix<T,idx_t>> rowIdx ) noexcept {
-        assert( rowIdx >= 0 and rowIdx < nrows(A));
-        return legacyVector<T,idx_t,idx_t>( A.n, &A(rowIdx,0), A.ldim );
-    }
-    
-    // Get a row of a row-major legacyMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    row( const legacyMatrix<T,idx_t,Layout::RowMajor>& A, size_type<legacyMatrix<T,idx_t,Layout::RowMajor>> rowIdx ) noexcept {
-        assert( rowIdx >= 0 and rowIdx < nrows(A));
-        return legacyVector<T,idx_t>( A.n, &A(rowIdx,0) );
-    }
-    
-    // Get columns of legacyMatrix
-    template< typename T, class idx_t, Layout layout, class SliceSpec >
-    inline constexpr auto
-    cols( const legacyMatrix<T,idx_t,layout>& A, SliceSpec&& cols ) noexcept {
-        assert( cols.first >= 0 and (idx_t) cols.first < ncols(A));
-        assert( cols.second >= 0 and (idx_t) cols.second <= ncols(A));
-        return legacyMatrix<T,idx_t,layout>(
-            A.m, cols.second-cols.first,
-            &A(0,cols.first), A.ldim
-        );
-    }
-    
-    // Get a column of a column-major legacyMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    col( const legacyMatrix<T,idx_t>& A, size_type<legacyMatrix<T,idx_t>> colIdx ) noexcept {
-        assert( colIdx >= 0 and colIdx < ncols(A));
-        return legacyVector<T,idx_t>( A.m, &A(0,colIdx) );
-    }
-    
-    // Get a column of a row-major legacyMatrix
-    template< typename T, class idx_t >
-    inline constexpr auto
-    col( const legacyMatrix<T,idx_t,Layout::RowMajor>& A, size_type<legacyMatrix<T,idx_t,Layout::RowMajor>> colIdx ) noexcept {
-        assert( colIdx >= 0 and colIdx < ncols(A));
-        return legacyVector<T,idx_t,idx_t>( A.m, &A(0,colIdx), A.ldim );
-    }
+// Get a row of a row-major legacyMatrix
+template <typename T, class idx_t>
+inline constexpr auto row(
+    const legacyMatrix<T, idx_t, Layout::RowMajor>& A,
+    size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> rowIdx) noexcept
+{
+    assert(rowIdx >= 0 and rowIdx < nrows(A));
+    return legacyVector<T, idx_t>(A.n, &A(rowIdx, 0));
+}
 
-    // Diagonal of a legacyMatrix
-    template< typename T, class idx_t, Layout layout >
-    inline constexpr auto
-    diag( const legacyMatrix<T,idx_t,layout>& A, int diagIdx = 0 ) noexcept {
-        
-        T* ptr  = (diagIdx >= 0) ? &A(0,diagIdx) : &A(-diagIdx,0);
-        idx_t n = (diagIdx >= 0)
-                    ? std::min( A.m+diagIdx, A.n ) - (idx_t) diagIdx
-                    : std::min( A.m, A.n-diagIdx ) + (idx_t) diagIdx;
-        
-        return legacyVector<T,idx_t,idx_t>( n, ptr, A.ldim + 1 );
-    }
+// Get columns of legacyMatrix
+template <typename T, class idx_t, Layout layout, class SliceSpec>
+inline constexpr auto cols(const legacyMatrix<T, idx_t, layout>& A,
+                           SliceSpec&& cols) noexcept
+{
+    assert(cols.first >= 0 and (idx_t) cols.first < ncols(A));
+    assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
+    return legacyMatrix<T, idx_t, layout>(A.m, cols.second - cols.first,
+                                          &A(0, cols.first), A.ldim);
+}
 
-    // slice legacyVector
-    template< typename T, class idx_t, typename int_t, Direction direction, class SliceSpec >
-    inline constexpr auto
-    slice( const legacyVector<T,idx_t,int_t,direction>& v, SliceSpec&& rows ) noexcept {
-        assert( rows.first >= 0 and (idx_t) rows.first < size(v));
-        assert( rows.second >= 0 and (idx_t) rows.second <= size(v));
-        return legacyVector<T,idx_t,int_t,direction>( rows.second-rows.first, &v[rows.first], v.inc );
-    }
+// Get a column of a column-major legacyMatrix
+template <typename T, class idx_t>
+inline constexpr auto col(const legacyMatrix<T, idx_t>& A,
+                          size_type<legacyMatrix<T, idx_t>> colIdx) noexcept
+{
+    assert(colIdx >= 0 and colIdx < ncols(A));
+    return legacyVector<T, idx_t>(A.m, &A(0, colIdx));
+}
 
-    // -----------------------------------------------------------------------------
-    // Deduce matrix and vector type from two provided ones
+// Get a column of a row-major legacyMatrix
+template <typename T, class idx_t>
+inline constexpr auto col(
+    const legacyMatrix<T, idx_t, Layout::RowMajor>& A,
+    size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> colIdx) noexcept
+{
+    assert(colIdx >= 0 and colIdx < ncols(A));
+    return legacyVector<T, idx_t, idx_t>(A.m, &A(0, colIdx), A.ldim);
+}
 
-    namespace internal {
+// Diagonal of a legacyMatrix
+template <typename T, class idx_t, Layout layout>
+inline constexpr auto diag(const legacyMatrix<T, idx_t, layout>& A,
+                           int diagIdx = 0) noexcept
+{
+    T* ptr = (diagIdx >= 0) ? &A(0, diagIdx) : &A(-diagIdx, 0);
+    idx_t n = (diagIdx >= 0) ? std::min(A.m + diagIdx, A.n) - (idx_t)diagIdx
+                             : std::min(A.m, A.n - diagIdx) + (idx_t)diagIdx;
 
-        #ifdef TLAPACK_PREFERRED_MATRIX_LEGACY
+    return legacyVector<T, idx_t, idx_t>(n, ptr, A.ldim + 1);
+}
 
-            #ifndef TLAPACK_EIGEN_HH
-                #ifndef TLAPACK_MDSPAN_HH
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) true
-                #else
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_mdspan_type<T>
-                #endif
-            #else
-                #ifndef TLAPACK_MDSPAN_HH
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_eigen_type<T>
-                #else
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) (!is_eigen_type<T> && !is_mdspan_type<T>)
-                #endif
-            #endif
+// slice legacyVector
+template <typename T,
+          class idx_t,
+          typename int_t,
+          Direction direction,
+          class SliceSpec>
+inline constexpr auto slice(const legacyVector<T, idx_t, int_t, direction>& v,
+                            SliceSpec&& rows) noexcept
+{
+    assert(rows.first >= 0 and (idx_t) rows.first < size(v));
+    assert(rows.second >= 0 and (idx_t) rows.second <= size(v));
+    return legacyVector<T, idx_t, int_t, direction>(rows.second - rows.first,
+                                                    &v[rows.first], v.inc);
+}
 
-            // for two types
-            // should be especialized for every new matrix class
-            template< class matrixA_t, typename matrixB_t >
-            struct matrix_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixB_t)
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
+// -----------------------------------------------------------------------------
+// Deduce matrix and vector type from two provided ones
 
-                static constexpr Layout LA = layout<matrixA_t>;
-                static constexpr Layout LB = layout<matrixB_t>;
-                static constexpr Layout L  =
-                    ((LA == Layout::RowMajor) && (LB == Layout::RowMajor))
-                        ? Layout::RowMajor
-                        : Layout::ColMajor;
+namespace internal {
 
-                using type = legacyMatrix<T,idx_t,L>;
-            };
+#ifdef TLAPACK_PREFERRED_MATRIX_LEGACY
 
-            // for two types
-            // should be especialized for every new vector class
-            template< typename vecA_t, typename vecB_t >
-            struct vector_type_traits< vecA_t, vecB_t, typename std::enable_if<
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecA_t) ||
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecB_t)
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<vecA_t>, type_t<vecB_t> >;
-                using idx_t = size_type<vecA_t>;
-
-                using type = legacyVector<T,idx_t,idx_t>;
-            };
-
-            #undef TLAPACK_USE_PREFERRED_MATRIX_TYPE
-
+    #ifndef TLAPACK_EIGEN_HH
+        #ifndef TLAPACK_MDSPAN_HH
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) true
         #else
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_mdspan_type<T>
+        #endif
+    #else
+        #ifndef TLAPACK_MDSPAN_HH
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_eigen_type<T>
+        #else
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) \
+                (!is_eigen_type<T> && !is_mdspan_type<T>)
+        #endif
+    #endif
 
-            // for two types
-            // should be especialized for every new matrix class
-            template< class matrixA_t, class matrixB_t >
-            struct matrix_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                is_legacy_type<matrixA_t> && is_legacy_type<matrixB_t>
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
+    // for two types
+    // should be especialized for every new matrix class
+    template <class matrixA_t, typename matrixB_t>
+    struct matrix_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
+                                    TLAPACK_USE_PREFERRED_MATRIX_TYPE(
+                                        matrixB_t),
+                                int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t>>;
+        using idx_t = size_type<matrixA_t>;
 
-                static constexpr Layout LA = layout<matrixA_t>;
-                static constexpr Layout LB = layout<matrixB_t>;
-                static constexpr Layout L  =
-                    ((LA == Layout::RowMajor) && (LB == Layout::RowMajor))
-                        ? Layout::RowMajor
-                        : Layout::ColMajor;
+        static constexpr Layout LA = layout<matrixA_t>;
+        static constexpr Layout LB = layout<matrixB_t>;
+        static constexpr Layout L =
+            ((LA == Layout::RowMajor) && (LB == Layout::RowMajor))
+                ? Layout::RowMajor
+                : Layout::ColMajor;
 
-                using type = legacyMatrix<T,idx_t,L>;
-            };
+        using type = legacyMatrix<T, idx_t, L>;
+    };
 
-            // for two types
-            // should be especialized for every new vector class
-            template< class matrixA_t, class matrixB_t >
-            struct vector_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                is_legacy_type<matrixA_t> && is_legacy_type<matrixB_t>
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
+    // for two types
+    // should be especialized for every new vector class
+    template <typename vecA_t, typename vecB_t>
+    struct vector_type_traits<
+        vecA_t,
+        vecB_t,
+        typename std::enable_if<TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecA_t) ||
+                                    TLAPACK_USE_PREFERRED_MATRIX_TYPE(vecB_t),
+                                int>::type> {
+        using T = scalar_type<type_t<vecA_t>, type_t<vecB_t>>;
+        using idx_t = size_type<vecA_t>;
 
-                using type = legacyVector<T,idx_t,idx_t>;
-            };
+        using type = legacyVector<T, idx_t, idx_t>;
+    };
 
-        #endif // TLAPACK_PREFERRED_MATRIX
-    }
+    #undef TLAPACK_USE_PREFERRED_MATRIX_TYPE
 
-    // -----------------------------------------------------------------------------
-    // Cast to Legacy arrays
+#else
 
-    template< typename T, class idx_t, Layout layout >
-    inline constexpr auto
-    legacy_matrix( const legacyMatrix<T,idx_t,layout>& A ) noexcept { return A; }
+    // for two types
+    // should be especialized for every new matrix class
+    template <class matrixA_t, class matrixB_t>
+    struct matrix_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<is_legacy_type<matrixA_t> &&
+                                    is_legacy_type<matrixB_t>,
+                                int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t>>;
+        using idx_t = size_type<matrixA_t>;
 
-    template< class T, class idx_t, class int_t, Direction direction >
-    inline constexpr auto
-    legacy_matrix( const legacyVector<T,idx_t,int_t,direction>& v ) noexcept {
-        return legacyMatrix<T,idx_t>( 1, v.n, v.ptr, v.inc );
-    }
+        static constexpr Layout LA = layout<matrixA_t>;
+        static constexpr Layout LB = layout<matrixB_t>;
+        static constexpr Layout L =
+            ((LA == Layout::RowMajor) && (LB == Layout::RowMajor))
+                ? Layout::RowMajor
+                : Layout::ColMajor;
 
-    // template< class T, class idx_t, Direction direction >
-    // inline constexpr auto
-    // legacy_matrix( const legacyVector<T,idx_t,internal::StrongOne,direction>& v ) noexcept {
-    //     return legacyMatrix<T,idx_t>( v.n, 1, v.ptr );
-    // }
+        using type = legacyMatrix<T, idx_t, L>;
+    };
 
-    template< typename T, class idx_t, typename int_t, Direction direction >
-    inline constexpr auto
-    legacy_vector( const legacyVector<T,idx_t,int_t,direction>& v ) noexcept { return v; }
+    // for two types
+    // should be especialized for every new vector class
+    template <class matrixA_t, class matrixB_t>
+    struct vector_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<is_legacy_type<matrixA_t> &&
+                                    is_legacy_type<matrixB_t>,
+                                int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t>>;
+        using idx_t = size_type<matrixA_t>;
 
-} // namespace tlapack
+        using type = legacyVector<T, idx_t, idx_t>;
+    };
 
-#endif // TLAPACK_LEGACYARRAY_HH
+#endif  // TLAPACK_PREFERRED_MATRIX
+}  // namespace internal
+
+// -----------------------------------------------------------------------------
+// Cast to Legacy arrays
+
+template <typename T, class idx_t, Layout layout>
+inline constexpr auto legacy_matrix(
+    const legacyMatrix<T, idx_t, layout>& A) noexcept
+{
+    return A;
+}
+
+template <class T, class idx_t, class int_t, Direction direction>
+inline constexpr auto legacy_matrix(
+    const legacyVector<T, idx_t, int_t, direction>& v) noexcept
+{
+    return legacyMatrix<T, idx_t>(1, v.n, v.ptr, v.inc);
+}
+
+// template< class T, class idx_t, Direction direction >
+// inline constexpr auto
+// legacy_matrix( const legacyVector<T,idx_t,internal::StrongOne,direction>& v )
+// noexcept {
+//     return legacyMatrix<T,idx_t>( v.n, 1, v.ptr );
+// }
+
+template <typename T, class idx_t, typename int_t, Direction direction>
+inline constexpr auto legacy_vector(
+    const legacyVector<T, idx_t, int_t, direction>& v) noexcept
+{
+    return v;
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_LEGACYARRAY_HH

--- a/include/tlapack/plugins/mdspan.hpp
+++ b/include/tlapack/plugins/mdspan.hpp
@@ -19,518 +19,617 @@
 
 namespace tlapack {
 
-    // -----------------------------------------------------------------------------
-    // Helpers
+// -----------------------------------------------------------------------------
+// Helpers
 
-    namespace internal
-    {
-        template< class ET, class Exts, class LP, class AP >
-        std::true_type is_mdspan_type_f(const std::experimental::mdspan<ET,Exts,LP,AP> *);
+namespace internal {
+    template <class ET, class Exts, class LP, class AP>
+    std::true_type is_mdspan_type_f(
+        const std::experimental::mdspan<ET, Exts, LP, AP>*);
 
-        std::false_type is_mdspan_type_f(const void *);
-    }
+    std::false_type is_mdspan_type_f(const void*);
+}  // namespace internal
 
-    /// True if T is a mdspan array
-    /// @see https://stackoverflow.com/a/25223400/5253097
-    template<class T>
-    constexpr bool is_mdspan_type = decltype(internal::is_mdspan_type_f(std::declval<T*>()))::value;
+/// True if T is a mdspan array
+/// @see https://stackoverflow.com/a/25223400/5253097
+template <class T>
+constexpr bool is_mdspan_type =
+    decltype(internal::is_mdspan_type_f(std::declval<T*>()))::value;
 
-    // -----------------------------------------------------------------------------
-    // Data traits
+// -----------------------------------------------------------------------------
+// Data traits
 
-    namespace internal
-    {
-        /// Layout for mdspan
-        template< class ET, class Exts, class AP >
-        struct LayoutImpl< std::experimental::mdspan<ET,Exts,std::experimental::layout_left,AP>, int > {
-            static constexpr Layout layout = Layout::ColMajor;
-        };
-        template< class ET, class Exts, class AP >
-        struct LayoutImpl< std::experimental::mdspan<ET,Exts,std::experimental::layout_right,AP>, int > {
-            static constexpr Layout layout = Layout::RowMajor;
-        };
+namespace internal {
+    /// Layout for mdspan
+    template <class ET, class Exts, class AP>
+    struct LayoutImpl<
+        std::experimental::mdspan<ET, Exts, std::experimental::layout_left, AP>,
+        int> {
+        static constexpr Layout layout = Layout::ColMajor;
+    };
+    template <class ET, class Exts, class AP>
+    struct LayoutImpl<std::experimental::
+                          mdspan<ET, Exts, std::experimental::layout_right, AP>,
+                      int> {
+        static constexpr Layout layout = Layout::RowMajor;
+    };
 
-        /// Implementation of AllowOptBLASImpl for mdspan datatypes
-        template< class ET, class Exts, class LP, class AP >
-        struct AllowOptBLASImpl< std::experimental::mdspan<ET,Exts,LP,AP>,
-            std::enable_if_t<
-            /* Requires: */
-                LP::template mapping<Exts>::is_always_strided()
-            , int >
-        >
+    /// Implementation of AllowOptBLASImpl for mdspan datatypes
+    template <class ET, class Exts, class LP, class AP>
+    struct AllowOptBLASImpl<std::experimental::mdspan<ET, Exts, LP, AP>,
+                            std::enable_if_t<
+                                /* Requires: */
+                                LP::template mapping<Exts>::is_always_strided(),
+                                int> > {
+        static constexpr bool value = allow_optblas<ET>;
+    };
+
+    /// Transpose type for legacyMatrix
+    template <class ET, class Exts, class AP>
+    struct TransposeTypeImpl<
+        std::experimental::mdspan<ET, Exts, std::experimental::layout_left, AP>,
+        int> {
+        using type = std::experimental::
+            mdspan<ET, Exts, std::experimental::layout_right, AP>;
+    };
+    template <class ET, class Exts, class AP>
+    struct TransposeTypeImpl<
+        std::experimental::
+            mdspan<ET, Exts, std::experimental::layout_right, AP>,
+        int> {
+        using type = std::experimental::
+            mdspan<ET, Exts, std::experimental::layout_left, AP>;
+    };
+    template <class ET, class Exts, class AP>
+    struct TransposeTypeImpl<
+        std::experimental::
+            mdspan<ET, Exts, std::experimental::layout_stride, AP>,
+        int> {
+        using type = std::experimental::
+            mdspan<ET, Exts, std::experimental::layout_stride, AP>;
+    };
+
+    /// Create mdspan @see Create
+    template <class ET, class Exts, class LP, class AP>
+    struct CreateImpl<std::experimental::mdspan<ET, Exts, LP, AP>,
+                      std::enable_if_t<Exts::rank() == 1, int> > {
+        using idx_t =
+            typename std::experimental::mdspan<ET, Exts, LP>::size_type;
+        using extents_t = std::experimental::dextents<idx_t, 1>;
+
+        inline constexpr auto operator()(std::vector<ET>& v, idx_t m) const
         {
-            static constexpr bool value = allow_optblas<ET>;
-        };
+            assert(m >= 0);
+            v.resize(m);  // Allocates space in memory
+            return std::experimental::mdspan<ET, extents_t>(v.data(), m);
+        }
 
-        /// Transpose type for legacyMatrix
-        template< class ET, class Exts, class AP >
-        struct TransposeTypeImpl< std::experimental::mdspan<ET,Exts,std::experimental::layout_left,AP>, int > {
-            using type = std::experimental::mdspan<ET,Exts,std::experimental::layout_right,AP>;
-        };
-        template< class ET, class Exts, class AP >
-        struct TransposeTypeImpl< std::experimental::mdspan<ET,Exts,std::experimental::layout_right,AP>, int > {
-            using type = std::experimental::mdspan<ET,Exts,std::experimental::layout_left,AP>;
-        };
-        template< class ET, class Exts, class AP >
-        struct TransposeTypeImpl< std::experimental::mdspan<ET,Exts,std::experimental::layout_stride,AP>, int > {
-            using type = std::experimental::mdspan<ET,Exts,std::experimental::layout_stride,AP>;
-        };
-
-        /// Create mdspan @see Create 
-        template< class ET, class Exts, class LP, class AP >
-        struct CreateImpl< std::experimental::mdspan<ET,Exts,LP,AP>, std::enable_if_t< Exts::rank() == 1 ,int> >
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         Workspace& rW) const
         {
-            using idx_t = typename std::experimental::mdspan<ET,Exts,LP>::size_type;
-            using extents_t = std::experimental::dextents<idx_t,1>;
+            using std::array;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<extents_t>;
+            using matrix_t =
+                std::experimental::mdspan<ET, extents_t, layout_stride>;
 
-            inline constexpr auto
-            operator()( std::vector<ET>& v, idx_t m ) const
-            {
-                assert( m >= 0 );
-                v.resize( m ); // Allocates space in memory
-                return std::experimental::mdspan<ET,extents_t>( v.data(), m );
-            }
+            assert(m >= 0);
 
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, Workspace& rW ) const
-            {
-                using std::array;
-                using std::experimental::layout_stride;
-                using mapping   = typename layout_stride::template mapping< extents_t >;
-                using matrix_t  = std::experimental::mdspan<ET,extents_t,layout_stride>;
+            rW = W.extract(sizeof(ET), m);
+            mapping map =
+                (W.isContiguous())
+                    ? mapping(extents_t(m), array<idx_t, 1>{1})
+                    : mapping(extents_t(m),
+                              array<idx_t, 1>{W.getLdim() / sizeof(ET)});
 
-                assert( m >= 0 );
+            return matrix_t((ET*)W.data(), std::move(map));
+        }
 
-                rW = W.extract( sizeof(ET), m );
-                mapping map = ( W.isContiguous() )
-                            ? mapping( extents_t(m), array<idx_t,1>{1} )
-                            : mapping( extents_t(m), array<idx_t,1>{W.getLdim()/sizeof(ET)} );
-
-                return matrix_t( (ET*) W.data(), std::move(map) );
-            }
-
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m ) const
-            {
-                using std::array;
-                using std::experimental::layout_stride;
-                using mapping   = typename layout_stride::template mapping< extents_t >;
-                using matrix_t  = std::experimental::mdspan<ET,extents_t,layout_stride>;
-
-                assert( m >= 0 );
-
-                tlapack_check( W.contains( sizeof(ET), m ) );
-                mapping map = ( W.isContiguous() )
-                            ? mapping( extents_t(m), array<idx_t,1>{1} )
-                            : mapping( extents_t(m), array<idx_t,1>{W.getLdim()/sizeof(ET)} );
-
-                return matrix_t( (ET*) W.data(), std::move(map) );
-            }
-        };
-
-        /// Create mdspan @see Create 
-        template< class ET, class Exts, class LP, class AP >
-        struct CreateImpl< std::experimental::mdspan<ET,Exts,LP,AP>, std::enable_if_t< Exts::rank() == 2 ,int> >
+        inline constexpr auto operator()(const Workspace& W, idx_t m) const
         {
-            using idx_t = typename std::experimental::mdspan<ET,Exts,LP>::size_type;
-            using extents_t = std::experimental::dextents<idx_t,2>;
+            using std::array;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<extents_t>;
+            using matrix_t =
+                std::experimental::mdspan<ET, extents_t, layout_stride>;
 
-            inline constexpr auto
-            operator()( std::vector<ET>& v, idx_t m, idx_t n ) const
-            {
-                assert( m >= 0 && n >= 0 );
-                v.resize( m*n ); // Allocates space in memory
-                return std::experimental::mdspan<ET,extents_t>( v.data(), m, n );
-            }
+            assert(m >= 0);
 
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n, Workspace& rW ) const
-            {
-                using std::array;
-                using std::experimental::layout_stride;
-                using mapping   = typename layout_stride::template mapping< extents_t >;
-                using matrix_t  = std::experimental::mdspan<ET,extents_t,layout_stride>;
+            tlapack_check(W.contains(sizeof(ET), m));
+            mapping map =
+                (W.isContiguous())
+                    ? mapping(extents_t(m), array<idx_t, 1>{1})
+                    : mapping(extents_t(m),
+                              array<idx_t, 1>{W.getLdim() / sizeof(ET)});
 
-                assert( m >= 0 && n >= 0 );
-                
-                // Variables to be forwarded to the returned matrix
-                array<idx_t,2> strides = [&]( Workspace& rW )
-                {
-                    if( W.isContiguous() )
-                    {
-                        rW = W.extract( m*sizeof(ET), n );
-                        return array<idx_t,2>{1,m};
-                    }
-                    else if( W.getM() >= m*sizeof(ET) && W.getN() >= n )
-                    {
-                        rW = W.extract( m*sizeof(ET), n );
-                        return array<idx_t,2>{1,W.getLdim()/sizeof(ET)};
-                    }
-                    else
-                    {
-                        rW = W.extract( n*sizeof(ET), m );
-                        return array<idx_t,2>{W.getLdim()/sizeof(ET),1};
-                    }
-                }(rW);
-                mapping map = mapping( extents_t(m,n), std::move(strides) );
+            return matrix_t((ET*)W.data(), std::move(map));
+        }
+    };
 
-                return matrix_t( (ET*) W.data(), std::move(map) );
-            }
+    /// Create mdspan @see Create
+    template <class ET, class Exts, class LP, class AP>
+    struct CreateImpl<std::experimental::mdspan<ET, Exts, LP, AP>,
+                      std::enable_if_t<Exts::rank() == 2, int> > {
+        using idx_t =
+            typename std::experimental::mdspan<ET, Exts, LP>::size_type;
+        using extents_t = std::experimental::dextents<idx_t, 2>;
 
-            inline constexpr auto
-            operator()( const Workspace& W, idx_t m, idx_t n ) const
-            {
-                using std::array;
-                using std::experimental::layout_stride;
-                using mapping   = typename layout_stride::template mapping< extents_t >;
-                using matrix_t  = std::experimental::mdspan<ET,extents_t,layout_stride,AP>;
+        inline constexpr auto operator()(std::vector<ET>& v,
+                                         idx_t m,
+                                         idx_t n) const
+        {
+            assert(m >= 0 && n >= 0);
+            v.resize(m * n);  // Allocates space in memory
+            return std::experimental::mdspan<ET, extents_t>(v.data(), m, n);
+        }
 
-                assert( m >= 0 && n >= 0 );
-                
-                // Variables to be forwarded to the returned matrix
-                array<idx_t,2> strides = [&]()
-                {
-                    if( W.isContiguous() )
-                    {
-                        tlapack_check( W.contains( m*sizeof(ET), n ) );
-                        return array<idx_t,2>{1,m};
-                    }
-                    else if( W.getM() >= m*sizeof(ET) && W.getN() >= n )
-                    {
-                        tlapack_check( W.contains( m*sizeof(ET), n ) );
-                        return array<idx_t,2>{1,W.getLdim()/sizeof(ET)};
-                    }
-                    else
-                    {
-                        tlapack_check( W.contains( n*sizeof(ET), m ) );
-                        return array<idx_t,2>{W.getLdim()/sizeof(ET),1};
-                    }
-                }();
-                mapping map = mapping( extents_t(m,n), std::move(strides) );
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n,
+                                         Workspace& rW) const
+        {
+            using std::array;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<extents_t>;
+            using matrix_t =
+                std::experimental::mdspan<ET, extents_t, layout_stride>;
 
-                return matrix_t( (ET*) W.data(), std::move(map) );
-            }
-        };
-    }
+            assert(m >= 0 && n >= 0);
 
-    // -----------------------------------------------------------------------------
-    // Data descriptors
+            // Variables to be forwarded to the returned matrix
+            array<idx_t, 2> strides = [&](Workspace& rW) {
+                if (W.isContiguous()) {
+                    rW = W.extract(m * sizeof(ET), n);
+                    return array<idx_t, 2>{1, m};
+                }
+                else if (W.getM() >= m * sizeof(ET) && W.getN() >= n) {
+                    rW = W.extract(m * sizeof(ET), n);
+                    return array<idx_t, 2>{1, W.getLdim() / sizeof(ET)};
+                }
+                else {
+                    rW = W.extract(n * sizeof(ET), m);
+                    return array<idx_t, 2>{W.getLdim() / sizeof(ET), 1};
+                }
+            }(rW);
+            mapping map = mapping(extents_t(m, n), std::move(strides));
 
-    // Size
-    template< class ET, class Exts, class LP, class AP >
-    inline constexpr auto
-    size( const std::experimental::mdspan<ET,Exts,LP,AP>& x ) {
-        return x.size();
-    }
-    // Number of rows
-    template< class ET, class Exts, class LP, class AP >
-    inline constexpr auto
-    nrows( const std::experimental::mdspan<ET,Exts,LP,AP>& x ) {
-        return x.extent(0);
-    }
-    // Number of columns
-    template< class ET, class Exts, class LP, class AP >
-    inline constexpr auto
-    ncols( const std::experimental::mdspan<ET,Exts,LP,AP>& x ) {
-        return x.extent(1);
-    }
+            return matrix_t((ET*)W.data(), std::move(map));
+        }
 
-    // -----------------------------------------------------------------------------
-    // Block operations
+        inline constexpr auto operator()(const Workspace& W,
+                                         idx_t m,
+                                         idx_t n) const
+        {
+            using std::array;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<extents_t>;
+            using matrix_t =
+                std::experimental::mdspan<ET, extents_t, layout_stride, AP>;
 
-    #define isSlice(SliceSpec) std::is_convertible< SliceSpec, std::tuple<std::size_t, std::size_t> >::value
+            assert(m >= 0 && n >= 0);
 
-    // Slice
-    template< class ET, class Exts, class LP, class AP,
-        class SliceSpecRow, class SliceSpecCol,
-        std::enable_if_t< isSlice(SliceSpecRow) || isSlice(SliceSpecCol), int > = 0
-    >
-    inline constexpr auto slice(
-        const std::experimental::mdspan<ET,Exts,LP,AP>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept
-    {
-        return std::experimental::submdspan( A, std::forward<SliceSpecRow>(rows), std::forward<SliceSpecCol>(cols) );
-    }
+            // Variables to be forwarded to the returned matrix
+            array<idx_t, 2> strides = [&]() {
+                if (W.isContiguous()) {
+                    tlapack_check(W.contains(m * sizeof(ET), n));
+                    return array<idx_t, 2>{1, m};
+                }
+                else if (W.getM() >= m * sizeof(ET) && W.getN() >= n) {
+                    tlapack_check(W.contains(m * sizeof(ET), n));
+                    return array<idx_t, 2>{1, W.getLdim() / sizeof(ET)};
+                }
+                else {
+                    tlapack_check(W.contains(n * sizeof(ET), m));
+                    return array<idx_t, 2>{W.getLdim() / sizeof(ET), 1};
+                }
+            }();
+            mapping map = mapping(extents_t(m, n), std::move(strides));
 
-    // Slice
-    template< class ET, class Exts, class LP, class AP,
-        class SliceSpec,
-        std::enable_if_t< isSlice(SliceSpec) && (Exts::rank() == 2), int > = 0
-    >
-    inline constexpr auto slice( const std::experimental::mdspan<ET,Exts,LP,AP>& A, SliceSpec&& rows ) noexcept
-    {
-        return std::experimental::submdspan( A, std::forward<SliceSpec>(rows), 0 );
-    }
+            return matrix_t((ET*)W.data(), std::move(map));
+        }
+    };
+}  // namespace internal
 
-    // Rows
-    template< class ET, class Exts, class LP, class AP, class SliceSpec,
-        std::enable_if_t< isSlice(SliceSpec), int > = 0
-    >
-    inline constexpr auto rows( const std::experimental::mdspan<ET,Exts,LP,AP>& A, SliceSpec&& rows ) noexcept
-    {
-        return std::experimental::submdspan( A, std::forward<SliceSpec>(rows), std::experimental::full_extent );
-    }
+// -----------------------------------------------------------------------------
+// Data descriptors
 
-    // Row
-    template< class ET, class Exts, class LP, class AP >
-    inline constexpr auto row( const std::experimental::mdspan<ET,Exts,LP,AP>& A, std::size_t rowIdx ) noexcept
-    {
-        return std::experimental::submdspan( A, rowIdx, std::experimental::full_extent );
-    }
+// Size
+template <class ET, class Exts, class LP, class AP>
+inline constexpr auto size(const std::experimental::mdspan<ET, Exts, LP, AP>& x)
+{
+    return x.size();
+}
+// Number of rows
+template <class ET, class Exts, class LP, class AP>
+inline constexpr auto nrows(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& x)
+{
+    return x.extent(0);
+}
+// Number of columns
+template <class ET, class Exts, class LP, class AP>
+inline constexpr auto ncols(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& x)
+{
+    return x.extent(1);
+}
 
-    // Columns
-    template< class ET, class Exts, class LP, class AP, class SliceSpec,
-        std::enable_if_t< isSlice(SliceSpec), int > = 0
-    >
-    inline constexpr auto cols( const std::experimental::mdspan<ET,Exts,LP,AP>& A, SliceSpec&& cols ) noexcept
-    {
-        return std::experimental::submdspan( A, std::experimental::full_extent, std::forward<SliceSpec>(cols) );
-    }
+// -----------------------------------------------------------------------------
+// Block operations
 
-    // Column
-    template< class ET, class Exts, class LP, class AP >
-    inline constexpr auto col( const std::experimental::mdspan<ET,Exts,LP,AP>& A, std::size_t colIdx ) noexcept
-    {
-        return std::experimental::submdspan( A, std::experimental::full_extent, colIdx );
-    }
+#define isSlice(SliceSpec) \
+    std::is_convertible<SliceSpec, std::tuple<std::size_t, std::size_t> >::value
 
-    // Slice
-    template< class ET, class Exts, class LP, class AP, class SliceSpec,
-        std::enable_if_t< isSlice(SliceSpec) && (Exts::rank() == 1), int > = 0
-    >
-    inline constexpr auto slice( const std::experimental::mdspan<ET,Exts,LP,AP>& v, SliceSpec&& rows ) noexcept
-    {
-        return std::experimental::submdspan( v, std::forward<SliceSpec>(rows) );
-    }
+// Slice
+template <
+    class ET,
+    class Exts,
+    class LP,
+    class AP,
+    class SliceSpecRow,
+    class SliceSpecCol,
+    std::enable_if_t<isSlice(SliceSpecRow) || isSlice(SliceSpecCol), int> = 0>
+inline constexpr auto slice(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& A,
+    SliceSpecRow&& rows,
+    SliceSpecCol&& cols) noexcept
+{
+    return std::experimental::submdspan(A, std::forward<SliceSpecRow>(rows),
+                                        std::forward<SliceSpecCol>(cols));
+}
 
-    // Extract a diagonal from a matrix
-    template< class ET, class Exts, class LP, class AP,
-        std::enable_if_t<
-        /* Requires: */
-            LP::template mapping<Exts>::is_always_strided()
-        , bool > = true
-    >
-    inline constexpr auto diag(
-        const std::experimental::mdspan<ET,Exts,LP,AP>& A,
-        int diagIdx = 0 )
-    {
-        using std::abs;
-        using std::min;
-        using std::array;
-        using std::experimental::layout_stride;
+// Slice
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          class SliceSpec,
+          std::enable_if_t<isSlice(SliceSpec) && (Exts::rank() == 2), int> = 0>
+inline constexpr auto slice(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& A,
+    SliceSpec&& rows) noexcept
+{
+    return std::experimental::submdspan(A, std::forward<SliceSpec>(rows), 0);
+}
 
-        using size_type = typename std::experimental::mdspan<ET,Exts,LP,AP>::size_type;
-        using extents_t = std::experimental::dextents<size_type,1>;
-        using mapping   = typename layout_stride::template mapping< extents_t >;
-        
-        // mdspan components
-        auto ptr = A.accessor().offset( &A(0,0),
+// Rows
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          class SliceSpec,
+          std::enable_if_t<isSlice(SliceSpec), int> = 0>
+inline constexpr auto rows(const std::experimental::mdspan<ET, Exts, LP, AP>& A,
+                           SliceSpec&& rows) noexcept
+{
+    return std::experimental::submdspan(A, std::forward<SliceSpec>(rows),
+                                        std::experimental::full_extent);
+}
+
+// Row
+template <class ET, class Exts, class LP, class AP>
+inline constexpr auto row(const std::experimental::mdspan<ET, Exts, LP, AP>& A,
+                          std::size_t rowIdx) noexcept
+{
+    return std::experimental::submdspan(A, rowIdx,
+                                        std::experimental::full_extent);
+}
+
+// Columns
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          class SliceSpec,
+          std::enable_if_t<isSlice(SliceSpec), int> = 0>
+inline constexpr auto cols(const std::experimental::mdspan<ET, Exts, LP, AP>& A,
+                           SliceSpec&& cols) noexcept
+{
+    return std::experimental::submdspan(A, std::experimental::full_extent,
+                                        std::forward<SliceSpec>(cols));
+}
+
+// Column
+template <class ET, class Exts, class LP, class AP>
+inline constexpr auto col(const std::experimental::mdspan<ET, Exts, LP, AP>& A,
+                          std::size_t colIdx) noexcept
+{
+    return std::experimental::submdspan(A, std::experimental::full_extent,
+                                        colIdx);
+}
+
+// Slice
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          class SliceSpec,
+          std::enable_if_t<isSlice(SliceSpec) && (Exts::rank() == 1), int> = 0>
+inline constexpr auto slice(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& v,
+    SliceSpec&& rows) noexcept
+{
+    return std::experimental::submdspan(v, std::forward<SliceSpec>(rows));
+}
+
+// Extract a diagonal from a matrix
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          std::enable_if_t<
+              /* Requires: */
+              LP::template mapping<Exts>::is_always_strided(),
+              bool> = true>
+inline constexpr auto diag(const std::experimental::mdspan<ET, Exts, LP, AP>& A,
+                           int diagIdx = 0)
+{
+    using std::abs;
+    using std::array;
+    using std::min;
+    using std::experimental::layout_stride;
+
+    using size_type =
+        typename std::experimental::mdspan<ET, Exts, LP, AP>::size_type;
+    using extents_t = std::experimental::dextents<size_type, 1>;
+    using mapping = typename layout_stride::template mapping<extents_t>;
+
+    // mdspan components
+    auto ptr = A.accessor().offset(&A(0, 0), (diagIdx >= 0)
+                                                 ? A.mapping()(0, diagIdx)
+                                                 : A.mapping()(-diagIdx, 0));
+    auto map = mapping(
+        extents_t(
             (diagIdx >= 0)
-                ? A.mapping()(0,diagIdx)
-                : A.mapping()(-diagIdx,0)
-        );
-        auto map = mapping(
-            extents_t( (diagIdx >= 0)
-                ? min( A.extent(0)+diagIdx, A.extent(1) ) - (size_type) diagIdx
-                : min( A.extent(0), A.extent(1)-diagIdx ) + (size_type) diagIdx
-            ),
-            array<size_type, 1>{ A.stride(0) + A.stride(1) }
-        );
-        auto acc_pol = typename AP::offset_policy(A.accessor());
+                ? min(A.extent(0) + diagIdx, A.extent(1)) - (size_type)diagIdx
+                : min(A.extent(0), A.extent(1) - diagIdx) + (size_type)diagIdx),
+        array<size_type, 1>{A.stride(0) + A.stride(1)});
+    auto acc_pol = typename AP::offset_policy(A.accessor());
 
-        // return
-        return std::experimental::mdspan< ET, extents_t, layout_stride, AP > (
-            std::move(ptr), std::move(map), std::move(acc_pol)
-        );
-    }
+    // return
+    return std::experimental::mdspan<ET, extents_t, layout_stride, AP>(
+        std::move(ptr), std::move(map), std::move(acc_pol));
+}
 
-    #undef isSlice
+#undef isSlice
 
-    // -----------------------------------------------------------------------------
-    // Deduce matrix and vector type from two provided ones
+// -----------------------------------------------------------------------------
+// Deduce matrix and vector type from two provided ones
 
-    namespace internal {
+namespace internal {
 
-        #ifdef TLAPACK_PREFERRED_MATRIX_MDSPAN
+#ifdef TLAPACK_PREFERRED_MATRIX_MDSPAN
 
-            #ifndef TLAPACK_EIGEN_HH
-                #ifndef TLAPACK_LEGACYARRAY_HH
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) true
-                #else
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_legacy_type<T>
-                #endif
-            #else
-                #ifndef TLAPACK_LEGACYARRAY_HH
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_eigen_type<T>
-                #else
-                    #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) (!is_eigen_type<T> && !is_legacy_type<T>)
-                #endif
-            #endif
-
-            // for two types
-            // should be especialized for every new matrix class
-            template< class matrixA_t, typename matrixB_t >
-            struct matrix_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixB_t)
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
-                using extents_t = std::experimental::dextents<idx_t,2>;
-
-                using type = std::experimental::mdspan<T,extents_t,std::experimental::layout_stride>;
-            };
-
-            // for two types
-            // should be especialized for every new vector class
-            template< class matrixA_t, typename matrixB_t >
-            struct vector_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
-                TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixB_t)
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
-                using extents_t = std::experimental::dextents<idx_t,1>;
-
-                using type = std::experimental::mdspan<T,extents_t,std::experimental::layout_stride>;
-            };
-
-            #undef TLAPACK_USE_PREFERRED_MATRIX_TYPE
-
+    #ifndef TLAPACK_EIGEN_HH
+        #ifndef TLAPACK_LEGACYARRAY_HH
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) true
         #else
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_legacy_type<T>
+        #endif
+    #else
+        #ifndef TLAPACK_LEGACYARRAY_HH
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) !is_eigen_type<T>
+        #else
+            #define TLAPACK_USE_PREFERRED_MATRIX_TYPE(T) \
+                (!is_eigen_type<T> && !is_legacy_type<T>)
+        #endif
+    #endif
 
-            // for two types
-            // should be especialized for every new matrix class
-            template< class matrixA_t, class matrixB_t >
-            struct matrix_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
-                std::is_same<typename matrixA_t::layout_type, typename matrixB_t::layout_type>::value
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
-                using extents_t = std::experimental::dextents<idx_t,2>;
+    // for two types
+    // should be especialized for every new matrix class
+    template <class matrixA_t, typename matrixB_t>
+    struct matrix_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
+                                    TLAPACK_USE_PREFERRED_MATRIX_TYPE(
+                                        matrixB_t),
+                                int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t> >;
+        using idx_t = size_type<matrixA_t>;
+        using extents_t = std::experimental::dextents<idx_t, 2>;
 
-                using type = std::experimental::mdspan<T,extents_t,typename matrixA_t::layout_type>;
-            };
-            template< class matrixA_t, class matrixB_t >
-            struct matrix_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
-                !std::is_same<typename matrixA_t::layout_type, typename matrixB_t::layout_type>::value
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
-                using extents_t = std::experimental::dextents<idx_t,2>;
+        using type = std::experimental::
+            mdspan<T, extents_t, std::experimental::layout_stride>;
+    };
 
-                using type = std::experimental::mdspan<T,extents_t,std::experimental::layout_stride>;
-            };
+    // for two types
+    // should be especialized for every new vector class
+    template <class matrixA_t, typename matrixB_t>
+    struct vector_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<TLAPACK_USE_PREFERRED_MATRIX_TYPE(matrixA_t) ||
+                                    TLAPACK_USE_PREFERRED_MATRIX_TYPE(
+                                        matrixB_t),
+                                int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t> >;
+        using idx_t = size_type<matrixA_t>;
+        using extents_t = std::experimental::dextents<idx_t, 1>;
 
-            // for two types
-            // should be especialized for every new vector class
-            template< class matrixA_t, class matrixB_t >
-            struct vector_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
-                std::is_same<typename matrixA_t::layout_type, typename matrixB_t::layout_type>::value
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
-                using extents_t = std::experimental::dextents<idx_t,1>;
+        using type = std::experimental::
+            mdspan<T, extents_t, std::experimental::layout_stride>;
+    };
 
-                using type = std::experimental::mdspan<T,extents_t,typename matrixA_t::layout_type>;
-            };
+    #undef TLAPACK_USE_PREFERRED_MATRIX_TYPE
 
-            // for two types
-            // should be especialized for every new vector class
-            template< class matrixA_t, class matrixB_t >
-            struct vector_type_traits< matrixA_t, matrixB_t, typename std::enable_if<
-                is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
-                !std::is_same<typename matrixA_t::layout_type, typename matrixB_t::layout_type>::value
-            ,int>::type >
-            {
-                using T = scalar_type< type_t<matrixA_t>, type_t<matrixB_t> >;
-                using idx_t = size_type<matrixA_t>;
-                using extents_t = std::experimental::dextents<idx_t,1>;
+#else
 
-                using type = std::experimental::mdspan<T,extents_t,std::experimental::layout_stride>;
-            };
+    // for two types
+    // should be especialized for every new matrix class
+    template <class matrixA_t, class matrixB_t>
+    struct matrix_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<
+            is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
+                std::is_same<typename matrixA_t::layout_type,
+                             typename matrixB_t::layout_type>::value,
+            int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t> >;
+        using idx_t = size_type<matrixA_t>;
+        using extents_t = std::experimental::dextents<idx_t, 2>;
 
-        #endif // TLAPACK_PREFERRED_MATRIX
-    }
+        using type = std::experimental::
+            mdspan<T, extents_t, typename matrixA_t::layout_type>;
+    };
+    template <class matrixA_t, class matrixB_t>
+    struct matrix_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<
+            is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
+                !std::is_same<typename matrixA_t::layout_type,
+                              typename matrixB_t::layout_type>::value,
+            int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t> >;
+        using idx_t = size_type<matrixA_t>;
+        using extents_t = std::experimental::dextents<idx_t, 2>;
 
-    // -----------------------------------------------------------------------------
-    // Cast to Legacy arrays
+        using type = std::experimental::
+            mdspan<T, extents_t, std::experimental::layout_stride>;
+    };
 
-    template< class ET, class Exts, class LP, class AP, std::enable_if_t<
-        Exts::rank() == 2 &&
-        (   std::is_same<LP,std::experimental::layout_left>::value ||
-            std::is_same<LP,std::experimental::layout_right>::value )
-    ,int> = 0 >
-    inline constexpr auto
-    legacy_matrix( const std::experimental::mdspan<ET,Exts,LP,AP>& A ) noexcept
-    {
-        using idx_t = typename std::experimental::mdspan<ET,Exts,LP,AP>::size_type;
-        constexpr Layout L = layout< std::experimental::mdspan<ET,Exts,LP,AP> >;
-        assert( A.stride(0) == 1 || A.extent(0) <= 1 || A.stride(1) == 1 || A.extent(1) <= 1 );
+    // for two types
+    // should be especialized for every new vector class
+    template <class matrixA_t, class matrixB_t>
+    struct vector_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<
+            is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
+                std::is_same<typename matrixA_t::layout_type,
+                             typename matrixB_t::layout_type>::value,
+            int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t> >;
+        using idx_t = size_type<matrixA_t>;
+        using extents_t = std::experimental::dextents<idx_t, 1>;
 
-        return legacyMatrix<ET,idx_t,L>( A.extent(0), A.extent(1), &A(0,0) );
-    }
+        using type = std::experimental::
+            mdspan<T, extents_t, typename matrixA_t::layout_type>;
+    };
 
-    template< class ET, class Exts, class LP, class AP, std::enable_if_t<
-        Exts::rank() == 2 &&
-        LP::template mapping<Exts>::is_always_strided() &&
-        !(  std::is_same<LP,std::experimental::layout_left>::value ||
-            std::is_same<LP,std::experimental::layout_right>::value )
-    ,int> = 0 >
-    inline constexpr auto
-    legacy_matrix( const std::experimental::mdspan<ET,Exts,LP,AP>& A ) noexcept
-    {
-        using idx_t = typename std::experimental::mdspan<ET,Exts,LP,AP>::size_type;
-        constexpr Layout L = Layout::ColMajor;
-        assert( A.stride(0) == 1 || A.extent(1) <= 1 || A.stride(1) == 1 || A.extent(0) <= 1 );
+    // for two types
+    // should be especialized for every new vector class
+    template <class matrixA_t, class matrixB_t>
+    struct vector_type_traits<
+        matrixA_t,
+        matrixB_t,
+        typename std::enable_if<
+            is_mdspan_type<matrixA_t> && is_mdspan_type<matrixB_t> &&
+                !std::is_same<typename matrixA_t::layout_type,
+                              typename matrixB_t::layout_type>::value,
+            int>::type> {
+        using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t> >;
+        using idx_t = size_type<matrixA_t>;
+        using extents_t = std::experimental::dextents<idx_t, 1>;
 
-        if( A.stride(0) == 1 || A.extent(1) <= 1 )
-            return legacyMatrix<ET,idx_t,L>( A.extent(0), A.extent(1), &A(0,0), A.stride(1) );
-        else
-            return legacyMatrix<ET,idx_t,L>( A.extent(1), A.extent(0), &A(0,0), A.stride(0) );
-    }
+        using type = std::experimental::
+            mdspan<T, extents_t, std::experimental::layout_stride>;
+    };
 
-    template< class ET, class Exts, class LP, class AP, std::enable_if_t<
-        Exts::rank() == 1
-    ,int> = 0 >
-    inline constexpr auto
-    legacy_matrix( const std::experimental::mdspan<ET,Exts,LP,AP>& A ) noexcept
-    {
-        using idx_t = typename std::experimental::mdspan<ET,Exts,LP,AP>::size_type;
-        return legacyMatrix<ET,idx_t>( 1, A.extent(0), &A[0], A.stride(0) );
-    }
+#endif  // TLAPACK_PREFERRED_MATRIX
+}  // namespace internal
 
-    template< class ET, class Exts, class LP, class AP, std::enable_if_t<
-        Exts::rank() == 1 && 
-        (   std::is_same<LP,std::experimental::layout_left>::value ||
-            std::is_same<LP,std::experimental::layout_right>::value )
-    ,int> = 0 >
-    inline constexpr auto
-    legacy_vector( const std::experimental::mdspan<ET,Exts,LP,AP>& A ) noexcept
-    {
-        using idx_t = typename std::experimental::mdspan<ET,Exts,LP,AP>::size_type;
-        return legacyVector<ET,idx_t,internal::StrongOne>( A.extent(0), &A[0] );
-    }
+// -----------------------------------------------------------------------------
+// Cast to Legacy arrays
 
-    template< class ET, class Exts, class LP, class AP, std::enable_if_t<
-        Exts::rank() == 1 && 
-        !(  std::is_same<LP,std::experimental::layout_left>::value ||
-            std::is_same<LP,std::experimental::layout_right>::value )
-    ,int> = 0 >
-    inline constexpr auto
-    legacy_vector( const std::experimental::mdspan<ET,Exts,LP,AP>& A ) noexcept
-    {
-        using idx_t = typename std::experimental::mdspan<ET,Exts,LP,AP>::size_type;
-        return legacyVector<ET,idx_t,idx_t>( A.extent(0), &A[0], A.stride(0) );
-    }
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          std::enable_if_t<
+              Exts::rank() == 2 &&
+                  (std::is_same<LP, std::experimental::layout_left>::value ||
+                   std::is_same<LP, std::experimental::layout_right>::value),
+              int> = 0>
+inline constexpr auto legacy_matrix(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& A) noexcept
+{
+    using idx_t =
+        typename std::experimental::mdspan<ET, Exts, LP, AP>::size_type;
+    constexpr Layout L = layout<std::experimental::mdspan<ET, Exts, LP, AP> >;
+    assert(A.stride(0) == 1 || A.extent(0) <= 1 || A.stride(1) == 1 ||
+           A.extent(1) <= 1);
 
-} // namespace tlapack
+    return legacyMatrix<ET, idx_t, L>(A.extent(0), A.extent(1), &A(0, 0));
+}
 
-#endif // TLAPACK_MDSPAN_HH
+template <
+    class ET,
+    class Exts,
+    class LP,
+    class AP,
+    std::enable_if_t<
+        Exts::rank() == 2 && LP::template mapping<Exts>::is_always_strided() &&
+            !(std::is_same<LP, std::experimental::layout_left>::value ||
+              std::is_same<LP, std::experimental::layout_right>::value),
+        int> = 0>
+inline constexpr auto legacy_matrix(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& A) noexcept
+{
+    using idx_t =
+        typename std::experimental::mdspan<ET, Exts, LP, AP>::size_type;
+    constexpr Layout L = Layout::ColMajor;
+    assert(A.stride(0) == 1 || A.extent(1) <= 1 || A.stride(1) == 1 ||
+           A.extent(0) <= 1);
+
+    if (A.stride(0) == 1 || A.extent(1) <= 1)
+        return legacyMatrix<ET, idx_t, L>(A.extent(0), A.extent(1), &A(0, 0),
+                                          A.stride(1));
+    else
+        return legacyMatrix<ET, idx_t, L>(A.extent(1), A.extent(0), &A(0, 0),
+                                          A.stride(0));
+}
+
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          std::enable_if_t<Exts::rank() == 1, int> = 0>
+inline constexpr auto legacy_matrix(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& A) noexcept
+{
+    using idx_t =
+        typename std::experimental::mdspan<ET, Exts, LP, AP>::size_type;
+    return legacyMatrix<ET, idx_t>(1, A.extent(0), &A[0], A.stride(0));
+}
+
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          std::enable_if_t<
+              Exts::rank() == 1 &&
+                  (std::is_same<LP, std::experimental::layout_left>::value ||
+                   std::is_same<LP, std::experimental::layout_right>::value),
+              int> = 0>
+inline constexpr auto legacy_vector(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& A) noexcept
+{
+    using idx_t =
+        typename std::experimental::mdspan<ET, Exts, LP, AP>::size_type;
+    return legacyVector<ET, idx_t, internal::StrongOne>(A.extent(0), &A[0]);
+}
+
+template <class ET,
+          class Exts,
+          class LP,
+          class AP,
+          std::enable_if_t<
+              Exts::rank() == 1 &&
+                  !(std::is_same<LP, std::experimental::layout_left>::value ||
+                    std::is_same<LP, std::experimental::layout_right>::value),
+              int> = 0>
+inline constexpr auto legacy_vector(
+    const std::experimental::mdspan<ET, Exts, LP, AP>& A) noexcept
+{
+    using idx_t =
+        typename std::experimental::mdspan<ET, Exts, LP, AP>::size_type;
+    return legacyVector<ET, idx_t, idx_t>(A.extent(0), &A[0], A.stride(0));
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_MDSPAN_HH

--- a/include/tlapack/plugins/mpreal.hpp
+++ b/include/tlapack/plugins/mpreal.hpp
@@ -11,56 +11,64 @@
 #define TLAPACK_MPREAL_HH
 
 #include <mpreal.h>
+
 #include <complex>
 
 namespace tlapack {
 
-    // Forward declarations
-    template< typename T > T abs ( const T& x );
-    template< typename T > bool isnan( const std::complex<T>& x );
-    template< typename T > bool isinf( const std::complex<T>& x );
+// Forward declarations
+template <typename T>
+T abs(const T& x);
+template <typename T>
+bool isnan(const std::complex<T>& x);
+template <typename T>
+bool isinf(const std::complex<T>& x);
 
-    /// Absolute value
-    template<>
-    inline mpfr::mpreal abs( const mpfr::mpreal& x ) {
-        return mpfr::abs( x );
-    }
-    
-    /// 2-norm absolute value, sqrt( |Re(x)|^2 + |Im(x)|^2 )
-    ///
-    /// Note that std::abs< std::complex > does not overflow or underflow at
-    /// intermediate stages of the computation.
-    /// @see https://en.cppreference.com/w/cpp/numeric/complex/abs
-    /// but it may not propagate NaNs.
-    ///
-    /// Also, std::abs< mpfr::mpreal > may not propagate Infs.
-    ///
-    inline mpfr::mpreal abs( const std::complex<mpfr::mpreal>& x ) {
-        if( isnan(x) )
-            return std::numeric_limits< mpfr::mpreal >::quiet_NaN();
-        else if( isinf(x) )
-            return std::numeric_limits< mpfr::mpreal >::infinity();
-        else
-            return std::abs( x );
-    }
+/// Absolute value
+template <>
+inline mpfr::mpreal abs(const mpfr::mpreal& x)
+{
+    return mpfr::abs(x);
+}
 
-    // Argument-dependent lookup (ADL) will include the remaining functions,
-    // e.g., mpfr::sin, mpfr::cos.
-    // Including them here may cause ambiguous call of overloaded function.
-    // See: https://en.cppreference.com/w/cpp/language/adl
+/// 2-norm absolute value, sqrt( |Re(x)|^2 + |Im(x)|^2 )
+///
+/// Note that std::abs< std::complex > does not overflow or underflow at
+/// intermediate stages of the computation.
+/// @see https://en.cppreference.com/w/cpp/numeric/complex/abs
+/// but it may not propagate NaNs.
+///
+/// Also, std::abs< mpfr::mpreal > may not propagate Infs.
+///
+inline mpfr::mpreal abs(const std::complex<mpfr::mpreal>& x)
+{
+    if (isnan(x))
+        return std::numeric_limits<mpfr::mpreal>::quiet_NaN();
+    else if (isinf(x))
+        return std::numeric_limits<mpfr::mpreal>::infinity();
+    else
+        return std::abs(x);
+}
 
-    #ifdef MPREAL_HAVE_DYNAMIC_STD_NUMERIC_LIMITS
-        
-        // Forward declaration
-        template< typename real_t > const int digits();
+// Argument-dependent lookup (ADL) will include the remaining functions,
+// e.g., mpfr::sin, mpfr::cos.
+// Including them here may cause ambiguous call of overloaded function.
+// See: https://en.cppreference.com/w/cpp/language/adl
 
-        /// Specialization for the mpfr::mpreal datatype
-        template<>
-        inline const int digits<mpfr::mpreal>() {
-            return std::numeric_limits< mpfr::mpreal >::digits(); 
-        }
-    #endif
+#ifdef MPREAL_HAVE_DYNAMIC_STD_NUMERIC_LIMITS
 
-} // namespace tlapack
+// Forward declaration
+template <typename real_t>
+const int digits();
 
-#endif // TLAPACK_MPREAL_HH
+/// Specialization for the mpfr::mpreal datatype
+template <>
+inline const int digits<mpfr::mpreal>()
+{
+    return std::numeric_limits<mpfr::mpreal>::digits();
+}
+#endif
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_MPREAL_HH

--- a/include/tlapack/plugins/stdvector.hpp
+++ b/include/tlapack/plugins/stdvector.hpp
@@ -11,6 +11,7 @@
 #define TLAPACK_STDVECTOR_HH
 
 #include <vector>
+
 #include "tlapack/base/arrayTraits.hpp"
 #include "tlapack/base/workspace.hpp"
 
@@ -22,32 +23,33 @@
 
 namespace tlapack {
 
-    // -----------------------------------------------------------------------------
-    // blas functions to access std::vector properties
+// -----------------------------------------------------------------------------
+// blas functions to access std::vector properties
 
-    // Size
-    template< class T, class Allocator >
-    inline constexpr auto
-    size( const std::vector<T,Allocator>& x ) {
-        return x.size();
-    }
+// Size
+template <class T, class Allocator>
+inline constexpr auto size(const std::vector<T, Allocator>& x)
+{
+    return x.size();
+}
 
-    // -----------------------------------------------------------------------------
-    // blas functions to access std::vector block operations
+// -----------------------------------------------------------------------------
+// blas functions to access std::vector block operations
 
-    // slice
-    template< class T, class Allocator, class SliceSpec >
-    inline constexpr auto slice( const std::vector<T,Allocator>& v, SliceSpec&& rows )
-    {
-        #ifndef TLAPACK_USE_MDSPAN
-            return legacyVector<T,std::size_t>( rows.second - rows.first, (T*) &v[ rows.first ] );
-        #else
-            return std::experimental::mdspan< T, std::experimental::dextents<1> >(
-                (T*) &v[ rows.first ], (std::size_t) (rows.second - rows.first)
-            );
-        #endif
-    }
+// slice
+template <class T, class Allocator, class SliceSpec>
+inline constexpr auto slice(const std::vector<T, Allocator>& v,
+                            SliceSpec&& rows)
+{
+#ifndef TLAPACK_USE_MDSPAN
+    return legacyVector<T, std::size_t>(rows.second - rows.first,
+                                        (T*)&v[rows.first]);
+#else
+    return std::experimental::mdspan<T, std::experimental::dextents<1> >(
+        (T*)&v[rows.first], (std::size_t)(rows.second - rows.first));
+#endif
+}
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_STDVECTOR_HH
+#endif  // TLAPACK_STDVECTOR_HH

--- a/include/tlapack_cblas.h.in
+++ b/include/tlapack_cblas.h.in
@@ -8,10 +8,12 @@
 #define TLAPACK_CBLAS_H
 
 // -----------------------------------------------------------------------------
-#include <stddef.h>
 #include <complex.h>
+#include <stddef.h>
 
+// clang-format off
 @TLAPACK_CBLAS_DEFINES@
+// clang-format on
 
 // -----------------------------------------------------------------------------
 // Integer types CBLAS_INDEX and CBLAS_INT
@@ -26,1110 +28,567 @@
 // -----------------------------------------------------------------------------
 
 #ifdef __cplusplus
-extern "C" {
+    extern "C"
+{
 #endif
 
-// -----------------------------------------------------------------------------
-// Enumerations
-typedef enum CBLAS_LAYOUT {CblasRowMajor=101, CblasColMajor=102} CBLAS_LAYOUT;
-typedef enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113} CBLAS_TRANSPOSE;
-typedef enum CBLAS_UPLO {CblasUpper=121, CblasLower=122} CBLAS_UPLO;
-typedef enum CBLAS_DIAG {CblasNonUnit=131, CblasUnit=132} CBLAS_DIAG;
-typedef enum CBLAS_SIDE {CblasLeft=141, CblasRight=142} CBLAS_SIDE;
-
-#define CBLAS_ORDER CBLAS_LAYOUT // this for backward compatibility with CBLAS_ORDER
-
-// =============================================================================
-// Level 1 BLAS
-
-float cblas_sasum(
-    CBLAS_INT n,
-    float const * x, CBLAS_INT incx );
-
-double cblas_dasum(
-    CBLAS_INT n,
-    double const * x, CBLAS_INT incx );
-
-float cblas_casum(
-    CBLAS_INT n,
-    float  _Complex const * x, CBLAS_INT incx );
-
-double cblas_zasum(
-    CBLAS_INT n,
-    double _Complex const * x, CBLAS_INT incx );
-
-void cblas_saxpy(
-    CBLAS_INT n,
-    float alpha,
-    float const * x, CBLAS_INT incx,
-    float * y, CBLAS_INT incy );
-
-void cblas_daxpy(
-    CBLAS_INT n,
-    double alpha,
-    double const * x, CBLAS_INT incx,
-    double * y, CBLAS_INT incy );
-
-void cblas_caxpy(
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex * y, CBLAS_INT incy );
-
-void cblas_zaxpy(
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex * y, CBLAS_INT incy );
-
-void cblas_scopy(
-    CBLAS_INT n,
-    float const * x, CBLAS_INT incx,
-    float * y, CBLAS_INT incy );
-
-void cblas_dcopy(
-    CBLAS_INT n,
-    double const * x, CBLAS_INT incx,
-    double * y, CBLAS_INT incy );
-
-void cblas_ccopy(
-    CBLAS_INT n,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex * y, CBLAS_INT incy );
-
-void cblas_zcopy(
-    CBLAS_INT n,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex * y, CBLAS_INT incy );
-
-float cblas_sdot(
-    CBLAS_INT n,
-    float const * x, CBLAS_INT incx,
-    float const * y, CBLAS_INT incy );
-
-double cblas_ddot(
-    CBLAS_INT n,
-    double const * x, CBLAS_INT incx,
-    double const * y, CBLAS_INT incy );
-
-float  _Complex cblas_cdot(
-    CBLAS_INT n,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex const * y, CBLAS_INT incy );
-
-double _Complex cblas_zdot(
-    CBLAS_INT n,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex const * y, CBLAS_INT incy );
-
-float cblas_sdotu(
-    CBLAS_INT n,
-    float const * x, CBLAS_INT incx,
-    float const * y, CBLAS_INT incy );
-
-double cblas_ddotu(
-    CBLAS_INT n,
-    double const * x, CBLAS_INT incx,
-    double const * y, CBLAS_INT incy );
-
-float  _Complex cblas_cdotu(
-    CBLAS_INT n,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex const * y, CBLAS_INT incy );
-
-double _Complex cblas_zdotu(
-    CBLAS_INT n,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex const * y, CBLAS_INT incy );
-
-CBLAS_INDEX cblas_isamax(
-    CBLAS_INT n,
-    float const * x, CBLAS_INT incx );
-
-CBLAS_INDEX cblas_idamax(
-    CBLAS_INT n,
-    double const * x, CBLAS_INT incx );
-
-CBLAS_INDEX cblas_icamax(
-    CBLAS_INT n,
-    float  _Complex const * x, CBLAS_INT incx );
-
-CBLAS_INDEX cblas_izamax(
-    CBLAS_INT n,
-    double _Complex const * x, CBLAS_INT incx );
-
-float cblas_snrm2(
-    CBLAS_INT n,
-    float const * x, CBLAS_INT incx );
-
-double cblas_dnrm2(
-    CBLAS_INT n,
-    double const * x, CBLAS_INT incx );
-
-float cblas_cnrm2(
-    CBLAS_INT n,
-    float  _Complex const * x, CBLAS_INT incx );
-
-double cblas_znrm2(
-    CBLAS_INT n,
-    double _Complex const * x, CBLAS_INT incx );
-
-void cblas_srot(
-    CBLAS_INT n,
-    float * x, CBLAS_INT incx,
-    float * y, CBLAS_INT incy,
-    float c,
-    float s );
-
-void cblas_drot(
-    CBLAS_INT n,
-    double * x, CBLAS_INT incx,
-    double * y, CBLAS_INT incy,
-    double c,
-    double s );
-
-void cblas_csrot(
-    CBLAS_INT n,
-    float  _Complex * x, CBLAS_INT incx,
-    float  _Complex * y, CBLAS_INT incy,
-    float c,
-    float s );
-
-void cblas_zdrot(
-    CBLAS_INT n,
-    double _Complex * x, CBLAS_INT incx,
-    double _Complex * y, CBLAS_INT incy,
-    double c,
-    double s );
-
-void cblas_crot(
-    CBLAS_INT n,
-    float  _Complex * x, CBLAS_INT incx,
-    float  _Complex * y, CBLAS_INT incy,
-    float c,
-    float  _Complex s );
-
-void cblas_zrot(
-    CBLAS_INT n,
-    double _Complex * x, CBLAS_INT incx,
-    double _Complex * y, CBLAS_INT incy,
-    double c,
-    double _Complex s );
-
-void cblas_srotg(
-    float * a,
-    float * b,
-    float * c,
-    float * s );
-
-void cblas_drotg(
-    double * a,
-    double * b,
-    double * c,
-    double * s );
-
-void cblas_crotg(
-    float  _Complex * a,
-    float  _Complex * b,
-    float * c,
-    float  _Complex * s );
-
-void cblas_zrotg(
-    double _Complex * a,
-    double _Complex * b,
-    double * c,
-    double _Complex * s );
-
-void cblas_srotm(
-    CBLAS_INT n,
-    float * x, CBLAS_INT incx,
-    float * y, CBLAS_INT incy,
-    float const * param );
-
-void cblas_drotm(
-    CBLAS_INT n,
-    double * x, CBLAS_INT incx,
-    double * y, CBLAS_INT incy,
-    double const * param );
-
-void cblas_srotmg(
-    float * d1,
-    float * d2,
-    float * a,
-    float b,
-    float * param );
-
-void cblas_drotmg(
-    double * d1,
-    double * d2,
-    double * a,
-    double b,
-    double * param );
-
-void cblas_sscal(
-    CBLAS_INT n,
-    float alpha,
-    float * x, CBLAS_INT incx );
-
-void cblas_dscal(
-    CBLAS_INT n,
-    double alpha,
-    double * x, CBLAS_INT incx );
-
-void cblas_cscal(
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex * x, CBLAS_INT incx );
-
-void cblas_zscal(
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex * x, CBLAS_INT incx );
-
-void cblas_sswap(
-    CBLAS_INT n,
-    float * x, CBLAS_INT incx,
-    float * y, CBLAS_INT incy );
-
-void cblas_dswap(
-    CBLAS_INT n,
-    double * x, CBLAS_INT incx,
-    double * y, CBLAS_INT incy );
-
-void cblas_cswap(
-    CBLAS_INT n,
-    float  _Complex * x, CBLAS_INT incx,
-    float  _Complex * y, CBLAS_INT incy );
-
-void cblas_zswap(
-    CBLAS_INT n,
-    double _Complex * x, CBLAS_INT incx,
-    double _Complex * y, CBLAS_INT incy );
-
-// =============================================================================
-// Level 2 BLAS
-
-void cblas_sgemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * x, CBLAS_INT incx,
-    float beta,
-    float * y, CBLAS_INT incy );
-
-void cblas_dgemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * x, CBLAS_INT incx,
-    double beta,
-    double * y, CBLAS_INT incy );
-
-void cblas_cgemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex beta,
-    float  _Complex * y, CBLAS_INT incy );
-
-void cblas_zgemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex beta,
-    double _Complex * y, CBLAS_INT incy );
-
-void cblas_sger(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float alpha,
-    float const * x, CBLAS_INT incx,
-    float const * y, CBLAS_INT incy,
-    float * A, CBLAS_INT lda );
-
-void cblas_dger(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double alpha,
-    double const * x, CBLAS_INT incx,
-    double const * y, CBLAS_INT incy,
-    double * A, CBLAS_INT lda );
-
-void cblas_cger(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex const * y, CBLAS_INT incy,
-    float  _Complex * A, CBLAS_INT lda );
-
-void cblas_zger(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex const * y, CBLAS_INT incy,
-    double _Complex * A, CBLAS_INT lda );
-
-void cblas_sgeru(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float alpha,
-    float const * x, CBLAS_INT incx,
-    float const * y, CBLAS_INT incy,
-    float * A, CBLAS_INT lda );
-
-void cblas_dgeru(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double alpha,
-    double const * x, CBLAS_INT incx,
-    double const * y, CBLAS_INT incy,
-    double * A, CBLAS_INT lda );
-
-void cblas_cgeru(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex const * y, CBLAS_INT incy,
-    float  _Complex * A, CBLAS_INT lda );
-
-void cblas_zgeru(
-    CBLAS_LAYOUT layout,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex const * y, CBLAS_INT incy,
-    double _Complex * A, CBLAS_INT lda );
-
-void cblas_shemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * x, CBLAS_INT incx,
-    float beta,
-    float * y, CBLAS_INT incy );
-
-void cblas_dhemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * x, CBLAS_INT incx,
-    double beta,
-    double * y, CBLAS_INT incy );
-
-void cblas_chemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex beta,
-    float  _Complex * y, CBLAS_INT incy );
-
-void cblas_zhemv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex beta,
-    double _Complex * y, CBLAS_INT incy );
-
-void cblas_sher(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float alpha,
-    float const * x, CBLAS_INT incx,
-    float * A, CBLAS_INT lda );
-
-void cblas_dher(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double alpha,
-    double const * x, CBLAS_INT incx,
-    double * A, CBLAS_INT lda );
-
-void cblas_cher(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float alpha,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex * A, CBLAS_INT lda );
-
-void cblas_zher(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double alpha,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex * A, CBLAS_INT lda );
-
-void cblas_sher2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float alpha,
-    float const * x, CBLAS_INT incx,
-    float const * y, CBLAS_INT incy,
-    float * A, CBLAS_INT lda );
-
-void cblas_dher2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double alpha,
-    double const * x, CBLAS_INT incx,
-    double const * y, CBLAS_INT incy,
-    double * A, CBLAS_INT lda );
-
-void cblas_cher2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex const * y, CBLAS_INT incy,
-    float  _Complex * A, CBLAS_INT lda );
-
-void cblas_zher2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex const * y, CBLAS_INT incy,
-    double _Complex * A, CBLAS_INT lda );
-
-void cblas_ssymv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * x, CBLAS_INT incx,
-    float beta,
-    float * y, CBLAS_INT incy );
-
-void cblas_dsymv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * x, CBLAS_INT incx,
-    double beta,
-    double * y, CBLAS_INT incy );
-
-void cblas_csymv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex beta,
-    float  _Complex * y, CBLAS_INT incy );
-
-void cblas_zsymv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex beta,
-    double _Complex * y, CBLAS_INT incy );
-
-void cblas_ssyr(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float alpha,
-    float const * x, CBLAS_INT incx,
-    float * A, CBLAS_INT lda );
-
-void cblas_dsyr(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double alpha,
-    double const * x, CBLAS_INT incx,
-    double * A, CBLAS_INT lda );
-
-void cblas_ssyr2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float alpha,
-    float const * x, CBLAS_INT incx,
-    float const * y, CBLAS_INT incy,
-    float * A, CBLAS_INT lda );
-
-void cblas_dsyr2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double alpha,
-    double const * x, CBLAS_INT incx,
-    double const * y, CBLAS_INT incy,
-    double * A, CBLAS_INT lda );
-
-void cblas_csyr2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * x, CBLAS_INT incx,
-    float  _Complex const * y, CBLAS_INT incy,
-    float  _Complex * A, CBLAS_INT lda );
-
-void cblas_zsyr2(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * x, CBLAS_INT incx,
-    double _Complex const * y, CBLAS_INT incy,
-    double _Complex * A, CBLAS_INT lda );
-
-void cblas_strmv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    float const * A, CBLAS_INT lda,
-    float * x, CBLAS_INT incx );
-
-void cblas_dtrmv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    double const * A, CBLAS_INT lda,
-    double * x, CBLAS_INT incx );
-
-void cblas_ctrmv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex * x, CBLAS_INT incx );
-
-void cblas_ztrmv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex * x, CBLAS_INT incx );
-
-void cblas_strsv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    float const * A, CBLAS_INT lda,
-    float * x, CBLAS_INT incx );
-
-void cblas_dtrsv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    double const * A, CBLAS_INT lda,
-    double * x, CBLAS_INT incx );
-
-void cblas_ctrsv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex * x, CBLAS_INT incx );
-
-void cblas_ztrsv(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT n,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex * x, CBLAS_INT incx );
-
-// =============================================================================
-// Level 3 BLAS
-
-void cblas_sgemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE transA,
-    CBLAS_TRANSPOSE transB,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * B, CBLAS_INT ldb,
-    float beta,
-    float * C, CBLAS_INT ldc );
-
-void cblas_dgemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE transA,
-    CBLAS_TRANSPOSE transB,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * B, CBLAS_INT ldb,
-    double beta,
-    double * C, CBLAS_INT ldc );
-
-void cblas_cgemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE transA,
-    CBLAS_TRANSPOSE transB,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * B, CBLAS_INT ldb,
-    float  _Complex beta,
-    float  _Complex * C, CBLAS_INT ldc );
-
-void cblas_zgemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_TRANSPOSE transA,
-    CBLAS_TRANSPOSE transB,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * B, CBLAS_INT ldb,
-    double _Complex beta,
-    double _Complex * C, CBLAS_INT ldc );
-
-void cblas_shemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * B, CBLAS_INT ldb,
-    float beta,
-    float * C, CBLAS_INT ldc );
-
-void cblas_dhemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * B, CBLAS_INT ldb,
-    double beta,
-    double * C, CBLAS_INT ldc );
-
-void cblas_chemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * B, CBLAS_INT ldb,
-    float  _Complex beta,
-    float  _Complex * C, CBLAS_INT ldc );
-
-void cblas_zhemm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * B, CBLAS_INT ldb,
-    double _Complex beta,
-    double _Complex * C, CBLAS_INT ldc );
-
-void cblas_sher2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * B, CBLAS_INT ldb,
-    float beta,
-    float * C, CBLAS_INT ldc );
-
-void cblas_dher2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * B, CBLAS_INT ldb,
-    double beta,
-    double * C, CBLAS_INT ldc );
-
-void cblas_cher2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * B, CBLAS_INT ldb,
-    float beta,
-    float  _Complex * C, CBLAS_INT ldc );
-
-void cblas_zher2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * B, CBLAS_INT ldb,
-    double beta,
-    double _Complex * C, CBLAS_INT ldc );
-
-void cblas_sherk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float beta,
-    float * C, CBLAS_INT ldc );
-
-void cblas_dherk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double beta,
-    double * C, CBLAS_INT ldc );
-
-void cblas_cherk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float beta,
-    float  _Complex * C, CBLAS_INT ldc );
-
-void cblas_zherk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double beta,
-    double _Complex * C, CBLAS_INT ldc );
-
-void cblas_ssymm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * B, CBLAS_INT ldb,
-    float beta,
-    float * C, CBLAS_INT ldc );
-
-void cblas_dsymm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * B, CBLAS_INT ldb,
-    double beta,
-    double * C, CBLAS_INT ldc );
-
-void cblas_csymm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * B, CBLAS_INT ldb,
-    float  _Complex beta,
-    float  _Complex * C, CBLAS_INT ldc );
-
-void cblas_zsymm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * B, CBLAS_INT ldb,
-    double _Complex beta,
-    double _Complex * C, CBLAS_INT ldc );
-
-void cblas_ssyr2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float const * B, CBLAS_INT ldb,
-    float beta,
-    float * C, CBLAS_INT ldc );
-
-void cblas_dsyr2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double const * B, CBLAS_INT ldb,
-    double beta,
-    double * C, CBLAS_INT ldc );
-
-void cblas_csyr2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex const * B, CBLAS_INT ldb,
-    float  _Complex beta,
-    float  _Complex * C, CBLAS_INT ldc );
-
-void cblas_zsyr2k(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex const * B, CBLAS_INT ldb,
-    double _Complex beta,
-    double _Complex * C, CBLAS_INT ldc );
-
-void cblas_ssyrk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float beta,
-    float * C, CBLAS_INT ldc );
-
-void cblas_dsyrk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double beta,
-    double * C, CBLAS_INT ldc );
-
-void cblas_csyrk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex beta,
-    float  _Complex * C, CBLAS_INT ldc );
-
-void cblas_zsyrk(
-    CBLAS_LAYOUT layout,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_INT n,
-    CBLAS_INT k,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex beta,
-    double _Complex * C, CBLAS_INT ldc );
-
-void cblas_strmm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float * B, CBLAS_INT ldb );
-
-void cblas_dtrmm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double * B, CBLAS_INT ldb );
-
-void cblas_ctrmm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex * B, CBLAS_INT ldb );
-
-void cblas_ztrmm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex * B, CBLAS_INT ldb );
-
-void cblas_strsm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float alpha,
-    float const * A, CBLAS_INT lda,
-    float * B, CBLAS_INT ldb );
-
-void cblas_dtrsm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double alpha,
-    double const * A, CBLAS_INT lda,
-    double * B, CBLAS_INT ldb );
-
-void cblas_ctrsm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    float  _Complex alpha,
-    float  _Complex const * A, CBLAS_INT lda,
-    float  _Complex * B, CBLAS_INT ldb );
-
-void cblas_ztrsm(
-    CBLAS_LAYOUT layout,
-    CBLAS_SIDE side,
-    CBLAS_UPLO uplo,
-    CBLAS_TRANSPOSE trans,
-    CBLAS_DIAG diag,
-    CBLAS_INT m,
-    CBLAS_INT n,
-    double _Complex alpha,
-    double _Complex const * A, CBLAS_INT lda,
-    double _Complex * B, CBLAS_INT ldb );
+    // -----------------------------------------------------------------------------
+    // Enumerations
+    typedef enum CBLAS_LAYOUT {
+        CblasRowMajor = 101,
+        CblasColMajor = 102
+    } CBLAS_LAYOUT;
+    typedef enum CBLAS_TRANSPOSE {
+        CblasNoTrans = 111,
+        CblasTrans = 112,
+        CblasConjTrans = 113
+    } CBLAS_TRANSPOSE;
+    typedef enum CBLAS_UPLO { CblasUpper = 121, CblasLower = 122 } CBLAS_UPLO;
+    typedef enum CBLAS_DIAG { CblasNonUnit = 131, CblasUnit = 132 } CBLAS_DIAG;
+    typedef enum CBLAS_SIDE { CblasLeft = 141, CblasRight = 142 } CBLAS_SIDE;
+
+#define CBLAS_ORDER \
+    CBLAS_LAYOUT  // this for backward compatibility with CBLAS_ORDER
+
+    // =============================================================================
+    // Level 1 BLAS
+
+    float cblas_sasum(CBLAS_INT n, float const* x, CBLAS_INT incx);
+
+    double cblas_dasum(CBLAS_INT n, double const* x, CBLAS_INT incx);
+
+    float cblas_casum(CBLAS_INT n, float _Complex const* x, CBLAS_INT incx);
+
+    double cblas_zasum(CBLAS_INT n, double _Complex const* x, CBLAS_INT incx);
+
+    void cblas_saxpy(CBLAS_INT n, float alpha, float const* x, CBLAS_INT incx,
+                     float* y, CBLAS_INT incy);
+
+    void cblas_daxpy(CBLAS_INT n, double alpha, double const* x, CBLAS_INT incx,
+                     double* y, CBLAS_INT incy);
+
+    void cblas_caxpy(CBLAS_INT n, float _Complex alpha, float _Complex const* x,
+                     CBLAS_INT incx, float _Complex* y, CBLAS_INT incy);
+
+    void cblas_zaxpy(CBLAS_INT n, double _Complex alpha,
+                     double _Complex const* x, CBLAS_INT incx,
+                     double _Complex* y, CBLAS_INT incy);
+
+    void cblas_scopy(CBLAS_INT n, float const* x, CBLAS_INT incx, float* y,
+                     CBLAS_INT incy);
+
+    void cblas_dcopy(CBLAS_INT n, double const* x, CBLAS_INT incx, double* y,
+                     CBLAS_INT incy);
+
+    void cblas_ccopy(CBLAS_INT n, float _Complex const* x, CBLAS_INT incx,
+                     float _Complex* y, CBLAS_INT incy);
+
+    void cblas_zcopy(CBLAS_INT n, double _Complex const* x, CBLAS_INT incx,
+                     double _Complex* y, CBLAS_INT incy);
+
+    float cblas_sdot(CBLAS_INT n, float const* x, CBLAS_INT incx,
+                     float const* y, CBLAS_INT incy);
+
+    double cblas_ddot(CBLAS_INT n, double const* x, CBLAS_INT incx,
+                      double const* y, CBLAS_INT incy);
+
+    float _Complex cblas_cdot(CBLAS_INT n, float _Complex const* x,
+                              CBLAS_INT incx, float _Complex const* y,
+                              CBLAS_INT incy);
+
+    double _Complex cblas_zdot(CBLAS_INT n, double _Complex const* x,
+                               CBLAS_INT incx, double _Complex const* y,
+                               CBLAS_INT incy);
+
+    float cblas_sdotu(CBLAS_INT n, float const* x, CBLAS_INT incx,
+                      float const* y, CBLAS_INT incy);
+
+    double cblas_ddotu(CBLAS_INT n, double const* x, CBLAS_INT incx,
+                       double const* y, CBLAS_INT incy);
+
+    float _Complex cblas_cdotu(CBLAS_INT n, float _Complex const* x,
+                               CBLAS_INT incx, float _Complex const* y,
+                               CBLAS_INT incy);
+
+    double _Complex cblas_zdotu(CBLAS_INT n, double _Complex const* x,
+                                CBLAS_INT incx, double _Complex const* y,
+                                CBLAS_INT incy);
+
+    CBLAS_INDEX cblas_isamax(CBLAS_INT n, float const* x, CBLAS_INT incx);
+
+    CBLAS_INDEX cblas_idamax(CBLAS_INT n, double const* x, CBLAS_INT incx);
+
+    CBLAS_INDEX cblas_icamax(CBLAS_INT n, float _Complex const* x,
+                             CBLAS_INT incx);
+
+    CBLAS_INDEX cblas_izamax(CBLAS_INT n, double _Complex const* x,
+                             CBLAS_INT incx);
+
+    float cblas_snrm2(CBLAS_INT n, float const* x, CBLAS_INT incx);
+
+    double cblas_dnrm2(CBLAS_INT n, double const* x, CBLAS_INT incx);
+
+    float cblas_cnrm2(CBLAS_INT n, float _Complex const* x, CBLAS_INT incx);
+
+    double cblas_znrm2(CBLAS_INT n, double _Complex const* x, CBLAS_INT incx);
+
+    void cblas_srot(CBLAS_INT n, float* x, CBLAS_INT incx, float* y,
+                    CBLAS_INT incy, float c, float s);
+
+    void cblas_drot(CBLAS_INT n, double* x, CBLAS_INT incx, double* y,
+                    CBLAS_INT incy, double c, double s);
+
+    void cblas_csrot(CBLAS_INT n, float _Complex* x, CBLAS_INT incx,
+                     float _Complex* y, CBLAS_INT incy, float c, float s);
+
+    void cblas_zdrot(CBLAS_INT n, double _Complex* x, CBLAS_INT incx,
+                     double _Complex* y, CBLAS_INT incy, double c, double s);
+
+    void cblas_crot(CBLAS_INT n, float _Complex* x, CBLAS_INT incx,
+                    float _Complex* y, CBLAS_INT incy, float c,
+                    float _Complex s);
+
+    void cblas_zrot(CBLAS_INT n, double _Complex* x, CBLAS_INT incx,
+                    double _Complex* y, CBLAS_INT incy, double c,
+                    double _Complex s);
+
+    void cblas_srotg(float* a, float* b, float* c, float* s);
+
+    void cblas_drotg(double* a, double* b, double* c, double* s);
+
+    void cblas_crotg(float _Complex* a, float _Complex* b, float* c,
+                     float _Complex* s);
+
+    void cblas_zrotg(double _Complex* a, double _Complex* b, double* c,
+                     double _Complex* s);
+
+    void cblas_srotm(CBLAS_INT n, float* x, CBLAS_INT incx, float* y,
+                     CBLAS_INT incy, float const* param);
+
+    void cblas_drotm(CBLAS_INT n, double* x, CBLAS_INT incx, double* y,
+                     CBLAS_INT incy, double const* param);
+
+    void cblas_srotmg(float* d1, float* d2, float* a, float b, float* param);
+
+    void cblas_drotmg(double* d1, double* d2, double* a, double b,
+                      double* param);
+
+    void cblas_sscal(CBLAS_INT n, float alpha, float* x, CBLAS_INT incx);
+
+    void cblas_dscal(CBLAS_INT n, double alpha, double* x, CBLAS_INT incx);
+
+    void cblas_cscal(CBLAS_INT n, float _Complex alpha, float _Complex* x,
+                     CBLAS_INT incx);
+
+    void cblas_zscal(CBLAS_INT n, double _Complex alpha, double _Complex* x,
+                     CBLAS_INT incx);
+
+    void cblas_sswap(CBLAS_INT n, float* x, CBLAS_INT incx, float* y,
+                     CBLAS_INT incy);
+
+    void cblas_dswap(CBLAS_INT n, double* x, CBLAS_INT incx, double* y,
+                     CBLAS_INT incy);
+
+    void cblas_cswap(CBLAS_INT n, float _Complex* x, CBLAS_INT incx,
+                     float _Complex* y, CBLAS_INT incy);
+
+    void cblas_zswap(CBLAS_INT n, double _Complex* x, CBLAS_INT incx,
+                     double _Complex* y, CBLAS_INT incy);
+
+    // =============================================================================
+    // Level 2 BLAS
+
+    void cblas_sgemv(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE trans, CBLAS_INT m,
+                     CBLAS_INT n, float alpha, float const* A, CBLAS_INT lda,
+                     float const* x, CBLAS_INT incx, float beta, float* y,
+                     CBLAS_INT incy);
+
+    void cblas_dgemv(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE trans, CBLAS_INT m,
+                     CBLAS_INT n, double alpha, double const* A, CBLAS_INT lda,
+                     double const* x, CBLAS_INT incx, double beta, double* y,
+                     CBLAS_INT incy);
+
+    void cblas_cgemv(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE trans, CBLAS_INT m,
+                     CBLAS_INT n, float _Complex alpha, float _Complex const* A,
+                     CBLAS_INT lda, float _Complex const* x, CBLAS_INT incx,
+                     float _Complex beta, float _Complex* y, CBLAS_INT incy);
+
+    void cblas_zgemv(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE trans, CBLAS_INT m,
+                     CBLAS_INT n, double _Complex alpha,
+                     double _Complex const* A, CBLAS_INT lda,
+                     double _Complex const* x, CBLAS_INT incx,
+                     double _Complex beta, double _Complex* y, CBLAS_INT incy);
+
+    void cblas_sger(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n, float alpha,
+                    float const* x, CBLAS_INT incx, float const* y,
+                    CBLAS_INT incy, float* A, CBLAS_INT lda);
+
+    void cblas_dger(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n, double alpha,
+                    double const* x, CBLAS_INT incx, double const* y,
+                    CBLAS_INT incy, double* A, CBLAS_INT lda);
+
+    void cblas_cger(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n,
+                    float _Complex alpha, float _Complex const* x,
+                    CBLAS_INT incx, float _Complex const* y, CBLAS_INT incy,
+                    float _Complex* A, CBLAS_INT lda);
+
+    void cblas_zger(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n,
+                    double _Complex alpha, double _Complex const* x,
+                    CBLAS_INT incx, double _Complex const* y, CBLAS_INT incy,
+                    double _Complex* A, CBLAS_INT lda);
+
+    void cblas_sgeru(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n, float alpha,
+                     float const* x, CBLAS_INT incx, float const* y,
+                     CBLAS_INT incy, float* A, CBLAS_INT lda);
+
+    void cblas_dgeru(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n,
+                     double alpha, double const* x, CBLAS_INT incx,
+                     double const* y, CBLAS_INT incy, double* A, CBLAS_INT lda);
+
+    void cblas_cgeru(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n,
+                     float _Complex alpha, float _Complex const* x,
+                     CBLAS_INT incx, float _Complex const* y, CBLAS_INT incy,
+                     float _Complex* A, CBLAS_INT lda);
+
+    void cblas_zgeru(CBLAS_LAYOUT layout, CBLAS_INT m, CBLAS_INT n,
+                     double _Complex alpha, double _Complex const* x,
+                     CBLAS_INT incx, double _Complex const* y, CBLAS_INT incy,
+                     double _Complex* A, CBLAS_INT lda);
+
+    void cblas_shemv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float alpha, float const* A, CBLAS_INT lda, float const* x,
+                     CBLAS_INT incx, float beta, float* y, CBLAS_INT incy);
+
+    void cblas_dhemv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double alpha, double const* A, CBLAS_INT lda,
+                     double const* x, CBLAS_INT incx, double beta, double* y,
+                     CBLAS_INT incy);
+
+    void cblas_chemv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float _Complex alpha, float _Complex const* A,
+                     CBLAS_INT lda, float _Complex const* x, CBLAS_INT incx,
+                     float _Complex beta, float _Complex* y, CBLAS_INT incy);
+
+    void cblas_zhemv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double _Complex alpha, double _Complex const* A,
+                     CBLAS_INT lda, double _Complex const* x, CBLAS_INT incx,
+                     double _Complex beta, double _Complex* y, CBLAS_INT incy);
+
+    void cblas_sher(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                    float alpha, float const* x, CBLAS_INT incx, float* A,
+                    CBLAS_INT lda);
+
+    void cblas_dher(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                    double alpha, double const* x, CBLAS_INT incx, double* A,
+                    CBLAS_INT lda);
+
+    void cblas_cher(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                    float alpha, float _Complex const* x, CBLAS_INT incx,
+                    float _Complex* A, CBLAS_INT lda);
+
+    void cblas_zher(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                    double alpha, double _Complex const* x, CBLAS_INT incx,
+                    double _Complex* A, CBLAS_INT lda);
+
+    void cblas_sher2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float alpha, float const* x, CBLAS_INT incx,
+                     float const* y, CBLAS_INT incy, float* A, CBLAS_INT lda);
+
+    void cblas_dher2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double alpha, double const* x, CBLAS_INT incx,
+                     double const* y, CBLAS_INT incy, double* A, CBLAS_INT lda);
+
+    void cblas_cher2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float _Complex alpha, float _Complex const* x,
+                     CBLAS_INT incx, float _Complex const* y, CBLAS_INT incy,
+                     float _Complex* A, CBLAS_INT lda);
+
+    void cblas_zher2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double _Complex alpha, double _Complex const* x,
+                     CBLAS_INT incx, double _Complex const* y, CBLAS_INT incy,
+                     double _Complex* A, CBLAS_INT lda);
+
+    void cblas_ssymv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float alpha, float const* A, CBLAS_INT lda, float const* x,
+                     CBLAS_INT incx, float beta, float* y, CBLAS_INT incy);
+
+    void cblas_dsymv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double alpha, double const* A, CBLAS_INT lda,
+                     double const* x, CBLAS_INT incx, double beta, double* y,
+                     CBLAS_INT incy);
+
+    void cblas_csymv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float _Complex alpha, float _Complex const* A,
+                     CBLAS_INT lda, float _Complex const* x, CBLAS_INT incx,
+                     float _Complex beta, float _Complex* y, CBLAS_INT incy);
+
+    void cblas_zsymv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double _Complex alpha, double _Complex const* A,
+                     CBLAS_INT lda, double _Complex const* x, CBLAS_INT incx,
+                     double _Complex beta, double _Complex* y, CBLAS_INT incy);
+
+    void cblas_ssyr(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                    float alpha, float const* x, CBLAS_INT incx, float* A,
+                    CBLAS_INT lda);
+
+    void cblas_dsyr(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                    double alpha, double const* x, CBLAS_INT incx, double* A,
+                    CBLAS_INT lda);
+
+    void cblas_ssyr2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float alpha, float const* x, CBLAS_INT incx,
+                     float const* y, CBLAS_INT incy, float* A, CBLAS_INT lda);
+
+    void cblas_dsyr2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double alpha, double const* x, CBLAS_INT incx,
+                     double const* y, CBLAS_INT incy, double* A, CBLAS_INT lda);
+
+    void cblas_csyr2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     float _Complex alpha, float _Complex const* x,
+                     CBLAS_INT incx, float _Complex const* y, CBLAS_INT incy,
+                     float _Complex* A, CBLAS_INT lda);
+
+    void cblas_zsyr2(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_INT n,
+                     double _Complex alpha, double _Complex const* x,
+                     CBLAS_INT incx, double _Complex const* y, CBLAS_INT incy,
+                     double _Complex* A, CBLAS_INT lda);
+
+    void cblas_strmv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     float const* A, CBLAS_INT lda, float* x, CBLAS_INT incx);
+
+    void cblas_dtrmv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     double const* A, CBLAS_INT lda, double* x, CBLAS_INT incx);
+
+    void cblas_ctrmv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     float _Complex const* A, CBLAS_INT lda, float _Complex* x,
+                     CBLAS_INT incx);
+
+    void cblas_ztrmv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     double _Complex const* A, CBLAS_INT lda,
+                     double _Complex* x, CBLAS_INT incx);
+
+    void cblas_strsv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     float const* A, CBLAS_INT lda, float* x, CBLAS_INT incx);
+
+    void cblas_dtrsv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     double const* A, CBLAS_INT lda, double* x, CBLAS_INT incx);
+
+    void cblas_ctrsv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     float _Complex const* A, CBLAS_INT lda, float _Complex* x,
+                     CBLAS_INT incx);
+
+    void cblas_ztrsv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT n,
+                     double _Complex const* A, CBLAS_INT lda,
+                     double _Complex* x, CBLAS_INT incx);
+
+    // =============================================================================
+    // Level 3 BLAS
+
+    void cblas_sgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transA,
+                     CBLAS_TRANSPOSE transB, CBLAS_INT m, CBLAS_INT n,
+                     CBLAS_INT k, float alpha, float const* A, CBLAS_INT lda,
+                     float const* B, CBLAS_INT ldb, float beta, float* C,
+                     CBLAS_INT ldc);
+
+    void cblas_dgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transA,
+                     CBLAS_TRANSPOSE transB, CBLAS_INT m, CBLAS_INT n,
+                     CBLAS_INT k, double alpha, double const* A, CBLAS_INT lda,
+                     double const* B, CBLAS_INT ldb, double beta, double* C,
+                     CBLAS_INT ldc);
+
+    void cblas_cgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transA,
+                     CBLAS_TRANSPOSE transB, CBLAS_INT m, CBLAS_INT n,
+                     CBLAS_INT k, float _Complex alpha, float _Complex const* A,
+                     CBLAS_INT lda, float _Complex const* B, CBLAS_INT ldb,
+                     float _Complex beta, float _Complex* C, CBLAS_INT ldc);
+
+    void cblas_zgemm(
+        CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB,
+        CBLAS_INT m, CBLAS_INT n, CBLAS_INT k, double _Complex alpha,
+        double _Complex const* A, CBLAS_INT lda, double _Complex const* B,
+        CBLAS_INT ldb, double _Complex beta, double _Complex* C, CBLAS_INT ldc);
+
+    void cblas_shemm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, float alpha, float const* A,
+                     CBLAS_INT lda, float const* B, CBLAS_INT ldb, float beta,
+                     float* C, CBLAS_INT ldc);
+
+    void cblas_dhemm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, double alpha, double const* A,
+                     CBLAS_INT lda, double const* B, CBLAS_INT ldb, double beta,
+                     double* C, CBLAS_INT ldc);
+
+    void cblas_chemm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, float _Complex alpha,
+                     float _Complex const* A, CBLAS_INT lda,
+                     float _Complex const* B, CBLAS_INT ldb,
+                     float _Complex beta, float _Complex* C, CBLAS_INT ldc);
+
+    void cblas_zhemm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, double _Complex alpha,
+                     double _Complex const* A, CBLAS_INT lda,
+                     double _Complex const* B, CBLAS_INT ldb,
+                     double _Complex beta, double _Complex* C, CBLAS_INT ldc);
+
+    void cblas_sher2k(
+        CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_TRANSPOSE trans,
+        CBLAS_INT n, CBLAS_INT k, float alpha, float const* A, CBLAS_INT lda,
+        float const* B, CBLAS_INT ldb, float beta, float* C, CBLAS_INT ldc);
+
+    void cblas_dher2k(
+        CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_TRANSPOSE trans,
+        CBLAS_INT n, CBLAS_INT k, double alpha, double const* A, CBLAS_INT lda,
+        double const* B, CBLAS_INT ldb, double beta, double* C, CBLAS_INT ldc);
+
+    void cblas_cher2k(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                      CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                      float _Complex alpha, float _Complex const* A,
+                      CBLAS_INT lda, float _Complex const* B, CBLAS_INT ldb,
+                      float beta, float _Complex* C, CBLAS_INT ldc);
+
+    void cblas_zher2k(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                      CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                      double _Complex alpha, double _Complex const* A,
+                      CBLAS_INT lda, double _Complex const* B, CBLAS_INT ldb,
+                      double beta, double _Complex* C, CBLAS_INT ldc);
+
+    void cblas_sherk(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                     float alpha, float const* A, CBLAS_INT lda, float beta,
+                     float* C, CBLAS_INT ldc);
+
+    void cblas_dherk(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                     double alpha, double const* A, CBLAS_INT lda, double beta,
+                     double* C, CBLAS_INT ldc);
+
+    void cblas_cherk(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                     float alpha, float _Complex const* A, CBLAS_INT lda,
+                     float beta, float _Complex* C, CBLAS_INT ldc);
+
+    void cblas_zherk(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                     double alpha, double _Complex const* A, CBLAS_INT lda,
+                     double beta, double _Complex* C, CBLAS_INT ldc);
+
+    void cblas_ssymm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, float alpha, float const* A,
+                     CBLAS_INT lda, float const* B, CBLAS_INT ldb, float beta,
+                     float* C, CBLAS_INT ldc);
+
+    void cblas_dsymm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, double alpha, double const* A,
+                     CBLAS_INT lda, double const* B, CBLAS_INT ldb, double beta,
+                     double* C, CBLAS_INT ldc);
+
+    void cblas_csymm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, float _Complex alpha,
+                     float _Complex const* A, CBLAS_INT lda,
+                     float _Complex const* B, CBLAS_INT ldb,
+                     float _Complex beta, float _Complex* C, CBLAS_INT ldc);
+
+    void cblas_zsymm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_INT m, CBLAS_INT n, double _Complex alpha,
+                     double _Complex const* A, CBLAS_INT lda,
+                     double _Complex const* B, CBLAS_INT ldb,
+                     double _Complex beta, double _Complex* C, CBLAS_INT ldc);
+
+    void cblas_ssyr2k(
+        CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_TRANSPOSE trans,
+        CBLAS_INT n, CBLAS_INT k, float alpha, float const* A, CBLAS_INT lda,
+        float const* B, CBLAS_INT ldb, float beta, float* C, CBLAS_INT ldc);
+
+    void cblas_dsyr2k(
+        CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_TRANSPOSE trans,
+        CBLAS_INT n, CBLAS_INT k, double alpha, double const* A, CBLAS_INT lda,
+        double const* B, CBLAS_INT ldb, double beta, double* C, CBLAS_INT ldc);
+
+    void cblas_csyr2k(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                      CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                      float _Complex alpha, float _Complex const* A,
+                      CBLAS_INT lda, float _Complex const* B, CBLAS_INT ldb,
+                      float _Complex beta, float _Complex* C, CBLAS_INT ldc);
+
+    void cblas_zsyr2k(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                      CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                      double _Complex alpha, double _Complex const* A,
+                      CBLAS_INT lda, double _Complex const* B, CBLAS_INT ldb,
+                      double _Complex beta, double _Complex* C, CBLAS_INT ldc);
+
+    void cblas_ssyrk(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                     float alpha, float const* A, CBLAS_INT lda, float beta,
+                     float* C, CBLAS_INT ldc);
+
+    void cblas_dsyrk(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                     double alpha, double const* A, CBLAS_INT lda, double beta,
+                     double* C, CBLAS_INT ldc);
+
+    void cblas_csyrk(
+        CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_TRANSPOSE trans,
+        CBLAS_INT n, CBLAS_INT k, float _Complex alpha, float _Complex const* A,
+        CBLAS_INT lda, float _Complex beta, float _Complex* C, CBLAS_INT ldc);
+
+    void cblas_zsyrk(CBLAS_LAYOUT layout, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_INT n, CBLAS_INT k,
+                     double _Complex alpha, double _Complex const* A,
+                     CBLAS_INT lda, double _Complex beta, double _Complex* C,
+                     CBLAS_INT ldc);
+
+    void cblas_strmm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, float alpha, float const* A, CBLAS_INT lda,
+                     float* B, CBLAS_INT ldb);
+
+    void cblas_dtrmm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, double alpha, double const* A, CBLAS_INT lda,
+                     double* B, CBLAS_INT ldb);
+
+    void cblas_ctrmm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, float _Complex alpha, float _Complex const* A,
+                     CBLAS_INT lda, float _Complex* B, CBLAS_INT ldb);
+
+    void cblas_ztrmm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, double _Complex alpha,
+                     double _Complex const* A, CBLAS_INT lda,
+                     double _Complex* B, CBLAS_INT ldb);
+
+    void cblas_strsm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, float alpha, float const* A, CBLAS_INT lda,
+                     float* B, CBLAS_INT ldb);
+
+    void cblas_dtrsm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, double alpha, double const* A, CBLAS_INT lda,
+                     double* B, CBLAS_INT ldb);
+
+    void cblas_ctrsm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, float _Complex alpha, float _Complex const* A,
+                     CBLAS_INT lda, float _Complex* B, CBLAS_INT ldb);
+
+    void cblas_ztrsm(CBLAS_LAYOUT layout, CBLAS_SIDE side, CBLAS_UPLO uplo,
+                     CBLAS_TRANSPOSE trans, CBLAS_DIAG diag, CBLAS_INT m,
+                     CBLAS_INT n, double _Complex alpha,
+                     double _Complex const* A, CBLAS_INT lda,
+                     double _Complex* B, CBLAS_INT ldb);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // TLAPACK_CBLAS_H
+#endif  // TLAPACK_CBLAS_H

--- a/performancetests/multishift_qr/profile_aed.cpp
+++ b/performancetests/multishift_qr/profile_aed.cpp
@@ -7,11 +7,15 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #define TLAPACK_PREFERRED_MATRIX_LEGACY
 #include <tlapack/plugins/stdvector.hpp>
 #include <tlapack/plugins/legacyArray.hpp>
+
+// <T>LAPACK
 #include <tlapack.hpp>
 
+// C++ headers
 #include <memory>
 #include <vector>
 #include <chrono> // for high_resolution_clock

--- a/performancetests/multishift_qr/profile_multishift_qr.cpp
+++ b/performancetests/multishift_qr/profile_multishift_qr.cpp
@@ -7,11 +7,15 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+// Plugins for <T>LAPACK (must come before <T>LAPACK headers)
 #define TLAPACK_PREFERRED_MATRIX_LEGACY
 #include <tlapack/plugins/stdvector.hpp>
 #include <tlapack/plugins/legacyArray.hpp>
+
+// <T>LAPACK
 #include <tlapack.hpp>
 
+// C++ headers
 #include <memory>
 #include <vector>
 #include <chrono> // for high_resolution_clock

--- a/src/tlapack_cwrappers.cpp
+++ b/src/tlapack_cwrappers.cpp
@@ -9,8 +9,8 @@
 
 #ifdef BUILD_CBLAS
 
-    #include "tlapack_cblas.h"
     #include "tlapack/legacy_api/blas.hpp"
+    #include "tlapack_cblas.h"
 
     // Mangling
     #ifdef ADD_
@@ -19,44 +19,65 @@
         #define BLAS_FUNCTION(fname) cblas_##fname
     #endif
 
-    typedef CBLAS_INT   blas_idx_t;
-    typedef CBLAS_INT   blas_int_t;
-    typedef CBLAS_INDEX blas_iamax_t;
+typedef CBLAS_INT blas_idx_t;
+typedef CBLAS_INT blas_int_t;
+typedef CBLAS_INDEX blas_iamax_t;
 
-    typedef CBLAS_LAYOUT Layout;
-    typedef CBLAS_TRANSPOSE Op;
-    typedef CBLAS_UPLO Uplo;
-    typedef CBLAS_DIAG Diag;
-    typedef CBLAS_SIDE Side;
+typedef CBLAS_LAYOUT Layout;
+typedef CBLAS_TRANSPOSE Op;
+typedef CBLAS_UPLO Uplo;
+typedef CBLAS_DIAG Diag;
+typedef CBLAS_SIDE Side;
 
-    // -----------------------------------------------------------------------------
-    // Convert CBLAS enum to <T>LAPACK enum
-    inline tlapack::Layout toTLAPACKlayout( Layout layout ) {
-        if( layout == CblasRowMajor )      return tlapack::Layout::RowMajor;
-        else if( layout == CblasColMajor ) return tlapack::Layout::ColMajor;
-        else                               return tlapack::Layout(0);
-    }
-    inline tlapack::Op toTLAPACKop( Op trans ) {
-        if( trans == CblasNoTrans )        return tlapack::Op::NoTrans;
-        else if( trans == CblasTrans )     return tlapack::Op::Trans;
-        else if( trans == CblasConjTrans ) return tlapack::Op::ConjTrans;
-        else                            return tlapack::Op(0);
-    }
-    inline tlapack::Uplo toTLAPACKuplo( Uplo uplo ) {
-        if( uplo == CblasUpper )      return tlapack::Uplo::Upper;
-        else if( uplo == CblasLower ) return tlapack::Uplo::Lower;
-        else                          return tlapack::Uplo(0);
-    }
-    inline tlapack::Diag toTLAPACKdiag( Diag diag ) {
-        if( diag == CblasNonUnit )   return tlapack::Diag::NonUnit;
-        else if( diag == CblasUnit ) return tlapack::Diag::Unit;
-        else                         return tlapack::Diag(0);
-    }
-    inline tlapack::Side toTLAPACKside( Side side ) {
-        if( side == CblasLeft )       return tlapack::Side::Left;
-        else if( side == CblasRight ) return tlapack::Side::Right;
-        else                          return tlapack::Side(0);
-    }
+// -----------------------------------------------------------------------------
+// Convert CBLAS enum to <T>LAPACK enum
+inline tlapack::Layout toTLAPACKlayout(Layout layout)
+{
+    if (layout == CblasRowMajor)
+        return tlapack::Layout::RowMajor;
+    else if (layout == CblasColMajor)
+        return tlapack::Layout::ColMajor;
+    else
+        return tlapack::Layout(0);
+}
+inline tlapack::Op toTLAPACKop(Op trans)
+{
+    if (trans == CblasNoTrans)
+        return tlapack::Op::NoTrans;
+    else if (trans == CblasTrans)
+        return tlapack::Op::Trans;
+    else if (trans == CblasConjTrans)
+        return tlapack::Op::ConjTrans;
+    else
+        return tlapack::Op(0);
+}
+inline tlapack::Uplo toTLAPACKuplo(Uplo uplo)
+{
+    if (uplo == CblasUpper)
+        return tlapack::Uplo::Upper;
+    else if (uplo == CblasLower)
+        return tlapack::Uplo::Lower;
+    else
+        return tlapack::Uplo(0);
+}
+inline tlapack::Diag toTLAPACKdiag(Diag diag)
+{
+    if (diag == CblasNonUnit)
+        return tlapack::Diag::NonUnit;
+    else if (diag == CblasUnit)
+        return tlapack::Diag::Unit;
+    else
+        return tlapack::Diag(0);
+}
+inline tlapack::Side toTLAPACKside(Side side)
+{
+    if (side == CblasLeft)
+        return tlapack::Side::Left;
+    else if (side == CblasRight)
+        return tlapack::Side::Right;
+    else
+        return tlapack::Side(0);
+}
 
 #else
 
@@ -70,2326 +91,1929 @@
         #define BLAS_FUNCTION(fname) fname
     #endif
 
-    typedef TLAPACK_SIZE_T blas_idx_t;
-    typedef TLAPACK_INT_T  blas_int_t;
-    typedef TLAPACK_SIZE_T blas_iamax_t;
+typedef TLAPACK_SIZE_T blas_idx_t;
+typedef TLAPACK_INT_T blas_int_t;
+typedef TLAPACK_SIZE_T blas_iamax_t;
 
-    // -----------------------------------------------------------------------------
-    // Convert BLAS enum to <T>LAPACK enum
-    inline tlapack::Layout toTLAPACKlayout( Layout layout ) { return (tlapack::Layout) layout; }
-    inline tlapack::Op toTLAPACKop( Op op )                 { return (tlapack::Op) op; }
-    inline tlapack::Uplo toTLAPACKuplo( Uplo uplo )         { return (tlapack::Uplo) uplo; }
-    inline tlapack::Diag toTLAPACKdiag( Diag diag )         { return (tlapack::Diag) diag; }
-    inline tlapack::Side toTLAPACKside( Side side )         { return (tlapack::Side) side; }
+// -----------------------------------------------------------------------------
+// Convert BLAS enum to <T>LAPACK enum
+inline tlapack::Layout toTLAPACKlayout(Layout layout)
+{
+    return (tlapack::Layout)layout;
+}
+inline tlapack::Op toTLAPACKop(Op op) { return (tlapack::Op)op; }
+inline tlapack::Uplo toTLAPACKuplo(Uplo uplo) { return (tlapack::Uplo)uplo; }
+inline tlapack::Diag toTLAPACKdiag(Diag diag) { return (tlapack::Diag)diag; }
+inline tlapack::Side toTLAPACKside(Side side) { return (tlapack::Side)side; }
 
 #endif
 
 // -----------------------------------------------------------------------------
 // Complex types
-typedef float  _Complex complexFloat;
+typedef float _Complex complexFloat;
 typedef double _Complex complexDouble;
 
 typedef std::complex<float> tlapack_complexFloat;
 typedef std::complex<double> tlapack_complexDouble;
 
-#define tlapack_cteC(z) reinterpret_cast<const tlapack_complexFloat*>( z )
-#define tlapack_cteZ(z) reinterpret_cast<const tlapack_complexDouble*>( z )
-#define tlapack_C(z) reinterpret_cast<tlapack_complexFloat*>( z )
-#define tlapack_Z(z) reinterpret_cast<tlapack_complexDouble*>( z )
+#define tlapack_cteC(z) reinterpret_cast<const tlapack_complexFloat*>(z)
+#define tlapack_cteZ(z) reinterpret_cast<const tlapack_complexDouble*>(z)
+#define tlapack_C(z) reinterpret_cast<tlapack_complexFloat*>(z)
+#define tlapack_Z(z) reinterpret_cast<tlapack_complexDouble*>(z)
 // -----------------------------------------------------------------------------
 
 extern "C" {
 
 #define _sasum BLAS_FUNCTION(sasum)
-float _sasum(
-    blas_idx_t n,
-    float const * x, blas_int_t incx ) {
-    return tlapack::asum<float>(
-        n,
-        x, incx );
+float _sasum(blas_idx_t n, float const* x, blas_int_t incx)
+{
+    return tlapack::asum<float>(n, x, incx);
 }
 
 #define _dasum BLAS_FUNCTION(dasum)
-double _dasum(
-    blas_idx_t n,
-    double const * x, blas_int_t incx ) {
-    return tlapack::asum<double>(
-        n,
-        x, incx );
+double _dasum(blas_idx_t n, double const* x, blas_int_t incx)
+{
+    return tlapack::asum<double>(n, x, incx);
 }
 
 #define _casum BLAS_FUNCTION(casum)
-float _casum(
-    blas_idx_t n,
-    complexFloat const * x, blas_int_t incx ) {
-    return tlapack::asum<tlapack_complexFloat>(
-        n,
-        tlapack_cteC(x), incx );
+float _casum(blas_idx_t n, complexFloat const* x, blas_int_t incx)
+{
+    return tlapack::asum<tlapack_complexFloat>(n, tlapack_cteC(x), incx);
 }
 
 #define _zasum BLAS_FUNCTION(zasum)
-double _zasum(
-    blas_idx_t n,
-    complexDouble const * x, blas_int_t incx ) {
-    return tlapack::asum<tlapack_complexDouble>(
-        n,
-        tlapack_cteZ(x), incx );
+double _zasum(blas_idx_t n, complexDouble const* x, blas_int_t incx)
+{
+    return tlapack::asum<tlapack_complexDouble>(n, tlapack_cteZ(x), incx);
 }
 
 #define _saxpy BLAS_FUNCTION(saxpy)
-void _saxpy(
-    blas_idx_t n,
-    float alpha,
-    float const * x, blas_int_t incx,
-    float * y, blas_int_t incy ) {
-    return tlapack::axpy<float, float>(
-        n,
-        alpha,
-        x, incx,
-        y, incy );
+void _saxpy(blas_idx_t n,
+            float alpha,
+            float const* x,
+            blas_int_t incx,
+            float* y,
+            blas_int_t incy)
+{
+    return tlapack::axpy<float, float>(n, alpha, x, incx, y, incy);
 }
 
 #define _daxpy BLAS_FUNCTION(daxpy)
-void _daxpy(
-    blas_idx_t n,
-    double alpha,
-    double const * x, blas_int_t incx,
-    double * y, blas_int_t incy ) {
-    return tlapack::axpy<double, double>(
-        n,
-        alpha,
-        x, incx,
-        y, incy );
+void _daxpy(blas_idx_t n,
+            double alpha,
+            double const* x,
+            blas_int_t incx,
+            double* y,
+            blas_int_t incy)
+{
+    return tlapack::axpy<double, double>(n, alpha, x, incx, y, incy);
 }
 
 #define _caxpy BLAS_FUNCTION(caxpy)
-void _caxpy(
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat * y, blas_int_t incy ) {
+void _caxpy(blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat* y,
+            blas_int_t incy)
+{
     return tlapack::axpy<tlapack_complexFloat, tlapack_complexFloat>(
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(x), incx,
-        tlapack_C(y), incy );
+        n, *tlapack_C(&alpha), tlapack_cteC(x), incx, tlapack_C(y), incy);
 }
 
 #define _zaxpy BLAS_FUNCTION(zaxpy)
-void _zaxpy(
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble * y, blas_int_t incy ) {
+void _zaxpy(blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble* y,
+            blas_int_t incy)
+{
     return tlapack::axpy<tlapack_complexDouble, tlapack_complexDouble>(
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(x), incx,
-        tlapack_Z(y), incy );
+        n, *tlapack_Z(&alpha), tlapack_cteZ(x), incx, tlapack_Z(y), incy);
 }
 
 #define _scopy BLAS_FUNCTION(scopy)
 void _scopy(
-    blas_idx_t n,
-    float const * x, blas_int_t incx,
-    float * y, blas_int_t incy ) {
-    return tlapack::copy<float, float>(
-        n,
-        x, incx,
-        y, incy );
+    blas_idx_t n, float const* x, blas_int_t incx, float* y, blas_int_t incy)
+{
+    return tlapack::copy<float, float>(n, x, incx, y, incy);
 }
 
 #define _dcopy BLAS_FUNCTION(dcopy)
 void _dcopy(
-    blas_idx_t n,
-    double const * x, blas_int_t incx,
-    double * y, blas_int_t incy ) {
-    return tlapack::copy<double, double>(
-        n,
-        x, incx,
-        y, incy );
+    blas_idx_t n, double const* x, blas_int_t incx, double* y, blas_int_t incy)
+{
+    return tlapack::copy<double, double>(n, x, incx, y, incy);
 }
 
 #define _ccopy BLAS_FUNCTION(ccopy)
-void _ccopy(
-    blas_idx_t n,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat * y, blas_int_t incy ) {
+void _ccopy(blas_idx_t n,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat* y,
+            blas_int_t incy)
+{
     return tlapack::copy<tlapack_complexFloat, tlapack_complexFloat>(
-        n,
-        tlapack_cteC(x), incx,
-        tlapack_C(y), incy );
+        n, tlapack_cteC(x), incx, tlapack_C(y), incy);
 }
 
 #define _zcopy BLAS_FUNCTION(zcopy)
-void _zcopy(
-    blas_idx_t n,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble * y, blas_int_t incy ) {
+void _zcopy(blas_idx_t n,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble* y,
+            blas_int_t incy)
+{
     return tlapack::copy<tlapack_complexDouble, tlapack_complexDouble>(
-        n,
-        tlapack_cteZ(x), incx,
-        tlapack_Z(y), incy );
+        n, tlapack_cteZ(x), incx, tlapack_Z(y), incy);
 }
 
 #define _sdot BLAS_FUNCTION(sdot)
-float _sdot(
-    blas_idx_t n,
-    float const * x, blas_int_t incx,
-    float const * y, blas_int_t incy ) {
-    return tlapack::dot<float, float>(
-        n,
-        x, incx,
-        y, incy );
+float _sdot(blas_idx_t n,
+            float const* x,
+            blas_int_t incx,
+            float const* y,
+            blas_int_t incy)
+{
+    return tlapack::dot<float, float>(n, x, incx, y, incy);
 }
 
 #define _ddot BLAS_FUNCTION(ddot)
-double _ddot(
-    blas_idx_t n,
-    double const * x, blas_int_t incx,
-    double const * y, blas_int_t incy ) {
-    return tlapack::dot<double, double>(
-        n,
-        x, incx,
-        y, incy );
+double _ddot(blas_idx_t n,
+             double const* x,
+             blas_int_t incx,
+             double const* y,
+             blas_int_t incy)
+{
+    return tlapack::dot<double, double>(n, x, incx, y, incy);
 }
 
 #define _cdot BLAS_FUNCTION(cdot)
-complexFloat _cdot(
-    blas_idx_t n,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat const * y, blas_int_t incy ) {
-    tlapack_complexFloat c = tlapack::dot<tlapack_complexFloat, tlapack_complexFloat>(
-        n,
-        tlapack_cteC(x), incx,
-        tlapack_cteC(y), incy );
+complexFloat _cdot(blas_idx_t n,
+                   complexFloat const* x,
+                   blas_int_t incx,
+                   complexFloat const* y,
+                   blas_int_t incy)
+{
+    tlapack_complexFloat c =
+        tlapack::dot<tlapack_complexFloat, tlapack_complexFloat>(
+            n, tlapack_cteC(x), incx, tlapack_cteC(y), incy);
     return *reinterpret_cast<complexFloat*>(&c);
 }
 
 #define _zdot BLAS_FUNCTION(zdot)
-complexDouble _zdot(
-    blas_idx_t n,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble const * y, blas_int_t incy ) {
-    tlapack_complexDouble z = tlapack::dot<tlapack_complexDouble, tlapack_complexDouble>(
-        n,
-        tlapack_cteZ(x), incx,
-        tlapack_cteZ(y), incy );
+complexDouble _zdot(blas_idx_t n,
+                    complexDouble const* x,
+                    blas_int_t incx,
+                    complexDouble const* y,
+                    blas_int_t incy)
+{
+    tlapack_complexDouble z =
+        tlapack::dot<tlapack_complexDouble, tlapack_complexDouble>(
+            n, tlapack_cteZ(x), incx, tlapack_cteZ(y), incy);
     return *reinterpret_cast<complexDouble*>(&z);
 }
 
 #define _sdotu BLAS_FUNCTION(sdotu)
-float _sdotu(
-    blas_idx_t n,
-    float const * x, blas_int_t incx,
-    float const * y, blas_int_t incy ) {
-    return tlapack::dotu<float, float>(
-        n,
-        x, incx,
-        y, incy );
+float _sdotu(blas_idx_t n,
+             float const* x,
+             blas_int_t incx,
+             float const* y,
+             blas_int_t incy)
+{
+    return tlapack::dotu<float, float>(n, x, incx, y, incy);
 }
 
 #define _ddotu BLAS_FUNCTION(ddotu)
-double _ddotu(
-    blas_idx_t n,
-    double const * x, blas_int_t incx,
-    double const * y, blas_int_t incy ) {
-    return tlapack::dotu<double, double>(
-        n,
-        x, incx,
-        y, incy );
+double _ddotu(blas_idx_t n,
+              double const* x,
+              blas_int_t incx,
+              double const* y,
+              blas_int_t incy)
+{
+    return tlapack::dotu<double, double>(n, x, incx, y, incy);
 }
 
 #define _cdotu BLAS_FUNCTION(cdotu)
-complexFloat _cdotu(
-    blas_idx_t n,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat const * y, blas_int_t incy ) {
-    tlapack_complexFloat c = tlapack::dotu<tlapack_complexFloat, tlapack_complexFloat>(
-        n,
-        tlapack_cteC(x), incx,
-        tlapack_cteC(y), incy );
+complexFloat _cdotu(blas_idx_t n,
+                    complexFloat const* x,
+                    blas_int_t incx,
+                    complexFloat const* y,
+                    blas_int_t incy)
+{
+    tlapack_complexFloat c =
+        tlapack::dotu<tlapack_complexFloat, tlapack_complexFloat>(
+            n, tlapack_cteC(x), incx, tlapack_cteC(y), incy);
     return *reinterpret_cast<complexFloat*>(&c);
 }
 
 #define _zdotu BLAS_FUNCTION(zdotu)
-complexDouble _zdotu(
-    blas_idx_t n,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble const * y, blas_int_t incy ) {
-    tlapack_complexDouble z = tlapack::dotu<tlapack_complexDouble, tlapack_complexDouble>(
-        n,
-        tlapack_cteZ(x), incx,
-        tlapack_cteZ(y), incy );
+complexDouble _zdotu(blas_idx_t n,
+                     complexDouble const* x,
+                     blas_int_t incx,
+                     complexDouble const* y,
+                     blas_int_t incy)
+{
+    tlapack_complexDouble z =
+        tlapack::dotu<tlapack_complexDouble, tlapack_complexDouble>(
+            n, tlapack_cteZ(x), incx, tlapack_cteZ(y), incy);
     return *reinterpret_cast<complexDouble*>(&z);
 }
 
 #define _isamax BLAS_FUNCTION(isamax)
-blas_iamax_t _isamax(
-    blas_idx_t n,
-    float const * x, blas_int_t incx ) {
-    return (blas_iamax_t) tlapack::iamax<float>(
-        n,
-        x, incx );
+blas_iamax_t _isamax(blas_idx_t n, float const* x, blas_int_t incx)
+{
+    return (blas_iamax_t)tlapack::iamax<float>(n, x, incx);
 }
 
 #define _idamax BLAS_FUNCTION(idamax)
-blas_iamax_t _idamax(
-    blas_idx_t n,
-    double const * x, blas_int_t incx ) {
-    return (blas_iamax_t) tlapack::iamax<double>(
-        n,
-        x, incx );
+blas_iamax_t _idamax(blas_idx_t n, double const* x, blas_int_t incx)
+{
+    return (blas_iamax_t)tlapack::iamax<double>(n, x, incx);
 }
 
 #define _icamax BLAS_FUNCTION(icamax)
-blas_iamax_t _icamax(
-    blas_idx_t n,
-    complexFloat const * x, blas_int_t incx ) {
-    return (blas_iamax_t) tlapack::iamax<tlapack_complexFloat>(
-        n,
-        tlapack_cteC(x), incx );
+blas_iamax_t _icamax(blas_idx_t n, complexFloat const* x, blas_int_t incx)
+{
+    return (blas_iamax_t)tlapack::iamax<tlapack_complexFloat>(
+        n, tlapack_cteC(x), incx);
 }
 
 #define _izamax BLAS_FUNCTION(izamax)
-blas_iamax_t _izamax(
-    blas_idx_t n,
-    complexDouble const * x, blas_int_t incx ) {
-    return (blas_iamax_t) tlapack::iamax<tlapack_complexDouble>(
-        n,
-        tlapack_cteZ(x), incx );
+blas_iamax_t _izamax(blas_idx_t n, complexDouble const* x, blas_int_t incx)
+{
+    return (blas_iamax_t)tlapack::iamax<tlapack_complexDouble>(
+        n, tlapack_cteZ(x), incx);
 }
 
 #define _snrm2 BLAS_FUNCTION(snrm2)
-float _snrm2(
-    blas_idx_t n,
-    float const * x, blas_int_t incx ) {
-    return tlapack::nrm2<float>(
-        n,
-        x, incx );
+float _snrm2(blas_idx_t n, float const* x, blas_int_t incx)
+{
+    return tlapack::nrm2<float>(n, x, incx);
 }
 
 #define _dnrm2 BLAS_FUNCTION(dnrm2)
-double _dnrm2(
-    blas_idx_t n,
-    double const * x, blas_int_t incx ) {
-    return tlapack::nrm2<double>(
-        n,
-        x, incx );
+double _dnrm2(blas_idx_t n, double const* x, blas_int_t incx)
+{
+    return tlapack::nrm2<double>(n, x, incx);
 }
 
 #define _cnrm2 BLAS_FUNCTION(cnrm2)
-float _cnrm2(
-    blas_idx_t n,
-    complexFloat const * x, blas_int_t incx ) {
-    return tlapack::nrm2<tlapack_complexFloat>(
-        n,
-        tlapack_cteC(x), incx );
+float _cnrm2(blas_idx_t n, complexFloat const* x, blas_int_t incx)
+{
+    return tlapack::nrm2<tlapack_complexFloat>(n, tlapack_cteC(x), incx);
 }
 
 #define _znrm2 BLAS_FUNCTION(znrm2)
-double _znrm2(
-    blas_idx_t n,
-    complexDouble const * x, blas_int_t incx ) {
-    return tlapack::nrm2<tlapack_complexDouble>(
-        n,
-        tlapack_cteZ(x), incx );
+double _znrm2(blas_idx_t n, complexDouble const* x, blas_int_t incx)
+{
+    return tlapack::nrm2<tlapack_complexDouble>(n, tlapack_cteZ(x), incx);
 }
 
 #define _srot BLAS_FUNCTION(srot)
-void _srot(
-    blas_idx_t n,
-    float * x, blas_int_t incx,
-    float * y, blas_int_t incy,
-    float c,
-    float s ) {
-    return tlapack::rot<float, float>(
-        n,
-        x, incx,
-        y, incy,
-        c,
-        s );
+void _srot(blas_idx_t n,
+           float* x,
+           blas_int_t incx,
+           float* y,
+           blas_int_t incy,
+           float c,
+           float s)
+{
+    return tlapack::rot<float, float>(n, x, incx, y, incy, c, s);
 }
 
 #define _drot BLAS_FUNCTION(drot)
-void _drot(
-    blas_idx_t n,
-    double * x, blas_int_t incx,
-    double * y, blas_int_t incy,
-    double c,
-    double s ) {
-    return tlapack::rot<double, double>(
-        n,
-        x, incx,
-        y, incy,
-        c,
-        s );
+void _drot(blas_idx_t n,
+           double* x,
+           blas_int_t incx,
+           double* y,
+           blas_int_t incy,
+           double c,
+           double s)
+{
+    return tlapack::rot<double, double>(n, x, incx, y, incy, c, s);
 }
 
 #define _csrot BLAS_FUNCTION(csrot)
-void _csrot(
-    blas_idx_t n,
-    complexFloat * x, blas_int_t incx,
-    complexFloat * y, blas_int_t incy,
-    float c,
-    float s ) {
-    return tlapack::rot(
-        n,
-        tlapack_C(x), incx,
-        tlapack_C(y), incy,
-        c,
-        s );
+void _csrot(blas_idx_t n,
+            complexFloat* x,
+            blas_int_t incx,
+            complexFloat* y,
+            blas_int_t incy,
+            float c,
+            float s)
+{
+    return tlapack::rot(n, tlapack_C(x), incx, tlapack_C(y), incy, c, s);
 }
 
 #define _zdrot BLAS_FUNCTION(zdrot)
-void _zdrot(
-    blas_idx_t n,
-    complexDouble * x, blas_int_t incx,
-    complexDouble * y, blas_int_t incy,
-    double c,
-    double s ) {
-    return tlapack::rot(
-        n,
-        tlapack_Z(x), incx,
-        tlapack_Z(y), incy,
-        c,
-        s );
+void _zdrot(blas_idx_t n,
+            complexDouble* x,
+            blas_int_t incx,
+            complexDouble* y,
+            blas_int_t incy,
+            double c,
+            double s)
+{
+    return tlapack::rot(n, tlapack_Z(x), incx, tlapack_Z(y), incy, c, s);
 }
 
 #define _crot BLAS_FUNCTION(crot)
-void _crot(
-    blas_idx_t n,
-    complexFloat * x, blas_int_t incx,
-    complexFloat * y, blas_int_t incy,
-    float c,
-    complexFloat s ) {
+void _crot(blas_idx_t n,
+           complexFloat* x,
+           blas_int_t incx,
+           complexFloat* y,
+           blas_int_t incy,
+           float c,
+           complexFloat s)
+{
     return tlapack::rot<tlapack_complexFloat, tlapack_complexFloat>(
-        n,
-        tlapack_C(x), incx,
-        tlapack_C(y), incy,
-        c,
-        *tlapack_C(&s) );
+        n, tlapack_C(x), incx, tlapack_C(y), incy, c, *tlapack_C(&s));
 }
 
 #define _zrot BLAS_FUNCTION(zrot)
-void _zrot(
-    blas_idx_t n,
-    complexDouble * x, blas_int_t incx,
-    complexDouble * y, blas_int_t incy,
-    double c,
-    complexDouble s ) {
+void _zrot(blas_idx_t n,
+           complexDouble* x,
+           blas_int_t incx,
+           complexDouble* y,
+           blas_int_t incy,
+           double c,
+           complexDouble s)
+{
     return tlapack::rot<tlapack_complexDouble, tlapack_complexDouble>(
-        n,
-        tlapack_Z(x), incx,
-        tlapack_Z(y), incy,
-        c,
-        *tlapack_Z(&s) );
+        n, tlapack_Z(x), incx, tlapack_Z(y), incy, c, *tlapack_Z(&s));
 }
 
 #define _srotg BLAS_FUNCTION(srotg)
-void _srotg(
-    float * a,
-    float * b,
-    float * c,
-    float * s ) {
-    return tlapack::rotg<float>(
-        *a,
-        *b,
-        *c,
-        *s );
+void _srotg(float* a, float* b, float* c, float* s)
+{
+    return tlapack::rotg<float>(*a, *b, *c, *s);
 }
 
 #define _drotg BLAS_FUNCTION(drotg)
-void _drotg(
-    double * a,
-    double * b,
-    double * c,
-    double * s ) {
-    return tlapack::rotg<double>(
-        *a,
-        *b,
-        *c,
-        *s );
+void _drotg(double* a, double* b, double* c, double* s)
+{
+    return tlapack::rotg<double>(*a, *b, *c, *s);
 }
 
 #define _crotg BLAS_FUNCTION(crotg)
-void _crotg(
-    complexFloat * a,
-    complexFloat * b,
-    float * c,
-    complexFloat * s ) {
-    return tlapack::rotg<tlapack_complexFloat>(
-        *tlapack_C(a),
-        *tlapack_C(b),
-        *c,
-        *tlapack_C(s) );
+void _crotg(complexFloat* a, complexFloat* b, float* c, complexFloat* s)
+{
+    return tlapack::rotg<tlapack_complexFloat>(*tlapack_C(a), *tlapack_C(b), *c,
+                                               *tlapack_C(s));
 }
 
 #define _zrotg BLAS_FUNCTION(zrotg)
-void _zrotg(
-    complexDouble * a,
-    complexDouble * b,
-    double * c,
-    complexDouble * s ) {
-    return tlapack::rotg<tlapack_complexDouble>(
-        *tlapack_Z(a),
-        *tlapack_Z(b),
-        *c,
-        *tlapack_Z(s) );
+void _zrotg(complexDouble* a, complexDouble* b, double* c, complexDouble* s)
+{
+    return tlapack::rotg<tlapack_complexDouble>(*tlapack_Z(a), *tlapack_Z(b),
+                                                *c, *tlapack_Z(s));
 }
 
 #define _srotm BLAS_FUNCTION(srotm)
-void _srotm(
-    blas_idx_t n,
-    float * x, blas_int_t incx,
-    float * y, blas_int_t incy,
-    float const * param ) {
-    return tlapack::rotm<float, float>(
-        n,
-        x, incx,
-        y, incy,
-        param );
+void _srotm(blas_idx_t n,
+            float* x,
+            blas_int_t incx,
+            float* y,
+            blas_int_t incy,
+            float const* param)
+{
+    return tlapack::rotm<float, float>(n, x, incx, y, incy, param);
 }
 
 #define _drotm BLAS_FUNCTION(drotm)
-void _drotm(
-    blas_idx_t n,
-    double * x, blas_int_t incx,
-    double * y, blas_int_t incy,
-    double const * param ) {
-    return tlapack::rotm<double, double>(
-        n,
-        x, incx,
-        y, incy,
-        param );
+void _drotm(blas_idx_t n,
+            double* x,
+            blas_int_t incx,
+            double* y,
+            blas_int_t incy,
+            double const* param)
+{
+    return tlapack::rotm<double, double>(n, x, incx, y, incy, param);
 }
 
 #define _srotmg BLAS_FUNCTION(srotmg)
-void _srotmg(
-    float * d1,
-    float * d2,
-    float * a,
-    float b,
-    float * param ) {
-    return tlapack::rotmg<float>(
-        d1,
-        d2,
-        a,
-        b,
-        param );
+void _srotmg(float* d1, float* d2, float* a, float b, float* param)
+{
+    return tlapack::rotmg<float>(d1, d2, a, b, param);
 }
 
 #define _drotmg BLAS_FUNCTION(drotmg)
-void _drotmg(
-    double * d1,
-    double * d2,
-    double * a,
-    double b,
-    double * param ) {
-    return tlapack::rotmg<double>(
-        d1,
-        d2,
-        a,
-        b,
-        param );
+void _drotmg(double* d1, double* d2, double* a, double b, double* param)
+{
+    return tlapack::rotmg<double>(d1, d2, a, b, param);
 }
 
 #define _sscal BLAS_FUNCTION(sscal)
-void _sscal(
-    blas_idx_t n,
-    float alpha,
-    float * x, blas_int_t incx ) {
-    return tlapack::scal<float>(
-        n,
-        alpha,
-        x, incx );
+void _sscal(blas_idx_t n, float alpha, float* x, blas_int_t incx)
+{
+    return tlapack::scal<float>(n, alpha, x, incx);
 }
 
 #define _dscal BLAS_FUNCTION(dscal)
-void _dscal(
-    blas_idx_t n,
-    double alpha,
-    double * x, blas_int_t incx ) {
-    return tlapack::scal<double>(
-        n,
-        alpha,
-        x, incx );
+void _dscal(blas_idx_t n, double alpha, double* x, blas_int_t incx)
+{
+    return tlapack::scal<double>(n, alpha, x, incx);
 }
 
 #define _cscal BLAS_FUNCTION(cscal)
-void _cscal(
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat * x, blas_int_t incx ) {
-    return tlapack::scal<tlapack_complexFloat>(
-        n,
-        *tlapack_C(&alpha),
-        tlapack_C(x), incx );
+void _cscal(blas_idx_t n, complexFloat alpha, complexFloat* x, blas_int_t incx)
+{
+    return tlapack::scal<tlapack_complexFloat>(n, *tlapack_C(&alpha),
+                                               tlapack_C(x), incx);
 }
 
 #define _zscal BLAS_FUNCTION(zscal)
-void _zscal(
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble * x, blas_int_t incx ) {
-    return tlapack::scal<tlapack_complexDouble>(
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_Z(x), incx );
+void _zscal(blas_idx_t n,
+            complexDouble alpha,
+            complexDouble* x,
+            blas_int_t incx)
+{
+    return tlapack::scal<tlapack_complexDouble>(n, *tlapack_Z(&alpha),
+                                                tlapack_Z(x), incx);
 }
 
 #define _sswap BLAS_FUNCTION(sswap)
-void _sswap(
-    blas_idx_t n,
-    float * x, blas_int_t incx,
-    float * y, blas_int_t incy ) {
-    return tlapack::swap<float, float>(
-        n,
-        x, incx,
-        y, incy );
+void _sswap(blas_idx_t n, float* x, blas_int_t incx, float* y, blas_int_t incy)
+{
+    return tlapack::swap<float, float>(n, x, incx, y, incy);
 }
 
 #define _dswap BLAS_FUNCTION(dswap)
 void _dswap(
-    blas_idx_t n,
-    double * x, blas_int_t incx,
-    double * y, blas_int_t incy ) {
-    return tlapack::swap<double, double>(
-        n,
-        x, incx,
-        y, incy );
+    blas_idx_t n, double* x, blas_int_t incx, double* y, blas_int_t incy)
+{
+    return tlapack::swap<double, double>(n, x, incx, y, incy);
 }
 
 #define _cswap BLAS_FUNCTION(cswap)
-void _cswap(
-    blas_idx_t n,
-    complexFloat * x, blas_int_t incx,
-    complexFloat * y, blas_int_t incy ) {
+void _cswap(blas_idx_t n,
+            complexFloat* x,
+            blas_int_t incx,
+            complexFloat* y,
+            blas_int_t incy)
+{
     return tlapack::swap<tlapack_complexFloat, tlapack_complexFloat>(
-        n,
-        tlapack_C(x), incx,
-        tlapack_C(y), incy );
+        n, tlapack_C(x), incx, tlapack_C(y), incy);
 }
 
 #define _zswap BLAS_FUNCTION(zswap)
-void _zswap(
-    blas_idx_t n,
-    complexDouble * x, blas_int_t incx,
-    complexDouble * y, blas_int_t incy ) {
+void _zswap(blas_idx_t n,
+            complexDouble* x,
+            blas_int_t incx,
+            complexDouble* y,
+            blas_int_t incy)
+{
     return tlapack::swap<tlapack_complexDouble, tlapack_complexDouble>(
-        n,
-        tlapack_Z(x), incx,
-        tlapack_Z(y), incy );
+        n, tlapack_Z(x), incx, tlapack_Z(y), incy);
 }
 
 #define _sgemv BLAS_FUNCTION(sgemv)
-void _sgemv(
-    Layout layout,
-    Op trans,
-    blas_idx_t m,
-    blas_idx_t n,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * x, blas_int_t incx,
-    float beta,
-    float * y, blas_int_t incy ) {
-    return tlapack::gemv<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKop( trans ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        x, incx,
-        beta,
-        y, incy );
+void _sgemv(Layout layout,
+            Op trans,
+            blas_idx_t m,
+            blas_idx_t n,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float const* x,
+            blas_int_t incx,
+            float beta,
+            float* y,
+            blas_int_t incy)
+{
+    return tlapack::gemv<float, float, float>(toTLAPACKlayout(layout),
+                                              toTLAPACKop(trans), m, n, alpha,
+                                              A, lda, x, incx, beta, y, incy);
 }
 
 #define _dgemv BLAS_FUNCTION(dgemv)
-void _dgemv(
-    Layout layout,
-    Op trans,
-    blas_idx_t m,
-    blas_idx_t n,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * x, blas_int_t incx,
-    double beta,
-    double * y, blas_int_t incy ) {
+void _dgemv(Layout layout,
+            Op trans,
+            blas_idx_t m,
+            blas_idx_t n,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double const* x,
+            blas_int_t incx,
+            double beta,
+            double* y,
+            blas_int_t incy)
+{
     return tlapack::gemv<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKop( trans ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        x, incx,
-        beta,
-        y, incy );
+        toTLAPACKlayout(layout), toTLAPACKop(trans), m, n, alpha, A, lda, x,
+        incx, beta, y, incy);
 }
 
 #define _cgemv BLAS_FUNCTION(cgemv)
-void _cgemv(
-    Layout layout,
-    Op trans,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat beta,
-    complexFloat * y, blas_int_t incy ) {
-    return tlapack::gemv<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKop( trans ),
-        m,
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(x), incx,
-        *tlapack_C(&beta),
-        tlapack_C(y), incy );
+void _cgemv(Layout layout,
+            Op trans,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat beta,
+            complexFloat* y,
+            blas_int_t incy)
+{
+    return tlapack::gemv<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKop(trans), m, n, *tlapack_C(&alpha),
+        tlapack_cteC(A), lda, tlapack_cteC(x), incx, *tlapack_C(&beta),
+        tlapack_C(y), incy);
 }
 
 #define _zgemv BLAS_FUNCTION(zgemv)
-void _zgemv(
-    Layout layout,
-    Op trans,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble beta,
-    complexDouble * y, blas_int_t incy ) {
-    return tlapack::gemv<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKop( trans ),
-        m,
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(x), incx,
-        *tlapack_Z(&beta),
-        tlapack_Z(y), incy );
+void _zgemv(Layout layout,
+            Op trans,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble beta,
+            complexDouble* y,
+            blas_int_t incy)
+{
+    return tlapack::gemv<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKop(trans), m, n, *tlapack_Z(&alpha),
+        tlapack_cteZ(A), lda, tlapack_cteZ(x), incx, *tlapack_Z(&beta),
+        tlapack_Z(y), incy);
 }
 
 #define _sger BLAS_FUNCTION(sger)
-void _sger(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    float alpha,
-    float const * x, blas_int_t incx,
-    float const * y, blas_int_t incy,
-    float * A, blas_idx_t lda ) {
-    return tlapack::ger<float, float, float>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+void _sger(Layout layout,
+           blas_idx_t m,
+           blas_idx_t n,
+           float alpha,
+           float const* x,
+           blas_int_t incx,
+           float const* y,
+           blas_int_t incy,
+           float* A,
+           blas_idx_t lda)
+{
+    return tlapack::ger<float, float, float>(toTLAPACKlayout(layout), m, n,
+                                             alpha, x, incx, y, incy, A, lda);
 }
 
 #define _dger BLAS_FUNCTION(dger)
-void _dger(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    double alpha,
-    double const * x, blas_int_t incx,
-    double const * y, blas_int_t incy,
-    double * A, blas_idx_t lda ) {
+void _dger(Layout layout,
+           blas_idx_t m,
+           blas_idx_t n,
+           double alpha,
+           double const* x,
+           blas_int_t incx,
+           double const* y,
+           blas_int_t incy,
+           double* A,
+           blas_idx_t lda)
+{
     return tlapack::ger<double, double, double>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+        toTLAPACKlayout(layout), m, n, alpha, x, incx, y, incy, A, lda);
 }
 
 #define _cger BLAS_FUNCTION(cger)
-void _cger(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat const * y, blas_int_t incy,
-    complexFloat * A, blas_idx_t lda ) {
-    return tlapack::ger<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(x), incx,
-        tlapack_cteC(y), incy,
-        tlapack_C(A), lda );
+void _cger(Layout layout,
+           blas_idx_t m,
+           blas_idx_t n,
+           complexFloat alpha,
+           complexFloat const* x,
+           blas_int_t incx,
+           complexFloat const* y,
+           blas_int_t incy,
+           complexFloat* A,
+           blas_idx_t lda)
+{
+    return tlapack::ger<tlapack_complexFloat, tlapack_complexFloat,
+                        tlapack_complexFloat>(
+        toTLAPACKlayout(layout), m, n, *tlapack_C(&alpha), tlapack_cteC(x),
+        incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
 
 #define _zger BLAS_FUNCTION(zger)
-void _zger(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble const * y, blas_int_t incy,
-    complexDouble * A, blas_idx_t lda ) {
-    return tlapack::ger<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(x), incx,
-        tlapack_cteZ(y), incy,
-        tlapack_Z(A), lda );
+void _zger(Layout layout,
+           blas_idx_t m,
+           blas_idx_t n,
+           complexDouble alpha,
+           complexDouble const* x,
+           blas_int_t incx,
+           complexDouble const* y,
+           blas_int_t incy,
+           complexDouble* A,
+           blas_idx_t lda)
+{
+    return tlapack::ger<tlapack_complexDouble, tlapack_complexDouble,
+                        tlapack_complexDouble>(
+        toTLAPACKlayout(layout), m, n, *tlapack_Z(&alpha), tlapack_cteZ(x),
+        incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
 
 #define _sgeru BLAS_FUNCTION(sgeru)
-void _sgeru(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    float alpha,
-    float const * x, blas_int_t incx,
-    float const * y, blas_int_t incy,
-    float * A, blas_idx_t lda ) {
-    return tlapack::geru<float, float, float>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+void _sgeru(Layout layout,
+            blas_idx_t m,
+            blas_idx_t n,
+            float alpha,
+            float const* x,
+            blas_int_t incx,
+            float const* y,
+            blas_int_t incy,
+            float* A,
+            blas_idx_t lda)
+{
+    return tlapack::geru<float, float, float>(toTLAPACKlayout(layout), m, n,
+                                              alpha, x, incx, y, incy, A, lda);
 }
 
 #define _dgeru BLAS_FUNCTION(dgeru)
-void _dgeru(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    double alpha,
-    double const * x, blas_int_t incx,
-    double const * y, blas_int_t incy,
-    double * A, blas_idx_t lda ) {
+void _dgeru(Layout layout,
+            blas_idx_t m,
+            blas_idx_t n,
+            double alpha,
+            double const* x,
+            blas_int_t incx,
+            double const* y,
+            blas_int_t incy,
+            double* A,
+            blas_idx_t lda)
+{
     return tlapack::geru<double, double, double>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+        toTLAPACKlayout(layout), m, n, alpha, x, incx, y, incy, A, lda);
 }
 
 #define _cgeru BLAS_FUNCTION(cgeru)
-void _cgeru(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat const * y, blas_int_t incy,
-    complexFloat * A, blas_idx_t lda ) {
-    return tlapack::geru<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(x), incx,
-        tlapack_cteC(y), incy,
-        tlapack_C(A), lda );
+void _cgeru(Layout layout,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat const* y,
+            blas_int_t incy,
+            complexFloat* A,
+            blas_idx_t lda)
+{
+    return tlapack::geru<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), m, n, *tlapack_C(&alpha), tlapack_cteC(x),
+        incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
 
 #define _zgeru BLAS_FUNCTION(zgeru)
-void _zgeru(
-    Layout layout,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble const * y, blas_int_t incy,
-    complexDouble * A, blas_idx_t lda ) {
-    return tlapack::geru<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        m,
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(x), incx,
-        tlapack_cteZ(y), incy,
-        tlapack_Z(A), lda );
+void _zgeru(Layout layout,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble const* y,
+            blas_int_t incy,
+            complexDouble* A,
+            blas_idx_t lda)
+{
+    return tlapack::geru<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), m, n, *tlapack_Z(&alpha), tlapack_cteZ(x),
+        incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
 
 #define _shemv BLAS_FUNCTION(shemv)
-void _shemv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * x, blas_int_t incx,
-    float beta,
-    float * y, blas_int_t incy ) {
-    return tlapack::hemv<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        A, lda,
-        x, incx,
-        beta,
-        y, incy );
+void _shemv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float const* x,
+            blas_int_t incx,
+            float beta,
+            float* y,
+            blas_int_t incy)
+{
+    return tlapack::hemv<float, float, float>(toTLAPACKlayout(layout),
+                                              toTLAPACKuplo(uplo), n, alpha, A,
+                                              lda, x, incx, beta, y, incy);
 }
 
 #define _dhemv BLAS_FUNCTION(dhemv)
-void _dhemv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * x, blas_int_t incx,
-    double beta,
-    double * y, blas_int_t incy ) {
+void _dhemv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double const* x,
+            blas_int_t incx,
+            double beta,
+            double* y,
+            blas_int_t incy)
+{
     return tlapack::hemv<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        A, lda,
-        x, incx,
-        beta,
-        y, incy );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, A, lda, x, incx,
+        beta, y, incy);
 }
 
 #define _chemv BLAS_FUNCTION(chemv)
-void _chemv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat beta,
-    complexFloat * y, blas_int_t incy ) {
-    return tlapack::hemv<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(x), incx,
-        *tlapack_C(&beta),
-        tlapack_C(y), incy );
+void _chemv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat beta,
+            complexFloat* y,
+            blas_int_t incy)
+{
+    return tlapack::hemv<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
+        tlapack_cteC(A), lda, tlapack_cteC(x), incx, *tlapack_C(&beta),
+        tlapack_C(y), incy);
 }
 
 #define _zhemv BLAS_FUNCTION(zhemv)
-void _zhemv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble beta,
-    complexDouble * y, blas_int_t incy ) {
-    return tlapack::hemv<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(x), incx,
-        *tlapack_Z(&beta),
-        tlapack_Z(y), incy );
+void _zhemv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble beta,
+            complexDouble* y,
+            blas_int_t incy)
+{
+    return tlapack::hemv<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
+        tlapack_cteZ(A), lda, tlapack_cteZ(x), incx, *tlapack_Z(&beta),
+        tlapack_Z(y), incy);
 }
 
 #define _sher BLAS_FUNCTION(sher)
-void _sher(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    float alpha,
-    float const * x, blas_int_t incx,
-    float * A, blas_idx_t lda ) {
-    return tlapack::her<float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        A, lda );
+void _sher(Layout layout,
+           Uplo uplo,
+           blas_idx_t n,
+           float alpha,
+           float const* x,
+           blas_int_t incx,
+           float* A,
+           blas_idx_t lda)
+{
+    return tlapack::her<float, float>(toTLAPACKlayout(layout),
+                                      toTLAPACKuplo(uplo), n, alpha, x, incx, A,
+                                      lda);
 }
 
 #define _dher BLAS_FUNCTION(dher)
-void _dher(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    double alpha,
-    double const * x, blas_int_t incx,
-    double * A, blas_idx_t lda ) {
-    return tlapack::her<double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        A, lda );
+void _dher(Layout layout,
+           Uplo uplo,
+           blas_idx_t n,
+           double alpha,
+           double const* x,
+           blas_int_t incx,
+           double* A,
+           blas_idx_t lda)
+{
+    return tlapack::her<double, double>(toTLAPACKlayout(layout),
+                                        toTLAPACKuplo(uplo), n, alpha, x, incx,
+                                        A, lda);
 }
 
 #define _cher BLAS_FUNCTION(cher)
-void _cher(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    float alpha,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat * A, blas_idx_t lda ) {
+void _cher(Layout layout,
+           Uplo uplo,
+           blas_idx_t n,
+           float alpha,
+           complexFloat const* x,
+           blas_int_t incx,
+           complexFloat* A,
+           blas_idx_t lda)
+{
     return tlapack::her<tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        tlapack_cteC(x), incx,
-        tlapack_C(A), lda );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, tlapack_cteC(x),
+        incx, tlapack_C(A), lda);
 }
 
 #define _zher BLAS_FUNCTION(zher)
-void _zher(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    double alpha,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble * A, blas_idx_t lda ) {
+void _zher(Layout layout,
+           Uplo uplo,
+           blas_idx_t n,
+           double alpha,
+           complexDouble const* x,
+           blas_int_t incx,
+           complexDouble* A,
+           blas_idx_t lda)
+{
     return tlapack::her<tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        tlapack_cteZ(x), incx,
-        tlapack_Z(A), lda );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, tlapack_cteZ(x),
+        incx, tlapack_Z(A), lda);
 }
 
 #define _sher2 BLAS_FUNCTION(sher2)
-void _sher2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    float alpha,
-    float const * x, blas_int_t incx,
-    float const * y, blas_int_t incy,
-    float * A, blas_idx_t lda ) {
-    return tlapack::her2<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+void _sher2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            float alpha,
+            float const* x,
+            blas_int_t incx,
+            float const* y,
+            blas_int_t incy,
+            float* A,
+            blas_idx_t lda)
+{
+    return tlapack::her2<float, float, float>(toTLAPACKlayout(layout),
+                                              toTLAPACKuplo(uplo), n, alpha, x,
+                                              incx, y, incy, A, lda);
 }
 
 #define _dher2 BLAS_FUNCTION(dher2)
-void _dher2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    double alpha,
-    double const * x, blas_int_t incx,
-    double const * y, blas_int_t incy,
-    double * A, blas_idx_t lda ) {
-    return tlapack::her2<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+void _dher2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            double alpha,
+            double const* x,
+            blas_int_t incx,
+            double const* y,
+            blas_int_t incy,
+            double* A,
+            blas_idx_t lda)
+{
+    return tlapack::her2<double, double, double>(toTLAPACKlayout(layout),
+                                                 toTLAPACKuplo(uplo), n, alpha,
+                                                 x, incx, y, incy, A, lda);
 }
 
 #define _cher2 BLAS_FUNCTION(cher2)
-void _cher2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat const * y, blas_int_t incy,
-    complexFloat * A, blas_idx_t lda ) {
-    return tlapack::her2<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(x), incx,
-        tlapack_cteC(y), incy,
-        tlapack_C(A), lda );
+void _cher2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat const* y,
+            blas_int_t incy,
+            complexFloat* A,
+            blas_idx_t lda)
+{
+    return tlapack::her2<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
+        tlapack_cteC(x), incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
 
 #define _zher2 BLAS_FUNCTION(zher2)
-void _zher2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble const * y, blas_int_t incy,
-    complexDouble * A, blas_idx_t lda ) {
-    return tlapack::her2<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(x), incx,
-        tlapack_cteZ(y), incy,
-        tlapack_Z(A), lda );
+void _zher2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble const* y,
+            blas_int_t incy,
+            complexDouble* A,
+            blas_idx_t lda)
+{
+    return tlapack::her2<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
+        tlapack_cteZ(x), incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
 
 #define _ssymv BLAS_FUNCTION(ssymv)
-void _ssymv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * x, blas_int_t incx,
-    float beta,
-    float * y, blas_int_t incy ) {
-    return tlapack::symv<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        A, lda,
-        x, incx,
-        beta,
-        y, incy );
+void _ssymv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float const* x,
+            blas_int_t incx,
+            float beta,
+            float* y,
+            blas_int_t incy)
+{
+    return tlapack::symv<float, float, float>(toTLAPACKlayout(layout),
+                                              toTLAPACKuplo(uplo), n, alpha, A,
+                                              lda, x, incx, beta, y, incy);
 }
 
 #define _dsymv BLAS_FUNCTION(dsymv)
-void _dsymv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * x, blas_int_t incx,
-    double beta,
-    double * y, blas_int_t incy ) {
+void _dsymv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double const* x,
+            blas_int_t incx,
+            double beta,
+            double* y,
+            blas_int_t incy)
+{
     return tlapack::symv<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        A, lda,
-        x, incx,
-        beta,
-        y, incy );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, A, lda, x, incx,
+        beta, y, incy);
 }
 
 #define _csymv BLAS_FUNCTION(csymv)
-void _csymv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat beta,
-    complexFloat * y, blas_int_t incy ) {
-    return tlapack::symv<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(x), incx,
-        *tlapack_C(&beta),
-        tlapack_C(y), incy );
+void _csymv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat beta,
+            complexFloat* y,
+            blas_int_t incy)
+{
+    return tlapack::symv<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
+        tlapack_cteC(A), lda, tlapack_cteC(x), incx, *tlapack_C(&beta),
+        tlapack_C(y), incy);
 }
 
 #define _zsymv BLAS_FUNCTION(zsymv)
-void _zsymv(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble beta,
-    complexDouble * y, blas_int_t incy ) {
-    return tlapack::symv<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(x), incx,
-        *tlapack_Z(&beta),
-        tlapack_Z(y), incy );
+void _zsymv(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble beta,
+            complexDouble* y,
+            blas_int_t incy)
+{
+    return tlapack::symv<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
+        tlapack_cteZ(A), lda, tlapack_cteZ(x), incx, *tlapack_Z(&beta),
+        tlapack_Z(y), incy);
 }
 
 #define _ssyr BLAS_FUNCTION(ssyr)
-void _ssyr(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    float alpha,
-    float const * x, blas_int_t incx,
-    float * A, blas_idx_t lda ) {
-    return tlapack::syr<float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        A, lda );
+void _ssyr(Layout layout,
+           Uplo uplo,
+           blas_idx_t n,
+           float alpha,
+           float const* x,
+           blas_int_t incx,
+           float* A,
+           blas_idx_t lda)
+{
+    return tlapack::syr<float, float>(toTLAPACKlayout(layout),
+                                      toTLAPACKuplo(uplo), n, alpha, x, incx, A,
+                                      lda);
 }
 
 #define _dsyr BLAS_FUNCTION(dsyr)
-void _dsyr(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    double alpha,
-    double const * x, blas_int_t incx,
-    double * A, blas_idx_t lda ) {
-    return tlapack::syr<double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        A, lda );
+void _dsyr(Layout layout,
+           Uplo uplo,
+           blas_idx_t n,
+           double alpha,
+           double const* x,
+           blas_int_t incx,
+           double* A,
+           blas_idx_t lda)
+{
+    return tlapack::syr<double, double>(toTLAPACKlayout(layout),
+                                        toTLAPACKuplo(uplo), n, alpha, x, incx,
+                                        A, lda);
 }
 
 #define _ssyr2 BLAS_FUNCTION(ssyr2)
-void _ssyr2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    float alpha,
-    float const * x, blas_int_t incx,
-    float const * y, blas_int_t incy,
-    float * A, blas_idx_t lda ) {
-    return tlapack::syr2<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+void _ssyr2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            float alpha,
+            float const* x,
+            blas_int_t incx,
+            float const* y,
+            blas_int_t incy,
+            float* A,
+            blas_idx_t lda)
+{
+    return tlapack::syr2<float, float, float>(toTLAPACKlayout(layout),
+                                              toTLAPACKuplo(uplo), n, alpha, x,
+                                              incx, y, incy, A, lda);
 }
 
 #define _dsyr2 BLAS_FUNCTION(dsyr2)
-void _dsyr2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    double alpha,
-    double const * x, blas_int_t incx,
-    double const * y, blas_int_t incy,
-    double * A, blas_idx_t lda ) {
-    return tlapack::syr2<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        alpha,
-        x, incx,
-        y, incy,
-        A, lda );
+void _dsyr2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            double alpha,
+            double const* x,
+            blas_int_t incx,
+            double const* y,
+            blas_int_t incy,
+            double* A,
+            blas_idx_t lda)
+{
+    return tlapack::syr2<double, double, double>(toTLAPACKlayout(layout),
+                                                 toTLAPACKuplo(uplo), n, alpha,
+                                                 x, incx, y, incy, A, lda);
 }
 
 #define _csyr2 BLAS_FUNCTION(csyr2)
-void _csyr2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * x, blas_int_t incx,
-    complexFloat const * y, blas_int_t incy,
-    complexFloat * A, blas_idx_t lda ) {
-    return tlapack::syr2<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(x), incx,
-        tlapack_cteC(y), incy,
-        tlapack_C(A), lda );
+void _csyr2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* x,
+            blas_int_t incx,
+            complexFloat const* y,
+            blas_int_t incy,
+            complexFloat* A,
+            blas_idx_t lda)
+{
+    return tlapack::syr2<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
+        tlapack_cteC(x), incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
 
 #define _zsyr2 BLAS_FUNCTION(zsyr2)
-void _zsyr2(
-    Layout layout,
-    Uplo uplo,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * x, blas_int_t incx,
-    complexDouble const * y, blas_int_t incy,
-    complexDouble * A, blas_idx_t lda ) {
-    return tlapack::syr2<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(x), incx,
-        tlapack_cteZ(y), incy,
-        tlapack_Z(A), lda );
+void _zsyr2(Layout layout,
+            Uplo uplo,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* x,
+            blas_int_t incx,
+            complexDouble const* y,
+            blas_int_t incy,
+            complexDouble* A,
+            blas_idx_t lda)
+{
+    return tlapack::syr2<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
+        tlapack_cteZ(x), incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
 
 #define _strmv BLAS_FUNCTION(strmv)
-void _strmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    float const * A, blas_idx_t lda,
-    float * x, blas_int_t incx ) {
-    return tlapack::trmv<float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        A, lda,
-        x, incx );
+void _strmv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            float const* A,
+            blas_idx_t lda,
+            float* x,
+            blas_int_t incx)
+{
+    return tlapack::trmv<float, float>(toTLAPACKlayout(layout),
+                                       toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                                       toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
 
 #define _dtrmv BLAS_FUNCTION(dtrmv)
-void _dtrmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    double const * A, blas_idx_t lda,
-    double * x, blas_int_t incx ) {
+void _dtrmv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            double const* A,
+            blas_idx_t lda,
+            double* x,
+            blas_int_t incx)
+{
     return tlapack::trmv<double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        A, lda,
-        x, incx );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
 
 #define _ctrmv BLAS_FUNCTION(ctrmv)
-void _ctrmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat * x, blas_int_t incx ) {
+void _ctrmv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat* x,
+            blas_int_t incx)
+{
     return tlapack::trmv<tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        tlapack_cteC(A), lda,
-        tlapack_C(x), incx );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, tlapack_cteC(A), lda, tlapack_C(x), incx);
 }
 
 #define _ztrmv BLAS_FUNCTION(ztrmv)
-void _ztrmv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble * x, blas_int_t incx ) {
+void _ztrmv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble* x,
+            blas_int_t incx)
+{
     return tlapack::trmv<tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        tlapack_cteZ(A), lda,
-        tlapack_Z(x), incx );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, tlapack_cteZ(A), lda, tlapack_Z(x), incx);
 }
 
 #define _strsv BLAS_FUNCTION(strsv)
-void _strsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    float const * A, blas_idx_t lda,
-    float * x, blas_int_t incx ) {
-    return tlapack::trsv<float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        A, lda,
-        x, incx );
+void _strsv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            float const* A,
+            blas_idx_t lda,
+            float* x,
+            blas_int_t incx)
+{
+    return tlapack::trsv<float, float>(toTLAPACKlayout(layout),
+                                       toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                                       toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
 
 #define _dtrsv BLAS_FUNCTION(dtrsv)
-void _dtrsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    double const * A, blas_idx_t lda,
-    double * x, blas_int_t incx ) {
+void _dtrsv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            double const* A,
+            blas_idx_t lda,
+            double* x,
+            blas_int_t incx)
+{
     return tlapack::trsv<double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        A, lda,
-        x, incx );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
 
 #define _ctrsv BLAS_FUNCTION(ctrsv)
-void _ctrsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat * x, blas_int_t incx ) {
+void _ctrsv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat* x,
+            blas_int_t incx)
+{
     return tlapack::trsv<tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        tlapack_cteC(A), lda,
-        tlapack_C(x), incx );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, tlapack_cteC(A), lda, tlapack_C(x), incx);
 }
 
 #define _ztrsv BLAS_FUNCTION(ztrsv)
-void _ztrsv(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t n,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble * x, blas_int_t incx ) {
+void _ztrsv(Layout layout,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t n,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble* x,
+            blas_int_t incx)
+{
     return tlapack::trsv<tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        n,
-        tlapack_cteZ(A), lda,
-        tlapack_Z(x), incx );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, tlapack_cteZ(A), lda, tlapack_Z(x), incx);
 }
 
 #define _sgemm BLAS_FUNCTION(sgemm)
-void _sgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    blas_idx_t m,
-    blas_idx_t n,
-    blas_idx_t k,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * B, blas_idx_t ldb,
-    float beta,
-    float * C, blas_idx_t ldc ) {
-    return tlapack::gemm(
-        toTLAPACKlayout( layout ),
-        (tlapack::Op) transA,
-        (tlapack::Op) transB,
-        m,
-        n,
-        k,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+void _sgemm(Layout layout,
+            Op transA,
+            Op transB,
+            blas_idx_t m,
+            blas_idx_t n,
+            blas_idx_t k,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float const* B,
+            blas_idx_t ldb,
+            float beta,
+            float* C,
+            blas_idx_t ldc)
+{
+    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
+                         (tlapack::Op)transB, m, n, k, alpha, A, lda, B, ldb,
+                         beta, C, ldc);
 }
 
 #define _dgemm BLAS_FUNCTION(dgemm)
-void _dgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    blas_idx_t m,
-    blas_idx_t n,
-    blas_idx_t k,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * B, blas_idx_t ldb,
-    double beta,
-    double * C, blas_idx_t ldc ) {
-    return tlapack::gemm(
-        toTLAPACKlayout( layout ),
-        (tlapack::Op) transA,
-        (tlapack::Op) transB,
-        m,
-        n,
-        k,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+void _dgemm(Layout layout,
+            Op transA,
+            Op transB,
+            blas_idx_t m,
+            blas_idx_t n,
+            blas_idx_t k,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double const* B,
+            blas_idx_t ldb,
+            double beta,
+            double* C,
+            blas_idx_t ldc)
+{
+    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
+                         (tlapack::Op)transB, m, n, k, alpha, A, lda, B, ldb,
+                         beta, C, ldc);
 }
 
 #define _cgemm BLAS_FUNCTION(cgemm)
-void _cgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    blas_idx_t m,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * B, blas_idx_t ldb,
-    complexFloat beta,
-    complexFloat * C, blas_idx_t ldc ) {
-    return tlapack::gemm(
-        toTLAPACKlayout( layout ),
-        (tlapack::Op) transA,
-        (tlapack::Op) transB,
-        m,
-        n,
-        k,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(B), ldb,
-        *tlapack_C(&beta),
-        tlapack_C(C), ldc );
+void _cgemm(Layout layout,
+            Op transA,
+            Op transB,
+            blas_idx_t m,
+            blas_idx_t n,
+            blas_idx_t k,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat const* B,
+            blas_idx_t ldb,
+            complexFloat beta,
+            complexFloat* C,
+            blas_idx_t ldc)
+{
+    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
+                         (tlapack::Op)transB, m, n, k, *tlapack_C(&alpha),
+                         tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
+                         *tlapack_C(&beta), tlapack_C(C), ldc);
 }
 
 #define _zgemm BLAS_FUNCTION(zgemm)
-void _zgemm(
-    Layout layout,
-    Op transA,
-    Op transB,
-    blas_idx_t m,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * B, blas_idx_t ldb,
-    complexDouble beta,
-    complexDouble * C, blas_idx_t ldc ) {
-    return tlapack::gemm(
-        toTLAPACKlayout( layout ),
-        (tlapack::Op) transA,
-        (tlapack::Op) transB,
-        m,
-        n,
-        k,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(B), ldb,
-        *tlapack_Z(&beta),
-        tlapack_Z(C), ldc );
+void _zgemm(Layout layout,
+            Op transA,
+            Op transB,
+            blas_idx_t m,
+            blas_idx_t n,
+            blas_idx_t k,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble const* B,
+            blas_idx_t ldb,
+            complexDouble beta,
+            complexDouble* C,
+            blas_idx_t ldc)
+{
+    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
+                         (tlapack::Op)transB, m, n, k, *tlapack_Z(&alpha),
+                         tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
+                         *tlapack_Z(&beta), tlapack_Z(C), ldc);
 }
 
 #define _shemm BLAS_FUNCTION(shemm)
-void _shemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * B, blas_idx_t ldb,
-    float beta,
-    float * C, blas_idx_t ldc ) {
+void _shemm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float const* B,
+            blas_idx_t ldb,
+            float beta,
+            float* C,
+            blas_idx_t ldc)
+{
     return tlapack::hemm<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _dhemm BLAS_FUNCTION(dhemm)
-void _dhemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * B, blas_idx_t ldb,
-    double beta,
-    double * C, blas_idx_t ldc ) {
+void _dhemm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double const* B,
+            blas_idx_t ldb,
+            double beta,
+            double* C,
+            blas_idx_t ldc)
+{
     return tlapack::hemm<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _chemm BLAS_FUNCTION(chemm)
-void _chemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * B, blas_idx_t ldb,
-    complexFloat beta,
-    complexFloat * C, blas_idx_t ldc ) {
-    return tlapack::hemm<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(B), ldb,
-        *tlapack_C(&beta),
-        tlapack_C(C), ldc );
+void _chemm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat const* B,
+            blas_idx_t ldb,
+            complexFloat beta,
+            complexFloat* C,
+            blas_idx_t ldc)
+{
+    return tlapack::hemm<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
+        *tlapack_C(&beta), tlapack_C(C), ldc);
 }
 
 #define _zhemm BLAS_FUNCTION(zhemm)
-void _zhemm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * B, blas_idx_t ldb,
-    complexDouble beta,
-    complexDouble * C, blas_idx_t ldc ) {
-    return tlapack::hemm<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(B), ldb,
-        *tlapack_Z(&beta),
-        tlapack_Z(C), ldc );
+void _zhemm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble const* B,
+            blas_idx_t ldb,
+            complexDouble beta,
+            complexDouble* C,
+            blas_idx_t ldc)
+{
+    return tlapack::hemm<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
+        *tlapack_Z(&beta), tlapack_Z(C), ldc);
 }
 
 #define _sher2k BLAS_FUNCTION(sher2k)
-void _sher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * B, blas_idx_t ldb,
-    float beta,
-    float * C, blas_idx_t ldc ) {
+void _sher2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             float alpha,
+             float const* A,
+             blas_idx_t lda,
+             float const* B,
+             blas_idx_t ldb,
+             float beta,
+             float* C,
+             blas_idx_t ldc)
+{
     return tlapack::her2k<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _dher2k BLAS_FUNCTION(dher2k)
-void _dher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * B, blas_idx_t ldb,
-    double beta,
-    double * C, blas_idx_t ldc ) {
+void _dher2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             double alpha,
+             double const* A,
+             blas_idx_t lda,
+             double const* B,
+             blas_idx_t ldb,
+             double beta,
+             double* C,
+             blas_idx_t ldc)
+{
     return tlapack::her2k<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _cher2k BLAS_FUNCTION(cher2k)
-void _cher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * B, blas_idx_t ldb,
-    float beta,
-    complexFloat * C, blas_idx_t ldc ) {
-    return tlapack::her2k<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(B), ldb,
-        beta,
-        tlapack_C(C), ldc );
+void _cher2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             complexFloat alpha,
+             complexFloat const* A,
+             blas_idx_t lda,
+             complexFloat const* B,
+             blas_idx_t ldb,
+             float beta,
+             complexFloat* C,
+             blas_idx_t ldc)
+{
+    return tlapack::her2k<tlapack_complexFloat, tlapack_complexFloat,
+                          tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb, beta,
+        tlapack_C(C), ldc);
 }
 
 #define _zher2k BLAS_FUNCTION(zher2k)
-void _zher2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * B, blas_idx_t ldb,
-    double beta,
-    complexDouble * C, blas_idx_t ldc ) {
-    return tlapack::her2k<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(B), ldb,
-        beta,
-        tlapack_Z(C), ldc );
+void _zher2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             complexDouble alpha,
+             complexDouble const* A,
+             blas_idx_t lda,
+             complexDouble const* B,
+             blas_idx_t ldb,
+             double beta,
+             complexDouble* C,
+             blas_idx_t ldc)
+{
+    return tlapack::her2k<tlapack_complexDouble, tlapack_complexDouble,
+                          tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb, beta,
+        tlapack_Z(C), ldc);
 }
 
 #define _sherk BLAS_FUNCTION(sherk)
-void _sherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float beta,
-    float * C, blas_idx_t ldc ) {
-    return tlapack::herk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        beta,
-        C, ldc );
+void _sherk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float beta,
+            float* C,
+            blas_idx_t ldc)
+{
+    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
 }
 
 #define _dherk BLAS_FUNCTION(dherk)
-void _dherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double beta,
-    double * C, blas_idx_t ldc ) {
-    return tlapack::herk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        beta,
-        C, ldc );
+void _dherk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double beta,
+            double* C,
+            blas_idx_t ldc)
+{
+    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
 }
 
 #define _cherk BLAS_FUNCTION(cherk)
-void _cherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    float alpha,
-    complexFloat const * A, blas_idx_t lda,
-    float beta,
-    complexFloat * C, blas_idx_t ldc ) {
-    return tlapack::herk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        tlapack_cteC(A), lda,
-        beta,
-        tlapack_C(C), ldc );
+void _cherk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            float alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            float beta,
+            complexFloat* C,
+            blas_idx_t ldc)
+{
+    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, alpha, tlapack_cteC(A), lda,
+                         beta, tlapack_C(C), ldc);
 }
 
 #define _zherk BLAS_FUNCTION(zherk)
-void _zherk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    double alpha,
-    complexDouble const * A, blas_idx_t lda,
-    double beta,
-    complexDouble * C, blas_idx_t ldc ) {
-    return tlapack::herk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        tlapack_cteZ(A), lda,
-        beta,
-        tlapack_Z(C), ldc );
+void _zherk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            double alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            double beta,
+            complexDouble* C,
+            blas_idx_t ldc)
+{
+    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, alpha, tlapack_cteZ(A), lda,
+                         beta, tlapack_Z(C), ldc);
 }
 
 #define _ssymm BLAS_FUNCTION(ssymm)
-void _ssymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * B, blas_idx_t ldb,
-    float beta,
-    float * C, blas_idx_t ldc ) {
+void _ssymm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float const* B,
+            blas_idx_t ldb,
+            float beta,
+            float* C,
+            blas_idx_t ldc)
+{
     return tlapack::symm<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _dsymm BLAS_FUNCTION(dsymm)
-void _dsymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * B, blas_idx_t ldb,
-    double beta,
-    double * C, blas_idx_t ldc ) {
+void _dsymm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double const* B,
+            blas_idx_t ldb,
+            double beta,
+            double* C,
+            blas_idx_t ldc)
+{
     return tlapack::symm<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _csymm BLAS_FUNCTION(csymm)
-void _csymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * B, blas_idx_t ldb,
-    complexFloat beta,
-    complexFloat * C, blas_idx_t ldc ) {
-    return tlapack::symm<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(B), ldb,
-        *tlapack_C(&beta),
-        tlapack_C(C), ldc );
+void _csymm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat const* B,
+            blas_idx_t ldb,
+            complexFloat beta,
+            complexFloat* C,
+            blas_idx_t ldc)
+{
+    return tlapack::symm<tlapack_complexFloat, tlapack_complexFloat,
+                         tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
+        *tlapack_C(&beta), tlapack_C(C), ldc);
 }
 
 #define _zsymm BLAS_FUNCTION(zsymm)
-void _zsymm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * B, blas_idx_t ldb,
-    complexDouble beta,
-    complexDouble * C, blas_idx_t ldc ) {
-    return tlapack::symm<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        m,
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(B), ldb,
-        *tlapack_Z(&beta),
-        tlapack_Z(C), ldc );
+void _zsymm(Layout layout,
+            Side side,
+            Uplo uplo,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble const* B,
+            blas_idx_t ldb,
+            complexDouble beta,
+            complexDouble* C,
+            blas_idx_t ldc)
+{
+    return tlapack::symm<tlapack_complexDouble, tlapack_complexDouble,
+                         tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
+        *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
+        *tlapack_Z(&beta), tlapack_Z(C), ldc);
 }
 
 #define _ssyr2k BLAS_FUNCTION(ssyr2k)
-void _ssyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float const * B, blas_idx_t ldb,
-    float beta,
-    float * C, blas_idx_t ldc ) {
+void _ssyr2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             float alpha,
+             float const* A,
+             blas_idx_t lda,
+             float const* B,
+             blas_idx_t ldb,
+             float beta,
+             float* C,
+             blas_idx_t ldc)
+{
     return tlapack::syr2k<float, float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _dsyr2k BLAS_FUNCTION(dsyr2k)
-void _dsyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double const * B, blas_idx_t ldb,
-    double beta,
-    double * C, blas_idx_t ldc ) {
+void _dsyr2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             double alpha,
+             double const* A,
+             blas_idx_t lda,
+             double const* B,
+             blas_idx_t ldb,
+             double beta,
+             double* C,
+             blas_idx_t ldc)
+{
     return tlapack::syr2k<double, double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        B, ldb,
-        beta,
-        C, ldc );
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #define _csyr2k BLAS_FUNCTION(csyr2k)
-void _csyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat const * B, blas_idx_t ldb,
-    complexFloat beta,
-    complexFloat * C, blas_idx_t ldc ) {
-    return tlapack::syr2k<tlapack_complexFloat, tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_cteC(B), ldb,
-        *tlapack_C(&beta),
-        tlapack_C(C), ldc );
+void _csyr2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             complexFloat alpha,
+             complexFloat const* A,
+             blas_idx_t lda,
+             complexFloat const* B,
+             blas_idx_t ldb,
+             complexFloat beta,
+             complexFloat* C,
+             blas_idx_t ldc)
+{
+    return tlapack::syr2k<tlapack_complexFloat, tlapack_complexFloat,
+                          tlapack_complexFloat>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
+        *tlapack_C(&beta), tlapack_C(C), ldc);
 }
 
 #define _zsyr2k BLAS_FUNCTION(zsyr2k)
-void _zsyr2k(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble const * B, blas_idx_t ldb,
-    complexDouble beta,
-    complexDouble * C, blas_idx_t ldc ) {
-    return tlapack::syr2k<tlapack_complexDouble, tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_cteZ(B), ldb,
-        *tlapack_Z(&beta),
-        tlapack_Z(C), ldc );
+void _zsyr2k(Layout layout,
+             Uplo uplo,
+             Op trans,
+             blas_idx_t n,
+             blas_idx_t k,
+             complexDouble alpha,
+             complexDouble const* A,
+             blas_idx_t lda,
+             complexDouble const* B,
+             blas_idx_t ldb,
+             complexDouble beta,
+             complexDouble* C,
+             blas_idx_t ldc)
+{
+    return tlapack::syr2k<tlapack_complexDouble, tlapack_complexDouble,
+                          tlapack_complexDouble>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
+        *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
+        *tlapack_Z(&beta), tlapack_Z(C), ldc);
 }
 
 #define _ssyrk BLAS_FUNCTION(ssyrk)
-void _ssyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float beta,
-    float * C, blas_idx_t ldc ) {
-    return tlapack::syrk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        beta,
-        C, ldc );
+void _ssyrk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float beta,
+            float* C,
+            blas_idx_t ldc)
+{
+    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
 }
 
 #define _dsyrk BLAS_FUNCTION(dsyrk)
-void _dsyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double beta,
-    double * C, blas_idx_t ldc ) {
-    return tlapack::syrk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        alpha,
-        A, lda,
-        beta,
-        C, ldc );
+void _dsyrk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double beta,
+            double* C,
+            blas_idx_t ldc)
+{
+    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
 }
 
 #define _csyrk BLAS_FUNCTION(csyrk)
-void _csyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat beta,
-    complexFloat * C, blas_idx_t ldc ) {
-    return tlapack::syrk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        *tlapack_C(&beta),
-        tlapack_C(C), ldc );
+void _csyrk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat beta,
+            complexFloat* C,
+            blas_idx_t ldc)
+{
+    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, *tlapack_C(&alpha),
+                         tlapack_cteC(A), lda, *tlapack_C(&beta), tlapack_C(C),
+                         ldc);
 }
 
 #define _zsyrk BLAS_FUNCTION(zsyrk)
-void _zsyrk(
-    Layout layout,
-    Uplo uplo,
-    Op trans,
-    blas_idx_t n,
-    blas_idx_t k,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble beta,
-    complexDouble * C, blas_idx_t ldc ) {
-    return tlapack::syrk(
-        toTLAPACKlayout( layout ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        n,
-        k,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        *tlapack_Z(&beta),
-        tlapack_Z(C), ldc );
+void _zsyrk(Layout layout,
+            Uplo uplo,
+            Op trans,
+            blas_idx_t n,
+            blas_idx_t k,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble beta,
+            complexDouble* C,
+            blas_idx_t ldc)
+{
+    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                         toTLAPACKop(trans), n, k, *tlapack_Z(&alpha),
+                         tlapack_cteZ(A), lda, *tlapack_Z(&beta), tlapack_Z(C),
+                         ldc);
 }
 
 #define _strmm BLAS_FUNCTION(strmm)
-void _strmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float * B, blas_idx_t ldb ) {
+void _strmm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float* B,
+            blas_idx_t ldb)
+{
     return tlapack::trmm<float, float>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
+        toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
 
 #define _dtrmm BLAS_FUNCTION(dtrmm)
-void _dtrmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double * B, blas_idx_t ldb ) {
+void _dtrmm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double* B,
+            blas_idx_t ldb)
+{
     return tlapack::trmm<double, double>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
+        toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
 
 #define _ctrmm BLAS_FUNCTION(ctrmm)
-void _ctrmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat * B, blas_idx_t ldb ) {
+void _ctrmm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat* B,
+            blas_idx_t ldb)
+{
     return tlapack::trmm<tlapack_complexFloat, tlapack_complexFloat>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_C(B), ldb );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
+        toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, *tlapack_C(&alpha),
+        tlapack_cteC(A), lda, tlapack_C(B), ldb);
 }
 
 #define _ztrmm BLAS_FUNCTION(ztrmm)
-void _ztrmm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble * B, blas_idx_t ldb ) {
+void _ztrmm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble* B,
+            blas_idx_t ldb)
+{
     return tlapack::trmm<tlapack_complexDouble, tlapack_complexDouble>(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_Z(B), ldb );
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
+        toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, *tlapack_Z(&alpha),
+        tlapack_cteZ(A), lda, tlapack_Z(B), ldb);
 }
 
 #define _strsm BLAS_FUNCTION(strsm)
-void _strsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    float alpha,
-    float const * A, blas_idx_t lda,
-    float * B, blas_idx_t ldb ) {
-    return tlapack::trsm(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb );
+void _strsm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            float alpha,
+            float const* A,
+            blas_idx_t lda,
+            float* B,
+            blas_idx_t ldb)
+{
+    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
+                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                         toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
 
 #define _dtrsm BLAS_FUNCTION(dtrsm)
-void _dtrsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    double alpha,
-    double const * A, blas_idx_t lda,
-    double * B, blas_idx_t ldb ) {
-    return tlapack::trsm(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        alpha,
-        A, lda,
-        B, ldb );
+void _dtrsm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            double alpha,
+            double const* A,
+            blas_idx_t lda,
+            double* B,
+            blas_idx_t ldb)
+{
+    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
+                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                         toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
 
 #define _ctrsm BLAS_FUNCTION(ctrsm)
-void _ctrsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexFloat alpha,
-    complexFloat const * A, blas_idx_t lda,
-    complexFloat * B, blas_idx_t ldb ) {
-    return tlapack::trsm(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        *tlapack_C(&alpha),
-        tlapack_cteC(A), lda,
-        tlapack_C(B), ldb );
+void _ctrsm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexFloat alpha,
+            complexFloat const* A,
+            blas_idx_t lda,
+            complexFloat* B,
+            blas_idx_t ldb)
+{
+    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
+                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                         toTLAPACKdiag(diag), m, n, *tlapack_C(&alpha),
+                         tlapack_cteC(A), lda, tlapack_C(B), ldb);
 }
 
 #define _ztrsm BLAS_FUNCTION(ztrsm)
-void _ztrsm(
-    Layout layout,
-    Side side,
-    Uplo uplo,
-    Op trans,
-    Diag diag,
-    blas_idx_t m,
-    blas_idx_t n,
-    complexDouble alpha,
-    complexDouble const * A, blas_idx_t lda,
-    complexDouble * B, blas_idx_t ldb ) {
-    return tlapack::trsm(
-        toTLAPACKlayout( layout ),
-        toTLAPACKside( side ),
-        toTLAPACKuplo( uplo ),
-        toTLAPACKop( trans ),
-        toTLAPACKdiag( diag ),
-        m,
-        n,
-        *tlapack_Z(&alpha),
-        tlapack_cteZ(A), lda,
-        tlapack_Z(B), ldb );
+void _ztrsm(Layout layout,
+            Side side,
+            Uplo uplo,
+            Op trans,
+            Diag diag,
+            blas_idx_t m,
+            blas_idx_t n,
+            complexDouble alpha,
+            complexDouble const* A,
+            blas_idx_t lda,
+            complexDouble* B,
+            blas_idx_t ldb)
+{
+    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
+                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                         toTLAPACKdiag(diag), m, n, *tlapack_Z(&alpha),
+                         tlapack_cteZ(A), lda, tlapack_Z(B), ldb);
 }
 
-} // extern "C"
+}  // extern "C"

--- a/test/include/TestUploMatrix.hpp
+++ b/test/include/TestUploMatrix.hpp
@@ -17,71 +17,87 @@ namespace tlapack {
 
 /**
  * @brief TestUploMatrix class
- * 
- * This class is used to test if a method is accessing the correct elements of a matrix. The access region can be either the upper or lower triangular part of the matrix.
- * 
+ *
+ * This class is used to test if a method is accessing the correct elements of a
+ * matrix. The access region can be either the upper or lower triangular part of
+ * the matrix.
+ *
  * @tparam T Type of the elements.
  * @tparam idx_t Type of the indices.
  * @tparam uplo Uplo value.
  * @tparam L Layout value.
- * 
+ *
  * @ingroup auxiliary
  */
-template<
-    class T,
-    class idx_t = std::size_t,
-    Uplo uplo = Uplo::Upper,
-    Layout L = Layout::ColMajor
->
-struct TestUploMatrix : public legacyMatrix<T,idx_t,L>
-{
-    int modifier = 0; ///< Modifier to the access region. Enables slicing of the matrix.
+template <class T,
+          class idx_t = std::size_t,
+          Uplo uplo = Uplo::Upper,
+          Layout L = Layout::ColMajor>
+struct TestUploMatrix : public legacyMatrix<T, idx_t, L> {
+    int modifier =
+        0;  ///< Modifier to the access region. Enables slicing of the matrix.
 
-    TestUploMatrix( const legacyMatrix<T,idx_t,L>& A )
-    : legacyMatrix<T,idx_t,L>(A) {}
-    
+    TestUploMatrix(const legacyMatrix<T, idx_t, L>& A)
+        : legacyMatrix<T, idx_t, L>(A)
+    {}
+
     // Overload of the access operator
-    inline constexpr T&
-    operator()( idx_t i, idx_t j ) const noexcept
+    inline constexpr T& operator()(idx_t i, idx_t j) const noexcept
     {
         if (uplo == Uplo::Upper)
-            assert( (int) i <= (int) j + modifier );
+            assert((int)i <= (int)j + modifier);
         else if (uplo == Uplo::Lower)
-            assert( (int) i >= (int) j + modifier );
-        
-        return legacyMatrix<T,idx_t,L>::operator()(i,j);
+            assert((int)i >= (int)j + modifier);
+
+        return legacyMatrix<T, idx_t, L>::operator()(i, j);
     };
 };
 
 // Block access specialization for TestUploMatrix
-    
-#define isSlice(SliceSpec) !std::is_convertible< SliceSpec, idx_t >::value
 
-template< typename T, class idx_t, Uplo uplo, Layout layout, class SliceSpecRow, class SliceSpecCol,
-    typename std::enable_if< isSlice(SliceSpecRow) && isSlice(SliceSpecCol), int >::type = 0
->
-inline constexpr auto slice( const TestUploMatrix<T,idx_t,uplo,layout>& A, SliceSpecRow&& rows, SliceSpecCol&& cols ) noexcept {
-    TestUploMatrix<T,idx_t,uplo,layout> B( slice(legacyMatrix<T,idx_t,layout>(A),rows,cols) );
+#define isSlice(SliceSpec) !std::is_convertible<SliceSpec, idx_t>::value
+
+template <
+    typename T,
+    class idx_t,
+    Uplo uplo,
+    Layout layout,
+    class SliceSpecRow,
+    class SliceSpecCol,
+    typename std::enable_if<isSlice(SliceSpecRow) && isSlice(SliceSpecCol),
+                            int>::type = 0>
+inline constexpr auto slice(const TestUploMatrix<T, idx_t, uplo, layout>& A,
+                            SliceSpecRow&& rows,
+                            SliceSpecCol&& cols) noexcept
+{
+    TestUploMatrix<T, idx_t, uplo, layout> B(
+        slice(legacyMatrix<T, idx_t, layout>(A), rows, cols));
     B.modifier = A.modifier + cols.first - rows.first;
     return B;
 }
 
 #undef isSlice
 
-template< typename T, class idx_t, Uplo uplo, Layout layout, class SliceSpec >
-inline constexpr auto rows( const TestUploMatrix<T,idx_t,uplo,layout>& A, SliceSpec&& rows ) noexcept {
-    TestUploMatrix<T,idx_t,uplo,layout> B( rows(legacyMatrix<T,idx_t,layout>(A),rows) );
+template <typename T, class idx_t, Uplo uplo, Layout layout, class SliceSpec>
+inline constexpr auto rows(const TestUploMatrix<T, idx_t, uplo, layout>& A,
+                           SliceSpec&& rows) noexcept
+{
+    TestUploMatrix<T, idx_t, uplo, layout> B(
+        rows(legacyMatrix<T, idx_t, layout>(A), rows));
     B.modifier = A.modifier - rows.first;
     return B;
 }
 
-template< typename T, class idx_t, Uplo uplo, Layout layout, class SliceSpec >
-inline constexpr auto cols( const TestUploMatrix<T,idx_t,uplo,layout>& A, SliceSpec&& cols ) noexcept {
-    TestUploMatrix<T,idx_t,uplo,layout> B( cols(legacyMatrix<T,idx_t,layout>(A),cols) );
+template <typename T, class idx_t, Uplo uplo, Layout layout, class SliceSpec>
+inline constexpr auto cols(const TestUploMatrix<T, idx_t, uplo, layout>& A,
+                           SliceSpec&& cols) noexcept
+{
+    TestUploMatrix<T, idx_t, uplo, layout> B(
+        cols(legacyMatrix<T, idx_t, layout>(A), cols));
     B.modifier = A.modifier + cols.first;
     return B;
 }
 
-} // namespace tlapack
+}  // namespace tlapack
 
-#endif // TLAPACK_TEST_TESTUPLOMATRIX_HH
+#endif  // TLAPACK_TEST_TESTUPLOMATRIX_HH

--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -21,6 +21,7 @@
     #include <tlapack/plugins/mdspan.hpp>
 #endif
 #include <tlapack/plugins/legacyArray.hpp>
+#include <tlapack/plugins/stdvector.hpp>
 
 #ifdef TLAPACK_TEST_MPFR
     #include <tlapack/plugins/mpreal.hpp>

--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -1,7 +1,7 @@
 /// @file testdefinitions.hpp
 /// @author Thijs Steel, KU Leuven, Belgium
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// 
+///
 /// @brief Definitions for the unit tests
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -26,89 +26,94 @@
     #include <tlapack/plugins/mpreal.hpp>
 #endif
 
-// 
+//
 // The matrix types that will be tested for routines
 // that only accept real matrices
-// 
+//
 #ifndef TLAPACK_REAL_TYPES_TO_TEST
 
-    #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST \
-        (legacyMatrix<float,std::size_t,Layout::ColMajor>), \
-        (legacyMatrix<double,std::size_t,Layout::ColMajor>), \
-        (legacyMatrix<float,std::size_t,Layout::RowMajor>), \
-        (legacyMatrix<double,std::size_t,Layout::RowMajor>)
+    #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST                      \
+        (legacyMatrix<float, std::size_t, Layout::ColMajor>),      \
+            (legacyMatrix<double, std::size_t, Layout::ColMajor>), \
+            (legacyMatrix<float, std::size_t, Layout::RowMajor>),  \
+            (legacyMatrix<double, std::size_t, Layout::RowMajor>)
 
     #ifdef TLAPACK_TEST_MPFR
         #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_MPREAL \
-            , \
-            legacyMatrix<mpfr::mpreal>
+            , legacyMatrix<mpfr::mpreal>
     #else
         #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_MPREAL
     #endif
-    
+
     #ifdef TLAPACK_TEST_EIGEN
-        #define TLAPACK_EIGEN_REAL_TYPES_TO_TEST \
-            , \
-            Eigen::MatrixXf, \
-            Eigen::MatrixXd, \
-            (Eigen::Matrix<float,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>), \
-            (Eigen::Matrix<Eigen::half,Eigen::Dynamic,Eigen::Dynamic>)
+        #define TLAPACK_EIGEN_REAL_TYPES_TO_TEST                      \
+            , Eigen::MatrixXf, Eigen::MatrixXd,                       \
+                (Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, \
+                               Eigen::RowMajor>),                     \
+                (Eigen::Matrix<Eigen::half, Eigen::Dynamic, Eigen::Dynamic>)
     #else
         #define TLAPACK_EIGEN_REAL_TYPES_TO_TEST
     #endif
-    
+
     #ifdef TLAPACK_TEST_MDSPAN
-        #define TLAPACK_MDSPAN_REAL_TYPES_TO_TEST \
-            , \
-            (std::experimental::mdspan<float,std::experimental::dextents<std::size_t,2>,std::experimental::layout_left>), \
-            (std::experimental::mdspan<float,std::experimental::dextents<std::size_t,2>,std::experimental::layout_right>)
+        #define TLAPACK_MDSPAN_REAL_TYPES_TO_TEST                       \
+            ,                                                           \
+                (std::experimental::mdspan<                             \
+                    float, std::experimental::dextents<std::size_t, 2>, \
+                    std::experimental::layout_left>),                   \
+                (std::experimental::mdspan<                             \
+                    float, std::experimental::dextents<std::size_t, 2>, \
+                    std::experimental::layout_right>)
     #else
         #define TLAPACK_MDSPAN_REAL_TYPES_TO_TEST
     #endif
 
-    #define TLAPACK_REAL_TYPES_TO_TEST \
-        TLAPACK_LEGACY_REAL_TYPES_TO_TEST \
+    #define TLAPACK_REAL_TYPES_TO_TEST                \
+        TLAPACK_LEGACY_REAL_TYPES_TO_TEST             \
         TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_MPREAL \
-        TLAPACK_EIGEN_REAL_TYPES_TO_TEST \
+        TLAPACK_EIGEN_REAL_TYPES_TO_TEST              \
         TLAPACK_MDSPAN_REAL_TYPES_TO_TEST
 #endif
 
-// 
+//
 // The matrix types that will be tested for routines
 // that only accept complex matrices
-// 
+//
 #ifndef TLAPACK_COMPLEX_TYPES_TO_TEST
 
     #ifndef TLAPACK_LEGACY_COMPLEX_TYPES_TO_TEST
-        #define TLAPACK_LEGACY_COMPLEX_TYPES_TO_TEST \
-            (legacyMatrix<std::complex<float>,std::size_t,Layout::ColMajor>), \
-            (legacyMatrix<std::complex<double>,std::size_t,Layout::ColMajor>), \
-            (legacyMatrix<std::complex<float>,std::size_t,Layout::RowMajor>), \
-            (legacyMatrix<std::complex<double>,std::size_t,Layout::RowMajor>)
+        #define TLAPACK_LEGACY_COMPLEX_TYPES_TO_TEST             \
+            (legacyMatrix<std::complex<float>, std::size_t,      \
+                          Layout::ColMajor>),                    \
+                (legacyMatrix<std::complex<double>, std::size_t, \
+                              Layout::ColMajor>),                \
+                (legacyMatrix<std::complex<float>, std::size_t,  \
+                              Layout::RowMajor>),                \
+                (legacyMatrix<std::complex<double>, std::size_t, \
+                              Layout::RowMajor>)
     #endif
-    
+
     #ifdef TLAPACK_TEST_EIGEN
-        #define TLAPACK_EIGEN_COMPLEX_TYPES_TO_TEST \
-            , \
-            Eigen::MatrixXcf, \
-            Eigen::MatrixXcd, \
-            (Eigen::Matrix<std::complex<float>,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>)
+        #define TLAPACK_EIGEN_COMPLEX_TYPES_TO_TEST                 \
+            , Eigen::MatrixXcf, Eigen::MatrixXcd,                   \
+                (Eigen::Matrix<std::complex<float>, Eigen::Dynamic, \
+                               Eigen::Dynamic, Eigen::RowMajor>)
     #else
         #define TLAPACK_EIGEN_COMPLEX_TYPES_TO_TEST
     #endif
 
-    #define TLAPACK_COMPLEX_TYPES_TO_TEST \
+    #define TLAPACK_COMPLEX_TYPES_TO_TEST    \
         TLAPACK_LEGACY_COMPLEX_TYPES_TO_TEST \
         TLAPACK_EIGEN_COMPLEX_TYPES_TO_TEST
 
 #endif
 
-// 
+//
 // List of matrix types that will be tested
-// 
+//
 #ifndef TLAPACK_TYPES_TO_TEST
     #define TLAPACK_TYPES_TO_TEST \
         TLAPACK_REAL_TYPES_TO_TEST, TLAPACK_COMPLEX_TYPES_TO_TEST
 #endif
 
-#endif // TLAPACK_TESTDEFINITIONS_HH
+#endif  // TLAPACK_TESTDEFINITIONS_HH

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -13,8 +13,9 @@
 #ifndef TLAPACK_TESTUTILS_HH
 #define TLAPACK_TESTUTILS_HH
 
+// clang-format off
 #include "testdefinitions.hpp"
-#include <tlapack/plugins/stdvector.hpp>
+// clang-format on
 
 #include <tlapack/base/utils.hpp>
 #include <tlapack/blas/gemm.hpp>

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -23,200 +23,189 @@
 #include <tlapack/lapack/lanhe.hpp>
 #include <tlapack/lapack/laset.hpp>
 
-namespace tlapack
+namespace tlapack {
+
+class rand_generator {
+   private:
+    const uint64_t a = 6364136223846793005;
+    const uint64_t c = 1442695040888963407;
+    uint64_t state = 1302;
+
+   public:
+    uint32_t min() { return 0; }
+
+    uint32_t max() { return UINT32_MAX; }
+
+    void seed(uint64_t s) { state = s; }
+
+    uint32_t operator()()
+    {
+        state = state * a + c;
+        return state >> 32;
+    }
+};
+
+template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
+T rand_helper(rand_generator& gen)
 {
-
-    class rand_generator
-    {
-
-    private:
-        const uint64_t a = 6364136223846793005;
-        const uint64_t c = 1442695040888963407;
-        uint64_t state = 1302;
-
-    public:
-        uint32_t min()
-        {
-            return 0;
-        }
-
-        uint32_t max()
-        {
-            return UINT32_MAX;
-        }
-
-        void seed(uint64_t s)
-        {
-            state = s;
-        }
-
-        uint32_t operator()()
-        {
-            state = state * a + c;
-            return state >> 32;
-        }
-    };
-
-    template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
-    T rand_helper(rand_generator &gen)
-    {
-        return T(static_cast<float>(gen()) / static_cast<float>(gen.max()));
-    }
-
-    template <typename T, enable_if_t<is_complex<T>::value, bool> = true>
-    T rand_helper(rand_generator &gen)
-    {
-        using real_t = real_type<T>;
-        real_t r1( static_cast<float>(gen()) / static_cast<float>(gen.max()) );
-        real_t r2( static_cast<float>(gen()) / static_cast<float>(gen.max()) );
-        return complex_type<real_t>(r1, r2);
-    }
-
-    template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
-    T rand_helper()
-    {
-        return T( static_cast<float>(rand()) / static_cast<float>(RAND_MAX) );
-    }
-
-    template <typename T, enable_if_t<is_complex<T>::value, bool> = true>
-    T rand_helper()
-    {
-        using real_t = real_type<T>;
-        real_t r1( static_cast<float>(rand()) / static_cast<float>(RAND_MAX) );
-        real_t r2( static_cast<float>(rand()) / static_cast<float>(RAND_MAX) );
-        return complex_type<real_t>(r1, r2);
-    }
-
-    /** Calculates res = Q'*Q - I if m <= n or res = Q*Q' otherwise
-     *  Also computes the frobenius norm of res.
-     *
-     * @return frobenius norm of res
-     *
-     * @param[in] Q m by n (almost) orthogonal matrix
-     * @param[out] res n by n matrix as defined above
-     *
-     * @ingroup auxiliary
-     */
-    template <class matrix_t>
-    real_type<type_t<matrix_t>> check_orthogonality(matrix_t &Q, matrix_t &res)
-    {
-        using idx_t = size_type<matrix_t>;
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
-
-        const idx_t m = nrows(Q);
-        const idx_t n = ncols(Q);
-
-        tlapack_check(nrows(res) == ncols(res));
-        tlapack_check(nrows(res) == min(m, n));
-
-        // res = I
-        laset(Uplo::Upper, (T)0.0, (T)1.0, res);
-        if (n <= m)
-        {
-            // res = Q'Q - I
-            herk(Uplo::Upper, Op::ConjTrans, (real_t)1.0, Q, (real_t)-1.0, res);
-        }
-        else
-        {
-            // res = QQ' - I
-            herk(Uplo::Upper, Op::NoTrans, (real_t)1.0, Q, (real_t)-1.0, res);
-        }
-
-        // Compute ||res||_F
-        return lanhe(frob_norm, Uplo::Upper, res);
-    }
-
-    /** Calculates ||Q'*Q - I||_F if m <= n or ||Q*Q' - I||_F otherwise
-     *
-     * @return frobenius norm of error
-     *
-     * @param[in] Q m by n (almost) orthogonal matrix
-     *
-     * @ingroup auxiliary
-     */
-    template <class matrix_t>
-    real_type<type_t<matrix_t>> check_orthogonality(matrix_t &Q)
-    {
-        using T = type_t<matrix_t>;
-        using idx_t = size_type<matrix_t>;
-
-        // Functor
-        Create<matrix_t> new_matrix;
-
-        const idx_t m = min(nrows(Q), ncols(Q));
-
-        std::vector<T> res_;
-        auto res = new_matrix(res_, m, m);
-        return check_orthogonality(Q, res);
-    }
-
-    /** Calculates res = Q'*A*Q - B and the frobenius norm of res
-     *
-     * @return frobenius norm of res
-     *
-     * @param[in] A n by n matrix
-     * @param[in] Q n by n unitary matrix
-     * @param[in] B n by n matrix
-     * @param[out] res n by n matrix as defined above
-     * @param[out] work n by n workspace matrix
-     *
-     * @ingroup auxiliary
-     */
-    template <class matrix_t>
-    real_type<type_t<matrix_t>> check_similarity_transform(matrix_t &A, matrix_t &Q, matrix_t &B, matrix_t &res, matrix_t &work)
-    {
-        using T = type_t<matrix_t>;
-        using real_t = real_type<T>;
-
-        tlapack_check(nrows(A) == ncols(A));
-        tlapack_check(nrows(Q) == ncols(Q));
-        tlapack_check(nrows(B) == ncols(B));
-        tlapack_check(nrows(res) == ncols(res));
-        tlapack_check(nrows(work) == ncols(work));
-        tlapack_check(nrows(A) == nrows(Q));
-        tlapack_check(nrows(A) == nrows(B));
-        tlapack_check(nrows(A) == nrows(res));
-        tlapack_check(nrows(A) == nrows(work));
-
-        // res = Q'*A*Q - B
-        lacpy(Uplo::General, B, res);
-        gemm(Op::ConjTrans, Op::NoTrans, (real_t)1.0, Q, A, work);
-        gemm(Op::NoTrans, Op::NoTrans, (real_t)1.0, work, Q, (real_t)-1.0, res);
-
-        // Compute ||res||_F
-        return lange(frob_norm, res);
-    }
-
-    /** Calculates ||Q'*A*Q - B||
-     *
-     * @return frobenius norm of res
-     *
-     * @param[in] A n by n matrix
-     * @param[in] Q n by n unitary matrix
-     * @param[in] B n by n matrix
-     *
-     * @ingroup auxiliary
-     */
-    template <class matrix_t>
-    real_type<type_t<matrix_t>> check_similarity_transform(matrix_t &A, matrix_t &Q, matrix_t &B)
-    {
-        using T = type_t<matrix_t>;
-        using idx_t = size_type<matrix_t>;
-
-        // Functor
-        Create<matrix_t> new_matrix;
-
-        const idx_t n = ncols(A);
-
-        std::vector<T> res_;
-        auto res = new_matrix(res_, n, n);
-        std::vector<T> work_;
-        auto work = new_matrix(work_, n, n);
-
-        return check_similarity_transform(A, Q, B, res, work);
-    }
-
+    return T(static_cast<float>(gen()) / static_cast<float>(gen.max()));
 }
 
-#endif // TLAPACK_TESTUTILS_HH
+template <typename T, enable_if_t<is_complex<T>::value, bool> = true>
+T rand_helper(rand_generator& gen)
+{
+    using real_t = real_type<T>;
+    real_t r1(static_cast<float>(gen()) / static_cast<float>(gen.max()));
+    real_t r2(static_cast<float>(gen()) / static_cast<float>(gen.max()));
+    return complex_type<real_t>(r1, r2);
+}
+
+template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
+T rand_helper()
+{
+    return T(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));
+}
+
+template <typename T, enable_if_t<is_complex<T>::value, bool> = true>
+T rand_helper()
+{
+    using real_t = real_type<T>;
+    real_t r1(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));
+    real_t r2(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));
+    return complex_type<real_t>(r1, r2);
+}
+
+/** Calculates res = Q'*Q - I if m <= n or res = Q*Q' otherwise
+ *  Also computes the frobenius norm of res.
+ *
+ * @return frobenius norm of res
+ *
+ * @param[in] Q m by n (almost) orthogonal matrix
+ * @param[out] res n by n matrix as defined above
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t>
+real_type<type_t<matrix_t>> check_orthogonality(matrix_t& Q, matrix_t& res)
+{
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+
+    const idx_t m = nrows(Q);
+    const idx_t n = ncols(Q);
+
+    tlapack_check(nrows(res) == ncols(res));
+    tlapack_check(nrows(res) == min(m, n));
+
+    // res = I
+    laset(Uplo::Upper, (T)0.0, (T)1.0, res);
+    if (n <= m) {
+        // res = Q'Q - I
+        herk(Uplo::Upper, Op::ConjTrans, (real_t)1.0, Q, (real_t)-1.0, res);
+    }
+    else {
+        // res = QQ' - I
+        herk(Uplo::Upper, Op::NoTrans, (real_t)1.0, Q, (real_t)-1.0, res);
+    }
+
+    // Compute ||res||_F
+    return lanhe(frob_norm, Uplo::Upper, res);
+}
+
+/** Calculates ||Q'*Q - I||_F if m <= n or ||Q*Q' - I||_F otherwise
+ *
+ * @return frobenius norm of error
+ *
+ * @param[in] Q m by n (almost) orthogonal matrix
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t>
+real_type<type_t<matrix_t>> check_orthogonality(matrix_t& Q)
+{
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+
+    // Functor
+    Create<matrix_t> new_matrix;
+
+    const idx_t m = min(nrows(Q), ncols(Q));
+
+    std::vector<T> res_;
+    auto res = new_matrix(res_, m, m);
+    return check_orthogonality(Q, res);
+}
+
+/** Calculates res = Q'*A*Q - B and the frobenius norm of res
+ *
+ * @return frobenius norm of res
+ *
+ * @param[in] A n by n matrix
+ * @param[in] Q n by n unitary matrix
+ * @param[in] B n by n matrix
+ * @param[out] res n by n matrix as defined above
+ * @param[out] work n by n workspace matrix
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t>
+real_type<type_t<matrix_t>> check_similarity_transform(
+    matrix_t& A, matrix_t& Q, matrix_t& B, matrix_t& res, matrix_t& work)
+{
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+
+    tlapack_check(nrows(A) == ncols(A));
+    tlapack_check(nrows(Q) == ncols(Q));
+    tlapack_check(nrows(B) == ncols(B));
+    tlapack_check(nrows(res) == ncols(res));
+    tlapack_check(nrows(work) == ncols(work));
+    tlapack_check(nrows(A) == nrows(Q));
+    tlapack_check(nrows(A) == nrows(B));
+    tlapack_check(nrows(A) == nrows(res));
+    tlapack_check(nrows(A) == nrows(work));
+
+    // res = Q'*A*Q - B
+    lacpy(Uplo::General, B, res);
+    gemm(Op::ConjTrans, Op::NoTrans, (real_t)1.0, Q, A, work);
+    gemm(Op::NoTrans, Op::NoTrans, (real_t)1.0, work, Q, (real_t)-1.0, res);
+
+    // Compute ||res||_F
+    return lange(frob_norm, res);
+}
+
+/** Calculates ||Q'*A*Q - B||
+ *
+ * @return frobenius norm of res
+ *
+ * @param[in] A n by n matrix
+ * @param[in] Q n by n unitary matrix
+ * @param[in] B n by n matrix
+ *
+ * @ingroup auxiliary
+ */
+template <class matrix_t>
+real_type<type_t<matrix_t>> check_similarity_transform(matrix_t& A,
+                                                       matrix_t& Q,
+                                                       matrix_t& B)
+{
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+
+    // Functor
+    Create<matrix_t> new_matrix;
+
+    const idx_t n = ncols(A);
+
+    std::vector<T> res_;
+    auto res = new_matrix(res_, n, n);
+    std::vector<T> work_;
+    auto work = new_matrix(work_, n, n);
+
+    return check_similarity_transform(A, Q, B, res, work);
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_TESTUTILS_HH

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -13,10 +13,10 @@
 #ifndef TLAPACK_TESTUTILS_HH
 #define TLAPACK_TESTUTILS_HH
 
-// clang-format off
+// Definitions
 #include "testdefinitions.hpp"
-// clang-format on
 
+// <T>LAPACK
 #include <tlapack/base/utils.hpp>
 #include <tlapack/blas/gemm.hpp>
 #include <tlapack/blas/herk.hpp>

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -15,8 +15,8 @@
 
 // Auxiliary routines
 #include <tlapack/lapack/lacpy.hpp>
-#include <tlapack/lapack/laset.hpp>
 #include <tlapack/lapack/lange.hpp>
+#include <tlapack/lapack/laset.hpp>
 
 // Other routines
 #include <tlapack/lapack/gehrd.hpp>
@@ -24,9 +24,10 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("Multishift QR",
+                   "[eigenvalues][multishift_qr]",
+                   TLAPACK_TYPES_TO_TEST)
 {
-
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
@@ -38,21 +39,19 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
 
     using test_tuple_t = std::tuple<std::string, idx_t>;
     const test_tuple_t test_tuple = GENERATE(
-        (test_tuple_t("Large Random", 100)),
-        (test_tuple_t("Random", 15)),
-        (test_tuple_t("Random", 20)),
-        (test_tuple_t("Random", 30)) );
+        (test_tuple_t("Large Random", 100)), (test_tuple_t("Random", 15)),
+        (test_tuple_t("Random", 20)), (test_tuple_t("Random", 30)));
     // The near overflow tests are disabled untill a bug in rotg is fixed
-    // const std::string matrix_type = GENERATE(as<std::string>{}, "Large Random", "Near overflow", "Random");
+    // const std::string matrix_type = GENERATE(as<std::string>{}, "Large
+    // Random", "Near overflow", "Random");
 
     const std::string matrix_type = std::get<0>(test_tuple);
     const idx_t n = std::get<1>(test_tuple);
 
-    const int seed = GENERATE(2,3,4,5,6,7,8,9,10);
-    
+    const int seed = GENERATE(2, 3, 4, 5, 6, 7, 8, 9, 10);
+
     // Only run the large random test once
-    if( matrix_type == "Large Random" && seed != 2 )
-        return;
+    if (matrix_type == "Large Random" && seed != 2) return;
 
     // Constants
     const idx_t ilo = 0;
@@ -65,12 +64,14 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
     gen.seed(seed);
 
     // Define the matrices
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> H_; auto H = new_matrix( H_, n, n );
-    std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<T> H_;
+    auto H = new_matrix(H_, n, n);
+    std::vector<T> Q_;
+    auto Q = new_matrix(Q_, n, n);
 
-    if (matrix_type == "Random")
-    {
+    if (matrix_type == "Random") {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < std::min(n, j + 2); ++i)
                 A(i, j) = rand_helper<T>(gen);
@@ -79,8 +80,7 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
             for (idx_t i = j + 2; i < n; ++i)
                 A(i, j) = zero;
     }
-    if (matrix_type == "Near overflow")
-    {
+    if (matrix_type == "Near overflow") {
         const real_t large_num = safe_max<real_t>() * ulp<real_t>();
 
         for (idx_t j = 0; j < n; ++j)
@@ -91,8 +91,7 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
             for (idx_t i = j + 2; i < n; ++i)
                 A(i, j) = zero;
     }
-    if (matrix_type == "Large Random")
-    {
+    if (matrix_type == "Large Random") {
         // Generate full matrix
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < n; ++i)
@@ -123,16 +122,15 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
     idx_t ns = GENERATE(4, 2);
     idx_t nw = GENERATE(4, 2);
 
-    INFO("matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi << " ns = " << ns << " nw = " << nw << " seed = " << seed);
+    INFO("matrix = " << matrix_type << " n = " << n << " ilo = " << ilo
+                     << " ihi = " << ihi << " ns = " << ns << " nw = " << nw
+                     << " seed = " << seed);
     {
-
         francis_opts_t<idx_t> opts;
-        opts.nshift_recommender = [ns](idx_t n, idx_t nh) -> idx_t
-        {
+        opts.nshift_recommender = [ns](idx_t n, idx_t nh) -> idx_t {
             return ns;
         };
-        opts.deflation_window_recommender = [nw](idx_t n, idx_t nh) -> idx_t
-        {
+        opts.deflation_window_recommender = [nw](idx_t n, idx_t nh) -> idx_t {
             return nw;
         };
         opts.nmin = 15;
@@ -149,8 +147,10 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
         const real_t eps = uroundoff<real_t>();
         const real_t tol = real_t(n * 1.0e2) * eps;
 
-        std::vector<T> res_; auto res = new_matrix( res_, n, n );
-        std::vector<T> work_; auto work = new_matrix( work_, n, n );
+        std::vector<T> res_;
+        auto res = new_matrix(res_, n, n);
+        std::vector<T> work_;
+        auto work = new_matrix(work_, n, n);
 
         // Calculate residuals
         auto orth_res_norm = check_orthogonality(Q, res);
@@ -162,35 +162,34 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
 
         // Check that the eigenvalues match with the diagonal elements
         idx_t i = ilo;
-        while (i < ihi)
-        {
+        while (i < ihi) {
             int nb = 1;
             if (!is_complex<T>::value)
                 if (i + 1 < ihi)
-                    if (H(i + 1, i) != zero)
-                        nb = 2;
+                    if (H(i + 1, i) != zero) nb = 2;
 
-            if (nb == 1)
-            {
-                CHECK( abs1( s[i] - H(i,i) ) <= tol * std::max(real_t(1),abs1(H(i,i))) );
+            if (nb == 1) {
+                CHECK(abs1(s[i] - H(i, i)) <=
+                      tol * std::max(real_t(1), abs1(H(i, i))));
                 i = i + 1;
-            } else {
-
+            }
+            else {
                 T a11, a12, a21, a22, sn;
                 real_t cs;
-                a11 = H(i,i);
-                a12 = H(i,i+1);
-                a21 = H(i+1,i);
-                a22 = H(i+1,i+1);
+                a11 = H(i, i);
+                a12 = H(i, i + 1);
+                a21 = H(i + 1, i);
+                a22 = H(i + 1, i + 1);
                 complex_t s1, s2, swp;
-                lahqr_schur22( a11, a12, a21, a22, s1, s2, cs, sn );
-                if( abs1( s1 - s[i] ) > abs1( s2 - s[i] ) ){
+                lahqr_schur22(a11, a12, a21, a22, s1, s2, cs, sn);
+                if (abs1(s1 - s[i]) > abs1(s2 - s[i])) {
                     swp = s1;
                     s1 = s2;
                     s2 = swp;
                 }
-                CHECK( abs1( s[i] - s1 ) <= tol * std::max(real_t(1),abs1(s1)) );
-                CHECK( abs1( s[i+1] - s2 ) <= tol * std::max(real_t(1),abs1(s2)) );
+                CHECK(abs1(s[i] - s1) <= tol * std::max(real_t(1), abs1(s1)));
+                CHECK(abs1(s[i + 1] - s2) <=
+                      tol * std::max(real_t(1), abs1(s2)));
                 i = i + 2;
             }
         }

--- a/test/src/test_eigenplugin.cpp
+++ b/test/src/test_eigenplugin.cpp
@@ -9,76 +9,75 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-
-#include <tlapack/plugins/eigen.hpp>
 #include <tlapack/base/utils.hpp>
+#include <tlapack/plugins/eigen.hpp>
 
-template< class block_t >
+template <class block_t>
 void test_block()
 {
-    CHECK( tlapack::internal::is_eigen_dense< block_t > == true );
-    CHECK( tlapack::internal::is_eigen_matrix< block_t > == true );
-    CHECK( tlapack::internal::is_eigen_block< block_t > == true );
-    CHECK( tlapack::internal::is_eigen_map< block_t > == false );
+    CHECK(tlapack::internal::is_eigen_dense<block_t> == true);
+    CHECK(tlapack::internal::is_eigen_matrix<block_t> == true);
+    CHECK(tlapack::internal::is_eigen_block<block_t> == true);
+    CHECK(tlapack::internal::is_eigen_map<block_t> == false);
 }
 
-template< class matrix_t >
+template <class matrix_t>
 void test_matrix()
 {
-    CHECK( tlapack::internal::is_eigen_dense< matrix_t > == true );
-    CHECK( tlapack::internal::is_eigen_matrix< matrix_t > == true );
-    CHECK( tlapack::internal::is_eigen_block< matrix_t > == false );
-    CHECK( tlapack::internal::is_eigen_map< matrix_t > == false );
+    CHECK(tlapack::internal::is_eigen_dense<matrix_t> == true);
+    CHECK(tlapack::internal::is_eigen_matrix<matrix_t> == true);
+    CHECK(tlapack::internal::is_eigen_block<matrix_t> == false);
+    CHECK(tlapack::internal::is_eigen_map<matrix_t> == false);
 }
 
-template< class map_t >
+template <class map_t>
 void test_map()
 {
-    CHECK( tlapack::internal::is_eigen_dense< map_t > == true );
-    CHECK( tlapack::internal::is_eigen_matrix< map_t > == true );
-    CHECK( tlapack::internal::is_eigen_block< map_t > == false );
-    CHECK( tlapack::internal::is_eigen_map< map_t > == true );
+    CHECK(tlapack::internal::is_eigen_dense<map_t> == true);
+    CHECK(tlapack::internal::is_eigen_matrix<map_t> == true);
+    CHECK(tlapack::internal::is_eigen_block<map_t> == false);
+    CHECK(tlapack::internal::is_eigen_map<map_t> == true);
 }
 
-template< class matrix_t >
+template <class matrix_t>
 void test_blocks()
 {
-    test_block< Eigen::Block<matrix_t> >();
-    test_block< Eigen::Block<matrix_t,3,2> >();
-    test_block< Eigen::Block<matrix_t,3,1> >();
-    test_block< Eigen::Block<matrix_t,1,3> >();
-    test_block< Eigen::Block<matrix_t,1,-1> >();
-    test_block< Eigen::Block<matrix_t,-1,1> >();
+    test_block<Eigen::Block<matrix_t>>();
+    test_block<Eigen::Block<matrix_t, 3, 2>>();
+    test_block<Eigen::Block<matrix_t, 3, 1>>();
+    test_block<Eigen::Block<matrix_t, 1, 3>>();
+    test_block<Eigen::Block<matrix_t, 1, -1>>();
+    test_block<Eigen::Block<matrix_t, -1, 1>>();
 }
 
-template< class vector_t >
+template <class vector_t>
 void test_vectorblocks()
 {
-    test_block< Eigen::VectorBlock<vector_t> >();
-    test_block< Eigen::VectorBlock<vector_t,1> >();
-    test_block< Eigen::VectorBlock<vector_t,0> >();
+    test_block<Eigen::VectorBlock<vector_t>>();
+    test_block<Eigen::VectorBlock<vector_t, 1>>();
+    test_block<Eigen::VectorBlock<vector_t, 0>>();
 }
 
-template< class matrix_t >
+template <class matrix_t>
 void test_maps()
 {
-    test_map< Eigen::Map<matrix_t> >();
-    test_map< Eigen::Map< matrix_t, 0, Eigen::OuterStride<> > >();
-    test_map< Eigen::Map< matrix_t, 0, Eigen::OuterStride<-1> > >();
-    test_map< Eigen::Map< matrix_t, 0, Eigen::OuterStride< 5> > >();
+    test_map<Eigen::Map<matrix_t>>();
+    test_map<Eigen::Map<matrix_t, 0, Eigen::OuterStride<>>>();
+    test_map<Eigen::Map<matrix_t, 0, Eigen::OuterStride<-1>>>();
+    test_map<Eigen::Map<matrix_t, 0, Eigen::OuterStride<5>>>();
 }
 
 TEST_CASE("is_eigen_dense, is_eigen_block and is_eigen_map work", "[plugins]")
 {
-    CHECK( tlapack::internal::is_eigen_dense< int > == false );
-    CHECK( tlapack::internal::is_eigen_dense< float > == false );
-    CHECK( tlapack::internal::is_eigen_dense< std::complex<float> > == false );
-    CHECK( tlapack::internal::is_eigen_dense< std::string > == false );
-    
+    CHECK(tlapack::internal::is_eigen_dense<int> == false);
+    CHECK(tlapack::internal::is_eigen_dense<float> == false);
+    CHECK(tlapack::internal::is_eigen_dense<std::complex<float>> == false);
+    CHECK(tlapack::internal::is_eigen_dense<std::string> == false);
+
     using M0 = Eigen::MatrixXd;
     using M1 = Eigen::VectorXd;
-    using M2 = Eigen::Matrix<float,2,5>;
-    using M3 = Eigen::Matrix<float,-1,-1,Eigen::RowMajor>;
+    using M2 = Eigen::Matrix<float, 2, 5>;
+    using M3 = Eigen::Matrix<float, -1, -1, Eigen::RowMajor>;
 
     test_matrix<M0>();
     test_matrix<M1>();
@@ -95,12 +94,15 @@ TEST_CASE("is_eigen_dense, is_eigen_block and is_eigen_map work", "[plugins]")
     test_maps<M2>();
     test_maps<M3>();
 
-    test_block< Eigen::Block< Eigen::Block<M0> > >();
-    test_block< Eigen::Block< Eigen::Map<M0> > >();
-    test_map< Eigen::Map< Eigen::Block<M0> > >();
-    test_map< Eigen::Map< Eigen::Map<M0> > >();
+    test_block<Eigen::Block<Eigen::Block<M0>>>();
+    test_block<Eigen::Block<Eigen::Map<M0>>>();
+    test_map<Eigen::Map<Eigen::Block<M0>>>();
+    test_map<Eigen::Map<Eigen::Map<M0>>>();
 
-    using B = Eigen::VectorBlock<const Eigen::Block<Eigen::Block<Eigen::MatrixXd,-1,1,true>,-1,1,false>,-1>;
+    using B = Eigen::VectorBlock<
+        const Eigen::Block<Eigen::Block<Eigen::MatrixXd, -1, 1, true>, -1, 1,
+                           false>,
+        -1>;
     test_block<B>();
 }
 
@@ -108,41 +110,39 @@ TEST_CASE("legacy_matrix works", "[plugins]")
 {
     {
         Eigen::Matrix2d A;
-        A << 1, 3,
-             2, 4;
-        Eigen::MatrixXd A2 = A.block<1,2>(1,0);
+        A << 1, 3, 2, 4;
+        Eigen::MatrixXd A2 = A.block<1, 2>(1, 0);
 
-        auto B = tlapack::legacy_matrix( A );
-        CHECK( B(0,0) == A(0,0) );
-        CHECK( B(1,0) == A(1,0) );
-        CHECK( B(0,1) == A(0,1) );
-        CHECK( B(1,1) == A(1,1) );
+        auto B = tlapack::legacy_matrix(A);
+        CHECK(B(0, 0) == A(0, 0));
+        CHECK(B(1, 0) == A(1, 0));
+        CHECK(B(0, 1) == A(0, 1));
+        CHECK(B(1, 1) == A(1, 1));
 
-        auto B2 = tlapack::legacy_matrix( A2 );
-        CHECK( B2(0,0) == 2 );
-        CHECK( B2(0,1) == 4 );
+        auto B2 = tlapack::legacy_matrix(A2);
+        CHECK(B2(0, 0) == 2);
+        CHECK(B2(0, 1) == 4);
 
-        auto B3 = tlapack::legacy_vector( A2 );
-        CHECK( B3[0] == 2 );
-        CHECK( B3[1] == 4 );
+        auto B3 = tlapack::legacy_vector(A2);
+        CHECK(B3[0] == 2);
+        CHECK(B3[1] == 4);
     }
     {
-        Eigen::Matrix<float,-1,-1,Eigen::RowMajor> A( 3, 5 );
-        A << 1, 2, 3, 4, 5,
-            6, 7, 8, 9, 0,
-            -1, -2, -3, -4, -5;
+        Eigen::Matrix<float, -1, -1, Eigen::RowMajor> A(3, 5);
+        A << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, -1, -2, -3, -4, -5;
 
-        auto B = tlapack::legacy_matrix( A );
-        CHECK( B(0,0) == A(0,0) );
-        CHECK( B(2,4) == A(2,4) );
+        auto B = tlapack::legacy_matrix(A);
+        CHECK(B(0, 0) == A(0, 0));
+        CHECK(B(2, 4) == A(2, 4));
 
-        Eigen::Matrix<float,-1,1> A2 = A.col(3);
-        auto B2 = tlapack::legacy_vector( A2 );
-        CHECK( B2[0] == A(0,3) );
-        CHECK( B2[1] == A(1,3) );
+        Eigen::Matrix<float, -1, 1> A2 = A.col(3);
+        auto B2 = tlapack::legacy_vector(A2);
+        CHECK(B2[0] == A(0, 3));
+        CHECK(B2[1] == A(1, 3));
     }
     // {
-    //     using B = Eigen::VectorBlock<Eigen::Block<Eigen::Block<Eigen::MatrixXd,-1,1,true>,-1,1,false>,-1>;
+    //     using B =
+    //     Eigen::VectorBlock<Eigen::Block<Eigen::Block<Eigen::MatrixXd,-1,1,true>,-1,1,false>,-1>;
     //     CHECK( tlapack::layout<B> == tlapack::Layout::Unspecified );
     // }
 }
@@ -153,49 +153,62 @@ TEST_CASE("slice works", "[plugins]")
 
     {
         Eigen::Matrix2d A;
-        A << 1, 3,
-            2, 4;
+        A << 1, 3, 2, 4;
 
-        auto B = tlapack::slice( A, pair{1,2}, pair{1,2} );
-        CHECK( B(0,0) == A(1,1) );
+        auto B = tlapack::slice(A, pair{1, 2}, pair{1, 2});
+        CHECK(B(0, 0) == A(1, 1));
     }
     {
-        Eigen::MatrixXd A(2,2);
-        A << 1, 3,
-             2, 4;
+        Eigen::MatrixXd A(2, 2);
+        A << 1, 3, 2, 4;
 
-        auto B = tlapack::slice( A, pair{1,2}, pair{1,2} );
-        CHECK( B(0,0) == A(1,1) );
+        auto B = tlapack::slice(A, pair{1, 2}, pair{1, 2});
+        CHECK(B(0, 0) == A(1, 1));
     }
 }
 
 TEST_CASE("Layout works", "[plugins]")
 {
-    CHECK( tlapack::layout< Eigen::Matrix<float,-1,-1,0,-1,-1> > == tlapack::Layout::ColMajor );
-    CHECK( tlapack::layout< Eigen::Matrix<float,-1,-1,1,-1,-1> > == tlapack::Layout::RowMajor );
+    CHECK(tlapack::layout<Eigen::Matrix<float, -1, -1, 0, -1, -1>> ==
+          tlapack::Layout::ColMajor);
+    CHECK(tlapack::layout<Eigen::Matrix<float, -1, -1, 1, -1, -1>> ==
+          tlapack::Layout::RowMajor);
 
-    CHECK( tlapack::layout< Eigen::Block<Eigen::MatrixXd> > == tlapack::Layout::ColMajor );
+    CHECK(tlapack::layout<Eigen::Block<Eigen::MatrixXd>> ==
+          tlapack::Layout::ColMajor);
 
-    CHECK( tlapack::layout< Eigen::Block<Eigen::Matrix<float,-1,-1,1,-1,-1>> > == tlapack::Layout::RowMajor );
+    CHECK(tlapack::layout<
+              Eigen::Block<Eigen::Matrix<float, -1, -1, 1, -1, -1>>> ==
+          tlapack::Layout::RowMajor);
 
-    CHECK( tlapack::layout< Eigen::Block<Eigen::Matrix<float,-1,-1,1,-1,-1>,-1,1> > == tlapack::Layout::RowMajor );
-    CHECK( tlapack::layout< Eigen::Block<Eigen::Matrix<float,-1,-1,1,-1,-1>,1,-1> > == tlapack::Layout::RowMajor );
-    CHECK( tlapack::layout< Eigen::Block<Eigen::Matrix<float,-1,-1,0,-1,-1>,-1,1> > == tlapack::Layout::ColMajor );
-    CHECK( tlapack::layout< Eigen::Block<Eigen::Matrix<float,-1,-1,0,-1,-1>,1,-1> > == tlapack::Layout::ColMajor );
+    CHECK(tlapack::layout<
+              Eigen::Block<Eigen::Matrix<float, -1, -1, 1, -1, -1>, -1, 1>> ==
+          tlapack::Layout::RowMajor);
+    CHECK(tlapack::layout<
+              Eigen::Block<Eigen::Matrix<float, -1, -1, 1, -1, -1>, 1, -1>> ==
+          tlapack::Layout::RowMajor);
+    CHECK(tlapack::layout<
+              Eigen::Block<Eigen::Matrix<float, -1, -1, 0, -1, -1>, -1, 1>> ==
+          tlapack::Layout::ColMajor);
+    CHECK(tlapack::layout<
+              Eigen::Block<Eigen::Matrix<float, -1, -1, 0, -1, -1>, 1, -1>> ==
+          tlapack::Layout::ColMajor);
 
     {
-        using Derived = Eigen::Block<Eigen::Matrix<float, -1, -1, 1, -1, -1>, -1, 1, false>;
-        CHECK( tlapack::layout< Derived > == tlapack::Layout::RowMajor );
-        
+        using Derived =
+            Eigen::Block<Eigen::Matrix<float, -1, -1, 1, -1, -1>, -1, 1, false>;
+        CHECK(tlapack::layout<Derived> == tlapack::Layout::RowMajor);
+
         using Derived2 = Eigen::Map<Derived>;
-        CHECK( tlapack::layout< Derived2 > == tlapack::Layout::RowMajor );
-        
+        CHECK(tlapack::layout<Derived2> == tlapack::Layout::RowMajor);
+
         using Derived3 = Eigen::VectorBlock<Derived>;
-        CHECK( tlapack::layout< Derived3 > == tlapack::Layout::Unspecified );
+        CHECK(tlapack::layout<Derived3> == tlapack::Layout::Unspecified);
     }
     {
-        using Derived = Eigen::Block<Eigen::Matrix<float, -1, -1, 1, -1, -1>, -1, 1, false>;
+        using Derived =
+            Eigen::Block<Eigen::Matrix<float, -1, -1, 1, -1, -1>, -1, 1, false>;
         using Derived2 = Eigen::Map<Derived>;
-        CHECK( tlapack::layout< Derived2 > == tlapack::Layout::RowMajor );
+        CHECK(tlapack::layout<Derived2> == tlapack::Layout::RowMajor);
     }
 }

--- a/test/src/test_gebd2.cpp
+++ b/test/src/test_gebd2.cpp
@@ -1,6 +1,7 @@
 /// @file test_gebd2.cpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// @brief Test GEBD2 using UNG2R and UNGL2. Output an upper bidiagonal matrix B for a m-by-n matrix A (m >= n).
+/// @brief Test GEBD2 using UNG2R and UNGL2. Output an upper bidiagonal matrix B
+/// for a m-by-n matrix A (m >= n).
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
@@ -15,8 +16,8 @@
 
 // Auxiliary routines
 #include <tlapack/lapack/lacpy.hpp>
-#include <tlapack/lapack/laset.hpp>
 #include <tlapack/lapack/lange.hpp>
+#include <tlapack/lapack/laset.hpp>
 
 // Other routines
 #include <tlapack/blas/gemm.hpp>
@@ -26,7 +27,9 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable", "[bidiagonal][svd]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
+                   "[bidiagonal][svd]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -47,20 +50,24 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable", "[bidiagonal][svd]
     m = GENERATE(10, 15, 20, 30);
     n = GENERATE(10, 12, 20, 30);
 
-    if (m >= n) // Only m >= n matrices are supported (yet). gebd2 will give upper bidiagonal matrix B
+    if (m >= n)  // Only m >= n matrices are supported (yet). gebd2 will give
+                 // upper bidiagonal matrix B
     {
-
         const real_t eps = ulp<real_t>();
         const real_t tol = real_t(max(m, n)) * eps;
 
-        std::vector<T> A_; auto A = new_matrix( A_, m, n );
-        std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, m, n );
-        std::vector<T> Q_; auto Q = new_matrix( Q_, m, m );
-        std::vector<T> Z_; auto Z = new_matrix( Z_, n, n );
+        std::vector<T> A_;
+        auto A = new_matrix(A_, m, n);
+        std::vector<T> A_copy_;
+        auto A_copy = new_matrix(A_copy_, m, n);
+        std::vector<T> Q_;
+        auto Q = new_matrix(Q_, m, m);
+        std::vector<T> Z_;
+        auto Z = new_matrix(Z_, n, n);
         auto Z11 = slice(Z, range(1, n), range(1, n));
 
-        std::vector<T> tauv(n); // min of m and n
-        std::vector<T> tauw(n); // min of m and n
+        std::vector<T> tauv(n);  // min of m and n
+        std::vector<T> tauw(n);  // min of m and n
 
         // Workspace computation:
         workinfo_t workinfo = {};
@@ -69,7 +76,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable", "[bidiagonal][svd]
         ungl2_worksize(Z11, tauw, workinfo);
 
         vectorOfBytes workVec;
-        workspace_opts_t<> workOpts( alloc_workspace( workVec, workinfo ) );
+        workspace_opts_t<> workOpts(alloc_workspace(workVec, workinfo));
 
         // Generate random m-by-n matrix
         for (idx_t j = 0; j < n; ++j)
@@ -83,12 +90,12 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable", "[bidiagonal][svd]
             gebd2(A, tauv, tauw, workOpts);
 
             // Get upper bidiagonal B
-            std::vector<T> B_; auto B = new_matrix( B_, m, n );
+            std::vector<T> B_;
+            auto B = new_matrix(B_, m, n);
             laset(Uplo::General, zero, zero, B);
 
             B(0, 0) = A(0, 0);
-            for (idx_t j = 1; j < n; ++j)
-            {
+            for (idx_t j = 1; j < n; ++j) {
                 B(j - 1, j) = A(j - 1, j);
                 B(j, j) = A(j, j);
             }
@@ -100,37 +107,45 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable", "[bidiagonal][svd]
             ung2r(n, Q, tauv, workOpts);
 
             // Test for Q's orthogonality
-            std::vector<T> Wq_; auto Wq = new_matrix( Wq_, m, m );
+            std::vector<T> Wq_;
+            auto Wq = new_matrix(Wq_, m, m);
             auto orth_Q = check_orthogonality(Q, Wq);
             CHECK(orth_Q <= tol);
 
             // Generate unitary matrix Z of n-by-n
-            laset(Uplo::General, zero, one, Z); // Initialize Z as identity matrix.
+            laset(Uplo::General, zero, one,
+                  Z);  // Initialize Z as identity matrix.
 
-            // Slice Z down to Z11 of size (n-1)-by-(n-1) and copy upper A to Z11
-            auto X = slice(A, range(0,n-1), range(1,n)); // X is (n-1)-by-(n-1) slice of A
+            // Slice Z down to Z11 of size (n-1)-by-(n-1) and copy upper A to
+            // Z11
+            auto X = slice(A, range(0, n - 1),
+                           range(1, n));  // X is (n-1)-by-(n-1) slice of A
             lacpy(Uplo::General, X, Z11);
 
-            ungl2(Z11, tauw, workOpts); // Note: the unitary matrix Z we get here is ConjTransed
+            ungl2(Z11, tauw, workOpts);  // Note: the unitary matrix Z we get
+                                         // here is ConjTransed
 
             // Test for Z's orthogonality
-            std::vector<T> Wz_; auto Wz = new_matrix( Wz_, n, n );
+            std::vector<T> Wz_;
+            auto Wz = new_matrix(Wz_, n, n);
             laset(Uplo::General, zero, one, Wz);
             auto orth_Z = check_orthogonality(Z, Wz);
             CHECK(orth_Z <= tol);
 
             // Test B = Q_H * A * Z
-            // Generate a zero matrix K of size m-by-n to be the product of Q_H * A
-            std::vector<T> K_; auto K = new_matrix( K_, m, n );
+            // Generate a zero matrix K of size m-by-n to be the product of Q_H
+            // * A
+            std::vector<T> K_;
+            auto K = new_matrix(K_, m, n);
             laset(Uplo::General, zero, zero, K);
-            gemm(Op::ConjTrans, Op::NoTrans, real_t(1.), Q, A_copy, real_t(0), K);
+            gemm(Op::ConjTrans, Op::NoTrans, real_t(1.), Q, A_copy, real_t(0),
+                 K);
 
             // B = K * Z - B
             gemm(Op::NoTrans, Op::ConjTrans, real_t(1.), K, Z, real_t(-1.), B);
 
             real_t repres = lange(Norm::Max, B);
             CHECK(repres <= tol * normB);
-            
         }
     }
 }

--- a/test/src/test_gebd2.cpp
+++ b/test/src/test_gebd2.cpp
@@ -12,6 +12,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -24,7 +24,11 @@
 using namespace tlapack;
 
 template <typename matrix_t, typename vector_t>
-void check_hess_reduction(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matrix_t H, vector_t tau, matrix_t A)
+void check_hess_reduction(size_type<matrix_t> ilo,
+                          size_type<matrix_t> ihi,
+                          matrix_t H,
+                          vector_t tau,
+                          matrix_t A)
 {
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
@@ -37,9 +41,12 @@ void check_hess_reduction(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matr
     const real_type<T> eps = uroundoff<real_type<T>>();
     const real_type<T> tol = real_type<T>(n * 1.0e2) * eps;
 
-    std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
-    std::vector<T> res_; auto res = new_matrix( res_, n, n );
-    std::vector<T> work_; auto work = new_matrix( work_, n, n );
+    std::vector<T> Q_;
+    auto Q = new_matrix(Q_, n, n);
+    std::vector<T> res_;
+    auto res = new_matrix(res_, n, n);
+    std::vector<T> work_;
+    auto work = new_matrix(work_, n, n);
 
     // Generate orthogonal matrix Q
     tlapack::lacpy(Uplo::General, H, Q);
@@ -59,7 +66,9 @@ void check_hess_reduction(size_type<matrix_t> ilo, size_type<matrix_t> ihi, matr
     CHECK(simil_res_norm <= tol * normA);
 }
 
-TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues][hessenberg]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable",
+                   "[eigenvalues][hessenberg]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -78,31 +87,30 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues][hes
 
     // Only runs the near overflow case
     // when n = 5 and ilo_offset = 0 and ihi_offset = 0
-    if( matrix_type == "Near overflow" &&
-        n != 5 && ilo_offset != 0 && ihi_offset != 0 )
+    if (matrix_type == "Near overflow" && n != 5 && ilo_offset != 0 &&
+        ihi_offset != 0)
         return;
-    
+
     // Constants
     const idx_t ilo = n > 1 ? ilo_offset : 0;
     const idx_t ihi = n > 1 + ilo_offset ? n - ihi_offset : n;
 
-    // Random number generator
     rand_generator gen;
 
     // Define the matrices and vectors
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> H_; auto H = new_matrix( H_, n, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<T> H_;
+    auto H = new_matrix(H_, n, n);
     std::vector<T> tau(n);
 
-    if (matrix_type == "Random")
-    {
+    if (matrix_type == "Random") {
         // Generate a random matrix in A
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < n; ++i)
                 A(i, j) = rand_helper<T>(gen);
     }
-    if (matrix_type == "Near overflow")
-    {
+    if (matrix_type == "Near overflow") {
         const real_t large_num = safe_max<real_t>() * uroundoff<real_t>();
 
         for (idx_t j = 0; j < n; ++j)
@@ -119,20 +127,21 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues][hes
             A(i, j) = (T)0.0;
     tlapack::lacpy(Uplo::General, A, H);
 
-    INFO("matrix = " << matrix_type << " n = " << n << " ilo = " << ilo << " ihi = " << ihi);
-    
+    INFO("matrix = " << matrix_type << " n = " << n << " ilo = " << ilo
+                     << " ihi = " << ihi);
+
     SECTION("GEHD2")
-    {    
+    {
         tlapack::gehd2(ilo, ihi, H, tau);
 
         check_hess_reduction(ilo, ihi, H, tau, A);
     }
-    
+
     SECTION("GEHRD")
     {
         idx_t nb = GENERATE(2, 3);
         INFO("nb = " << nb);
-        
+
         gehrd_opts_t<idx_t> opts;
         opts.nb = nb;
         opts.nx_switch = 2;

--- a/test/src/test_gelq2.cpp
+++ b/test/src/test_gelq2.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_gelqf.cpp
+++ b/test/src/test_gelqf.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_gelqf.cpp
+++ b/test/src/test_gelqf.cpp
@@ -24,7 +24,9 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked", "[lqf]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
+                   "[lqf]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -43,28 +45,35 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked", "[lqf
 
     m = GENERATE(10, 20, 30);
     n = GENERATE(10, 20, 30);
-    k = GENERATE(8, 10, 20, 30); // k is the number of rows for output Q. Can personalize it.
+    k = GENERATE(
+        8, 10, 20,
+        30);  // k is the number of rows for output Q. Can personalize it.
     nb = GENERATE(2, 3, 7, 12);  // nb is the block height. Can personalize it.
 
     const real_t eps = ulp<real_t>();
-    const real_t tol = real_t(m*n) * eps;
+    const real_t tol = real_t(m * n) * eps;
 
-    std::vector<T> A_; auto A = new_matrix( A_, m, n );
-    std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, m, n );
-    std::vector<T> TT_; auto TT = new_matrix( TT_, m, nb );
-    std::vector<T> Q_; auto Q = new_matrix( Q_, k, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, m, n);
+    std::vector<T> A_copy_;
+    auto A_copy = new_matrix(A_copy_, m, n);
+    std::vector<T> TT_;
+    auto TT = new_matrix(TT_, m, nb);
+    std::vector<T> Q_;
+    auto Q = new_matrix(Q_, k, n);
 
     std::vector<T> tauw(min(m, n));
 
     // Workspace computation:
-    gelqf_opts_t<idx_t> workOpts; workOpts.nb = nb;
+    gelqf_opts_t<idx_t> workOpts;
+    workOpts.nb = nb;
     workinfo_t workinfo;
     gelqf_worksize(A, TT, workinfo, workOpts);
     ungl2_worksize(Q, tauw, workinfo, workOpts);
 
     // Workspace allocation:
     vectorOfBytes workVec;
-    workOpts.work = alloc_workspace( workVec, workinfo );
+    workOpts.work = alloc_workspace(workVec, workinfo);
 
     for (idx_t j = 0; j < n; ++j)
         for (idx_t i = 0; i < m; ++i)
@@ -72,39 +81,43 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked", "[lqf
 
     lacpy(Uplo::General, A, A_copy);
 
-    if (k <= n) // k must be less than or equal to n, because we cannot get a Q bigger than n-by-n
+    if (k <= n)  // k must be less than or equal to n, because we cannot get a Q
+                 // bigger than n-by-n
     {
         INFO("m = " << m << " n = " << n << " k = " << k << " nb = " << nb);
         {
             gelqf(A, TT, workOpts);
 
             // Build tauw vector from matrix TT
-            for (idx_t j = 0; j < min(m,n); j += nb)
-            {
-                idx_t ib = std::min<idx_t>(nb, min(m,n) - j);
-                
+            for (idx_t j = 0; j < min(m, n); j += nb) {
+                idx_t ib = std::min<idx_t>(nb, min(m, n) - j);
+
                 for (idx_t i = 0; i < ib; i++)
-                    tauw[i+j] = TT(i+j,i);
+                    tauw[i + j] = TT(i + j, i);
             }
 
             // Q is sliced down to the desired size of output Q (k-by-n).
-            // It stores the desired number of Householder reflectors that UNGL2 will use.
+            // It stores the desired number of Householder reflectors that UNGL2
+            // will use.
             lacpy(Uplo::General, slice(A, range(0, min(m, k)), range(0, n)), Q);
 
             ungl2(Q, tauw, workOpts);
 
             // Wq is the identity matrix to check the orthogonality of Q
-            std::vector<T> Wq_; auto Wq = new_matrix( Wq_, k, k );
+            std::vector<T> Wq_;
+            auto Wq = new_matrix(Wq_, k, k);
             auto orth_Q = check_orthogonality(Q, Wq);
             CHECK(orth_Q <= tol);
 
             // L is sliced from A after GELQ2
-            std::vector<T> L_; auto L = new_matrix( L_, min(k, m), k );
+            std::vector<T> L_;
+            auto L = new_matrix(L_, min(k, m), k);
             laset(Uplo::Upper, zero, zero, L);
             lacpy(Uplo::Lower, slice(A, range(0, min(m, k)), range(0, k)), L);
 
             // R stores the product of L and Q
-            std::vector<T> R_; auto R = new_matrix( R_, min(k, m), n );
+            std::vector<T> R_;
+            auto R = new_matrix(R_, min(k, m), n);
 
             // Test A = L * Q
             gemm(Op::NoTrans, Op::NoTrans, real_t(1.), L, Q, R);
@@ -112,9 +125,10 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked", "[lqf
                 for (idx_t i = 0; i < min(m, k); ++i)
                     A_copy(i, j) -= R(i, j);
 
-            real_t repres = tlapack::lange(tlapack::Norm::Max, slice(A_copy, range(0, min(m, k)), range(0, n)));
+            real_t repres =
+                tlapack::lange(tlapack::Norm::Max,
+                               slice(A_copy, range(0, min(m, k)), range(0, n)));
             CHECK(repres <= tol);
-
         }
     }
 }

--- a/test/src/test_getrf.cpp
+++ b/test/src/test_getrf.cpp
@@ -24,82 +24,94 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix", "[getrf]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
+                   "[getrf]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    typedef real_type<T> real_t; // equivalent to using real_t = real_type<T>;
+    typedef real_type<T> real_t;  // equivalent to using real_t = real_type<T>;
 
     // Functor
     Create<matrix_t> new_matrix;
 
-    // m and n represent no. rows and columns of the matrices we will be testing respectively
+    // m and n represent no. rows and columns of the matrices we will be testing
+    // respectively
     idx_t m = GENERATE(10, 20, 30);
     idx_t n = GENERATE(10, 20, 30);
-    GetrfVariant variant = GENERATE( GetrfVariant::Level0, GetrfVariant::Recursive );
-    
-    idx_t k = min<idx_t>(m,n);
+    GetrfVariant variant =
+        GENERATE(GetrfVariant::Level0, GetrfVariant::Recursive);
 
-    // eps is the machine precision, and tol is the tolerance we accept for tests to pass
+    idx_t k = min<idx_t>(m, n);
+
+    // eps is the machine precision, and tol is the tolerance we accept for
+    // tests to pass
     const real_t eps = ulp<real_t>();
     const real_t tol = real_t(max(m, n)) * eps;
 
     // Initialize matrices A, and A_copy to run tests on
-    std::vector<T> A_; auto A = new_matrix( A_, m, n );
-    std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, m, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, m, n);
+    std::vector<T> A_copy_;
+    auto A_copy = new_matrix(A_copy_, m, n);
 
     // Update A with random numbers
     for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < m; ++i){
+        for (idx_t i = 0; i < m; ++i) {
             // A(i, j) = rand_helper<T>();
             A(i, j) = rand_helper<T>();
         }
 
     // We will make a deep copy A
-    // We intend to test A=LU, however, since after calling getrf, A will be udpated
-    // then to test A=LU, we'll make a deep copy of A prior to calling getrf
+    // We intend to test A=LU, however, since after calling getrf, A will be
+    // udpated then to test A=LU, we'll make a deep copy of A prior to calling
+    // getrf
     lacpy(Uplo::General, A, A_copy);
 
-    real_t norma = tlapack::lange( tlapack::Norm::Max, A);
+    real_t norma = tlapack::lange(tlapack::Norm::Max, A);
     // Initialize Piv vector to all zeros
-    std::vector<idx_t> Piv( k , idx_t(0) );
+    std::vector<idx_t> Piv(k, idx_t(0));
     // Run getrf and both A and Piv will be update
-    getrf(A,Piv, getrf_opts_t{variant} );
+    getrf(A, Piv, getrf_opts_t{variant});
 
     // A contains L and U now, then form A <--- LU
-    if( m > n )
-    {
-        auto A0 = tlapack::slice(A,tlapack::range<idx_t>(0,n),tlapack::range<idx_t>(0,n));
-        auto A1 = tlapack::slice(A,tlapack::range<idx_t>(n,m),tlapack::range<idx_t>(0,n));
-        trmm( Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, real_t(1), A0, A1 );
-        lu_mult( A0 );
+    if (m > n) {
+        auto A0 = tlapack::slice(A, tlapack::range<idx_t>(0, n),
+                                 tlapack::range<idx_t>(0, n));
+        auto A1 = tlapack::slice(A, tlapack::range<idx_t>(n, m),
+                                 tlapack::range<idx_t>(0, n));
+        trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, real_t(1),
+             A0, A1);
+        lu_mult(A0);
     }
-    else if( m < n )
-    {
-        auto A0 = tlapack::slice(A,tlapack::range<idx_t>(0,m),tlapack::range<idx_t>(0,m));
-        auto A1 = tlapack::slice(A,tlapack::range<idx_t>(0,m),tlapack::range<idx_t>(m,n));
-        trmm( Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, real_t(1), A0, A1 );
-        lu_mult( A0 );
+    else if (m < n) {
+        auto A0 = tlapack::slice(A, tlapack::range<idx_t>(0, m),
+                                 tlapack::range<idx_t>(0, m));
+        auto A1 = tlapack::slice(A, tlapack::range<idx_t>(0, m),
+                                 tlapack::range<idx_t>(m, n));
+        trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, real_t(1), A0,
+             A1);
+        lu_mult(A0);
     }
     else
-        lu_mult( A );
+        lu_mult(A);
 
-    // Now that Piv is updated, we work our way backwards in Piv and switch rows of LU
-    for(idx_t j=k-idx_t(1);j!=idx_t(-1);j--){
-        auto vect1=tlapack::row(A,j);
-        auto vect2=tlapack::row(A,Piv[j]);
-        tlapack::swap(vect1,vect2);
+    // Now that Piv is updated, we work our way backwards in Piv and switch rows
+    // of LU
+    for (idx_t j = k - idx_t(1); j != idx_t(-1); j--) {
+        auto vect1 = tlapack::row(A, j);
+        auto vect2 = tlapack::row(A, Piv[j]);
+        tlapack::swap(vect1, vect2);
     }
 
     // A <- A_original - LU
     for (idx_t i = 0; i < m; i++)
         for (idx_t j = 0; j < n; j++)
-            A(i,j) -= A_copy(i,j);
+            A(i, j) -= A_copy(i, j);
 
     // Check for relative error: norm(A-LU)/norm(A)
-    real_t error = tlapack::lange( tlapack::Norm::Max, A)/norma;
+    real_t error = tlapack::lange(tlapack::Norm::Max, A) / norma;
     CHECK(error <= tol);
-
 }

--- a/test/src/test_getrf.cpp
+++ b/test/src/test_getrf.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_getri.cpp
+++ b/test/src/test_getri.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_getri.cpp
+++ b/test/src/test_getri.cpp
@@ -1,6 +1,7 @@
 /// @file test_getri.cpp
 /// @author Ali Lotfi, University of Colorado Denver, USA
-/// @brief Test functions that calculate inverse of matrices such as getri family.
+/// @brief Test functions that calculate inverse of matrices such as getri
+/// family.
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 // This file is part of <T>LAPACK.
@@ -18,87 +19,90 @@
 
 // Other routines
 #include <tlapack/blas/gemm.hpp>
-#include <tlapack/lapack/getri.hpp>
 #include <tlapack/lapack/getrf.hpp>
+#include <tlapack/lapack/getri.hpp>
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("Inversion of a general m-by-n matrix", "[getri]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("Inversion of a general m-by-n matrix",
+                   "[getri]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    typedef real_type<T> real_t; // equivalent to using real_t = real_type<T>;
+    typedef real_type<T> real_t;  // equivalent to using real_t = real_type<T>;
 
     // Functor
     Create<matrix_t> new_matrix;
-    
-    //n represent no. rows and columns of the square matrices we will performing tests on
-    idx_t n = GENERATE(5,10,20,100);
-    GetriVariant variant = GENERATE( GetriVariant::UXLI, GetriVariant::UILI );
 
-    // eps is the machine precision, and tol is the tolerance we accept for tests to pass
+    // n represent no. rows and columns of the square matrices we will
+    // performing tests on
+    idx_t n = GENERATE(5, 10, 20, 100);
+    GetriVariant variant = GENERATE(GetriVariant::UXLI, GetriVariant::UILI);
+
+    // eps is the machine precision, and tol is the tolerance we accept for
+    // tests to pass
     const real_t eps = ulp<real_t>();
-    const real_t tol = real_t(n*n)*eps;
-    
+    const real_t tol = real_t(n * n) * eps;
+
     // Initialize matrices A, and invA to run tests on
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> invA_; auto invA = new_matrix( invA_, n, n );
-    
-    // forming A, a random matrix 
+    std::vector<T> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<T> invA_;
+    auto invA = new_matrix(invA_, n, n);
+
+    // forming A, a random matrix
     for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i){
+        for (idx_t i = 0; i < n; ++i) {
             A(i, j) = rand_helper<T>();
         }
 
-    
     // make a deep copy A
     lacpy(Uplo::General, A, invA);
-    
+
     // calculate norm of A for later use in relative error
-    real_t norma = tlapack::lange( tlapack::Norm::Max, A);
-    
+    real_t norma = tlapack::lange(tlapack::Norm::Max, A);
+
     // LU factorize Pivoted A
-    std::vector<idx_t> Piv( n , idx_t(0) );
-    getrf(invA,Piv);
+    std::vector<idx_t> Piv(n, idx_t(0));
+    getrf(invA, Piv);
 
     // run inverse function, this could test any inverse function of choice
-    getri_opts_t opts; opts.variant = variant;
-    getri(invA,Piv,opts);
+    getri_opts_t opts;
+    opts.variant = variant;
+    getri(invA, Piv, opts);
 
     // building error matrix E
-    std::vector<T> E_; auto E = new_matrix( E_, n, n );
-    
+    std::vector<T> E_;
+    auto E = new_matrix(E_, n, n);
+
     // E <----- inv(A)*A - I
-    gemm(Op::NoTrans,Op::NoTrans,real_t(1),A,invA,E);
+    gemm(Op::NoTrans, Op::NoTrans, real_t(1), A, invA, E);
     for (idx_t i = 0; i < n; i++)
-        E(i,i) -= real_t(1);
-    
+        E(i, i) -= real_t(1);
+
     // error is  || inv(A)*A - I || / ( ||A|| * ||inv(A)|| )
-    real_t error = tlapack::lange( tlapack::Norm::Max, E)
-                    / (norma * tlapack::lange( tlapack::Norm::Max, invA ));
+    real_t error = tlapack::lange(tlapack::Norm::Max, E) /
+                   (norma * tlapack::lange(tlapack::Norm::Max, invA));
 
-    INFO( "|| inv(A)*A - I || / ( ||A|| * ||inv(A)|| )" );
-    INFO( "n = " << n );
-    INFO( "variant = " << (char) variant );
-    CHECK(error/tol <= real_t(1)); // tests if error<=tol
-    
+    INFO("|| inv(A)*A - I || / ( ||A|| * ||inv(A)|| )");
+    INFO("n = " << n);
+    INFO("variant = " << (char)variant);
+    CHECK(error / tol <= real_t(1));  // tests if error<=tol
+
     // E <----- A*inv(A) - I
-    gemm(Op::NoTrans,Op::NoTrans,real_t(1),invA,A,E);
+    gemm(Op::NoTrans, Op::NoTrans, real_t(1), invA, A, E);
     for (idx_t i = 0; i < n; i++)
-        E(i,i) -= real_t(1);
-    
+        E(i, i) -= real_t(1);
+
     // error is  || A*inv(A) - I || / ( ||A|| * ||inv(A)|| )
-    error = tlapack::lange( tlapack::Norm::Max, E)
-                    / (norma * tlapack::lange( tlapack::Norm::Max, invA ));
+    error = tlapack::lange(tlapack::Norm::Max, E) /
+            (norma * tlapack::lange(tlapack::Norm::Max, invA));
 
-    INFO( "|| A*inv(A) - I || / ( ||A|| * ||inv(A)|| )" );
-    INFO( "n = " << n );
-    INFO( "variant = " << (char) variant );
-    CHECK(error/tol <= real_t(1)); // tests if error<=tol
-    
+    INFO("|| A*inv(A) - I || / ( ||A|| * ||inv(A)|| )");
+    INFO("n = " << n);
+    INFO("variant = " << (char)variant);
+    CHECK(error / tol <= real_t(1));  // tests if error<=tol
 }
-
-
-

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Other routines

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -19,7 +19,9 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("sylvester solver gives correct result", "[sylvester]", TLAPACK_REAL_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("sylvester solver gives correct result",
+                   "[sylvester]",
+                   TLAPACK_REAL_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -38,11 +40,16 @@ TEMPLATE_TEST_CASE("sylvester solver gives correct result", "[sylvester]", TLAPA
     const real_t eps = uroundoff<real_t>();
     const real_t tol = real_t(1.0e2) * eps;
 
-    std::vector<T> TL_; auto TL = new_matrix( TL_, n1, n1 );
-    std::vector<T> TR_; auto TR = new_matrix( TR_, n2, n2 );
-    std::vector<T> B_; auto B = new_matrix( B_, n1, n2 );
-    std::vector<T> X_; auto X = new_matrix( X_, n1, n2 );
-    std::vector<T> X_exact_; auto X_exact = new_matrix( X_exact_, n1, n2 );
+    std::vector<T> TL_;
+    auto TL = new_matrix(TL_, n1, n1);
+    std::vector<T> TR_;
+    auto TR = new_matrix(TR_, n2, n2);
+    std::vector<T> B_;
+    auto B = new_matrix(B_, n1, n2);
+    std::vector<T> X_;
+    auto X = new_matrix(X_, n1, n2);
+    std::vector<T> X_exact_;
+    auto X_exact = new_matrix(X_exact_, n1, n2);
 
     for (idx_t i = 0; i < n1; ++i)
         for (idx_t j = 0; j < n1; ++j)
@@ -59,12 +66,11 @@ TEMPLATE_TEST_CASE("sylvester solver gives correct result", "[sylvester]", TLAPA
     Op trans_l = Op::NoTrans;
     Op trans_r = Op::NoTrans;
 
-    real_t sign( 1 );
+    real_t sign(1);
 
     // Calculate op(TL)*X + ISGN*X*op(TR)
     gemm(trans_l, Op::NoTrans, one, TL, X_exact, B);
     gemm(Op::NoTrans, trans_r, sign, X_exact, TR, one, B);
-
 
     INFO("n1 = " << n1 << " n2 =" << n2);
     {
@@ -75,6 +81,7 @@ TEMPLATE_TEST_CASE("sylvester solver gives correct result", "[sylvester]", TLAPA
         // Check that X_exact == X
         for (idx_t i = 0; i < n1; ++i)
             for (idx_t j = 0; j < n2; ++j)
-                CHECK(abs1(X_exact(i, j) - scale * X(i, j)) <= tol * X_exact(i, j));
+                CHECK(abs1(X_exact(i, j) - scale * X(i, j)) <=
+                      tol * X_exact(i, j));
     }
 }

--- a/test/src/test_lauum.cpp
+++ b/test/src/test_lauum.cpp
@@ -17,8 +17,8 @@
 #include <tlapack/lapack/lacpy.hpp>
 
 // Other routines
-#include <tlapack/lapack/lauum_recursive.hpp>
 #include <tlapack/lapack/lantr.hpp>
+#include <tlapack/lapack/lauum_recursive.hpp>
 
 using namespace tlapack;
 
@@ -40,8 +40,10 @@ TEMPLATE_TEST_CASE("LAUUM is stable", "[lauum]", TLAPACK_TYPES_TO_TEST)
     const real_t eps = uroundoff<real_t>();
     const real_t tol = real_t(1.0e2 * n) * eps;
 
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> C_; auto C = new_matrix( C_, n, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<T> C_;
+    auto C = new_matrix(C_, n, n);
 
     // Generate random matrix
     for (idx_t j = 0; j < n; ++j)
@@ -57,15 +59,13 @@ TEMPLATE_TEST_CASE("LAUUM is stable", "[lauum]", TLAPACK_TYPES_TO_TEST)
         // Calculate residual
         real_t normC = lantr(max_norm, uplo, Diag::NonUnit, C);
 
-        if (uplo == Uplo::Lower)
-        {
+        if (uplo == Uplo::Lower) {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < j; ++i)
                     C(i, j) = T(0.);
             herk(Uplo::Lower, Op::ConjTrans, real_t(1), C, real_t(-1), A);
         }
-        else
-        {
+        else {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = j + 1; i < n; ++i)
                     C(i, j) = T(0.);

--- a/test/src/test_lauum.cpp
+++ b/test/src/test_lauum.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_lu_mult.cpp
+++ b/test/src/test_lu_mult.cpp
@@ -23,7 +23,9 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("lu multiplication is backward stable", "[lu check][lu][qrt]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("lu multiplication is backward stable",
+                   "[lu check][lu][qrt]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -37,17 +39,21 @@ TEMPLATE_TEST_CASE("lu multiplication is backward stable", "[lu check][lu][qrt]"
 
     idx_t n, nx;
 
-    n = GENERATE(1, 2, 6, 9); INFO("n = " << n);
-    nx = GENERATE(1, 2, 4, 5); INFO("nx = " << nx);
+    n = GENERATE(1, 2, 6, 9);
+    INFO("n = " << n);
+    nx = GENERATE(1, 2, 4, 5);
+    INFO("nx = " << nx);
 
-    if(nx <= n){
-
+    if (nx <= n) {
         const real_t eps = ulp<real_t>();
         const real_t tol = real_t(n) * eps;
 
-        std::vector<T> L_; auto L = new_matrix( L_, n, n );
-        std::vector<T> U_; auto U = new_matrix( U_, n, n );
-        std::vector<T> A_; auto A = new_matrix( A_, n, n );
+        std::vector<T> L_;
+        auto L = new_matrix(L_, n, n);
+        std::vector<T> U_;
+        auto U = new_matrix(U_, n, n);
+        std::vector<T> A_;
+        auto A = new_matrix(A_, n, n);
 
         // Generate n-by-n random matrix
         for (idx_t j = 0; j < n; ++j)

--- a/test/src/test_lu_mult.cpp
+++ b/test/src/test_lu_mult.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_optBLAS.cpp
+++ b/test/src/test_optBLAS.cpp
@@ -16,39 +16,40 @@ using namespace tlapack;
 
 TEST_CASE("has_compatible_layout gives the correct result", "[optBLAS]")
 {
-    using matrixA_t = legacyMatrix< float, size_t, Layout::ColMajor >;
-    using matrixB_t = legacyMatrix< float, size_t, Layout::RowMajor >;
-    using vector_t  = legacyVector< float >;
+    using matrixA_t = legacyMatrix<float, size_t, Layout::ColMajor>;
+    using matrixB_t = legacyMatrix<float, size_t, Layout::RowMajor>;
+    using vector_t = legacyVector<float>;
 
-    CHECK( has_compatible_layout< matrixA_t, matrixA_t > );
-    CHECK(!has_compatible_layout< matrixA_t, matrixB_t > );
-    CHECK( has_compatible_layout< matrixB_t, matrixB_t > );
-    CHECK(!has_compatible_layout< matrixB_t, matrixA_t > );
+    CHECK(has_compatible_layout<matrixA_t, matrixA_t>);
+    CHECK(!has_compatible_layout<matrixA_t, matrixB_t>);
+    CHECK(has_compatible_layout<matrixB_t, matrixB_t>);
+    CHECK(!has_compatible_layout<matrixB_t, matrixA_t>);
 
-    CHECK( has_compatible_layout< matrixA_t, vector_t > );
-    CHECK( has_compatible_layout< vector_t, matrixA_t > );
-    CHECK( has_compatible_layout< matrixB_t, vector_t > );
-    CHECK( has_compatible_layout< vector_t, matrixB_t > );
+    CHECK(has_compatible_layout<matrixA_t, vector_t>);
+    CHECK(has_compatible_layout<vector_t, matrixA_t>);
+    CHECK(has_compatible_layout<matrixB_t, vector_t>);
+    CHECK(has_compatible_layout<vector_t, matrixB_t>);
 
-    CHECK( has_compatible_layout< matrixA_t, matrixA_t, matrixA_t > );
-    CHECK(!has_compatible_layout< matrixA_t, matrixA_t, matrixB_t > );
-    CHECK(!has_compatible_layout< matrixA_t, matrixB_t, matrixA_t > );
-    CHECK(!has_compatible_layout< matrixA_t, matrixB_t, matrixB_t > );
-    CHECK(!has_compatible_layout< matrixB_t, matrixA_t, matrixA_t > );
-    CHECK(!has_compatible_layout< matrixB_t, matrixA_t, matrixB_t > );
-    CHECK(!has_compatible_layout< matrixB_t, matrixB_t, matrixA_t > );
-    CHECK( has_compatible_layout< matrixB_t, matrixB_t, matrixB_t > );
+    CHECK(has_compatible_layout<matrixA_t, matrixA_t, matrixA_t>);
+    CHECK(!has_compatible_layout<matrixA_t, matrixA_t, matrixB_t>);
+    CHECK(!has_compatible_layout<matrixA_t, matrixB_t, matrixA_t>);
+    CHECK(!has_compatible_layout<matrixA_t, matrixB_t, matrixB_t>);
+    CHECK(!has_compatible_layout<matrixB_t, matrixA_t, matrixA_t>);
+    CHECK(!has_compatible_layout<matrixB_t, matrixA_t, matrixB_t>);
+    CHECK(!has_compatible_layout<matrixB_t, matrixB_t, matrixA_t>);
+    CHECK(has_compatible_layout<matrixB_t, matrixB_t, matrixB_t>);
 }
 
 TEST_CASE("allow_optblas does not allow bool, int, long int, char", "[optBLAS]")
 {
-    CHECK(!allow_optblas<bool> );
-    CHECK(!allow_optblas<int> );
-    CHECK(!allow_optblas<long double> );
-    CHECK(!allow_optblas<char> );
+    CHECK(!allow_optblas<bool>);
+    CHECK(!allow_optblas<int>);
+    CHECK(!allow_optblas<long double>);
+    CHECK(!allow_optblas<char>);
 }
 
-// TEMPLATE_TEST_CASE("legacy_matrix() exists", "[utils]", TLAPACK_TYPES_TO_TEST)
+// TEMPLATE_TEST_CASE("legacy_matrix() exists", "[utils]",
+// TLAPACK_TYPES_TO_TEST)
 // {
 //     using matrix_t = TestType;
 //     using legacy_t = decltype( legacy_matrix( std::declval<matrix_t>() ) );
@@ -56,28 +57,34 @@ TEST_CASE("allow_optblas does not allow bool, int, long int, char", "[optBLAS]")
 //     CHECK ( is_same_v< matrix_t, legacy_t > );
 // }
 
-TEMPLATE_TEST_CASE("allow_optblas gives the correct result", "[optBLAS]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("allow_optblas gives the correct result",
+                   "[optBLAS]",
+                   TLAPACK_TYPES_TO_TEST)
 {
-    using matrix_t  = TestType;
+    using matrix_t = TestType;
     using T = type_t<matrix_t>;
 
     // Test matrix_t and pair< matrix_t, T >
-    CHECK( allow_optblas<matrix_t> == allow_optblas<T> );
-    CHECK( allow_optblas< pair< matrix_t, T > > == allow_optblas<T> );
+    CHECK(allow_optblas<matrix_t> == allow_optblas<T>);
+    CHECK(allow_optblas<pair<matrix_t, T>> == allow_optblas<T>);
 
     // Test pairs of convertible types
-    CHECK( allow_optblas< pair< float, double > > == allow_optblas<double> );
-    CHECK( allow_optblas< pair< int, float > > == allow_optblas<float> );
-    CHECK( allow_optblas< pair< double, std::complex<double> > > == allow_optblas<std::complex<double>> );
-    CHECK( allow_optblas< pair< double, long double > > == allow_optblas<long double> );
-    CHECK( allow_optblas< pair< std::complex<double>, double > > == false );
-    
+    CHECK(allow_optblas<pair<float, double>> == allow_optblas<double>);
+    CHECK(allow_optblas<pair<int, float>> == allow_optblas<float>);
+    CHECK(allow_optblas<pair<double, std::complex<double>>> ==
+          allow_optblas<std::complex<double>>);
+    CHECK(allow_optblas<pair<double, long double>> ==
+          allow_optblas<long double>);
+    CHECK(allow_optblas<pair<std::complex<double>, double>> == false);
+
     // Test pair< matrix_t, T > and pairs of convertible types
-    CHECK( allow_optblas< pair< matrix_t, T >, pair< T, T > > == allow_optblas<T> );
-    CHECK( allow_optblas< pair< matrix_t, T >, pair< int, T > > == allow_optblas<T> );
-    CHECK( allow_optblas< pair< matrix_t, T >, pair< float, T > > == allow_optblas<T> );
-    CHECK( allow_optblas< pair< matrix_t, T >, pair< long double, T > > == allow_optblas<T> );
-    
+    CHECK(allow_optblas<pair<matrix_t, T>, pair<T, T>> == allow_optblas<T>);
+    CHECK(allow_optblas<pair<matrix_t, T>, pair<int, T>> == allow_optblas<T>);
+    CHECK(allow_optblas<pair<matrix_t, T>, pair<float, T>> == allow_optblas<T>);
+    CHECK(allow_optblas<pair<matrix_t, T>, pair<long double, T>> ==
+          allow_optblas<T>);
+
     // Test pair< matrix_t, T > and pair< matrix_t, T >
-    CHECK( allow_optblas< pair< matrix_t, T >, pair< matrix_t, T > > == allow_optblas<T> );
+    CHECK(allow_optblas<pair<matrix_t, T>, pair<matrix_t, T>> ==
+          allow_optblas<T>);
 }

--- a/test/src/test_optBLAS.cpp
+++ b/test/src/test_optBLAS.cpp
@@ -10,6 +10,7 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 using namespace tlapack;

--- a/test/src/test_potrf.cpp
+++ b/test/src/test_potrf.cpp
@@ -11,7 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include "TestUploMatrix.hpp"
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines
@@ -21,6 +21,8 @@
 // Other routines
 #include <tlapack/blas/trmm.hpp>
 #include <tlapack/lapack/potrf.hpp>
+
+#include "TestUploMatrix.hpp"
 
 using namespace tlapack;
 

--- a/test/src/test_potrf.cpp
+++ b/test/src/test_potrf.cpp
@@ -11,8 +11,8 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include "testutils.hpp"
 #include "TestUploMatrix.hpp"
+#include "testutils.hpp"
 
 // Auxiliary routines
 #include <tlapack/lapack/lacpy.hpp>
@@ -24,7 +24,10 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("Cholesky factorization of a Hermitian positive-definite matrix", "[potrf]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE(
+    "Cholesky factorization of a Hermitian positive-definite matrix",
+    "[potrf]",
+    TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;
@@ -35,14 +38,12 @@ TEMPLATE_TEST_CASE("Cholesky factorization of a Hermitian positive-definite matr
     // Functor
     Create<matrix_t> new_matrix;
 
-    using variant_t = std::pair<PotrfVariant,idx_t>;
-    const variant_t variant = GENERATE(
-        (variant_t(PotrfVariant::Blocked,1)),
-        (variant_t(PotrfVariant::Blocked,2)),
-        (variant_t(PotrfVariant::Blocked,7)),
-        (variant_t(PotrfVariant::Blocked,10)),
-        (variant_t(PotrfVariant::Recursive,0))
-    );
+    using variant_t = std::pair<PotrfVariant, idx_t>;
+    const variant_t variant = GENERATE((variant_t(PotrfVariant::Blocked, 1)),
+                                       (variant_t(PotrfVariant::Blocked, 2)),
+                                       (variant_t(PotrfVariant::Blocked, 7)),
+                                       (variant_t(PotrfVariant::Blocked, 10)),
+                                       (variant_t(PotrfVariant::Recursive, 0)));
     const idx_t n = GENERATE(10, 19, 30);
     const Uplo uplo = GENERATE(Uplo::Lower, Uplo::Upper);
 
@@ -50,21 +51,25 @@ TEMPLATE_TEST_CASE("Cholesky factorization of a Hermitian positive-definite matr
     INFO("Matrix size: " << n << "x" << n);
     INFO("Uplo: " << uplo);
 
-    // eps is the machine precision, and tol is the tolerance we accept for tests to pass
+    // eps is the machine precision, and tol is the tolerance we accept for
+    // tests to pass
     const real_t eps = ulp<real_t>();
     const real_t tol = real_t(n) * eps;
 
     // Create matrices
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> L_; auto L = new_matrix( L_, n, n );
-    std::vector<T> E_; auto E = new_matrix( E_, n, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<T> L_;
+    auto L = new_matrix(L_, n, n);
+    std::vector<T> E_;
+    auto E = new_matrix(E_, n, n);
 
     // Update A with random numbers
     for (idx_t j = 0; j < n; ++j) {
         for (idx_t i = 0; i < n; ++i) {
-            if( uplo == Uplo::Lower && i >= j )
+            if (uplo == Uplo::Lower && i >= j)
                 A(i, j) = rand_helper<T>();
-            else if( uplo == Uplo::Upper && i <= j )
+            else if (uplo == Uplo::Upper && i <= j)
                 A(i, j) = rand_helper<T>();
             else
                 A(i, j) = real_t(0xCAFEBABE);
@@ -73,8 +78,8 @@ TEMPLATE_TEST_CASE("Cholesky factorization of a Hermitian positive-definite matr
     }
 
     lacpy(dense, A, L);
-    real_t normA = tlapack::lanhe( tlapack::Norm::Max, uplo, A);
-    
+    real_t normA = tlapack::lanhe(tlapack::Norm::Max, uplo, A);
+
     // Run the Cholesky factorization
     potrf_opts_t<idx_t> opts;
     opts.variant = variant.first;
@@ -82,40 +87,44 @@ TEMPLATE_TEST_CASE("Cholesky factorization of a Hermitian positive-definite matr
     int info = potrf(uplo, L, opts);
 
     // Check that the factorization was successful
-    REQUIRE( info == 0 );
+    REQUIRE(info == 0);
 
     // Initialize E with the hermitian part of L
     for (idx_t j = 0; j < n; ++j)
         for (idx_t i = 0; i < n; ++i) {
-            if( uplo == Uplo::Lower && i <= j )
+            if (uplo == Uplo::Lower && i <= j)
                 E(i, j) = conj(L(j, i));
-            else if( uplo == Uplo::Upper && i >= j )
+            else if (uplo == Uplo::Upper && i >= j)
                 E(i, j) = conj(L(j, i));
             else
                 E(i, j) = real_t(0);
         }
 
     // Compute E = L*L^H or E = L^H*L
-    if( uplo == Uplo::Lower )
-        trmm( Side::Left, Uplo::Lower, Op::NoTrans, Diag::NonUnit, real_t(1), L, E );
+    if (uplo == Uplo::Lower)
+        trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::NonUnit, real_t(1), L,
+             E);
     else
-        trmm( Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, real_t(1), L, E );
+        trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, real_t(1), L,
+             E);
 
-    // Check that the factorization is correct    
+    // Check that the factorization is correct
     for (idx_t i = 0; i < n; i++)
         for (idx_t j = 0; j < n; j++) {
-            if( uplo == Uplo::Lower && i >= j )
+            if (uplo == Uplo::Lower && i >= j)
                 E(i, j) -= A(i, j);
-            else if( uplo == Uplo::Upper && i <= j )
+            else if (uplo == Uplo::Upper && i <= j)
                 E(i, j) -= A(i, j);
         }
 
     // Check for relative error: norm(A-cholesky(A))/norm(A)
-    real_t error = tlapack::lanhe( tlapack::Norm::Max, uplo, E)/normA;
+    real_t error = tlapack::lanhe(tlapack::Norm::Max, uplo, E) / normA;
     CHECK(error <= tol);
 }
 
-TEMPLATE_TEST_CASE("Cholesky factorization access valid positions only", "[potrf]", TLAPACK_LEGACY_REAL_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("Cholesky factorization access valid positions only",
+                   "[potrf]",
+                   TLAPACK_LEGACY_REAL_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;
@@ -127,11 +136,9 @@ TEMPLATE_TEST_CASE("Cholesky factorization access valid positions only", "[potrf
     // Functor
     Create<matrix_t> new_matrix;
 
-    using variant_t = std::pair<PotrfVariant,idx_t>;
-    const variant_t variant = GENERATE(
-        (variant_t(PotrfVariant::Blocked,2)),
-        (variant_t(PotrfVariant::Recursive,0))
-    );
+    using variant_t = std::pair<PotrfVariant, idx_t>;
+    const variant_t variant = GENERATE((variant_t(PotrfVariant::Blocked, 2)),
+                                       (variant_t(PotrfVariant::Recursive, 0)));
     const idx_t n = GENERATE(10);
     const Uplo uplo = GENERATE(Uplo::Lower, Uplo::Upper);
 
@@ -140,37 +147,36 @@ TEMPLATE_TEST_CASE("Cholesky factorization access valid positions only", "[potrf
     INFO("Uplo: " << uplo);
 
     // Create matrices
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, n, n);
 
     // Update A with random numbers
     for (idx_t j = 0; j < n; ++j) {
         for (idx_t i = 0; i < n; ++i) {
-            if( uplo == Uplo::Lower && i >= j )
+            if (uplo == Uplo::Lower && i >= j)
                 A(i, j) = rand_helper<T>();
-            else if( uplo == Uplo::Upper && i <= j )
+            else if (uplo == Uplo::Upper && i <= j)
                 A(i, j) = rand_helper<T>();
             else
                 A(i, j) = real_t(0xCAFEBABE);
         }
         A(j, j) += real_t(n);
     }
-    
+
     // Run the Cholesky factorization
     potrf_opts_t<idx_t> opts;
     opts.variant = variant.first;
     opts.nb = variant.second;
-    if( uplo == Uplo::Lower )
-    {
-        TestUploMatrix<T,idx_t,Uplo::Lower,L> testA(A);
-        
-        int info = potrf(uplo, testA, opts);
-        REQUIRE( info == 0 );
-    }
-    else
-    {
-        TestUploMatrix<T,idx_t,Uplo::Upper,L> testA(A);
+    if (uplo == Uplo::Lower) {
+        TestUploMatrix<T, idx_t, Uplo::Lower, L> testA(A);
 
         int info = potrf(uplo, testA, opts);
-        REQUIRE( info == 0 );
+        REQUIRE(info == 0);
+    }
+    else {
+        TestUploMatrix<T, idx_t, Uplo::Upper, L> testA(A);
+
+        int info = potrf(uplo, testA, opts);
+        REQUIRE(info == 0);
     }
 }

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -22,7 +22,9 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalues]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results",
+                   "[eigenvalues]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -43,19 +45,20 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalu
     idx_t n1 = GENERATE(1, 2);
     idx_t n2 = GENERATE(1, 2);
 
-    if (!is_complex<T>::value || (n1 == 1 && n2 == 1))
-    {
+    if (!is_complex<T>::value || (n1 == 1 && n2 == 1)) {
         // ifst and ilst point to the same block, n1 must be equal to n2 for
         // the test to make sense.
-        if (ifst == ilst and n1 != n2)
-            n2 = n1;
+        if (ifst == ilst and n1 != n2) n2 = n1;
 
         const real_t eps = uroundoff<real_t>();
         const real_t tol = real_t(1.0e2 * n) * eps;
 
-        std::vector<T> A_; auto A = new_matrix( A_, n, n );
-        std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
-        std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, n, n );
+        std::vector<T> A_;
+        auto A = new_matrix(A_, n, n);
+        std::vector<T> Q_;
+        auto Q = new_matrix(Q_, n, n);
+        std::vector<T> A_copy_;
+        auto A_copy = new_matrix(A_copy_, n, n);
 
         // Generate random matrix in Schur form
         for (idx_t j = 0; j < n; ++j)
@@ -66,22 +69,20 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalu
             for (idx_t i = j + 1; i < n; ++i)
                 A(i, j) = zero;
 
-        if (n1 == 2)
-        {
+        if (n1 == 2) {
             if (ifst < n - 1)
                 A(ifst + 1, ifst) = rand_helper<T>();
             else
                 A(ifst, ifst - 1) = rand_helper<T>();
         }
-        if (n2 == 2)
-        {
+        if (n2 == 2) {
             if (ilst < n - 1)
                 A(ilst + 1, ilst) = rand_helper<T>();
             else
                 A(ilst, ilst - 1) = rand_helper<T>();
         }
 
-        if( !is_complex<T>::value ){
+        if (!is_complex<T>::value) {
             // Put a 2x2 block in the middle
             A(5, 4) = rand_helper<T>();
         }
@@ -89,18 +90,22 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalu
         lacpy(Uplo::General, A, A_copy);
         laset(Uplo::General, zero, one, Q);
 
-        INFO("ifst = " << ifst << " n1 = " << n1 << " ilst = " << ilst << " n2 =" << n2);
+        INFO("ifst = " << ifst << " n1 = " << n1 << " ilst = " << ilst
+                       << " n2 =" << n2);
         {
             schur_move(true, A, Q, ifst, ilst);
             // Calculate residuals
 
-            std::vector<T> res_; auto res = new_matrix( res_, n, n );
-            std::vector<T> work_; auto work = new_matrix( work_, n, n );
+            std::vector<T> res_;
+            auto res = new_matrix(res_, n, n);
+            std::vector<T> work_;
+            auto work = new_matrix(work_, n, n);
             auto orth_res_norm = check_orthogonality(Q, res);
             CHECK(orth_res_norm <= tol);
 
             auto normA = tlapack::lange(tlapack::frob_norm, A);
-            auto simil_res_norm = check_similarity_transform(A_copy, Q, A, res, work);
+            auto simil_res_norm =
+                check_similarity_transform(A_copy, Q, A, res, work);
             CHECK(simil_res_norm <= tol * normA);
         }
     }

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -22,8 +22,10 @@
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("schur swap gives correct result", "[eigenvalues]", TLAPACK_TYPES_TO_TEST)
-{    
+TEMPLATE_TEST_CASE("schur swap gives correct result",
+                   "[eigenvalues]",
+                   TLAPACK_TYPES_TO_TEST)
+{
     srand(1);
 
     using matrix_t = TestType;
@@ -42,15 +44,16 @@ TEMPLATE_TEST_CASE("schur swap gives correct result", "[eigenvalues]", TLAPACK_T
     const idx_t n1 = GENERATE(1, 2);
     const idx_t n2 = GENERATE(1, 2);
 
-    if (!is_complex<T>::value || (n1 == 1 && n2 == 1))
-    {
-        
+    if (!is_complex<T>::value || (n1 == 1 && n2 == 1)) {
         const real_t eps = uroundoff<real_t>();
         const real_t tol = real_t(1.0e2 * n) * eps;
 
-        std::vector<T> A_; auto A = new_matrix( A_, n, n );
-        std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
-        std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, n, n );
+        std::vector<T> A_;
+        auto A = new_matrix(A_, n, n);
+        std::vector<T> Q_;
+        auto Q = new_matrix(Q_, n, n);
+        std::vector<T> A_copy_;
+        auto A_copy = new_matrix(A_copy_, n, n);
 
         // Generate random matrix in Schur form
         for (idx_t j = 0; j < n; ++j)
@@ -61,10 +64,8 @@ TEMPLATE_TEST_CASE("schur swap gives correct result", "[eigenvalues]", TLAPACK_T
             for (idx_t i = j + 1; i < n; ++i)
                 A(i, j) = zero;
 
-        if( n1 == 2)
-            A( j + 1, j ) = rand_helper<T>();
-        if (n2 == 2)
-            A(j + n1 + 1, j + n1) = rand_helper<T>();
+        if (n1 == 2) A(j + 1, j) = rand_helper<T>();
+        if (n2 == 2) A(j + n1 + 1, j + n1) = rand_helper<T>();
 
         lacpy(Uplo::General, A, A_copy);
         laset(Uplo::General, zero, one, Q);
@@ -74,15 +75,17 @@ TEMPLATE_TEST_CASE("schur swap gives correct result", "[eigenvalues]", TLAPACK_T
             schur_swap(true, A, Q, j, n1, n2);
             // Calculate residuals
 
-            std::vector<T> res_; auto res = new_matrix( res_, n, n );
-            std::vector<T> work_; auto work = new_matrix( work_, n, n );
+            std::vector<T> res_;
+            auto res = new_matrix(res_, n, n);
+            std::vector<T> work_;
+            auto work = new_matrix(work_, n, n);
             auto orth_res_norm = check_orthogonality(Q, res);
             CHECK(orth_res_norm <= tol);
 
             auto normA = tlapack::lange(tlapack::frob_norm, A);
-            auto simil_res_norm = check_similarity_transform(A_copy, Q, A, res, work);
+            auto simil_res_norm =
+                check_similarity_transform(A_copy, Q, A, res, work);
             CHECK(simil_res_norm <= tol * normA);
-
         }
     }
 }

--- a/test/src/test_transpose.cpp
+++ b/test/src/test_transpose.cpp
@@ -10,14 +10,15 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <tlapack/lapack/transpose.hpp>
 
 #include "testutils.hpp"
 
-#include <tlapack/lapack/transpose.hpp>
-
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("Conjugate Transpose gives correct result", "[util]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("Conjugate Transpose gives correct result",
+                   "[util]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -34,8 +35,10 @@ TEMPLATE_TEST_CASE("Conjugate Transpose gives correct result", "[util]", TLAPACK
     idx_t m = GENERATE(1, 2, 3, 5, 10);
 
     // Define the matrices
-    std::vector<T> A_; auto A = new_matrix( A_, m, n );
-    std::vector<T> B_; auto B = new_matrix( B_, n, m );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, m, n);
+    std::vector<T> B_;
+    auto B = new_matrix(B_, n, m);
 
     // Generate a random matrix in A
     for (idx_t j = 0; j < n; ++j)
@@ -45,7 +48,8 @@ TEMPLATE_TEST_CASE("Conjugate Transpose gives correct result", "[util]", TLAPACK
     INFO("m = " << m << " n = " << n);
     {
         transpose_opts_t<idx_t> opts;
-        // Set nx to a small value so that the blocked algorithm gets tested even for small n and m;
+        // Set nx to a small value so that the blocked algorithm gets tested
+        // even for small n and m;
         opts.nx = 3;
         conjtranspose(A, B, opts);
 
@@ -55,7 +59,9 @@ TEMPLATE_TEST_CASE("Conjugate Transpose gives correct result", "[util]", TLAPACK
     }
 }
 
-TEMPLATE_TEST_CASE("Transpose gives correct result", "[util]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("Transpose gives correct result",
+                   "[util]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -72,8 +78,10 @@ TEMPLATE_TEST_CASE("Transpose gives correct result", "[util]", TLAPACK_TYPES_TO_
     idx_t m = GENERATE(1, 2, 3, 5, 10);
 
     // Define the matrices
-    std::vector<T> A_; auto A = new_matrix( A_, m, n );
-    std::vector<T> B_; auto B = new_matrix( B_, n, m );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, m, n);
+    std::vector<T> B_;
+    auto B = new_matrix(B_, n, m);
 
     // Generate a random matrix in A
     for (idx_t j = 0; j < n; ++j)
@@ -83,7 +91,8 @@ TEMPLATE_TEST_CASE("Transpose gives correct result", "[util]", TLAPACK_TYPES_TO_
     INFO("m = " << m << " n = " << n);
     {
         transpose_opts_t<idx_t> opts;
-        // Set nx to a small value so that the blocked algorithm gets tested even for small n and m;
+        // Set nx to a small value so that the blocked algorithm gets tested
+        // even for small n and m;
         opts.nx = 3;
         transpose(A, B, opts);
 

--- a/test/src/test_transpose.cpp
+++ b/test/src/test_transpose.cpp
@@ -10,9 +10,12 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <tlapack/lapack/transpose.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
+
+// <T>LAPACK
+#include <tlapack/lapack/transpose.hpp>
 
 using namespace tlapack;
 

--- a/test/src/test_trtri.cpp
+++ b/test/src/test_trtri.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_ul_mult.cpp
+++ b/test/src/test_ul_mult.cpp
@@ -24,81 +24,78 @@
 using namespace tlapack;
 using namespace std;
 
-TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix, blocked", "[ul_mul]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix, blocked",
+                   "[ul_mul]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    typedef real_type<T> real_t; // equivalent to using real_t = real_type<T>;
+    typedef real_type<T> real_t;  // equivalent to using real_t = real_type<T>;
 
     // Functor
     Create<matrix_t> new_matrix;
-    
-    // m and n represent no. rows and columns of the matrices we will be testing respectively
-    idx_t n = GENERATE(5,10,20,30,100);
 
-    // eps is the machine precision, and tol is the tolerance we accept for tests to pass
+    // m and n represent no. rows and columns of the matrices we will be testing
+    // respectively
+    idx_t n = GENERATE(5, 10, 20, 30, 100);
+
+    // eps is the machine precision, and tol is the tolerance we accept for
+    // tests to pass
     const real_t eps = ulp<real_t>();
-    const real_t tol = real_t(10*n)*eps;
-    
+    const real_t tol = real_t(10 * n) * eps;
+
     // Initialize matrices A, and A_copy to run tests on
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, n, n );
+    std::vector<T> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<T> A_copy_;
+    auto A_copy = new_matrix(A_copy_, n, n);
 
     // forming A, a random matrix with diagonal of 1
     for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i){
-            if(i==j){
+        for (idx_t i = 0; i < n; ++i) {
+            if (i == j) {
                 A(i, j) = rand_helper<T>();
-
             }
-            else{
+            else {
                 A(i, j) = rand_helper<T>();
-
             }
-            
         }
-            
+
     // We will make a deep copy A
     lacpy(Uplo::General, A, A_copy);
-    real_t norma=tlapack::lange( tlapack::Norm::Max, A);
-    
-    // Put diagonal and super-diagonal of A into U and sub-diagonal in L  
-    std::vector<T> L_; auto L = new_matrix( L_, n, n );
-    std::vector<T> U_; auto U = new_matrix( U_, n, n );
+    real_t norma = tlapack::lange(tlapack::Norm::Max, A);
 
-    for (idx_t j = 0; j < n; ++j){
-        for (idx_t i = 0; i < n; ++i){
-            if(i==j){
+    // Put diagonal and super-diagonal of A into U and sub-diagonal in L
+    std::vector<T> L_;
+    auto L = new_matrix(L_, n, n);
+    std::vector<T> U_;
+    auto U = new_matrix(U_, n, n);
+
+    for (idx_t j = 0; j < n; ++j) {
+        for (idx_t i = 0; i < n; ++i) {
+            if (i == j) {
                 L(i, j) = T(1);
-                U(i, j) = A(i,j);
-
+                U(i, j) = A(i, j);
             }
-            else if (i>j)
-            {
-                L(i, j) = A(i,j);
+            else if (i > j) {
+                L(i, j) = A(i, j);
                 U(i, j) = T(0);
             }
-            else{
-                L(i, j) =T(0);
-                U(i, j) = A(i,j);
-
+            else {
+                L(i, j) = T(0);
+                U(i, j) = A(i, j);
             }
-            
         }
     }
 
     // run ul_mult, which calculates U and L in place of A
     ul_mult(A);
-    
-    // store UL-A ---> A 
-    gemm(Op::NoTrans,Op::NoTrans,T(1),U,L,T(-1),A);
 
-    real_t error1 = tlapack::lange( tlapack::Norm::Max, A)/norma;
-    CHECK(error1/tol <= real_t(1));
-    
+    // store UL-A ---> A
+    gemm(Op::NoTrans, Op::NoTrans, T(1), U, L, T(-1), A);
+
+    real_t error1 = tlapack::lange(tlapack::Norm::Max, A) / norma;
+    CHECK(error1 / tol <= real_t(1));
 }
-
-
-

--- a/test/src/test_ul_mult.cpp
+++ b/test/src/test_ul_mult.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_unmhr.cpp
+++ b/test/src/test_unmhr.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 // Auxiliary routines

--- a/test/src/test_unmhr.cpp
+++ b/test/src/test_unmhr.cpp
@@ -18,13 +18,15 @@
 #include <tlapack/lapack/lange.hpp>
 
 // Other routines
+#include <tlapack/lapack/gehd2.hpp>
 #include <tlapack/lapack/unghr.hpp>
 #include <tlapack/lapack/unmhr.hpp>
-#include <tlapack/lapack/gehd2.hpp>
 
 using namespace tlapack;
 
-TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][hessenberg]", TLAPACK_TYPES_TO_TEST)
+TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr",
+                   "[eigenvalues][hessenberg]",
+                   TLAPACK_TYPES_TO_TEST)
 {
     srand(1);
 
@@ -41,9 +43,9 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][h
     Side side = GENERATE(Side::Left, Side::Right);
     Op op = GENERATE(Op::NoTrans, Op::ConjTrans);
 
-    INFO( "matrix_type = " << matrix_type );
-    INFO( "side = " << side );
-    INFO( "Op = " << op );
+    INFO("matrix_type = " << matrix_type);
+    INFO("side = " << side);
+    INFO("Op = " << op);
 
     idx_t m = 12;
     idx_t n = 10;
@@ -59,9 +61,12 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][h
     const real_type<T> tol = real_t(n * 1.0e2) * eps;
 
     // Define the matrices
-    std::vector<T> H_; auto H = new_matrix( H_, n, n );
-    std::vector<T> C_; auto C = new_matrix( C_, m, n );
-    std::vector<T> C_copy_; auto C_copy = new_matrix( C_copy_, m, n );
+    std::vector<T> H_;
+    auto H = new_matrix(H_, n, n);
+    std::vector<T> C_;
+    auto C = new_matrix(C_, m, n);
+    std::vector<T> C_copy_;
+    auto C_copy = new_matrix(C_copy_, m, n);
     std::vector<T> tau(n);
 
     // Workspace computation:
@@ -72,10 +77,9 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][h
 
     // Workspace allocation:
     vectorOfBytes workVec;
-    workspace_opts_t<> workOpts( alloc_workspace( workVec, workinfo ) );
+    workspace_opts_t<> workOpts(alloc_workspace(workVec, workinfo));
 
-    if (matrix_type == "Random")
-    {
+    if (matrix_type == "Random") {
         // Generate a random matrix in H
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < n; ++i)
@@ -100,7 +104,6 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][h
     gehd2(ilo, ihi, H, tau, workOpts);
 
     {
-
         real_t c_norm = lange(frob_norm, C);
 
         // Apply the orthogonal factor to C
@@ -111,29 +114,29 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr", "[eigenvalues][h
 
         // Multiply C_copy with the orthogonal factor
         auto Q = slice(H, pair{ilo + 1, ihi}, pair{ilo + 1, ihi});
-        if (side == Side::Left)
-        {
-            auto C_copy_s = slice(C_copy, pair{ilo + 1, ihi}, pair{0, ncols(C)});
+        if (side == Side::Left) {
+            auto C_copy_s =
+                slice(C_copy, pair{ilo + 1, ihi}, pair{0, ncols(C)});
             auto C_s = slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)});
             gemm(op, Op::NoTrans, one, Q, C_copy_s, -one, C_s);
-            for (idx_t i = 0; i < ilo+1; ++i)
+            for (idx_t i = 0; i < ilo + 1; ++i)
                 for (idx_t j = 0; j < ncols(C); ++j)
-                    C(i, j) =  C(i,j) - C_copy(i,j);
+                    C(i, j) = C(i, j) - C_copy(i, j);
             for (idx_t i = ihi; i < nrows(C); ++i)
                 for (idx_t j = 0; j < ncols(C); ++j)
-                    C(i, j) =  C(i,j) - C_copy(i,j);
+                    C(i, j) = C(i, j) - C_copy(i, j);
         }
-        else
-        {
-            auto C_copy_s = slice(C_copy, pair{0, nrows(C)}, pair{ilo + 1, ihi});
+        else {
+            auto C_copy_s =
+                slice(C_copy, pair{0, nrows(C)}, pair{ilo + 1, ihi});
             auto C_s = slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
             gemm(Op::NoTrans, op, one, C_copy_s, Q, -one, C_s);
-            for (idx_t j = 0; j < ilo+1; ++j)
+            for (idx_t j = 0; j < ilo + 1; ++j)
                 for (idx_t i = 0; i < nrows(C); ++i)
-                    C(i, j) =  C(i,j) - C_copy(i,j);
+                    C(i, j) = C(i, j) - C_copy(i, j);
             for (idx_t j = ihi; j < ncols(C); ++j)
                 for (idx_t i = 0; i < nrows(C); ++i)
-                    C(i, j) =  C(i,j) - C_copy(i,j);
+                    C(i, j) = C(i, j) - C_copy(i, j);
         }
 
         real_t e_norm = lange(frob_norm, C);

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -14,84 +14,86 @@
 
 using namespace tlapack;
 
-TEST_CASE( "Random generator is consistent if seed is fixed", "[utils]" ) {
+TEST_CASE("Random generator is consistent if seed is fixed", "[utils]")
+{
     rand_generator gen;
     gen.seed(6845315);
 
-    CHECK( gen() == 1225581775 );
-    CHECK( gen() == 1985311242 );
-    CHECK( gen() == 300629471 );
-    CHECK( gen() == 2636314308 );
-    CHECK( gen() == 1603395911 );
-    CHECK( gen() == 393807335 );
-    CHECK( gen() == 3641191292 );
+    CHECK(gen() == 1225581775);
+    CHECK(gen() == 1985311242);
+    CHECK(gen() == 300629471);
+    CHECK(gen() == 2636314308);
+    CHECK(gen() == 1603395911);
+    CHECK(gen() == 393807335);
+    CHECK(gen() == 3641191292);
 }
 
-TEST_CASE( "MatrixAccessPolicy can be cast to Uplo", "[utils]" ) {
+TEST_CASE("MatrixAccessPolicy can be cast to Uplo", "[utils]")
+{
     Uplo uplo;
     MatrixAccessPolicy runtimeAccess;
-    
+
     uplo = Uplo::Upper;
     runtimeAccess = MatrixAccessPolicy::UpperTriangle;
-    
-    CHECK( uplo == (Uplo) runtimeAccess );
-    CHECK( uplo == upperTriangle );
-    CHECK( uplo == (Uplo) upperTriangle );
 
-    CHECK( runtimeAccess == (MatrixAccessPolicy) uplo );
-    CHECK( runtimeAccess == upperTriangle );
-    CHECK( runtimeAccess == (MatrixAccessPolicy) upperTriangle );
+    CHECK(uplo == (Uplo)runtimeAccess);
+    CHECK(uplo == upperTriangle);
+    CHECK(uplo == (Uplo)upperTriangle);
 
-    CHECK( upperTriangle == (Uplo) runtimeAccess );
-    CHECK( upperTriangle == (MatrixAccessPolicy) uplo );
+    CHECK(runtimeAccess == (MatrixAccessPolicy)uplo);
+    CHECK(runtimeAccess == upperTriangle);
+    CHECK(runtimeAccess == (MatrixAccessPolicy)upperTriangle);
+
+    CHECK(upperTriangle == (Uplo)runtimeAccess);
+    CHECK(upperTriangle == (MatrixAccessPolicy)uplo);
 
     uplo = Uplo::Lower;
     runtimeAccess = MatrixAccessPolicy::LowerTriangle;
-    
-    CHECK( uplo == (Uplo) runtimeAccess );
-    CHECK( uplo == lowerTriangle );
-    CHECK( uplo == (Uplo) lowerTriangle );
 
-    CHECK( runtimeAccess == (MatrixAccessPolicy) uplo );
-    CHECK( runtimeAccess == lowerTriangle );
-    CHECK( runtimeAccess == (MatrixAccessPolicy) lowerTriangle );
+    CHECK(uplo == (Uplo)runtimeAccess);
+    CHECK(uplo == lowerTriangle);
+    CHECK(uplo == (Uplo)lowerTriangle);
 
-    CHECK( lowerTriangle == (Uplo) runtimeAccess );
-    CHECK( lowerTriangle == (MatrixAccessPolicy) uplo );
+    CHECK(runtimeAccess == (MatrixAccessPolicy)uplo);
+    CHECK(runtimeAccess == lowerTriangle);
+    CHECK(runtimeAccess == (MatrixAccessPolicy)lowerTriangle);
+
+    CHECK(lowerTriangle == (Uplo)runtimeAccess);
+    CHECK(lowerTriangle == (MatrixAccessPolicy)uplo);
 
     uplo = Uplo::General;
     runtimeAccess = MatrixAccessPolicy::Dense;
-    
-    CHECK( uplo == (Uplo) runtimeAccess );
-    CHECK( uplo == dense );
-    CHECK( uplo == (Uplo) dense );
 
-    CHECK( runtimeAccess == (MatrixAccessPolicy) uplo );
-    CHECK( runtimeAccess == dense );
-    CHECK( runtimeAccess == (MatrixAccessPolicy) dense );
+    CHECK(uplo == (Uplo)runtimeAccess);
+    CHECK(uplo == dense);
+    CHECK(uplo == (Uplo)dense);
 
-    CHECK( dense == (Uplo) runtimeAccess );
-    CHECK( dense == (MatrixAccessPolicy) uplo );
+    CHECK(runtimeAccess == (MatrixAccessPolicy)uplo);
+    CHECK(runtimeAccess == dense);
+    CHECK(runtimeAccess == (MatrixAccessPolicy)dense);
+
+    CHECK(dense == (Uplo)runtimeAccess);
+    CHECK(dense == (MatrixAccessPolicy)uplo);
 }
 
 TEMPLATE_TEST_CASE("is_matrix works", "[utils]", TLAPACK_TYPES_TO_TEST)
 {
-    using matrix_t  = TestType;
+    using matrix_t = TestType;
 
-    CHECK( is_matrix<matrix_t> );
+    CHECK(is_matrix<matrix_t>);
 }
 
 TEST_CASE("is_matrix and is_vector work", "[utils]")
 {
-    CHECK( !is_matrix< std::vector<float> > );
-    CHECK( !is_matrix< legacyVector<float> > );
+    CHECK(!is_matrix<std::vector<float> >);
+    CHECK(!is_matrix<legacyVector<float> >);
 
-    CHECK( is_vector< std::vector<float> > );
-    CHECK( is_vector< legacyVector<float> > );
+    CHECK(is_vector<std::vector<float> >);
+    CHECK(is_vector<legacyVector<float> >);
 
-    CHECK( !is_matrix< float > );
-    CHECK( !is_matrix< std::complex<double> > );
+    CHECK(!is_matrix<float>);
+    CHECK(!is_matrix<std::complex<double> >);
 
-    CHECK( !is_vector< float > );
-    CHECK( !is_vector< std::complex<double> > );
+    CHECK(!is_vector<float>);
+    CHECK(!is_vector<std::complex<double> >);
 }

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -10,6 +10,7 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+// Test utilities and definitions (must come before <T>LAPACK headers)
 #include "testutils.hpp"
 
 using namespace tlapack;


### PR DESCRIPTION
I am reviewing the code style so far applied in \<T\>LAPACK. One important piece of it concerns code formatting.

In C++, the standard way to enforce a homogeneous code formatting throughout the document is using the [ClangFormat tool](https://clang.llvm.org/docs/ClangFormat.html). This tool is able to automatically format the code according to a set of rules. The rules are defined in a configuration file, which is usually located at [`.clang-format`](.clang-format). This PR adds such a file to the repository and applies the formatting to the code.

My proposal bases on the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) with the following exceptions:

  * Use 4 spaces instead of 2 for indentation.
  * Indent preprocessor directives.
  * Indent internal namespaces. I decided not to indent on the top level namespace `tlapack`. This is also what happens on several libraries I used as basis, `std`, `Eigen`, `Ginkgo`, and is the default behavior on `LLVM` and `Google` format styles. 
  * Always break after function declarations, before `catch` and `else` and after a for loop definition.
  * Function declaration's or function definition's parameters will either all be on the same line or will have one line each.

I applied those rules to format 5 files in the library so we have an idea of how the style looks like.

Todo:

  * [x]  Agree on the configuration we want to use.
  * [x]  Apply the formatting to the whole code.
  * [x]  Add some of the choices in a section to the `CONTRIBUTING.md` file.