### PR TITLE
Removes a couple of repeated test cases

### DIFF
--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -36,40 +36,49 @@ TEMPLATE_TEST_CASE("Multishift QR", "[eigenvalues][multishift_qr]", TLAPACK_TYPE
     // Functor
     Create<matrix_t> new_matrix;
 
-    rand_generator gen;
-
-    const T zero(0);
-    const T one(1);
-
-    const std::string matrix_type = GENERATE(as<std::string>{}, "Large Random", "Random");
+    using test_tuple_t = std::tuple<std::string, idx_t, int>;
+    const test_tuple_t test_tuple = GENERATE(
+        (test_tuple_t("Large Random", 100, 1302)),
+        (test_tuple_t("Random", 15, 2)),
+        (test_tuple_t("Random", 15, 3)),
+        (test_tuple_t("Random", 15, 4)),
+        (test_tuple_t("Random", 15, 5)),
+        (test_tuple_t("Random", 15, 6)),
+        (test_tuple_t("Random", 15, 7)),
+        (test_tuple_t("Random", 15, 8)),
+        (test_tuple_t("Random", 15, 9)),
+        (test_tuple_t("Random", 15, 10)),
+        (test_tuple_t("Random", 20, 2)),
+        (test_tuple_t("Random", 20, 3)),
+        (test_tuple_t("Random", 20, 4)),
+        (test_tuple_t("Random", 20, 5)),
+        (test_tuple_t("Random", 20, 6)),
+        (test_tuple_t("Random", 20, 7)),
+        (test_tuple_t("Random", 20, 8)),
+        (test_tuple_t("Random", 20, 9)),
+        (test_tuple_t("Random", 20, 10)),
+        (test_tuple_t("Random", 30, 2)),
+        (test_tuple_t("Random", 30, 3)),
+        (test_tuple_t("Random", 30, 4)),
+        (test_tuple_t("Random", 30, 5)),
+        (test_tuple_t("Random", 30, 6)),
+        (test_tuple_t("Random", 30, 7)),
+        (test_tuple_t("Random", 30, 8)),
+        (test_tuple_t("Random", 30, 9)),
+        (test_tuple_t("Random", 30, 10)) );
     // The near overflow tests are disabled untill a bug in rotg is fixed
     // const std::string matrix_type = GENERATE(as<std::string>{}, "Large Random", "Near overflow", "Random");
 
-    idx_t n = 0;
-    idx_t ilo = 0;
-    idx_t ihi = 0;
-    int seed = 0;
-    if (matrix_type == "Random")
-    {
-        seed = GENERATE(2, 3, 4, 5, 6, 7, 8, 9, 10);
-        gen.seed(seed);
-        // Generate n
-        n = GENERATE(15, 20, 30);
-        ilo = 0;
-        ihi = n;
-    }
-    if (matrix_type == "Near overflow")
-    {
-        n = 30;
-        ilo = 0;
-        ihi = n;
-    }
-    if (matrix_type == "Large Random")
-    {
-        n = 100;
-        ilo = 0;
-        ihi = n;
-    }
+    const std::string matrix_type = std::get<0>(test_tuple);
+    const idx_t n = std::get<1>(test_tuple);
+    const idx_t ilo = 0;
+    const idx_t ihi = n;
+    const int seed = std::get<2>(test_tuple);
+    const real_t zero(0);
+    const real_t one(1);
+
+    rand_generator gen;
+    gen.seed(seed);
 
     // Define the matrices
     std::vector<T> A_; auto A = new_matrix( A_, n, n );

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -71,28 +71,38 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable", "[eigenvalues][hes
     // Functor
     Create<matrix_t> new_matrix;
 
-    const std::string matrix_type = GENERATE(as<std::string>{}, "Random", "Near overflow");
+    using test_tuple_t = std::tuple<std::string, idx_t, idx_t, idx_t>;
+    const test_tuple_t test_tuple = GENERATE(
+        (test_tuple_t("Near overflow", 5, 0, 0)),
+        (test_tuple_t("Random", 1, 0, 0)),
+        (test_tuple_t("Random", 1, 0, 1)),
+        (test_tuple_t("Random", 1, 1, 0)),
+        (test_tuple_t("Random", 1, 1, 1)),
+        (test_tuple_t("Random", 2, 0, 0)),
+        (test_tuple_t("Random", 2, 0, 1)),
+        (test_tuple_t("Random", 2, 1, 0)),
+        (test_tuple_t("Random", 2, 1, 1)),
+        (test_tuple_t("Random", 3, 0, 0)),
+        (test_tuple_t("Random", 3, 0, 1)),
+        (test_tuple_t("Random", 3, 1, 0)),
+        (test_tuple_t("Random", 3, 1, 1)),
+        (test_tuple_t("Random", 5, 0, 0)),
+        (test_tuple_t("Random", 5, 0, 1)),
+        (test_tuple_t("Random", 5, 1, 0)),
+        (test_tuple_t("Random", 5, 1, 1)),
+        (test_tuple_t("Random", 10, 0, 0)),
+        (test_tuple_t("Random", 10, 0, 1)),
+        (test_tuple_t("Random", 10, 1, 0)),
+        (test_tuple_t("Random", 10, 1, 1)) );
+
+    const std::string matrix_type = std::get<0>(test_tuple);
+    const idx_t n = std::get<1>(test_tuple);
+    const idx_t ilo_offset = std::get<2>(test_tuple);
+    const idx_t ihi_offset = std::get<3>(test_tuple);
+    const idx_t ilo = n > 1 ? ilo_offset : 0;
+    const idx_t ihi = n > 1 + ilo_offset ? n - ihi_offset : n;
 
     rand_generator gen;
-    idx_t n = 0;
-    idx_t ilo = 0;
-    idx_t ihi = 0;
-    if (matrix_type == "Random")
-    {
-        // Generate n
-        n = GENERATE(1, 2, 3, 5, 10);
-        // Generate ilo and ihi
-        idx_t ilo_offset = GENERATE(0, 1);
-        idx_t ihi_offset = GENERATE(0, 1);
-        ilo = n > 1 ? ilo_offset : 0;
-        ihi = n > 1 + ilo_offset ? n - ihi_offset : n;
-    }
-    if (matrix_type == "Near overflow")
-    {
-        n = 5;
-        ilo = 0;
-        ihi = n;
-    }
 
     // Define the matrices and vectors
     std::vector<T> A_; auto A = new_matrix( A_, n, n );

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -38,77 +38,70 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results", "[eigenvalu
     const T one(1);
     idx_t n = 10;
 
-    idx_t n1, n2, ifst, ilst;
-    ifst = GENERATE(0, 2, 6, 9);
-    ilst = GENERATE(0, 2, 6, 9);
+    idx_t ifst = GENERATE(0, 2, 6, 9);
+    idx_t ilst = GENERATE(0, 2, 6, 9);
+    idx_t n1 = GENERATE(1, 2);
+    idx_t n2 = GENERATE(1, 2);
 
-    if (is_complex<T>::value)
+    if (!is_complex<T>::value || (n1 == 1 && n2 == 1))
     {
-        n1 = 1;
-        n2 = 1;
-    }
-    else
-    {
-        n1 = GENERATE(1, 2);
-        n2 = GENERATE(1, 2);
-    }
+        // ifst and ilst point to the same block, n1 must be equal to n2 for
+        // the test to make sense.
+        if (ifst == ilst and n1 != n2)
+            n2 = n1;
 
-    // ifst and ilst point to the same block, n1 must be equal to n2 for
-    // the test to make sense.
-    if (ifst == ilst and n1 != n2)
-        n2 = n1;
+        const real_t eps = uroundoff<real_t>();
+        const real_t tol = real_t(1.0e2 * n) * eps;
 
-    const real_t eps = uroundoff<real_t>();
-    const real_t tol = real_t(1.0e2 * n) * eps;
+        std::vector<T> A_; auto A = new_matrix( A_, n, n );
+        std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
+        std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, n, n );
 
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
-    std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, n, n );
+        // Generate random matrix in Schur form
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < n; ++i)
+                A(i, j) = rand_helper<T>();
 
