### PR TITLE
Fix badge in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 C++ Template Linear Algebra PACKage
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/tlapack/tlapack/blob/master/LICENSE)
-[![GitHub Workflow Status](https://github.com/tlapack/tlapack/actions/workflows/cmake.yml/badge.svg)](https://github.com/tlapack/tlapack/actions/workflows/cmake.yml)
-[![Doxygen](https://github.com/tlapack/tlapack/actions/workflows/doxygen.yml/badge.svg)](https://github.com/tlapack/tlapack/actions/workflows/doxygen.yml)
+[![Continuous Testing](https://github.com/tlapack/tlapack/actions/workflows/cmake.yml/badge.svg?branch=master)](https://github.com/tlapack/tlapack/actions/workflows/cmake.yml)
+[![Doxygen](https://github.com/tlapack/tlapack/actions/workflows/doxygen.yml/badge.svg?branch=master)](https://github.com/tlapack/tlapack/actions/workflows/doxygen.yml)
 
 ## About
 


### PR DESCRIPTION
The badge should reflect the current state of the master branch. This wasn't the case. This PR fixes it.