### PR TITLE
Fix author information

### DIFF
--- a/include/tlapack/lapack/gebd2.hpp
+++ b/include/tlapack/lapack/gebd2.hpp
@@ -1,6 +1,6 @@
 /// @file gebd2.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgebd2.f
+/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgebd2.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -1,6 +1,6 @@
 /// @file gelq2.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelq2.f
+/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelq2.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/gelqf.hpp
+++ b/include/tlapack/lapack/gelqf.hpp
@@ -1,6 +1,6 @@
 /// @file gelqf.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelqf.f
+/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zgelqf.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/geqr2.hpp
+++ b/include/tlapack/lapack/geqr2.hpp
@@ -1,6 +1,6 @@
 /// @file geqr2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/geqr2.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/geqr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lacpy.hpp
+++ b/include/tlapack/lapack/lacpy.hpp
@@ -1,6 +1,6 @@
 /// @file lacpy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lacpy.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lacpy.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -1,6 +1,6 @@
 /// @file ladiv.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/ladiv.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ladiv.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lange.hpp
+++ b/include/tlapack/lapack/lange.hpp
@@ -1,6 +1,6 @@
 /// @file lange.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lange.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lange.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lanhe.hpp
+++ b/include/tlapack/lapack/lanhe.hpp
@@ -1,6 +1,6 @@
 /// @file lanhe.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lanhe.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lanhe.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lansy.hpp
+++ b/include/tlapack/lapack/lansy.hpp
@@ -1,6 +1,6 @@
 /// @file lansy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lansy.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lansy.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lantr.hpp
+++ b/include/tlapack/lapack/lantr.hpp
@@ -1,6 +1,6 @@
 /// @file lantr.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lantr.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lantr.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lapy2.hpp
+++ b/include/tlapack/lapack/lapy2.hpp
@@ -1,6 +1,6 @@
 /// @file lapy2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lapy2.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lapy2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/lapy3.hpp
+++ b/include/tlapack/lapack/lapy3.hpp
@@ -1,6 +1,6 @@
 /// @file lapy3.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lapy3.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lapy3.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -1,6 +1,6 @@
 /// @file larf.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larf.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larf.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -1,6 +1,6 @@
 /// @file larfb.hpp Applies a Householder block reflector to a matrix.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larfb.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfb.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -1,6 +1,6 @@
 /// @file larfg.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larfg.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfg.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larft.hpp
+++ b/include/tlapack/lapack/larft.hpp
@@ -1,6 +1,6 @@
 /// @file larft.hpp Forms the triangular factor T of a block reflector.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larft.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larft.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/larnv.hpp
+++ b/include/tlapack/lapack/larnv.hpp
@@ -1,7 +1,7 @@
 /// @file larnv.hpp Returns a vector of random numbers from a uniform or normal distribution.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larnv.h
-//
+/// Adapted from @see https://github.com/langou/latl/blob/mastUSA
+/// @note Adapted
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
 // This file is part of <T>LAPACK.

--- a/include/tlapack/lapack/lascl.hpp
+++ b/include/tlapack/lapack/lascl.hpp
@@ -1,6 +1,6 @@
 /// @file lascl.hpp Multiplies a matrix by a scalar.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lascl.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lascl.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/laset.hpp
+++ b/include/tlapack/lapack/laset.hpp
@@ -1,6 +1,6 @@
 /// @file laset.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/laset.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/laset.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -1,6 +1,6 @@
 /// @file ung2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/ungl2.hpp
+++ b/include/tlapack/lapack/ungl2.hpp
@@ -1,6 +1,6 @@
 /// @file ungl2.hpp
 /// @author Yuxin Cai, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zungl2.f
+/// @note Adapted from @see https://github.com/Reference-LAPACK/lapack/blob/master/SRC/zungl2.f
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -1,6 +1,6 @@
 /// @file unm2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/geqr2.hpp
+++ b/include/tlapack/legacy_api/lapack/geqr2.hpp
@@ -1,6 +1,6 @@
 /// @file geqr2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/geqr2.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/geqr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/lacpy.hpp
+++ b/include/tlapack/legacy_api/lapack/lacpy.hpp
@@ -1,6 +1,6 @@
 /// @file lacpy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lacpy.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lacpy.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/lange.hpp
+++ b/include/tlapack/legacy_api/lapack/lange.hpp
@@ -1,6 +1,6 @@
 /// @file lange.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/lange.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/lange.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larf.hpp
+++ b/include/tlapack/legacy_api/lapack/larf.hpp
@@ -1,6 +1,6 @@
 /// @file larf.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larf.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larf.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larfb.hpp
+++ b/include/tlapack/legacy_api/lapack/larfb.hpp
@@ -1,6 +1,6 @@
 /// @file larfb.hpp Applies a Householder block reflector to a matrix.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larfb.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfb.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larfg.hpp
+++ b/include/tlapack/legacy_api/lapack/larfg.hpp
@@ -1,6 +1,6 @@
 /// @file larfg.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larfg.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larfg.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larft.hpp
+++ b/include/tlapack/legacy_api/lapack/larft.hpp
@@ -1,6 +1,6 @@
 /// @file larft.hpp Forms the triangular factor T of a block reflector.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larft.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/larft.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/larnv.hpp
+++ b/include/tlapack/legacy_api/lapack/larnv.hpp
@@ -1,7 +1,7 @@
 /// @file larnv.hpp Returns a vector of random numbers from a uniform or normal distribution.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/larnv.h
-//
+/// Adapted from @see https://github.com/langou/latl/blob/mastUSA
+/// @note Adapted
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //
 // This file is part of <T>LAPACK.

--- a/include/tlapack/legacy_api/lapack/laset.hpp
+++ b/include/tlapack/legacy_api/lapack/laset.hpp
@@ -1,6 +1,6 @@
 /// @file laset.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/laset.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/laset.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/ung2r.hpp
+++ b/include/tlapack/legacy_api/lapack/ung2r.hpp
@@ -1,6 +1,6 @@
 /// @file ung2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ung2r.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //

--- a/include/tlapack/legacy_api/lapack/unm2r.hpp
+++ b/include/tlapack/legacy_api/lapack/unm2r.hpp
@@ -1,6 +1,6 @@
 /// @file unm2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
-/// Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
+/// @note Adapted from @see https://github.com/langou/latl/blob/master/include/ormr2.h
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
 //


### PR DESCRIPTION
Adds `@note` to the documentation where it is needed. Otherwise, the author information gets mixed with the text `Adapted from`.