-    // Generate random matrix in Schur form
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i)
-            A(i, j) = rand_helper<T>();
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 1; i < n; ++i)
+                A(i, j) = zero;
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = j + 1; i < n; ++i)
-            A(i, j) = zero;
+        if (n1 == 2)
+        {
+            if (ifst < n - 1)
+                A(ifst + 1, ifst) = rand_helper<T>();
+            else
+                A(ifst, ifst - 1) = rand_helper<T>();
+        }
+        if (n2 == 2)
+        {
+            if (ilst < n - 1)
+                A(ilst + 1, ilst) = rand_helper<T>();
+            else
+                A(ilst, ilst - 1) = rand_helper<T>();
+        }
 
-    if (n1 == 2)
-    {
-        if (ifst < n - 1)
-            A(ifst + 1, ifst) = rand_helper<T>();
-        else
-            A(ifst, ifst - 1) = rand_helper<T>();
-    }
-    if (n2 == 2)
-    {
-        if (ilst < n - 1)
-            A(ilst + 1, ilst) = rand_helper<T>();
-        else
-            A(ilst, ilst - 1) = rand_helper<T>();
-    }
+        if( !is_complex<T>::value ){
+            // Put a 2x2 block in the middle
+            A(5, 4) = rand_helper<T>();
+        }
 
-    if( !is_complex<T>::value ){
-        // Put a 2x2 block in the middle
-        A(5, 4) = rand_helper<T>();
-    }
+        lacpy(Uplo::General, A, A_copy);
+        laset(Uplo::General, zero, one, Q);
 
-    lacpy(Uplo::General, A, A_copy);
-    laset(Uplo::General, zero, one, Q);
+        INFO("ifst = " << ifst << " n1 = " << n1 << " ilst = " << ilst << " n2 =" << n2);
+        {
+            schur_move(true, A, Q, ifst, ilst);
+            // Calculate residuals
 
-    INFO("ifst = " << ifst << " n1 = " << n1 << " ilst = " << ilst << " n2 =" << n2);
-    {
-        schur_move(true, A, Q, ifst, ilst);
-        // Calculate residuals
+            std::vector<T> res_; auto res = new_matrix( res_, n, n );
+            std::vector<T> work_; auto work = new_matrix( work_, n, n );
+            auto orth_res_norm = check_orthogonality(Q, res);
+            CHECK(orth_res_norm <= tol);
 
-        std::vector<T> res_; auto res = new_matrix( res_, n, n );
-        std::vector<T> work_; auto work = new_matrix( work_, n, n );
-        auto orth_res_norm = check_orthogonality(Q, res);
-        CHECK(orth_res_norm <= tol);
-
-        auto normA = tlapack::lange(tlapack::frob_norm, A);
-        auto simil_res_norm = check_similarity_transform(A_copy, Q, A, res, work);
-        CHECK(simil_res_norm <= tol * normA);
+            auto normA = tlapack::lange(tlapack::frob_norm, A);
+            auto simil_res_norm = check_similarity_transform(A_copy, Q, A, res, work);
+            CHECK(simil_res_norm <= tol * normA);
+        }
     }
 }

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -38,56 +38,51 @@ TEMPLATE_TEST_CASE("schur swap gives correct result", "[eigenvalues]", TLAPACK_T
     const T one(1);
     idx_t n = 10;
 
-    idx_t n1, n2, j;
-    j = GENERATE(0, 1, 6);
+    const idx_t j = GENERATE(0, 1, 6);
+    const idx_t n1 = GENERATE(1, 2);
+    const idx_t n2 = GENERATE(1, 2);
 
-    if (is_complex<T>::value)
+    if (!is_complex<T>::value || (n1 == 1 && n2 == 1))
     {
-        n1 = 1;
-        n2 = 1;
-    }
-    else
-    {
-        n1 = GENERATE(1, 2);
-        n2 = GENERATE(1, 2);
-    }
-    const real_t eps = uroundoff<real_t>();
-    const real_t tol = real_t(1.0e2 * n) * eps;
+        
+        const real_t eps = uroundoff<real_t>();
+        const real_t tol = real_t(1.0e2 * n) * eps;
 
-    std::vector<T> A_; auto A = new_matrix( A_, n, n );
-    std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
-    std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, n, n );
+        std::vector<T> A_; auto A = new_matrix( A_, n, n );
+        std::vector<T> Q_; auto Q = new_matrix( Q_, n, n );
+        std::vector<T> A_copy_; auto A_copy = new_matrix( A_copy_, n, n );
 
-    // Generate random matrix in Schur form
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < n; ++i)
-            A(i, j) = rand_helper<T>();
+        // Generate random matrix in Schur form
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < n; ++i)
+                A(i, j) = rand_helper<T>();
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = j + 1; i < n; ++i)
-            A(i, j) = zero;
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 1; i < n; ++i)
+                A(i, j) = zero;
 
-    if( n1 == 2)
-        A( j + 1, j ) = rand_helper<T>();
-    if (n2 == 2)
-        A(j + n1 + 1, j + n1) = rand_helper<T>();
+        if( n1 == 2)
+            A( j + 1, j ) = rand_helper<T>();
+        if (n2 == 2)
+            A(j + n1 + 1, j + n1) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
-    laset(Uplo::General, zero, one, Q);
+        lacpy(Uplo::General, A, A_copy);
+        laset(Uplo::General, zero, one, Q);
 
-    INFO("j = " << j << " n1 = " << n1 << " n2 =" << n2);
-    {
-        schur_swap(true, A, Q, j, n1, n2);
-        // Calculate residuals
+        INFO("j = " << j << " n1 = " << n1 << " n2 =" << n2);
+        {
+            schur_swap(true, A, Q, j, n1, n2);
+            // Calculate residuals
 
-        std::vector<T> res_; auto res = new_matrix( res_, n, n );
-        std::vector<T> work_; auto work = new_matrix( work_, n, n );
-        auto orth_res_norm = check_orthogonality(Q, res);
-        CHECK(orth_res_norm <= tol);
+            std::vector<T> res_; auto res = new_matrix( res_, n, n );
+            std::vector<T> work_; auto work = new_matrix( work_, n, n );
+            auto orth_res_norm = check_orthogonality(Q, res);
+            CHECK(orth_res_norm <= tol);
 
-        auto normA = tlapack::lange(tlapack::frob_norm, A);
-        auto simil_res_norm = check_similarity_transform(A_copy, Q, A, res, work);
-        CHECK(simil_res_norm <= tol * normA);
+            auto normA = tlapack::lange(tlapack::frob_norm, A);
+            auto simil_res_norm = check_similarity_transform(A_copy, Q, A, res, work);
+            CHECK(simil_res_norm <= tol * normA);
 
+        }
     }
 }

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -39,24 +39,21 @@ TEMPLATE_TEST_CASE("Double shift QR", "[eigenvalues][doubleshift_qr]", TLAPACK_T
     const T zero(0);
     const T one(1);
 
-    const std::string matrix_type = GENERATE(as<std::string>{}, "Random", "Near overflow");
+    using test_tuple_t = std::tuple<std::string, idx_t>;
+    const test_tuple_t test_tuple = GENERATE(
+        (test_tuple_t("Near overflow", 4)),
+        (test_tuple_t("Near overflow", 10)),
+        (test_tuple_t("Random", 0)),
+        (test_tuple_t("Random", 1)),
+        (test_tuple_t("Random", 2)),
+        (test_tuple_t("Random", 5)),
+        (test_tuple_t("Random", 10)),
+        (test_tuple_t("Random", 15)) );
 
-    idx_t n = 0;
-    idx_t ilo = 0;
-    idx_t ihi = 0;
-    if (matrix_type == "Random")
-    {
-        // Generate n
-        n = GENERATE(0, 1, 2, 5, 10, 15);
-        ilo = 0;
-        ihi = n;
-    }
-    if (matrix_type == "Near overflow")
-    {
-        n = GENERATE(4, 10);
-        ilo = 0;
-        ihi = n;
-    }
+    const std::string matrix_type = std::get<0>(test_tuple);
+    const idx_t n = std::get<1>(test_tuple);
+    const idx_t ilo = 0;
+    const idx_t ihi = n;
 
     // Define the matrices
     std::vector<T> A_; auto A = new_matrix( A_, n, n );


### PR DESCRIPTION
The following piece of code

```c++
int n = GENERATE(1,2,3);

int m;
if (n > 1) {
    int m = GENERATE(1,2,3,4);
}
else {
    m = 1;
}
```

generates 12 Catch2 test sections. 4 of those sections have `m = 1` and `n = 1`. This is because `GENERATE` is a macro, and therefore it is executed regardless the value of `n > 1`.

This PR removes the repeated test cases that follow the pattern I gave above.