### PR TITLE
Adds storageMode on larfg and larf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,15 @@ if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git" AND CLANG_FORMAT_FOUND)
       2> format-all-hpp-cpp-files.err
     WORKING_DIRECTORY ${TLAPACK_SOURCE_DIR}
   )
+  add_custom_target( check-format-of-hpp-cpp-files
+    COMMAND
+      ${GIT_EXECUTABLE} ls-tree -r HEAD --name-only |
+      grep -E '\(config/|examples/|include/|src/|test/include/|test/src/\).*\\.\(hpp|cpp|h.in|c\)$$' |
+      xargs ${CLANG_FORMAT_EXECUTABLE} -i -style=file --dry-run
+      > format-all-hpp-cpp-files.log
+      2> format-all-hpp-cpp-files.err
+    WORKING_DIRECTORY ${TLAPACK_SOURCE_DIR}
+  )
 endif()
 
 #-------------------------------------------------------------------------------

--- a/include/tlapack/base/arrayTraits.hpp
+++ b/include/tlapack/base/arrayTraits.hpp
@@ -374,7 +374,7 @@ namespace internal {
     /// Vector type deduction for one type
     template <typename vector_t>
     struct vector_type_traits<vector_t, int> {
-        using type = typename matrix_type_traits<vector_t, vector_t, int>::type;
+        using type = typename vector_type_traits<vector_t, vector_t, int>::type;
     };
 
     /// Vector type deduction for three or more types

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -46,12 +46,15 @@ using range = pair<idx_t, idx_t>;
 using std::enable_if_t;
 
 // -----------------------------------------------------------------------------
-// is_same_v is defined in C++17; here's a C++11 definition
+// is_same_v, is_convertible_v are defined in C++17; here's a C++11 definition
 #if __cplusplus >= 201703L
+using std::is_convertible_v;
 using std::is_same_v;
 #else
 template <class T, class U>
-constexpr bool is_same_v = std::is_same<T, U>::value;
+inline constexpr bool is_convertible_v = std::is_convertible<T, U>::value;
+template <class T, class U>
+inline constexpr bool is_same_v = std::is_same<T, U>::value;
 #endif
 
 //------------------------------------------------------------------------------

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -426,24 +426,27 @@ void agressive_early_deflation(bool want_t,
     if (s_spike != zero) {
         // Reflect spike back
         {
-            T tau;
-            auto v = slice(WV, pair{0, ns}, 0);
             for (idx_t i = 0; i < ns; ++i) {
-                v[i] = conj(V(0, i));
+                WV(i, 0) = conj(V(0, i));
             }
-            larfg(v, tau);
+            T tau;
+            auto x = slice(WV, pair{1, ns}, 0);
+            larfg(columnwise_storage, WV(0, 0), x, tau);
 
             auto Wv_aux = slice(WV, pair{0, jw}, 1);
             workspace_opts_t<> work2(Wv_aux);
 
             auto TW_slice = slice(TW, pair{0, ns}, pair{0, jw});
-            larf(Side::Left, forward, v, conj(tau), TW_slice, work2);
+            larf(Side::Left, forward, columnwise_storage, x, conj(tau),
+                 TW_slice, work2);
 
             auto TW_slice2 = slice(TW, pair{0, jw}, pair{0, ns});
-            larf(Side::Right, forward, v, tau, TW_slice2, work2);
+            larf(Side::Right, forward, columnwise_storage, x, tau, TW_slice2,
+                 work2);
 
             auto V_slice = slice(V, pair{0, jw}, pair{0, ns});
-            larf(Side::Right, forward, v, tau, V_slice, work2);
+            larf(Side::Right, forward, columnwise_storage, x, tau, V_slice,
+                 work2);
         }
 
         // Hessenberg reduction

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -426,26 +426,26 @@ void agressive_early_deflation(bool want_t,
     if (s_spike != zero) {
         // Reflect spike back
         {
-            for (idx_t i = 0; i < ns; ++i) {
-                WV(i, 0) = conj(V(0, i));
-            }
             T tau;
-            auto x = slice(WV, pair{1, ns}, 0);
-            larfg(columnwise_storage, WV(0, 0), x, tau);
+            auto v = slice(WV, pair{0, ns}, 0);
+            for (idx_t i = 0; i < ns; ++i) {
+                v[i] = conj(V(0, i));
+            }
+            larfg(forward, columnwise_storage, v, tau);
 
             auto Wv_aux = slice(WV, pair{0, jw}, 1);
             workspace_opts_t<> work2(Wv_aux);
 
             auto TW_slice = slice(TW, pair{0, ns}, pair{0, jw});
-            larf(Side::Left, forward, columnwise_storage, x, conj(tau),
+            larf(Side::Left, forward, columnwise_storage, v, conj(tau),
                  TW_slice, work2);
 
             auto TW_slice2 = slice(TW, pair{0, jw}, pair{0, ns});
-            larf(Side::Right, forward, columnwise_storage, x, tau, TW_slice2,
+            larf(Side::Right, forward, columnwise_storage, v, tau, TW_slice2,
                  work2);
 
             auto V_slice = slice(V, pair{0, jw}, pair{0, ns});
-            larf(Side::Right, forward, columnwise_storage, x, tau, V_slice,
+            larf(Side::Right, forward, columnwise_storage, v, tau, V_slice,
                  work2);
         }
 

--- a/include/tlapack/lapack/gebd2.hpp
+++ b/include/tlapack/lapack/gebd2.hpp
@@ -151,25 +151,25 @@ int gebd2(matrix_t& A,
 
     for (idx_t j = 0; j < n; ++j) {
         // Generate elementary reflector H(j) to annihilate A(j+1:m,j)
-        auto x = slice(A, range(j + 1, m), j);
-        larfg(columnwise_storage, A(j, j), x, tauv[j]);
+        auto v = slice(A, range(j, m), j);
+        larfg(forward, columnwise_storage, v, tauv[j]);
 
         // Apply H(j)**H to A(j:m,j+1:n) from the left
         if (j < n - 1) {
             auto A11 = slice(A, range(j, m), range(j + 1, n));
-            larf(Side::Left, forward, columnwise_storage, x, conj(tauv[j]), A11,
+            larf(Side::Left, forward, columnwise_storage, v, conj(tauv[j]), A11,
                  larfOpts);
         }
 
         if (j < n - 1) {
             // Generate elementary reflector G(j) to annihilate A(j,j+2:n)
-            auto y = slice(A, j, range(j + 2, n));
-            larfg(rowwise_storage, A(j, j + 1), y, tauw[j]);
+            auto w = slice(A, j, range(j + 1, n));
+            larfg(forward, rowwise_storage, w, tauw[j]);
 
             // Apply G(j) to A(j+1:m,j+1:n) from the right
             if (j < m - 1) {
                 auto B11 = slice(A, range(j + 1, m), range(j + 1, n));
-                larf(Side::Right, forward, rowwise_storage, y, tauw[j], B11,
+                larf(Side::Right, forward, rowwise_storage, w, tauw[j], B11,
                      larfOpts);
             }
         }

--- a/include/tlapack/lapack/gebd2.hpp
+++ b/include/tlapack/lapack/gebd2.hpp
@@ -55,15 +55,15 @@ inline constexpr void gebd2_worksize(const matrix_t& A,
 
     if (n > 1) {
         auto A11 = cols(A, range<idx_t>{1, n});
-        larf_worksize(left_side, forward, col(A, 0), tauv[0], A11, workinfo,
-                      opts);
+        larf_worksize(left_side, forward, columnwise_storage, col(A, 0),
+                      tauv[0], A11, workinfo, opts);
 
         if (m > 1) {
             auto B11 = rows(A11, range<idx_t>{1, m});
             auto row0 = slice(A, 0, range<idx_t>{1, n});
 
-            larf_worksize(right_side, forward, row0, tauw[0], B11, workinfo,
-                          opts);
+            larf_worksize(right_side, forward, rowwise_storage, row0, tauw[0],
+                          B11, workinfo, opts);
         }
     }
 }
@@ -151,29 +151,27 @@ int gebd2(matrix_t& A,
 
     for (idx_t j = 0; j < n; ++j) {
         // Generate elementary reflector H(j) to annihilate A(j+1:m,j)
-        auto v = slice(A, range(j, m), j);
-        larfg(v, tauv[j]);
+        auto x = slice(A, range(j + 1, m), j);
+        larfg(columnwise_storage, A(j, j), x, tauv[j]);
 
         // Apply H(j)**H to A(j:m,j+1:n) from the left
         if (j < n - 1) {
             auto A11 = slice(A, range(j, m), range(j + 1, n));
-            larf(Side::Left, forward, v, conj(tauv[j]), A11, larfOpts);
+            larf(Side::Left, forward, columnwise_storage, x, conj(tauv[j]), A11,
+                 larfOpts);
         }
 
         if (j < n - 1) {
             // Generate elementary reflector G(j) to annihilate A(j,j+2:n)
-            auto w = slice(A, j, range(j + 1, n));
-            for (idx_t i = 0; i < n - j - 1; ++i)
-                w[i] = conj(w[i]);
-            larfg(w, tauw[j]);
+            auto y = slice(A, j, range(j + 2, n));
+            larfg(rowwise_storage, A(j, j + 1), y, tauw[j]);
 
             // Apply G(j) to A(j+1:m,j+1:n) from the right
             if (j < m - 1) {
                 auto B11 = slice(A, range(j + 1, m), range(j + 1, n));
-                larf(Side::Right, forward, w, tauw[j], B11, larfOpts);
+                larf(Side::Right, forward, rowwise_storage, y, tauw[j], B11,
+                     larfOpts);
             }
-            for (idx_t i = 0; i < n - j - 1; ++i)
-                w[i] = conj(w[i]);
         }
     }
 

--- a/include/tlapack/lapack/gehd2.hpp
+++ b/include/tlapack/lapack/gehd2.hpp
@@ -136,19 +136,19 @@ int gehd2(size_type<matrix_t> ilo,
     auto&& larfOpts = workspace_opts_t<>{work};
 
     for (idx_t i = ilo; i < ihi - 1; ++i) {
-        // Define x := A[i+1:ihi,i]
-        auto x = slice(A, pair{i + 2, ihi}, i);
+        // Define v := A[i+1:ihi,i]
+        auto v = slice(A, pair{i + 1, ihi}, i);
 
-        // Generate the (i+1)-th elementary Householder reflection on x
-        larfg(columnwise_storage, A(i + 1, i), x, tau[i]);
+        // Generate the (i+1)-th elementary Householder reflection on v
+        larfg(forward, columnwise_storage, v, tau[i]);
 
         // Apply Householder reflection from the right to A[0:ihi,i+1:ihi]
         auto C0 = slice(A, pair{0, ihi}, pair{i + 1, ihi});
-        larf(right_side, forward, columnwise_storage, x, tau[i], C0, larfOpts);
+        larf(right_side, forward, columnwise_storage, v, tau[i], C0, larfOpts);
 
         // Apply Householder reflection from the left to A[i+1:ihi,i+1:n-1]
         auto C1 = slice(A, pair{i + 1, ihi}, pair{i + 1, n});
-        larf(left_side, forward, columnwise_storage, x, conj(tau[i]), C1,
+        larf(left_side, forward, columnwise_storage, v, conj(tau[i]), C1,
              larfOpts);
     }
 

--- a/include/tlapack/lapack/gehd2.hpp
+++ b/include/tlapack/lapack/gehd2.hpp
@@ -54,10 +54,12 @@ inline constexpr void gehd2_worksize(size_type<matrix_t> ilo,
         const auto v = slice(A, pair{ilo + 1, ihi}, ilo);
 
         auto C0 = slice(A, pair{0, ihi}, pair{ilo + 1, ihi});
-        larf_worksize(right_side, forward, v, tau[0], C0, workinfo, opts);
+        larf_worksize(right_side, forward, columnwise_storage, v, tau[0], C0,
+                      workinfo, opts);
 
         auto C1 = slice(A, pair{ilo + 1, ihi}, pair{ilo + 1, n});
-        larf_worksize(left_side, forward, v, tau[0], C1, workinfo, opts);
+        larf_worksize(left_side, forward, columnwise_storage, v, tau[0], C1,
+                      workinfo, opts);
     }
 }
 
@@ -135,18 +137,19 @@ int gehd2(size_type<matrix_t> ilo,
 
     for (idx_t i = ilo; i < ihi - 1; ++i) {
         // Define x := A[i+1:ihi,i]
-        auto v = slice(A, pair{i + 1, ihi}, i);
+        auto x = slice(A, pair{i + 2, ihi}, i);
 
         // Generate the (i+1)-th elementary Householder reflection on x
-        larfg(v, tau[i]);
+        larfg(columnwise_storage, A(i + 1, i), x, tau[i]);
 
         // Apply Householder reflection from the right to A[0:ihi,i+1:ihi]
         auto C0 = slice(A, pair{0, ihi}, pair{i + 1, ihi});
-        larf(right_side, forward, v, tau[i], C0, larfOpts);
+        larf(right_side, forward, columnwise_storage, x, tau[i], C0, larfOpts);
 
         // Apply Householder reflection from the left to A[i+1:ihi,i+1:n-1]
         auto C1 = slice(A, pair{i + 1, ihi}, pair{i + 1, n});
-        larf(left_side, forward, v, conj(tau[i]), C1, larfOpts);
+        larf(left_side, forward, columnwise_storage, x, conj(tau[i]), C1,
+             larfOpts);
     }
 
     return 0;

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -45,8 +45,8 @@ inline constexpr void gelq2_worksize(const matrix_t& A,
 
     if (m > 1) {
         auto C = rows(A, range<idx_t>{1, m});
-        larf_worksize(right_side, forward, row(A, 0), tauw[0], C, workinfo,
-                      opts);
+        larf_worksize(right_side, forward, rowwise_storage, row(A, 0), tauw[0],
+                      C, workinfo, opts);
     }
 }
 
@@ -115,21 +115,18 @@ int gelq2(matrix_t& A, vector_t& tauw, const workspace_opts_t<>& opts = {})
 
     for (idx_t j = 0; j < k; ++j) {
         // Define w := A(j,j:n)
-        auto w = slice(A, j, range(j, n));
+        auto x = slice(A, j, range(j + 1, n));
 
         // Generate elementary reflector H(j) to annihilate A(j,j+1:n)
-        for (idx_t i = 0; i < n - j; ++i)
-            w[i] = conj(w[i]);
-        larfg(w, tauw[j]);
+        larfg(rowwise_storage, A(j, j), x, tauw[j]);
 
         // If either condition is satisfied, Q11 will not be empty
         if (j < k - 1 || k < m) {
             // Apply H(j) to A(j+1:m,j:n) from the right
             auto Q11 = slice(A, range(j + 1, m), range(j, n));
-            larf(Side::Right, forward, w, tauw[j], Q11, larfOpts);
+            larf(Side::Right, forward, rowwise_storage, x, tauw[j], Q11,
+                 larfOpts);
         }
-        for (idx_t i = 0; i < n - j; ++i)
-            w[i] = conj(w[i]);
     }
 
     return 0;

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -115,16 +115,16 @@ int gelq2(matrix_t& A, vector_t& tauw, const workspace_opts_t<>& opts = {})
 
     for (idx_t j = 0; j < k; ++j) {
         // Define w := A(j,j:n)
-        auto x = slice(A, j, range(j + 1, n));
+        auto w = slice(A, j, range(j, n));
 
         // Generate elementary reflector H(j) to annihilate A(j,j+1:n)
-        larfg(rowwise_storage, A(j, j), x, tauw[j]);
+        larfg(forward, rowwise_storage, w, tauw[j]);
 
         // If either condition is satisfied, Q11 will not be empty
         if (j < k - 1 || k < m) {
             // Apply H(j) to A(j+1:m,j:n) from the right
             auto Q11 = slice(A, range(j + 1, m), range(j, n));
-            larf(Side::Right, forward, rowwise_storage, x, tauw[j], Q11,
+            larf(Side::Right, forward, rowwise_storage, w, tauw[j], Q11,
                  larfOpts);
         }
     }

--- a/include/tlapack/lapack/geqr2.hpp
+++ b/include/tlapack/lapack/geqr2.hpp
@@ -128,7 +128,7 @@ int geqr2(matrix_t& A, vector_t& tau, const workspace_opts_t<>& opts = {})
     }
     if (n - 1 < m) {
         // Define v := A[n-1:m,n-1]
-        auto v = slice(A, pair{n-1, m}, n - 1);
+        auto v = slice(A, pair{n - 1, m}, n - 1);
         // Generate the n-th elementary Householder reflection on v
         larfg(forward, columnwise_storage, v, tau[n - 1]);
     }

--- a/include/tlapack/lapack/geqr2.hpp
+++ b/include/tlapack/lapack/geqr2.hpp
@@ -45,7 +45,8 @@ inline constexpr void geqr2_worksize(const matrix_t& A,
 
     if (n > 1) {
         auto C = cols(A, range<idx_t>{1, n});
-        larf_worksize(left_side, forward, col(A, 0), tau[0], C, workinfo, opts);
+        larf_worksize(left_side, forward, columnwise_storage, col(A, 0), tau[0],
+                      C, workinfo, opts);
     }
 }
 
@@ -113,22 +114,23 @@ int geqr2(matrix_t& A, vector_t& tau, const workspace_opts_t<>& opts = {})
 
     for (idx_t i = 0; i < k; ++i) {
         // Define v := A[i:m,i]
-        auto v = slice(A, pair{i, m}, i);
+        auto x = slice(A, pair{i + 1, m}, i);
 
         // Generate the (i+1)-th elementary Householder reflection on x
-        larfg(v, tau[i]);
+        larfg(columnwise_storage, A(i, i), x, tau[i]);
 
         // Define v := A[i:m,i] and C := A[i:m,i+1:n], and w := work[i:n-1]
         auto C = slice(A, pair{i, m}, pair{i + 1, n});
 
         // C := ( I - conj(tau_i) v v^H ) C
-        larf(left_side, forward, v, conj(tau[i]), C, larfOpts);
+        larf(left_side, forward, columnwise_storage, x, conj(tau[i]), C,
+             larfOpts);
     }
     if (n - 1 < m) {
         // Define v := A[n-1:m,n-1]
-        auto v = slice(A, pair{n - 1, m}, n - 1);
+        auto x = slice(A, pair{n, m}, n - 1);
         // Generate the n-th elementary Householder reflection on x
-        larfg(v, tau[n - 1]);
+        larfg(columnwise_storage, A(n - 1, n - 1), x, tau[n - 1]);
     }
 
     return 0;

--- a/include/tlapack/lapack/geqr2.hpp
+++ b/include/tlapack/lapack/geqr2.hpp
@@ -114,23 +114,23 @@ int geqr2(matrix_t& A, vector_t& tau, const workspace_opts_t<>& opts = {})
 
     for (idx_t i = 0; i < k; ++i) {
         // Define v := A[i:m,i]
-        auto x = slice(A, pair{i + 1, m}, i);
+        auto v = slice(A, pair{i, m}, i);
 
-        // Generate the (i+1)-th elementary Householder reflection on x
-        larfg(columnwise_storage, A(i, i), x, tau[i]);
+        // Generate the (i+1)-th elementary Householder reflection on v
+        larfg(forward, columnwise_storage, v, tau[i]);
 
-        // Define v := A[i:m,i] and C := A[i:m,i+1:n], and w := work[i:n-1]
+        // Define C := A[i:m,i+1:n]
         auto C = slice(A, pair{i, m}, pair{i + 1, n});
 
         // C := ( I - conj(tau_i) v v^H ) C
-        larf(left_side, forward, columnwise_storage, x, conj(tau[i]), C,
+        larf(left_side, forward, columnwise_storage, v, conj(tau[i]), C,
              larfOpts);
     }
     if (n - 1 < m) {
         // Define v := A[n-1:m,n-1]
-        auto x = slice(A, pair{n, m}, n - 1);
-        // Generate the n-th elementary Householder reflection on x
-        larfg(columnwise_storage, A(n - 1, n - 1), x, tau[n - 1]);
+        auto v = slice(A, pair{n-1, m}, n - 1);
+        // Generate the n-th elementary Householder reflection on v
+        larfg(forward, columnwise_storage, v, tau[n - 1]);
     }
 
     return 0;

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -18,7 +18,6 @@
 #include "tlapack/lapack/lahqr_eig22.hpp"
 #include "tlapack/lapack/lahqr_schur22.hpp"
 #include "tlapack/lapack/lahqr_shiftcolumn.hpp"
-#include "tlapack/lapack/larf.hpp"
 #include "tlapack/lapack/larfg.hpp"
 
 namespace tlapack {
@@ -292,7 +291,10 @@ int lahqr(bool want_t,
             for (idx_t i = istop - 3; i > istart; --i) {
                 auto H = slice(A, pair{i, i + 3}, pair{i, i + 3});
                 lahqr_shiftcolumn(H, v, s1, s2);
-                larfg(v, t1);
+                {
+                    auto x = slice(v, pair{1, 3});
+                    larfg(columnwise_storage, v[0], x, t1);
+                }
                 v[0] = t1;
                 const TA refsum =
                     conj(v[0]) * A(i, i - 1) + conj(v[1]) * A(i + 1, i - 1);
@@ -313,7 +315,7 @@ int lahqr(bool want_t,
                 auto x = slice(v, pair{0, nr});
                 lahqr_shiftcolumn(H, x, s1, s2);
                 auto y = slice(v, pair{1, nr});
-                larfg(v[0], y, t1);
+                larfg(columnwise_storage, v[0], y, t1);
                 if (i > istart) {
                     A(i, i - 1) = A(i, i - 1) * (one - conj(t1));
                 }
@@ -323,7 +325,7 @@ int lahqr(bool want_t,
                 v[1] = A(i + 1, i - 1);
                 if (nr == 3) v[2] = A(i + 2, i - 1);
                 auto x = slice(v, pair{1, nr});
-                larfg(v[0], x, t1);
+                larfg(columnwise_storage, v[0], x, t1);
                 A(i, i - 1) = v[0];
                 A(i + 1, i - 1) = zero;
                 if (nr == 3) A(i + 2, i - 1) = zero;

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -291,10 +291,7 @@ int lahqr(bool want_t,
             for (idx_t i = istop - 3; i > istart; --i) {
                 auto H = slice(A, pair{i, i + 3}, pair{i, i + 3});
                 lahqr_shiftcolumn(H, v, s1, s2);
-                {
-                    auto x = slice(v, pair{1, 3});
-                    larfg(columnwise_storage, v[0], x, t1);
-                }
+                larfg(forward, columnwise_storage, v, t1);
                 v[0] = t1;
                 const TA refsum =
                     conj(v[0]) * A(i, i - 1) + conj(v[1]) * A(i + 1, i - 1);

--- a/include/tlapack/lapack/lahqr_shiftcolumn.hpp
+++ b/include/tlapack/lapack/lahqr_shiftcolumn.hpp
@@ -38,7 +38,7 @@ namespace tlapack {
 template <class matrix_t,
           class vector_t,
           enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
-int lahqr_shiftcolumn(matrix_t& H,
+int lahqr_shiftcolumn(const matrix_t& H,
                       vector_t& v,
                       complex_type<type_t<matrix_t>> s1,
                       complex_type<type_t<matrix_t>> s2)
@@ -114,7 +114,7 @@ int lahqr_shiftcolumn(matrix_t& H,
 template <class matrix_t,
           class vector_t,
           enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
-int lahqr_shiftcolumn(matrix_t& H,
+int lahqr_shiftcolumn(const matrix_t& H,
                       vector_t& v,
                       type_t<matrix_t> s1,
                       type_t<matrix_t> s2)

--- a/include/tlapack/lapack/lahr2.hpp
+++ b/include/tlapack/lapack/lahr2.hpp
@@ -133,10 +133,7 @@ int lahr2(size_type<matrix_t> k,
             A(k + i, i - 1) = ei;
         }
         auto v = slice(A, pair{k + i + 1, n}, i);
-        {
-            auto x = slice(v, pair{1, size(v)});
-            larfg(columnwise_storage, v[0], x, tau[i]);
-        }
+        larfg(forward, columnwise_storage, v, tau[i]);
 
         // larf has been edited to not require A(k+i,i) = one
         // this is for thread safety. Since we already modified

--- a/include/tlapack/lapack/lahr2.hpp
+++ b/include/tlapack/lapack/lahr2.hpp
@@ -18,7 +18,6 @@
 #include "tlapack/blas/scal.hpp"
 #include "tlapack/blas/trmm.hpp"
 #include "tlapack/blas/trmv.hpp"
-#include "tlapack/lapack/larf.hpp"
 #include "tlapack/lapack/larfg.hpp"
 
 namespace tlapack {
@@ -134,7 +133,10 @@ int lahr2(size_type<matrix_t> k,
             A(k + i, i - 1) = ei;
         }
         auto v = slice(A, pair{k + i + 1, n}, i);
-        larfg(v, tau[i]);
+        {
+            auto x = slice(v, pair{1, size(v)});
+            larfg(columnwise_storage, v[0], x, tau[i]);
+        }
 
         // larf has been edited to not require A(k+i,i) = one
         // this is for thread safety. Since we already modified

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -29,7 +29,13 @@ namespace tlapack {
  *     v = [ 1 x ] if direction == Direction::Forward and
  *     v = [ x 1 ] if direction == Direction::Backward.
  *
- * @param[in] v Vector of size m-1 if side = Side::Left,
+ * @param[in] storeMode
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
+ *     - StoreV::Columnwise.
+ *     - StoreV::Rowwise.
+ *
+ * @param[in] x Vector of size m-1 if side = Side::Left,
  *                          or n-1 if side = Side::Right.
  *
  * @param[in] tau Value of tau in the representation of H.
@@ -90,6 +96,12 @@ inline constexpr void larf_worksize(side_t side,
  * @param[in] direction
  *     v = [ 1 x ] if direction == Direction::Forward and
  *     v = [ x 1 ] if direction == Direction::Backward.
+ *
+ * @param[in] storeMode
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
+ *     - StoreV::Columnwise.
+ *     - StoreV::Rowwise.
  *
  * @param[in] x Vector of size m-1 if side = Side::Left,
  *                          or n-1 if side = Side::Right.

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -52,27 +52,28 @@ namespace tlapack {
  * @ingroup workspace_query
  */
 template <class side_t,
-          class direction_t,
           class storage_t,
           class vector_t,
           class tau_t,
-          class matrix_t>
+          class vectorC0_t,
+          class matrixC1_t,
+          enable_if_t<is_convertible_v<storage_t, StoreV>, int> = 0>
 inline constexpr void larf_worksize(side_t side,
-                                    direction_t direction,
                                     storage_t storeMode,
                                     vector_t const& x,
                                     const tau_t& tau,
-                                    const matrix_t& C,
+                                    const vectorC0_t& C0,
+                                    const matrixC1_t& C1,
                                     workinfo_t& workinfo,
                                     const workspace_opts_t<>& opts = {})
 {
-    using work_t = vector_type<matrix_t, vector_t>;
-    using idx_t = size_type<matrix_t>;
+    using work_t = vector_type<vectorC0_t, matrixC1_t, vector_t>;
+    using idx_t = size_type<vectorC0_t>;
     using T = type_t<work_t>;
 
     // constants
-    const idx_t m = nrows(C);
-    const idx_t n = ncols(C);
+    const idx_t m = nrows(C1);
+    const idx_t n = ncols(C1);
 
     const workinfo_t myWorkinfo(sizeof(T), (side == Side::Left) ? n : m);
     workinfo.minMax(myWorkinfo);
@@ -120,32 +121,236 @@ inline constexpr void larf_worksize(side_t side,
  * @ingroup auxiliary
  */
 template <class side_t,
-          class direction_t,
           class storage_t,
           class vector_t,
           class tau_t,
-          class matrix_t>
+          class vectorC0_t,
+          class matrixC1_t,
+          enable_if_t<is_convertible_v<storage_t, StoreV>, int> = 0>
 void larf(side_t side,
-          direction_t direction,
           storage_t storeMode,
           vector_t const& x,
           const tau_t& tau,
-          matrix_t& C,
+          vectorC0_t& C0,
+          matrixC1_t& C1,
           const workspace_opts_t<>& opts = {})
 {
     // data traits
-    using work_t = vector_type<matrix_t, vector_t>;
-    using idx_t = size_type<matrix_t>;
+    using work_t = vector_type<vectorC0_t, matrixC1_t, vector_t>;
+    using idx_t = size_type<vectorC0_t>;
     using T = type_t<work_t>;
     using real_t = real_type<T>;
-
-    using pair = pair<idx_t, idx_t>;
 
     // Functor
     Create<work_t> new_vector;
 
     // constants
     const real_t one(1);
+    const idx_t k = size(C0);
+
+    // check arguments
+    tlapack_check(side == Side::Left || side == Side::Right);
+    tlapack_check(storeMode == StoreV::Columnwise ||
+                  storeMode == StoreV::Rowwise);
+    tlapack_check((idx_t)size(x) == (side == Side::Left) ? nrows(C1)
+                                                         : ncols(C1));
+
+    // Quick return if possible
+    if (nrows(C1) == 0 || ncols(C1) == 0) {
+        for (idx_t i = 0; i < k; ++i)
+            C0[i] -= tau * C0[i];
+        return;
+    }
+
+    // Allocates workspace
+    vectorOfBytes localworkdata;
+    const Workspace work = [&]() {
+        workinfo_t workinfo;
+        larf_worksize(side, storeMode, x, tau, C0, C1, workinfo, opts);
+        return alloc_workspace(localworkdata, workinfo, opts.work);
+    }();
+    auto w = new_vector(work, k);
+
+    if (side == Side::Left) {
+        if (storeMode == StoreV::Columnwise) {
+            // w := C0^H + C1^H*x
+            for (idx_t i = 0; i < k; ++i)
+                w[i] = conj(C0[i]);
+            gemv(Op::ConjTrans, one, C1, x, one, w);
+
+            // C1 := C1 - tau*x*w^H
+            ger(-tau, x, w, C1);
+
+            // C0 := C0 - tau*w^H
+            for (idx_t i = 0; i < k; ++i)
+                C0[i] -= tau * conj(w[i]);
+        }
+        else {
+            // w := C0^t + C1^t*x
+            for (idx_t i = 0; i < k; ++i)
+                w[i] = C0[i];
+            gemv(Op::Trans, one, C1, x, one, w);
+
+            // C1 := C1 - tau*conj(x)*w^t
+            for (idx_t j = 0; j < ncols(C1); ++j)
+                for (idx_t i = 0; i < nrows(C1); ++i)
+                    C1(i, j) -= tau * conj(x[i]) * w[j];
+
+            // C0 := C0 - tau*w^t
+            for (idx_t i = 0; i < k; ++i)
+                C0[i] -= tau * w[i];
+        }
+    }
+    else {  // side == Side::Right
+        if (storeMode == StoreV::Columnwise) {
+            // w := C0 + C1*x
+            for (idx_t i = 0; i < k; ++i)
+                w[i] = C0[i];
+            gemv(Op::NoTrans, one, C1, x, one, w);
+
+            // C1 := C1 - tau*w*x^H
+            ger(-tau, w, x, C1);
+
+            // C0 := C0 - tau*w
+            for (idx_t i = 0; i < k; ++i)
+                C0[i] -= tau * w[i];
+        }
+        else {
+            // w := C0 + C1*conj(x)
+            gemv(Op::Conj, one, C1, x, w);
+            for (idx_t i = 0; i < k; ++i)
+                w[i] = C0[i] + conj(w[i]);
+
+            // C1 := C1 - tau*w*x^t
+            geru(-tau, w, x, C1);
+
+            // C0 := C0 - tau*w
+            for (idx_t i = 0; i < k; ++i)
+                C0[i] -= tau * w[i];
+        }
+    }
+}
+
+/** Worspace query of larf().
+ *
+ * @param[in] side
+ *     - Side::Left:  apply $H$ from the Left.
+ *     - Side::Right: apply $H$ from the Right.
+ *
+ * @param[in] direction
+ *     v = [ 1 x ] if direction == Direction::Forward and
+ *     v = [ x 1 ] if direction == Direction::Backward.
+ *
+ * @param[in] storeMode
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
+ *     - StoreV::Columnwise.
+ *     - StoreV::Rowwise.
+ *
+ * @param[in] v Vector of size m if side = Side::Left,
+ *                          or n if side = Side::Right.
+ *
+ * @param[in] tau Value of tau in the representation of H.
+ *
+ * @param[in] C
+ *     On entry, the m-by-n matrix C.
+ *
+ * @param[in] opts Options.
+ *
+ * @param[in,out] workinfo
+ *      On output, the amount workspace required. It is larger than or equal
+ *      to that given on input.
+ *
+ * @ingroup workspace_query
+ */
+template <class side_t,
+          class direction_t,
+          class storage_t,
+          class vector_t,
+          class tau_t,
+          class matrix_t,
+          enable_if_t<is_convertible_v<direction_t, Direction>, int> = 0>
+inline constexpr void larf_worksize(side_t side,
+                                    direction_t direction,
+                                    storage_t storeMode,
+                                    vector_t const& v,
+                                    const tau_t& tau,
+                                    const matrix_t& C,
+                                    workinfo_t& workinfo,
+                                    const workspace_opts_t<>& opts = {})
+{
+    using work_t = vector_type<matrix_t, vector_t>;
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<work_t>;
+
+    // constants
+    const idx_t m = nrows(C);
+    const idx_t n = ncols(C);
+
+    const workinfo_t myWorkinfo(sizeof(T), (side == Side::Left) ? n : m);
+    workinfo.minMax(myWorkinfo);
+}
+
+/** Applies an elementary reflector H to a m-by-n matrix C.
+ *
+ * The elementary reflector H can be applied on either the left or right, with
+ * \[
+ *        H = I - \tau v v^H.
+ * \]
+ * where v = [ 1 x ] if direction == Direction::Forward and
+ *       v = [ x 1 ] if direction == Direction::Backward.
+ *
+ * @tparam side_t Either Side or any class that implements `operator Side()`.
+ *
+ * @param[in] side
+ *     - Side::Left:  apply $H$ from the Left.
+ *     - Side::Right: apply $H$ from the Right.
+ *
+ * @param[in] direction
+ *     v = [ 1 x ] if direction == Direction::Forward and
+ *     v = [ x 1 ] if direction == Direction::Backward.
+ *
+ * @param[in] storeMode
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
+ *     - StoreV::Columnwise.
+ *     - StoreV::Rowwise.
+ *
+ * @param[in] v Vector of size m if side = Side::Left,
+ *                          or n if side = Side::Right.
+ *
+ * @param[in] tau Value of tau in the representation of H.
+ *
+ * @param[in,out] C
+ *     On entry, the m-by-n matrix C.
+ *     On exit, C is overwritten by $H C$ if side = Side::Left,
+ *                               or $C H$ if side = Side::Right.
+ *
+ * @param[in] opts Options.
+ *      - @c opts.work is used if whenever it has sufficient size.
+ *        The sufficient size can be obtained through a workspace query.
+ *
+ * @ingroup auxiliary
+ */
+template <class side_t,
+          class direction_t,
+          class storage_t,
+          class vector_t,
+          class tau_t,
+          class matrix_t,
+          enable_if_t<is_convertible_v<direction_t, Direction>, int> = 0>
+inline void larf(side_t side,
+                 direction_t direction,
+                 storage_t storeMode,
+                 vector_t const& v,
+                 const tau_t& tau,
+                 matrix_t& C,
+                 const workspace_opts_t<>& opts = {})
+{
+    using idx_t = size_type<matrix_t>;
+    using pair = pair<idx_t, idx_t>;
+
+    // constants
     const idx_t m = nrows(C);
     const idx_t n = ncols(C);
 
@@ -155,109 +360,37 @@ void larf(side_t side,
                   direction == Direction::Forward);
     tlapack_check(storeMode == StoreV::Columnwise ||
                   storeMode == StoreV::Rowwise);
-    tlapack_check((idx_t)size(x) == ((side == Side::Left) ? m - 1 : n - 1));
-
-    // Allocates workspace
-    vectorOfBytes localworkdata;
-    const Workspace work = [&]() {
-        workinfo_t workinfo;
-        larf_worksize(side, direction, storeMode, x, tau, C, workinfo, opts);
-        return alloc_workspace(localworkdata, workinfo, opts.work);
-    }();
+    tlapack_check((idx_t)size(v) == ((side == Side::Left) ? m : n));
 
     // The following code was changed from:
     //
     // if( side == Side::Left ) {
-    //     gemv(Op::NoTrans, one, C, v, zero, work);
-    //     ger(-tau, work, v, C);
+    //     gemv(Op::ConjTrans, one, C, v, work);
+    //     ger(-tau, v, work, C);
     // }
     // else{
-    //     gemv(Op::ConjTrans, one, C, v, zero, work);
-    //     ger(-tau, v, work, C);
+    //     gemv(Op::NoTrans, one, C, v, work);
+    //     ger(-tau, work, v, C);
     // }
     //
     // This is so that v[0] doesn't need to be changed to 1,
     // which is better for thread safety.
 
     if (side == Side::Left) {
-        if (m <= 1) {
-            for (idx_t j = 0; j < n; ++j)
-                C(0, j) -= tau * C(0, j);
-            return;
-        }
-
         auto C0 = (direction == Direction::Forward) ? row(C, 0) : row(C, m - 1);
         auto C1 = (direction == Direction::Forward) ? rows(C, pair{1, m})
                                                     : rows(C, pair{0, m - 1});
-        auto w = new_vector(work, n);
-
-        if (storeMode == StoreV::Columnwise) {
-            // w := C0^H + C1^H*x
-            for (idx_t i = 0; i < n; ++i)
-                w[i] = conj(C0[i]);
-            gemv(Op::ConjTrans, one, C1, x, one, w);
-
-            // C1 := C1 - tau*x*w^H
-            ger(-tau, x, w, C1);
-
-            // C0 := C0 - tau*w^H
-            for (idx_t i = 0; i < n; ++i)
-                C0[i] -= tau * conj(w[i]);
-        }
-        else {
-            // w := C0^t + C1^t*x
-            for (idx_t i = 0; i < n; ++i)
-                w[i] = C0[i];
-            gemv(Op::Trans, one, C1, x, one, w);
-
-            // C1 := C1 - tau*conj(x)*w^t
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < m; ++i)
-                    C1(i, j) -= tau * conj(x[i]) * w[j];
-
-            // C0 := C0 - tau*w^t
-            for (idx_t i = 0; i < n; ++i)
-                C0[i] -= tau * w[i];
-        }
+        auto x = (direction == Direction::Forward) ? slice(v, pair{1, m})
+                                                   : slice(v, pair{0, m - 1});
+        larf(side, storeMode, x, tau, C0, C1, opts);
     }
     else {  // side == Side::Right
-        if (n <= 1) {
-            for (idx_t i = 0; i < m; ++i)
-                C(i, 0) -= tau * C(i, 0);
-            return;
-        }
-
         auto C0 = (direction == Direction::Forward) ? col(C, 0) : col(C, n - 1);
         auto C1 = (direction == Direction::Forward) ? cols(C, pair{1, n})
                                                     : cols(C, pair{0, n - 1});
-        auto w = new_vector(work, m);
-
-        if (storeMode == StoreV::Columnwise) {
-            // w := C0 + C1*x
-            for (idx_t i = 0; i < m; ++i)
-                w[i] = C0[i];
-            gemv(Op::NoTrans, one, C1, x, one, w);
-
-            // C1 := C1 - tau*w*x^H
-            ger(-tau, w, x, C1);
-
-            // C0 := C0 - tau*w
-            for (idx_t i = 0; i < m; ++i)
-                C0[i] -= tau * w[i];
-        }
-        else {
-            // w := C0 + C1*conj(x)
-            gemv(Op::Conj, one, C1, x, w);
-            for (idx_t i = 0; i < m; ++i)
-                w[i] = C0[i] + conj(w[i]);
-
-            // C1 := C1 - tau*w*x^t
-            geru(-tau, w, x, C1);
-
-            // C0 := C0 - tau*w
-            for (idx_t i = 0; i < m; ++i)
-                C0[i] -= tau * w[i];
-        }
+        auto x = (direction == Direction::Forward) ? slice(v, pair{1, n})
+                                                   : slice(v, pair{0, n - 1});
+        larf(side, storeMode, x, tau, C0, C1, opts);
     }
 }
 

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -71,10 +71,9 @@ inline constexpr void larf_worksize(side_t side,
     using T = type_t<work_t>;
 
     // constants
-    const idx_t m = nrows(C1);
-    const idx_t n = ncols(C1);
+    const idx_t k = size(C0);
 
-    const workinfo_t myWorkinfo(sizeof(T), (side == Side::Left) ? n : m);
+    const workinfo_t myWorkinfo(sizeof(T), k);
     workinfo.minMax(myWorkinfo);
 }
 
@@ -162,16 +161,17 @@ void larf(side_t side,
     // constants
     const real_t one(1);
     const idx_t k = size(C0);
+    const idx_t m = nrows(C1);
+    const idx_t n = ncols(C1);
 
     // check arguments
     tlapack_check(side == Side::Left || side == Side::Right);
     tlapack_check(storeMode == StoreV::Columnwise ||
                   storeMode == StoreV::Rowwise);
-    tlapack_check((idx_t)size(x) == (side == Side::Left) ? nrows(C1)
-                                                         : ncols(C1));
+    tlapack_check((idx_t)size(x) == (side == Side::Left) ? m : n);
 
     // Quick return if possible
-    if (nrows(C1) == 0 || ncols(C1) == 0) {
+    if (m == 0 || n == 0) {
         for (idx_t i = 0; i < k; ++i)
             C0[i] -= tau * C0[i];
         return;
@@ -207,8 +207,8 @@ void larf(side_t side,
             gemv(Op::Trans, one, C1, x, one, w);
 
             // C1 := C1 - tau*conj(x)*w^t
-            for (idx_t j = 0; j < ncols(C1); ++j)
-                for (idx_t i = 0; i < nrows(C1); ++i)
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
                     C1(i, j) -= tau * conj(x[i]) * w[j];
 
             // C0 := C0 - tau*w^t

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -235,6 +235,13 @@ int larfb(side_t side,
                         direction != Direction::Forward);
     tlapack_check_false(storeMode != StoreV::Columnwise &&
                         storeMode != StoreV::Rowwise);
+    tlapack_check(
+        (storeMode == StoreV::Columnwise)
+            ? ((ncols(V) == k) && (side == Side::Left) ? (nrows(V) == m)
+                                                       : (nrows(V) == n))
+            : ((nrows(V) == k) && (side == Side::Left) ? (ncols(V) == m)
+                                                       : (ncols(V) == n)));
+    tlapack_check(nrows(Tmatrix) == ncols(Tmatrix));
 
     // Quick return
     if (m <= 0 || n <= 0 || k <= 0) return 0;

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -256,9 +256,9 @@ int larfb(side_t side,
 
                 // Matrix views
                 const auto V1 = rows(V, pair{0, k});
-                const auto V2 = rows(V, (m > k) ? pair{k, m} : pair{0, 0});
+                const auto V2 = rows(V, pair{k, m});
                 auto C1 = rows(C, pair{0, k});
-                auto C2 = rows(C, (m > k) ? pair{k, m} : pair{0, 0});
+                auto C2 = rows(C, pair{k, m});
                 auto W = new_matrix(work, k, n);
 
                 // W := C1
@@ -287,9 +287,9 @@ int larfb(side_t side,
 
                 // Matrix views
                 const auto V1 = rows(V, pair{0, k});
-                const auto V2 = rows(V, (n > k) ? pair{k, n} : pair{0, 0});
+                const auto V2 = rows(V, pair{k, n});
                 auto C1 = cols(C, pair{0, k});
-                auto C2 = cols(C, (n > k) ? pair{k, n} : pair{0, 0});
+                auto C2 = cols(C, pair{k, n});
                 auto W = new_matrix(work, m, k);
 
                 // W := C1
@@ -387,9 +387,9 @@ int larfb(side_t side,
 
                 // Matrix views
                 const auto V1 = cols(V, pair{0, k});
-                const auto V2 = cols(V, (m > k) ? pair{k, m} : pair{0, 0});
+                const auto V2 = cols(V, pair{k, m});
                 auto C1 = rows(C, pair{0, k});
-                auto C2 = rows(C, (m > k) ? pair{k, m} : pair{0, 0});
+                auto C2 = rows(C, pair{k, m});
                 auto W = new_matrix(work, k, n);
 
                 // W := C1
@@ -418,9 +418,9 @@ int larfb(side_t side,
 
                 // Matrix views
                 const auto V1 = cols(V, pair{0, k});
-                const auto V2 = cols(V, (n > k) ? pair{k, n} : pair{0, 0});
+                const auto V2 = cols(V, pair{k, n});
                 auto C1 = cols(C, pair{0, k});
-                auto C2 = cols(C, (n > k) ? pair{k, n} : pair{0, 0});
+                auto C2 = cols(C, pair{k, n});
                 auto W = new_matrix(work, m, k);
 
                 // W := C1

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -34,16 +34,16 @@ namespace tlapack {
  * if storeMode == StoreV::Rowwise, where alpha and beta are scalars, with beta
  * real, and x is an (n-1)-element vector. H is represented in the form
  *
- *        H = I - tau * ( 1 ) * ( 1 v' )
- *                      ( v )
+ *        H = I - tau * ( 1 ) * ( 1 y' )
+ *                      ( y )
  *
  * if storeMode == StoreV::Columnwise, or
  *
- *        H = I - tau * ( 1  ) * ( 1 v )
- *                      ( v' )
+ *        H = I - tau * ( 1  ) * ( 1 y )
+ *                      ( y' )
  *
  * if storeMode == StoreV::Rowwise, where tau is a scalar and
- * v is a (n-1)-element vector. Note that H is symmetric but not hermitian.
+ * y is a (n-1)-element vector. Note that H is symmetric but not hermitian.
  *
  * If the elements of x are all zero and alpha is real, then tau = 0
  * and H is taken to be the identity matrix.
@@ -62,21 +62,24 @@ namespace tlapack {
  *
  * @param[in,out] x Vector of length n-1.
  *      On entry, the vector x.
- *      On exit, it is overwritten with the vector v.
+ *      On exit, it is overwritten with the vector y.
  *
  * @param[out] tau The value tau.
  *
  * @ingroup auxiliary
  */
-template <class storage_t, class vector_t, class alpha_t, class tau_t>
-void larfg(storage_t storeMode, alpha_t& alpha, vector_t& x, tau_t& tau)
+template <class storage_t, class vector_t>
+void larfg(storage_t storeMode,
+           type_t<vector_t>& alpha,
+           vector_t& x,
+           type_t<vector_t>& tau)
 {
     // data traits
-    using TX = type_t<vector_t>;
+    using T = type_t<vector_t>;
     using idx_t = size_type<vector_t>;
 
     // using
-    using real_t = real_type<alpha_t, TX>;
+    using real_t = real_type<T>;
 
     // constants
     const real_t one(1);
@@ -88,12 +91,12 @@ void larfg(storage_t storeMode, alpha_t& alpha, vector_t& x, tau_t& tau)
     tlapack_check(storeMode == StoreV::Columnwise ||
                   storeMode == StoreV::Rowwise);
 
-    tau = tau_t(0);
+    tau = zero;
     real_t xnorm = nrm2(x);
 
     if (xnorm > zero || (imag(alpha) != zero)) {
         // First estimate of beta
-        real_t temp = (!is_complex<alpha_t>::value)
+        real_t temp = (!is_complex<T>::value)
                           ? lapy2(real(alpha), xnorm)
                           : lapy3(real(alpha), imag(alpha), xnorm);
         real_t beta = (real(alpha) < zero) ? temp : -temp;
@@ -108,13 +111,13 @@ void larfg(storage_t storeMode, alpha_t& alpha, vector_t& x, tau_t& tau)
                 alpha *= rsafemin;
             }
             xnorm = nrm2(x);
-            temp = (!is_complex<alpha_t>::value)
+            temp = (!is_complex<T>::value)
                        ? lapy2(real(alpha), xnorm)
                        : lapy3(real(alpha), imag(alpha), xnorm);
             beta = (real(alpha) < zero) ? temp : -temp;
         }
 
-        // compute tau and v
+        // compute tau and y
         tau = (beta - alpha) / beta;
         scal(one / (alpha - beta), x);
         if (storeMode == StoreV::Rowwise) tau = conj(tau);
@@ -125,6 +128,90 @@ void larfg(storage_t storeMode, alpha_t& alpha, vector_t& x, tau_t& tau)
 
         // Store beta in alpha
         alpha = beta;
+    }
+}
+
+/**
+ * @brief Generates a elementary Householder reflection.
+ *
+ * larfg generates a elementary Householder reflection H of order n, such that
+ *
+ *        H' * ( alpha ) = ( beta ),   H' * H = I.
+ *             (   x   )   (   0  )
+ *
+ * if storeMode == StoreV::Columnwise, or
+ *
+ *        ( alpha x ) * H = ( beta 0 ),   H' * H = I.
+ *
+ * if storeMode == StoreV::Rowwise, where alpha and beta are scalars, with beta
+ * real, and x is an (n-1)-element vector. H is represented in the form
+ *
+ *        H = I - tau * ( 1 ) * ( 1 y' )
+ *                      ( y )
+ *
+ * if storeMode == StoreV::Columnwise, or
+ *
+ *        H = I - tau * ( 1  ) * ( 1 y )
+ *                      ( y' )
+ *
+ * if storeMode == StoreV::Rowwise, where tau is a scalar and
+ * y is a (n-1)-element vector. Note that H is symmetric but not hermitian.
+ *
+ * If the elements of x are all zero and alpha is real, then tau = 0
+ * and H is taken to be the identity matrix.
+ *
+ * Otherwise  1 <= real(tau) <= 2 and abs(tau-1) <= 1.
+ *
+ * @tparam direction_t Either Direction or any class that implements `operator
+ * Direction()`.
+ * @tparam storage_t Either StoreV or any class that implements `operator
+ * StoreV()`.
+ *
+ * @param[in] direction
+ *     v = [ alpha x ] if direction == Direction::Forward and
+ *     v = [ x alpha ] if direction == Direction::Backward.
+ *
+ * @param[in] storeMode
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
+ *     - StoreV::Columnwise.
+ *     - StoreV::Rowwise.
+ *
+ * @param[in,out] v Vector of length n.
+ *      On entry,
+ *          v = [ alpha x ] if direction == Direction::Forward and
+ *          v = [ x alpha ] if direction == Direction::Backward.
+ *      On exit,
+ *          v = [ 1 y ] if direction == Direction::Forward and
+ *          v = [ y 1 ] if direction == Direction::Backward.
+ *
+ * @param[out] tau The value tau.
+ *
+ * @ingroup auxiliary
+ */
+template <class direction_t,
+          class storage_t,
+          class vector_t,
+          enable_if_t<is_convertible_v<direction_t, Direction>, int> = 0>
+inline void larfg(direction_t direction,
+                  storage_t storeMode,
+                  vector_t& v,
+                  type_t<vector_t>& tau)
+{
+    using idx_t = size_type<vector_t>;
+    using pair = pair<idx_t, idx_t>;
+
+    // check arguments
+    tlapack_check_false(direction != Direction::Backward &&
+                        direction != Direction::Forward);
+
+    if (direction == Direction::Forward) {
+        auto x = slice(v, pair(1, size(v)));
+        larfg(storeMode, v[0], x, tau);
+    }
+    else {
+        auto x = slice(v, pair(0, size(v) - 1));
+        larfg(storeMode, v[size(v) - 1], x, tau);
     }
 }
 

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -50,6 +50,12 @@ namespace tlapack {
  *
  * Otherwise  1 <= real(tau) <= 2 and abs(tau-1) <= 1.
  *
+ * @param[in] storeMode
+ *     Indicates how the vectors which define the elementary reflectors are
+ * stored:
+ *     - StoreV::Columnwise.
+ *     - StoreV::Rowwise.
+ *
  * @param[in,out] alpha
  *      On entry, the value alpha.
  *      On exit, it is overwritten with the value beta.

--- a/include/tlapack/lapack/move_bulge.hpp
+++ b/include/tlapack/lapack/move_bulge.hpp
@@ -61,10 +61,7 @@ void move_bulge(matrix_t& H,
     v[0] = H(1, 0);
     v[1] = H(2, 0);
     v[2] = H(3, 0);
-    {
-        auto x = slice(v, pair{1, 3});
-        larfg(columnwise_storage, v[0], x, tau);
-    }
+    larfg(forward, columnwise_storage, v, tau);
     beta = v[0];
     v[0] = tau;
 
@@ -82,10 +79,7 @@ void move_bulge(matrix_t& H,
         auto vt = new_vector(vt_, 3);
         auto H2 = slice(H, pair{1, 4}, pair{1, 4});
         lahqr_shiftcolumn(H2, vt, s1, s2);
-        {
-            auto x = slice(vt, pair{1, 3});
-            larfg(columnwise_storage, vt[0], x, tau);
-        }
+        larfg(forward, columnwise_storage, vt, tau);
         vt[0] = tau;
 
         refsum = conj(vt[0]) * H(1, 0) + conj(vt[1]) * H(2, 0);

--- a/include/tlapack/lapack/move_bulge.hpp
+++ b/include/tlapack/lapack/move_bulge.hpp
@@ -22,8 +22,8 @@ namespace tlapack {
  *  down. If the bulge collapses, an attempt is made to
  *  reintroduce it using shifts s1 and s2.
  *
- * @param[in] H 4x3 matrix.
- * @param[out] v vector of size 3
+ * @param[in,out] H 4x3 matrix.
+ * @param[in,out] v vector of size 3
  *      On entry, the delayed reflector to apply
  *      The first element of the reflector is assumed to be one, and v[0]
  * instead stores tau. On exit, the reflector that moves the bulge down one
@@ -61,7 +61,10 @@ void move_bulge(matrix_t& H,
     v[0] = H(1, 0);
     v[1] = H(2, 0);
     v[2] = H(3, 0);
-    larfg(v, tau);
+    {
+        auto x = slice(v, pair{1, 3});
+        larfg(columnwise_storage, v[0], x, tau);
+    }
     beta = v[0];
     v[0] = tau;
 
@@ -79,7 +82,10 @@ void move_bulge(matrix_t& H,
         auto vt = new_vector(vt_, 3);
         auto H2 = slice(H, pair{1, 4}, pair{1, 4});
         lahqr_shiftcolumn(H2, vt, s1, s2);
-        larfg(vt, tau);
+        {
+            auto x = slice(vt, pair{1, 3});
+            larfg(columnwise_storage, vt[0], x, tau);
+        }
         vt[0] = tau;
 
         refsum = conj(vt[0]) * H(1, 0) + conj(vt[1]) * H(2, 0);

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -198,10 +198,7 @@ void multishift_QR_sweep(bool want_t,
                     auto H = slice(A, pair{ilo, ilo + 3}, pair{ilo, ilo + 3});
                     lahqr_shiftcolumn(H, v, s[size(s) - 1 - 2 * i_bulge],
                                       s[size(s) - 1 - 2 * i_bulge - 1]);
-                    {
-                        auto x = slice(v, pair{1, size(v)});
-                        larfg(columnwise_storage, v[0], x, tau);
-                    }
+                    larfg(forward, columnwise_storage, v, tau);
                     v[0] = tau;
                 }
                 else {
@@ -623,13 +620,10 @@ void multishift_QR_sweep(bool want_t,
                     // Special case, the bulge is at the bottom, needs a smaller
                     // reflector (order 2)
                     auto v = slice(V, pair{0, 2}, i_bulge);
-                    {
-                        auto x =
-                            slice(A, pair{i_pos + 1, i_pos + 2}, i_pos - 1);
-                        larfg(columnwise_storage, A(i_pos, i_pos - 1), x, v[0]);
-                    }
-                    v[1] = A(i_pos + 1, i_pos - 1);
-                    A(i_pos + 1, i_pos - 1) = zero;
+                    auto h = slice(A, pair{i_pos, i_pos + 2}, i_pos - 1);
+                    larfg(forward, columnwise_storage, h, v[0]);
+                    v[1] = h[1];
+                    h[1] = zero;
 
                     const TA t1 = conj(v[0]);
                     const TA v2 = v[1];

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -198,7 +198,10 @@ void multishift_QR_sweep(bool want_t,
                     auto H = slice(A, pair{ilo, ilo + 3}, pair{ilo, ilo + 3});
                     lahqr_shiftcolumn(H, v, s[size(s) - 1 - 2 * i_bulge],
                                       s[size(s) - 1 - 2 * i_bulge - 1]);
-                    larfg(v, tau);
+                    {
+                        auto x = slice(v, pair{1, size(v)});
+                        larfg(columnwise_storage, v[0], x, tau);
+                    }
                     v[0] = tau;
                 }
                 else {
@@ -620,10 +623,13 @@ void multishift_QR_sweep(bool want_t,
                     // Special case, the bulge is at the bottom, needs a smaller
                     // reflector (order 2)
                     auto v = slice(V, pair{0, 2}, i_bulge);
-                    auto h = slice(A, pair{i_pos, i_pos + 2}, i_pos - 1);
-                    larfg(h, v[0]);
-                    v[1] = h[1];
-                    h[1] = zero;
+                    {
+                        auto x =
+                            slice(A, pair{i_pos + 1, i_pos + 2}, i_pos - 1);
+                        larfg(columnwise_storage, A(i_pos, i_pos - 1), x, v[0]);
+                    }
+                    v[1] = A(i_pos + 1, i_pos - 1);
+                    A(i_pos + 1, i_pos - 1) = zero;
 
                     const TA t1 = conj(v[0]);
                     const TA v2 = v[1];

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -145,14 +145,14 @@ int schur_swap(bool want_q,
 
         // Make B upper triangular
         T tau1, tau2;
-        auto v1 = slice(B, pair{1, 3}, 0);
-        auto v2 = slice(B, pair{2, 3}, 1);
-        larfg(columnwise_storage, B(0, 0), v1, tau1);
-        const T sum = B(0, 1) + v1[0] * B(1, 1) + v1[1] * B(2, 1);
+        auto v1 = slice(B, pair{0, 3}, 0);
+        auto v2 = slice(B, pair{1, 3}, 1);
+        larfg(forward, columnwise_storage, v1, tau1);
+        const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
         B(0, 1) = B(0, 1) - sum * tau1;
-        B(1, 1) = B(1, 1) - sum * tau1 * v1[0];
-        B(2, 1) = B(2, 1) - sum * tau1 * v1[1];
-        larfg(columnwise_storage, B(1, 1), v2, tau2);
+        B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
+        B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
+        larfg(forward, columnwise_storage, v2, tau2);
 
         //
         // Apply reflections to A and Q
@@ -160,37 +160,37 @@ int schur_swap(bool want_q,
 
         // Reflections from the left
         for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j0, j) + v1[0] * A(j1, j) + v1[1] * A(j2, j);
+            T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j);
             A(j0, j) = A(j0, j) - sum * tau1;
-            A(j1, j) = A(j1, j) - sum * tau1 * v1[0];
-            A(j2, j) = A(j2, j) - sum * tau1 * v1[1];
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
+            A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
 
-            sum = A(j1, j) + v2[0] * A(j2, j);
+            sum = A(j1, j) + v2[1] * A(j2, j);
             A(j1, j) = A(j1, j) - sum * tau2;
-            A(j2, j) = A(j2, j) - sum * tau2 * v2[0];
+            A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
         }
         // Reflections from the right
         for (idx_t j = 0; j < j3; ++j) {
-            T sum = A(j, j0) + v1[0] * A(j, j1) + v1[1] * A(j, j2);
+            T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2);
             A(j, j0) = A(j, j0) - sum * tau1;
-            A(j, j1) = A(j, j1) - sum * tau1 * v1[0];
-            A(j, j2) = A(j, j2) - sum * tau1 * v1[1];
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
+            A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
 
-            sum = A(j, j1) + v2[0] * A(j, j2);
+            sum = A(j, j1) + v2[1] * A(j, j2);
             A(j, j1) = A(j, j1) - sum * tau2;
-            A(j, j2) = A(j, j2) - sum * tau2 * v2[0];
+            A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
         }
 
         if (want_q) {
             for (idx_t j = 0; j < n; ++j) {
-                T sum = Q(j, j0) + v1[0] * Q(j, j1) + v1[1] * Q(j, j2);
+                T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2);
                 Q(j, j0) = Q(j, j0) - sum * tau1;
-                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[0];
-                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[1];
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
+                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
 
-                sum = Q(j, j1) + v2[0] * Q(j, j2);
+                sum = Q(j, j1) + v2[1] * Q(j, j2);
                 Q(j, j1) = Q(j, j1) - sum * tau2;
-                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[0];
+                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
             }
         }
 
@@ -213,14 +213,14 @@ int schur_swap(bool want_q,
 
         // Make B upper triangular
         T tau1, tau2;
-        auto v1 = slice(B, pair{1, 3}, 0);
-        auto v2 = slice(B, pair{2, 3}, 1);
-        larfg(columnwise_storage, B(0, 0), v1, tau1);
-        const T sum = B(0, 1) + v1[0] * B(1, 1) + v1[1] * B(2, 1);
+        auto v1 = slice(B, pair{0, 3}, 0);
+        auto v2 = slice(B, pair{1, 3}, 1);
+        larfg(forward, columnwise_storage, v1, tau1);
+        const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
         B(0, 1) = B(0, 1) - sum * tau1;
-        B(1, 1) = B(1, 1) - sum * tau1 * v1[0];
-        B(2, 1) = B(2, 1) - sum * tau1 * v1[1];
-        larfg(columnwise_storage, B(1, 1), v2, tau2);
+        B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
+        B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
+        larfg(forward, columnwise_storage, v2, tau2);
 
         //
         // Apply reflections to A and Q
@@ -228,37 +228,37 @@ int schur_swap(bool want_q,
 
         // Reflections from the left
         for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j2, j) + v1[0] * A(j1, j) + v1[1] * A(j0, j);
+            T sum = A(j2, j) + v1[1] * A(j1, j) + v1[2] * A(j0, j);
             A(j2, j) = A(j2, j) - sum * tau1;
-            A(j1, j) = A(j1, j) - sum * tau1 * v1[0];
-            A(j0, j) = A(j0, j) - sum * tau1 * v1[1];
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
+            A(j0, j) = A(j0, j) - sum * tau1 * v1[2];
 
-            sum = A(j1, j) + v2[0] * A(j0, j);
+            sum = A(j1, j) + v2[1] * A(j0, j);
             A(j1, j) = A(j1, j) - sum * tau2;
-            A(j0, j) = A(j0, j) - sum * tau2 * v2[0];
+            A(j0, j) = A(j0, j) - sum * tau2 * v2[1];
         }
         // Reflections from the right
         for (idx_t j = 0; j < j3; ++j) {
-            T sum = A(j, j2) + v1[0] * A(j, j1) + v1[1] * A(j, j0);
+            T sum = A(j, j2) + v1[1] * A(j, j1) + v1[2] * A(j, j0);
             A(j, j2) = A(j, j2) - sum * tau1;
-            A(j, j1) = A(j, j1) - sum * tau1 * v1[0];
-            A(j, j0) = A(j, j0) - sum * tau1 * v1[1];
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
+            A(j, j0) = A(j, j0) - sum * tau1 * v1[2];
 
-            sum = A(j, j1) + v2[0] * A(j, j0);
+            sum = A(j, j1) + v2[1] * A(j, j0);
             A(j, j1) = A(j, j1) - sum * tau2;
-            A(j, j0) = A(j, j0) - sum * tau2 * v2[0];
+            A(j, j0) = A(j, j0) - sum * tau2 * v2[1];
         }
 
         if (want_q) {
             for (idx_t j = 0; j < n; ++j) {
-                T sum = Q(j, j2) + v1[0] * Q(j, j1) + v1[1] * Q(j, j0);
+                T sum = Q(j, j2) + v1[1] * Q(j, j1) + v1[2] * Q(j, j0);
                 Q(j, j2) = Q(j, j2) - sum * tau1;
-                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[0];
-                Q(j, j0) = Q(j, j0) - sum * tau1 * v1[1];
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
+                Q(j, j0) = Q(j, j0) - sum * tau1 * v1[2];
 
-                sum = Q(j, j1) + v2[0] * Q(j, j0);
+                sum = Q(j, j1) + v2[1] * Q(j, j0);
                 Q(j, j1) = Q(j, j1) - sum * tau2;
-                Q(j, j0) = Q(j, j0) - sum * tau2 * v2[0];
+                Q(j, j0) = Q(j, j0) - sum * tau2 * v2[1];
             }
         }
 
@@ -293,43 +293,43 @@ int schur_swap(bool want_q,
 
         // Make V upper triangular
         T tau1, tau2;
-        auto v1 = slice(V, pair{1, 4}, 0);
-        auto v2 = slice(V, pair{2, 4}, 1);
-        larfg(columnwise_storage, V(0, 0), v1, tau1);
+        auto v1 = slice(V, pair{0, 4}, 0);
+        auto v2 = slice(V, pair{1, 4}, 1);
+        larfg(forward, columnwise_storage, v1, tau1);
         const T sum =
-            V(0, 1) + v1[0] * V(1, 1) + v1[1] * V(2, 1) + v1[2] * V(3, 1);
+            V(0, 1) + v1[1] * V(1, 1) + v1[2] * V(2, 1) + v1[3] * V(3, 1);
         V(0, 1) = V(0, 1) - sum * tau1;
-        V(1, 1) = V(1, 1) - sum * tau1 * v1[0];
-        V(2, 1) = V(2, 1) - sum * tau1 * v1[1];
-        V(3, 1) = V(3, 1) - sum * tau1 * v1[2];
-        larfg(columnwise_storage, V(1, 1), v2, tau2);
+        V(1, 1) = V(1, 1) - sum * tau1 * v1[1];
+        V(2, 1) = V(2, 1) - sum * tau1 * v1[2];
+        V(3, 1) = V(3, 1) - sum * tau1 * v1[3];
+        larfg(forward, columnwise_storage, v2, tau2);
 
         // Apply reflections to D to check error
         for (idx_t j = 0; j < 4; ++j) {
             T sum =
-                D(0, j) + v1[0] * D(1, j) + v1[1] * D(2, j) + v1[2] * D(3, j);
+                D(0, j) + v1[1] * D(1, j) + v1[2] * D(2, j) + v1[3] * D(3, j);
             D(0, j) = D(0, j) - sum * tau1;
-            D(1, j) = D(1, j) - sum * tau1 * v1[0];
-            D(2, j) = D(2, j) - sum * tau1 * v1[1];
-            D(3, j) = D(3, j) - sum * tau1 * v1[2];
+            D(1, j) = D(1, j) - sum * tau1 * v1[1];
+            D(2, j) = D(2, j) - sum * tau1 * v1[2];
+            D(3, j) = D(3, j) - sum * tau1 * v1[3];
 
-            sum = D(1, j) + v2[0] * D(2, j) + v2[1] * D(3, j);
+            sum = D(1, j) + v2[1] * D(2, j) + v2[2] * D(3, j);
             D(1, j) = D(1, j) - sum * tau2;
-            D(2, j) = D(2, j) - sum * tau2 * v2[0];
-            D(3, j) = D(3, j) - sum * tau2 * v2[1];
+            D(2, j) = D(2, j) - sum * tau2 * v2[1];
+            D(3, j) = D(3, j) - sum * tau2 * v2[2];
         }
         for (idx_t j = 0; j < 4; ++j) {
             T sum =
-                D(j, 0) + v1[0] * D(j, 1) + v1[1] * D(j, 2) + v1[2] * D(j, 3);
+                D(j, 0) + v1[1] * D(j, 1) + v1[2] * D(j, 2) + v1[3] * D(j, 3);
             D(j, 0) = D(j, 0) - sum * tau1;
-            D(j, 1) = D(j, 1) - sum * tau1 * v1[0];
-            D(j, 2) = D(j, 2) - sum * tau1 * v1[1];
-            D(j, 3) = D(j, 3) - sum * tau1 * v1[2];
+            D(j, 1) = D(j, 1) - sum * tau1 * v1[1];
+            D(j, 2) = D(j, 2) - sum * tau1 * v1[2];
+            D(j, 3) = D(j, 3) - sum * tau1 * v1[3];
 
-            sum = D(j, 1) + v2[0] * D(j, 2) + v2[1] * D(j, 3);
+            sum = D(j, 1) + v2[1] * D(j, 2) + v2[2] * D(j, 3);
             D(j, 1) = D(j, 1) - sum * tau2;
-            D(j, 2) = D(j, 2) - sum * tau2 * v2[0];
-            D(j, 3) = D(j, 3) - sum * tau2 * v2[1];
+            D(j, 2) = D(j, 2) - sum * tau2 * v2[1];
+            D(j, 3) = D(j, 3) - sum * tau2 * v2[2];
         }
 
         if (max(max(abs(D(2, 0)), abs(D(2, 1))),
@@ -338,46 +338,46 @@ int schur_swap(bool want_q,
 
         // Reflections from the left
         for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j0, j) + v1[0] * A(j1, j) + v1[1] * A(j2, j) +
-                    v1[2] * A(j3, j);
+            T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j) +
+                    v1[3] * A(j3, j);
             A(j0, j) = A(j0, j) - sum * tau1;
-            A(j1, j) = A(j1, j) - sum * tau1 * v1[0];
-            A(j2, j) = A(j2, j) - sum * tau1 * v1[1];
-            A(j3, j) = A(j3, j) - sum * tau1 * v1[2];
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
+            A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
+            A(j3, j) = A(j3, j) - sum * tau1 * v1[3];
 
-            sum = A(j1, j) + v2[0] * A(j2, j) + v2[1] * A(j3, j);
+            sum = A(j1, j) + v2[1] * A(j2, j) + v2[2] * A(j3, j);
             A(j1, j) = A(j1, j) - sum * tau2;
-            A(j2, j) = A(j2, j) - sum * tau2 * v2[0];
-            A(j3, j) = A(j3, j) - sum * tau2 * v2[1];
+            A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
+            A(j3, j) = A(j3, j) - sum * tau2 * v2[2];
         }
         // Reflections from the right
         for (idx_t j = 0; j < j0 + 4; ++j) {
-            T sum = A(j, j0) + v1[0] * A(j, j1) + v1[1] * A(j, j2) +
-                    v1[2] * A(j, j3);
+            T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2) +
+                    v1[3] * A(j, j3);
             A(j, j0) = A(j, j0) - sum * tau1;
-            A(j, j1) = A(j, j1) - sum * tau1 * v1[0];
-            A(j, j2) = A(j, j2) - sum * tau1 * v1[1];
-            A(j, j3) = A(j, j3) - sum * tau1 * v1[2];
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
+            A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
+            A(j, j3) = A(j, j3) - sum * tau1 * v1[3];
 
-            sum = A(j, j1) + v2[0] * A(j, j2) + v2[1] * A(j, j3);
+            sum = A(j, j1) + v2[1] * A(j, j2) + v2[2] * A(j, j3);
             A(j, j1) = A(j, j1) - sum * tau2;
-            A(j, j2) = A(j, j2) - sum * tau2 * v2[0];
-            A(j, j3) = A(j, j3) - sum * tau2 * v2[1];
+            A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
+            A(j, j3) = A(j, j3) - sum * tau2 * v2[2];
         }
 
         if (want_q) {
             for (idx_t j = 0; j < n; ++j) {
-                T sum = Q(j, j0) + v1[0] * Q(j, j1) + v1[1] * Q(j, j2) +
-                        v1[2] * Q(j, j3);
+                T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2) +
+                        v1[3] * Q(j, j3);
                 Q(j, j0) = Q(j, j0) - sum * tau1;
-                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[0];
-                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[1];
-                Q(j, j3) = Q(j, j3) - sum * tau1 * v1[2];
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
+                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
+                Q(j, j3) = Q(j, j3) - sum * tau1 * v1[3];
 
-                sum = Q(j, j1) + v2[0] * Q(j, j2) + v2[1] * Q(j, j3);
+                sum = Q(j, j1) + v2[1] * Q(j, j2) + v2[2] * Q(j, j3);
                 Q(j, j1) = Q(j, j1) - sum * tau2;
-                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[0];
-                Q(j, j3) = Q(j, j3) - sum * tau2 * v2[1];
+                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
+                Q(j, j3) = Q(j, j3) - sum * tau2 * v2[2];
             }
         }
 

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -145,14 +145,14 @@ int schur_swap(bool want_q,
 
         // Make B upper triangular
         T tau1, tau2;
-        auto v1 = slice(B, pair{0, 3}, 0);
-        auto v2 = slice(B, pair{1, 3}, 1);
-        larfg(v1, tau1);
-        const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
+        auto v1 = slice(B, pair{1, 3}, 0);
+        auto v2 = slice(B, pair{2, 3}, 1);
+        larfg(columnwise_storage, B(0, 0), v1, tau1);
+        const T sum = B(0, 1) + v1[0] * B(1, 1) + v1[1] * B(2, 1);
         B(0, 1) = B(0, 1) - sum * tau1;
-        B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
-        B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
-        larfg(v2, tau2);
+        B(1, 1) = B(1, 1) - sum * tau1 * v1[0];
+        B(2, 1) = B(2, 1) - sum * tau1 * v1[1];
+        larfg(columnwise_storage, B(1, 1), v2, tau2);
 
         //
         // Apply reflections to A and Q
@@ -160,37 +160,37 @@ int schur_swap(bool want_q,
 
         // Reflections from the left
         for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j);
+            T sum = A(j0, j) + v1[0] * A(j1, j) + v1[1] * A(j2, j);
             A(j0, j) = A(j0, j) - sum * tau1;
-            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
-            A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[0];
+            A(j2, j) = A(j2, j) - sum * tau1 * v1[1];
 
-            sum = A(j1, j) + v2[1] * A(j2, j);
+            sum = A(j1, j) + v2[0] * A(j2, j);
             A(j1, j) = A(j1, j) - sum * tau2;
-            A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
+            A(j2, j) = A(j2, j) - sum * tau2 * v2[0];
         }
         // Reflections from the right
         for (idx_t j = 0; j < j3; ++j) {
-            T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2);
+            T sum = A(j, j0) + v1[0] * A(j, j1) + v1[1] * A(j, j2);
             A(j, j0) = A(j, j0) - sum * tau1;
-            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
-            A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[0];
+            A(j, j2) = A(j, j2) - sum * tau1 * v1[1];
 
-            sum = A(j, j1) + v2[1] * A(j, j2);
+            sum = A(j, j1) + v2[0] * A(j, j2);
             A(j, j1) = A(j, j1) - sum * tau2;
-            A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
+            A(j, j2) = A(j, j2) - sum * tau2 * v2[0];
         }
 
         if (want_q) {
             for (idx_t j = 0; j < n; ++j) {
-                T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2);
+                T sum = Q(j, j0) + v1[0] * Q(j, j1) + v1[1] * Q(j, j2);
                 Q(j, j0) = Q(j, j0) - sum * tau1;
-                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
-                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[0];
+                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[1];
 
-                sum = Q(j, j1) + v2[1] * Q(j, j2);
+                sum = Q(j, j1) + v2[0] * Q(j, j2);
                 Q(j, j1) = Q(j, j1) - sum * tau2;
-                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
+                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[0];
             }
         }
 
@@ -213,14 +213,14 @@ int schur_swap(bool want_q,
 
         // Make B upper triangular
         T tau1, tau2;
-        auto v1 = slice(B, pair{0, 3}, 0);
-        auto v2 = slice(B, pair{1, 3}, 1);
-        larfg(v1, tau1);
-        const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
+        auto v1 = slice(B, pair{1, 3}, 0);
+        auto v2 = slice(B, pair{2, 3}, 1);
+        larfg(columnwise_storage, B(0, 0), v1, tau1);
+        const T sum = B(0, 1) + v1[0] * B(1, 1) + v1[1] * B(2, 1);
         B(0, 1) = B(0, 1) - sum * tau1;
-        B(1, 1) = B(1, 1) - sum * tau1 * v1[1];
-        B(2, 1) = B(2, 1) - sum * tau1 * v1[2];
-        larfg(v2, tau2);
+        B(1, 1) = B(1, 1) - sum * tau1 * v1[0];
+        B(2, 1) = B(2, 1) - sum * tau1 * v1[1];
+        larfg(columnwise_storage, B(1, 1), v2, tau2);
 
         //
         // Apply reflections to A and Q
@@ -228,37 +228,37 @@ int schur_swap(bool want_q,
 
         // Reflections from the left
         for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j2, j) + v1[1] * A(j1, j) + v1[2] * A(j0, j);
+            T sum = A(j2, j) + v1[0] * A(j1, j) + v1[1] * A(j0, j);
             A(j2, j) = A(j2, j) - sum * tau1;
-            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
-            A(j0, j) = A(j0, j) - sum * tau1 * v1[2];
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[0];
+            A(j0, j) = A(j0, j) - sum * tau1 * v1[1];
 
-            sum = A(j1, j) + v2[1] * A(j0, j);
+            sum = A(j1, j) + v2[0] * A(j0, j);
             A(j1, j) = A(j1, j) - sum * tau2;
-            A(j0, j) = A(j0, j) - sum * tau2 * v2[1];
+            A(j0, j) = A(j0, j) - sum * tau2 * v2[0];
         }
         // Reflections from the right
         for (idx_t j = 0; j < j3; ++j) {
-            T sum = A(j, j2) + v1[1] * A(j, j1) + v1[2] * A(j, j0);
+            T sum = A(j, j2) + v1[0] * A(j, j1) + v1[1] * A(j, j0);
             A(j, j2) = A(j, j2) - sum * tau1;
-            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
-            A(j, j0) = A(j, j0) - sum * tau1 * v1[2];
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[0];
+            A(j, j0) = A(j, j0) - sum * tau1 * v1[1];
 
-            sum = A(j, j1) + v2[1] * A(j, j0);
+            sum = A(j, j1) + v2[0] * A(j, j0);
             A(j, j1) = A(j, j1) - sum * tau2;
-            A(j, j0) = A(j, j0) - sum * tau2 * v2[1];
+            A(j, j0) = A(j, j0) - sum * tau2 * v2[0];
         }
 
         if (want_q) {
             for (idx_t j = 0; j < n; ++j) {
-                T sum = Q(j, j2) + v1[1] * Q(j, j1) + v1[2] * Q(j, j0);
+                T sum = Q(j, j2) + v1[0] * Q(j, j1) + v1[1] * Q(j, j0);
                 Q(j, j2) = Q(j, j2) - sum * tau1;
-                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
-                Q(j, j0) = Q(j, j0) - sum * tau1 * v1[2];
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[0];
+                Q(j, j0) = Q(j, j0) - sum * tau1 * v1[1];
 
-                sum = Q(j, j1) + v2[1] * Q(j, j0);
+                sum = Q(j, j1) + v2[0] * Q(j, j0);
                 Q(j, j1) = Q(j, j1) - sum * tau2;
-                Q(j, j0) = Q(j, j0) - sum * tau2 * v2[1];
+                Q(j, j0) = Q(j, j0) - sum * tau2 * v2[0];
             }
         }
 
@@ -293,43 +293,43 @@ int schur_swap(bool want_q,
 
         // Make V upper triangular
         T tau1, tau2;
-        auto v1 = slice(V, pair{0, 4}, 0);
-        auto v2 = slice(V, pair{1, 4}, 1);
-        larfg(v1, tau1);
+        auto v1 = slice(V, pair{1, 4}, 0);
+        auto v2 = slice(V, pair{2, 4}, 1);
+        larfg(columnwise_storage, V(0, 0), v1, tau1);
         const T sum =
-            V(0, 1) + v1[1] * V(1, 1) + v1[2] * V(2, 1) + v1[3] * V(3, 1);
+            V(0, 1) + v1[0] * V(1, 1) + v1[1] * V(2, 1) + v1[2] * V(3, 1);
         V(0, 1) = V(0, 1) - sum * tau1;
-        V(1, 1) = V(1, 1) - sum * tau1 * v1[1];
-        V(2, 1) = V(2, 1) - sum * tau1 * v1[2];
-        V(3, 1) = V(3, 1) - sum * tau1 * v1[3];
-        larfg(v2, tau2);
+        V(1, 1) = V(1, 1) - sum * tau1 * v1[0];
+        V(2, 1) = V(2, 1) - sum * tau1 * v1[1];
+        V(3, 1) = V(3, 1) - sum * tau1 * v1[2];
+        larfg(columnwise_storage, V(1, 1), v2, tau2);
 
         // Apply reflections to D to check error
         for (idx_t j = 0; j < 4; ++j) {
             T sum =
-                D(0, j) + v1[1] * D(1, j) + v1[2] * D(2, j) + v1[3] * D(3, j);
+                D(0, j) + v1[0] * D(1, j) + v1[1] * D(2, j) + v1[2] * D(3, j);
             D(0, j) = D(0, j) - sum * tau1;
-            D(1, j) = D(1, j) - sum * tau1 * v1[1];
-            D(2, j) = D(2, j) - sum * tau1 * v1[2];
-            D(3, j) = D(3, j) - sum * tau1 * v1[3];
+            D(1, j) = D(1, j) - sum * tau1 * v1[0];
+            D(2, j) = D(2, j) - sum * tau1 * v1[1];
+            D(3, j) = D(3, j) - sum * tau1 * v1[2];
 
-            sum = D(1, j) + v2[1] * D(2, j) + v2[2] * D(3, j);
+            sum = D(1, j) + v2[0] * D(2, j) + v2[1] * D(3, j);
             D(1, j) = D(1, j) - sum * tau2;
-            D(2, j) = D(2, j) - sum * tau2 * v2[1];
-            D(3, j) = D(3, j) - sum * tau2 * v2[2];
+            D(2, j) = D(2, j) - sum * tau2 * v2[0];
+            D(3, j) = D(3, j) - sum * tau2 * v2[1];
         }
         for (idx_t j = 0; j < 4; ++j) {
             T sum =
-                D(j, 0) + v1[1] * D(j, 1) + v1[2] * D(j, 2) + v1[3] * D(j, 3);
+                D(j, 0) + v1[0] * D(j, 1) + v1[1] * D(j, 2) + v1[2] * D(j, 3);
             D(j, 0) = D(j, 0) - sum * tau1;
-            D(j, 1) = D(j, 1) - sum * tau1 * v1[1];
-            D(j, 2) = D(j, 2) - sum * tau1 * v1[2];
-            D(j, 3) = D(j, 3) - sum * tau1 * v1[3];
+            D(j, 1) = D(j, 1) - sum * tau1 * v1[0];
+            D(j, 2) = D(j, 2) - sum * tau1 * v1[1];
+            D(j, 3) = D(j, 3) - sum * tau1 * v1[2];
 
-            sum = D(j, 1) + v2[1] * D(j, 2) + v2[2] * D(j, 3);
+            sum = D(j, 1) + v2[0] * D(j, 2) + v2[1] * D(j, 3);
             D(j, 1) = D(j, 1) - sum * tau2;
-            D(j, 2) = D(j, 2) - sum * tau2 * v2[1];
-            D(j, 3) = D(j, 3) - sum * tau2 * v2[2];
+            D(j, 2) = D(j, 2) - sum * tau2 * v2[0];
+            D(j, 3) = D(j, 3) - sum * tau2 * v2[1];
         }
 
         if (max(max(abs(D(2, 0)), abs(D(2, 1))),
@@ -338,46 +338,46 @@ int schur_swap(bool want_q,
 
         // Reflections from the left
         for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j0, j) + v1[1] * A(j1, j) + v1[2] * A(j2, j) +
-                    v1[3] * A(j3, j);
+            T sum = A(j0, j) + v1[0] * A(j1, j) + v1[1] * A(j2, j) +
+                    v1[2] * A(j3, j);
             A(j0, j) = A(j0, j) - sum * tau1;
-            A(j1, j) = A(j1, j) - sum * tau1 * v1[1];
-            A(j2, j) = A(j2, j) - sum * tau1 * v1[2];
-            A(j3, j) = A(j3, j) - sum * tau1 * v1[3];
+            A(j1, j) = A(j1, j) - sum * tau1 * v1[0];
+            A(j2, j) = A(j2, j) - sum * tau1 * v1[1];
+            A(j3, j) = A(j3, j) - sum * tau1 * v1[2];
 
-            sum = A(j1, j) + v2[1] * A(j2, j) + v2[2] * A(j3, j);
+            sum = A(j1, j) + v2[0] * A(j2, j) + v2[1] * A(j3, j);
             A(j1, j) = A(j1, j) - sum * tau2;
-            A(j2, j) = A(j2, j) - sum * tau2 * v2[1];
-            A(j3, j) = A(j3, j) - sum * tau2 * v2[2];
+            A(j2, j) = A(j2, j) - sum * tau2 * v2[0];
+            A(j3, j) = A(j3, j) - sum * tau2 * v2[1];
         }
         // Reflections from the right
         for (idx_t j = 0; j < j0 + 4; ++j) {
-            T sum = A(j, j0) + v1[1] * A(j, j1) + v1[2] * A(j, j2) +
-                    v1[3] * A(j, j3);
+            T sum = A(j, j0) + v1[0] * A(j, j1) + v1[1] * A(j, j2) +
+                    v1[2] * A(j, j3);
             A(j, j0) = A(j, j0) - sum * tau1;
-            A(j, j1) = A(j, j1) - sum * tau1 * v1[1];
-            A(j, j2) = A(j, j2) - sum * tau1 * v1[2];
-            A(j, j3) = A(j, j3) - sum * tau1 * v1[3];
+            A(j, j1) = A(j, j1) - sum * tau1 * v1[0];
+            A(j, j2) = A(j, j2) - sum * tau1 * v1[1];
+            A(j, j3) = A(j, j3) - sum * tau1 * v1[2];
 
-            sum = A(j, j1) + v2[1] * A(j, j2) + v2[2] * A(j, j3);
+            sum = A(j, j1) + v2[0] * A(j, j2) + v2[1] * A(j, j3);
             A(j, j1) = A(j, j1) - sum * tau2;
-            A(j, j2) = A(j, j2) - sum * tau2 * v2[1];
-            A(j, j3) = A(j, j3) - sum * tau2 * v2[2];
+            A(j, j2) = A(j, j2) - sum * tau2 * v2[0];
+            A(j, j3) = A(j, j3) - sum * tau2 * v2[1];
         }
 
         if (want_q) {
             for (idx_t j = 0; j < n; ++j) {
-                T sum = Q(j, j0) + v1[1] * Q(j, j1) + v1[2] * Q(j, j2) +
-                        v1[3] * Q(j, j3);
+                T sum = Q(j, j0) + v1[0] * Q(j, j1) + v1[1] * Q(j, j2) +
+                        v1[2] * Q(j, j3);
                 Q(j, j0) = Q(j, j0) - sum * tau1;
-                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[1];
-                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[2];
-                Q(j, j3) = Q(j, j3) - sum * tau1 * v1[3];
+                Q(j, j1) = Q(j, j1) - sum * tau1 * v1[0];
+                Q(j, j2) = Q(j, j2) - sum * tau1 * v1[1];
+                Q(j, j3) = Q(j, j3) - sum * tau1 * v1[2];
 
-                sum = Q(j, j1) + v2[1] * Q(j, j2) + v2[2] * Q(j, j3);
+                sum = Q(j, j1) + v2[0] * Q(j, j2) + v2[1] * Q(j, j3);
                 Q(j, j1) = Q(j, j1) - sum * tau2;
-                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[1];
-                Q(j, j3) = Q(j, j3) - sum * tau2 * v2[2];
+                Q(j, j2) = Q(j, j2) - sum * tau2 * v2[0];
+                Q(j, j3) = Q(j, j3) - sum * tau2 * v2[1];
             }
         }
 

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -125,16 +125,16 @@ int ung2r(size_type<matrix_t> k,
     }
 
     for (idx_t i = k - 1; i != idx_t(-1); --i) {
-        // Define x
-        auto x = slice(A, pair{i + 1, m}, i);
-
         // Apply $H_{i+1}$ to $A( i:m-1, i:n-1 )$ from the left
         if (i + 1 < n) {
+            // Define v and C
+            auto v = slice(A, pair{i, m}, i);
             auto C = slice(A, pair{i, m}, pair{i + 1, n});
-            larf(left_side, forward, columnwise_storage, x, tau[i], C,
+            larf(left_side, forward, columnwise_storage, v, tau[i], C,
                  larfOpts);
         }
         if (i + 1 < m) {
+            auto x = slice(A, pair{i + 1, m}, i);
             scal(-tau[i], x);
         }
         A(i, i) = one - tau[i];

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -51,7 +51,8 @@ inline constexpr void ung2r_worksize(size_type<matrix_t> k,
 
     if (n > 1) {
         auto C = cols(A, range<idx_t>{1, n});
-        larf_worksize(left_side, forward, col(A, 0), tau[0], C, workinfo, opts);
+        larf_worksize(left_side, forward, columnwise_storage, col(A, 0), tau[0],
+                      C, workinfo, opts);
     }
 }
 
@@ -124,17 +125,17 @@ int ung2r(size_type<matrix_t> k,
     }
 
     for (idx_t i = k - 1; i != idx_t(-1); --i) {
+        // Define x
+        auto x = slice(A, pair{i + 1, m}, i);
+
         // Apply $H_{i+1}$ to $A( i:m-1, i:n-1 )$ from the left
         if (i + 1 < n) {
-            // Define v and C
-            auto v = slice(A, pair{i, m}, i);
             auto C = slice(A, pair{i, m}, pair{i + 1, n});
-
-            larf(left_side, forward, v, tau[i], C, larfOpts);
+            larf(left_side, forward, columnwise_storage, x, tau[i], C,
+                 larfOpts);
         }
         if (i + 1 < m) {
-            auto v = slice(A, pair{i + 1, m}, i);
-            scal(-tau[i], v);
+            scal(-tau[i], x);
         }
         A(i, i) = one - tau[i];
 

--- a/include/tlapack/lapack/unghr.hpp
+++ b/include/tlapack/lapack/unghr.hpp
@@ -11,7 +11,6 @@
 #define TLAPACK_UNGHR_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larf.hpp"
 #include "tlapack/lapack/ung2r.hpp"
 
 namespace tlapack {

--- a/include/tlapack/lapack/ungl2.hpp
+++ b/include/tlapack/lapack/ungl2.hpp
@@ -124,7 +124,7 @@ int ungl2(matrix_t& Q,
     for (idx_t j = t - 1; j != idx_t(-1); --j) {
         // Apply H(j)**H to Q(j:k,j:n) from the right
         if (j + 1 < n) {
-            auto x = slice(Q, j, range(j + 1, n));
+            auto w = slice(Q, j, range(j, n));
 
             // Apply to the Q11 below the w
             if ((k > m && j + 1 == t) || (j + 1 < t)) {
@@ -133,11 +133,11 @@ int ungl2(matrix_t& Q,
                 // both conditions are satisfied
 
                 auto Q11 = slice(Q, range(j + 1, k), range(j, n));
-                larf(Side::Right, forward, rowwise_storage, x, conj(tauw[j]),
+                larf(Side::Right, forward, rowwise_storage, w, conj(tauw[j]),
                      Q11, larfOpts);
             }
 
-            scal(-conj(tauw[j]), x);
+            scal(-conj(tauw[j]), w);
         }
 
         Q(j, j) = real_t(1.) - conj(tauw[j]);

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -178,17 +178,17 @@ int unm2r(side_t side,
 
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
-        auto x = slice(A, pair{i + 1, nA}, i);
+        auto v = slice(A, pair{i, nA}, i);
 
         if (side == Side::Left) {
             auto Ci = rows(C, pair{i, m});
-            larf(left_side, forward, columnwise_storage, x,
+            larf(left_side, forward, columnwise_storage, v,
                  (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
                  larfOpts);
         }
         else {
             auto Ci = cols(C, pair{i, n});
-            larf(right_side, forward, columnwise_storage, x,
+            larf(right_side, forward, columnwise_storage, v,
                  (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
                  larfOpts);
         }

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -68,7 +68,8 @@ inline constexpr void unm2r_worksize(side_t side,
     const idx_t nA = (side == Side::Left) ? m : n;
 
     auto v = slice(A, pair{0, nA}, 0);
-    larf_worksize(side, forward, v, tau[0], C, workinfo, opts);
+    larf_worksize(side, forward, columnwise_storage, v, tau[0], C, workinfo,
+                  opts);
 }
 
 /** Applies unitary matrix Q to a matrix C.
@@ -177,17 +178,17 @@ int unm2r(side_t side,
 
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
-        auto v = slice(A, pair{i, nA}, i);
+        auto x = slice(A, pair{i + 1, nA}, i);
 
         if (side == Side::Left) {
             auto Ci = rows(C, pair{i, m});
-            larf(left_side, forward, v,
+            larf(left_side, forward, columnwise_storage, x,
                  (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
                  larfOpts);
         }
         else {
             auto Ci = cols(C, pair{i, n});
-            larf(right_side, forward, v,
+            larf(right_side, forward, columnwise_storage, x,
                  (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
                  larfOpts);
         }

--- a/include/tlapack/lapack/unmhr.hpp
+++ b/include/tlapack/lapack/unmhr.hpp
@@ -11,7 +11,6 @@
 #define TLAPACK_UNMHR_HH
 
 #include "tlapack/base/utils.hpp"
-#include "tlapack/lapack/larf.hpp"
 #include "tlapack/lapack/ung2r.hpp"
 #include "tlapack/lapack/unm2r.hpp"
 

--- a/include/tlapack/legacy_api/lapack/larf.hpp
+++ b/include/tlapack/legacy_api/lapack/larf.hpp
@@ -48,8 +48,9 @@ inline void larf(side_t side,
     // Matrix views
     auto C_ = colmajor_matrix<TC>(C, m, n, ldC);
 
-    tlapack_expr_with_vector(v_, TV, lenv, v, incv,
-                             return larf(side, v_, tau, C_));
+    tlapack_expr_with_vector(
+        v_, TV, lenv, v, incv,
+        return larf(side, forward, columnwise_storage, v_, tau, C_));
 }
 
 }  // namespace tlapack

--- a/include/tlapack/legacy_api/lapack/larfg.hpp
+++ b/include/tlapack/legacy_api/lapack/larfg.hpp
@@ -17,10 +17,10 @@
 namespace tlapack {
 
 template <typename T>
-void larfg(idx_t n, T& alpha, T* x, int_t incx, T& tau)
+void inline larfg(idx_t n, T& alpha, T* x, int_t incx, T& tau)
 {
     tlapack_expr_with_vector(x_, T, n - 1, x, incx,
-                             return larfg(alpha, x_, tau));
+                             return larfg(columnwise_storage, alpha, x_, tau));
 }
 
 /** Generates a elementary Householder reflection.

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -222,13 +222,13 @@ inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
                             SliceSpecRow&& rows,
                             SliceSpecCol&& cols) noexcept
 {
-    assert((rows.first >= 0 && (idx_t)rows.first < nrows(A)) ||
+    assert((rows.first >= 0 and (idx_t) rows.first < nrows(A)) ||
            rows.first == rows.second);
-    assert(rows.second >= 0 && (idx_t)rows.second <= nrows(A));
+    assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
     assert(rows.first <= rows.second);
-    assert((cols.first >= 0 && (idx_t)cols.first < ncols(A)) ||
+    assert((cols.first >= 0 and (idx_t) cols.first < ncols(A)) ||
            cols.first == cols.second);
-    assert(cols.second >= 0 && (idx_t)cols.second <= ncols(A));
+    assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
     return legacyMatrix<T, idx_t, layout>(
         rows.second - rows.first, cols.second - cols.first,
@@ -245,11 +245,11 @@ inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
                             size_type<legacyMatrix<T, idx_t, layout>> rowIdx,
                             SliceSpecCol&& cols) noexcept
 {
-    assert((cols.first >= 0 && (idx_t)cols.first < ncols(A)) ||
+    assert((cols.first >= 0 and (idx_t) cols.first < ncols(A)) ||
            cols.first == cols.second);
-    assert(cols.second >= 0 && (idx_t)cols.second <= ncols(A));
+    assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
-    assert(rowIdx >= 0 && rowIdx < nrows(A));
+    assert(rowIdx >= 0 and rowIdx < nrows(A));
     return legacyVector<T, idx_t, idx_t>(
         cols.second - cols.first,
         (layout == Layout::ColMajor) ? &A.ptr[rowIdx + cols.first * A.ldim]
@@ -264,11 +264,11 @@ inline constexpr auto slice(
     SliceSpecRow&& rows,
     size_type<legacyMatrix<T, idx_t, layout>> colIdx) noexcept
 {
-    assert((rows.first >= 0 && (idx_t)rows.first < nrows(A)) ||
+    assert((rows.first >= 0 and (idx_t) rows.first < nrows(A)) ||
            rows.first == rows.second);
-    assert(rows.second >= 0 && (idx_t)rows.second <= nrows(A));
+    assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
     assert(rows.first <= rows.second);
-    assert(colIdx >= 0 && colIdx < ncols(A));
+    assert(colIdx >= 0 and colIdx < ncols(A));
     return legacyVector<T, idx_t, idx_t>(
         rows.second - rows.first,
         (layout == Layout::ColMajor) ? &A.ptr[rows.first + colIdx * A.ldim]
@@ -281,9 +281,9 @@ template <typename T, class idx_t, Layout layout, class SliceSpec>
 inline constexpr auto rows(const legacyMatrix<T, idx_t, layout>& A,
                            SliceSpec&& rows) noexcept
 {
-    assert((rows.first >= 0 && (idx_t)rows.first < nrows(A)) ||
+    assert((rows.first >= 0 and (idx_t) rows.first < nrows(A)) ||
            rows.first == rows.second);
-    assert(rows.second >= 0 && (idx_t)rows.second <= nrows(A));
+    assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
     assert(rows.first <= rows.second);
     return legacyMatrix<T, idx_t, layout>(rows.second - rows.first, A.n,
                                           (layout == Layout::ColMajor)
@@ -297,7 +297,7 @@ template <typename T, class idx_t>
 inline constexpr auto row(const legacyMatrix<T, idx_t>& A,
                           size_type<legacyMatrix<T, idx_t>> rowIdx) noexcept
 {
-    assert(rowIdx >= 0 && rowIdx < nrows(A));
+    assert(rowIdx >= 0 and rowIdx < nrows(A));
     return legacyVector<T, idx_t, idx_t>(A.n, &A(rowIdx, 0), A.ldim);
 }
 
@@ -307,7 +307,7 @@ inline constexpr auto row(
     const legacyMatrix<T, idx_t, Layout::RowMajor>& A,
     size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> rowIdx) noexcept
 {
-    assert(rowIdx >= 0 && rowIdx < nrows(A));
+    assert(rowIdx >= 0 and rowIdx < nrows(A));
     return legacyVector<T, idx_t>(A.n, &A(rowIdx, 0));
 }
 
@@ -316,9 +316,9 @@ template <typename T, class idx_t, Layout layout, class SliceSpec>
 inline constexpr auto cols(const legacyMatrix<T, idx_t, layout>& A,
                            SliceSpec&& cols) noexcept
 {
-    assert((cols.first >= 0 && (idx_t)cols.first < ncols(A)) ||
+    assert((cols.first >= 0 and (idx_t) cols.first < ncols(A)) ||
            cols.first == cols.second);
-    assert(cols.second >= 0 && (idx_t)cols.second <= ncols(A));
+    assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
     return legacyMatrix<T, idx_t, layout>(A.m, cols.second - cols.first,
                                           (layout == Layout::ColMajor)
@@ -332,7 +332,7 @@ template <typename T, class idx_t>
 inline constexpr auto col(const legacyMatrix<T, idx_t>& A,
                           size_type<legacyMatrix<T, idx_t>> colIdx) noexcept
 {
-    assert(colIdx >= 0 && colIdx < ncols(A));
+    assert(colIdx >= 0 and colIdx < ncols(A));
     return legacyVector<T, idx_t>(A.m, &A(0, colIdx));
 }
 
@@ -342,7 +342,7 @@ inline constexpr auto col(
     const legacyMatrix<T, idx_t, Layout::RowMajor>& A,
     size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> colIdx) noexcept
 {
-    assert(colIdx >= 0 && colIdx < ncols(A));
+    assert(colIdx >= 0 and colIdx < ncols(A));
     return legacyVector<T, idx_t, idx_t>(A.m, &A(0, colIdx), A.ldim);
 }
 
@@ -369,9 +369,9 @@ template <typename T,
 inline constexpr auto slice(const legacyVector<T, idx_t, int_t, direction>& v,
                             SliceSpec&& rows) noexcept
 {
-    assert((rows.first >= 0 && (idx_t)rows.first < size(v)) ||
+    assert((rows.first >= 0 and (idx_t) rows.first < size(v)) ||
            rows.first == rows.second);
-    assert(rows.second >= 0 && (idx_t)rows.second <= size(v));
+    assert(rows.second >= 0 and (idx_t) rows.second <= size(v));
     assert(rows.first <= rows.second);
     return legacyVector<T, idx_t, int_t, direction>(
         rows.second - rows.first, &v.ptr[rows.first * v.inc], v.inc);

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -298,7 +298,7 @@ inline constexpr auto row(const legacyMatrix<T, idx_t>& A,
                           size_type<legacyMatrix<T, idx_t>> rowIdx) noexcept
 {
     assert(rowIdx >= 0 && rowIdx < nrows(A));
-    return legacyVector<T, idx_t, idx_t>(A.n, &A.ptr[rowIdx], A.ldim);
+    return legacyVector<T, idx_t, idx_t>(A.n, &A(rowIdx, 0), A.ldim);
 }
 
 // Get a row of a row-major legacyMatrix
@@ -308,7 +308,7 @@ inline constexpr auto row(
     size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> rowIdx) noexcept
 {
     assert(rowIdx >= 0 && rowIdx < nrows(A));
-    return legacyVector<T, idx_t>(A.n, &A.ptr[rowIdx * A.ldim]);
+    return legacyVector<T, idx_t>(A.n, &A(rowIdx, 0));
 }
 
 // Get columns of legacyMatrix
@@ -333,7 +333,7 @@ inline constexpr auto col(const legacyMatrix<T, idx_t>& A,
                           size_type<legacyMatrix<T, idx_t>> colIdx) noexcept
 {
     assert(colIdx >= 0 && colIdx < ncols(A));
-    return legacyVector<T, idx_t>(A.m, &A.ptr[colIdx * A.ldim]);
+    return legacyVector<T, idx_t>(A.m, &A(0, colIdx));
 }
 
 // Get a column of a row-major legacyMatrix
@@ -343,7 +343,7 @@ inline constexpr auto col(
     size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> colIdx) noexcept
 {
     assert(colIdx >= 0 && colIdx < ncols(A));
-    return legacyVector<T, idx_t, idx_t>(A.m, &A.ptr[colIdx], A.ldim);
+    return legacyVector<T, idx_t, idx_t>(A.m, &A(0, colIdx), A.ldim);
 }
 
 // Diagonal of a legacyMatrix
@@ -373,8 +373,8 @@ inline constexpr auto slice(const legacyVector<T, idx_t, int_t, direction>& v,
            rows.first == rows.second);
     assert(rows.second >= 0 && (idx_t)rows.second <= size(v));
     assert(rows.first <= rows.second);
-    return legacyVector<T, idx_t, int_t, direction>(rows.second - rows.first,
-                                                    &v[rows.first], v.inc);
+    return legacyVector<T, idx_t, int_t, direction>(
+        rows.second - rows.first, &v.ptr[rows.first * v.inc], v.inc);
 }
 
 // -----------------------------------------------------------------------------

--- a/include/tlapack/plugins/mdspan.hpp
+++ b/include/tlapack/plugins/mdspan.hpp
@@ -376,7 +376,7 @@ inline constexpr auto diag(const std::experimental::mdspan<ET, Exts, LP, AP>& A,
     using mapping = typename layout_stride::template mapping<extents_t>;
 
     // mdspan components
-    auto ptr = A.accessor().offset(&A(0, 0), (diagIdx >= 0)
+    auto ptr = A.accessor().offset(A.data(), (diagIdx >= 0)
                                                  ? A.mapping()(0, diagIdx)
                                                  : A.mapping()(-diagIdx, 0));
     auto map = mapping(
@@ -553,7 +553,7 @@ inline constexpr auto legacy_matrix(
     assert(A.stride(0) == 1 || A.extent(0) <= 1 || A.stride(1) == 1 ||
            A.extent(1) <= 1);
 
-    return legacyMatrix<ET, idx_t, L>(A.extent(0), A.extent(1), &A(0, 0));
+    return legacyMatrix<ET, idx_t, L>(A.extent(0), A.extent(1), A.data());
 }
 
 template <
@@ -576,10 +576,10 @@ inline constexpr auto legacy_matrix(
            A.extent(0) <= 1);
 
     if (A.stride(0) == 1 || A.extent(1) <= 1)
-        return legacyMatrix<ET, idx_t, L>(A.extent(0), A.extent(1), &A(0, 0),
+        return legacyMatrix<ET, idx_t, L>(A.extent(0), A.extent(1), A.data(),
                                           A.stride(1));
     else
-        return legacyMatrix<ET, idx_t, L>(A.extent(1), A.extent(0), &A(0, 0),
+        return legacyMatrix<ET, idx_t, L>(A.extent(1), A.extent(0), A.data(),
                                           A.stride(0));
 }
 

--- a/include/tlapack/plugins/stdvector.hpp
+++ b/include/tlapack/plugins/stdvector.hpp
@@ -41,12 +41,16 @@ template <class T, class Allocator, class SliceSpec>
 inline constexpr auto slice(const std::vector<T, Allocator>& v,
                             SliceSpec&& rows)
 {
+    assert((rows.first >= 0 && (std::size_t)rows.first < size(v)) ||
+           rows.first == rows.second);
+    assert(rows.second >= 0 && (std::size_t)rows.second <= size(v));
+    assert(rows.first <= rows.second);
 #ifndef TLAPACK_USE_MDSPAN
     return legacyVector<T, std::size_t>(rows.second - rows.first,
-                                        (T*)&v[rows.first]);
+                                        (T*)v.data() + rows.first);
 #else
     return std::experimental::mdspan<T, std::experimental::dextents<1> >(
-        (T*)&v[rows.first], (std::size_t)(rows.second - rows.first));
+        (T*)v.data() + rows.first, (std::size_t)(rows.second - rows.first));
 #endif
 }
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable( test_getri test_getri.cpp )
 add_executable( test_ul_mult test_ul_mult.cpp )
 add_executable( test_lauum test_lauum.cpp )
 add_executable( test_potrf test_potrf.cpp )
+add_executable( test_larf test_larf.cpp )
 
 if( TLAPACK_TEST_EIGEN )
   add_executable( test_eigenplugin test_eigenplugin.cpp )

--- a/test/src/test_larf.cpp
+++ b/test/src/test_larf.cpp
@@ -1,0 +1,252 @@
+/// @file test_larf.cpp Test the operations with Householder reflectors
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+// Test utilities and definitions (must come before <T>LAPACK headers)
+#include "testutils.hpp"
+
+// Auxiliary routines
+#include <tlapack/blas/dot.hpp>
+#include <tlapack/blas/nrm2.hpp>
+#include <tlapack/lapack/lange.hpp>
+
+// Other routines
+#include <tlapack/lapack/larf.hpp>
+#include <tlapack/lapack/larfg.hpp>
+
+using namespace tlapack;
+
+TEMPLATE_TEST_CASE("Generation of Householder reflectors",
+                   "[larfg]",
+                   TLAPACK_TYPES_TO_TEST)
+{
+    srand(1);
+    using vector_t = vector_type<TestType>;
+    using T = type_t<vector_t>;
+    using idx_t = size_type<vector_t>;
+    using real_t = real_type<T>;
+    using pair = pair<idx_t, idx_t>;
+
+    // Functor
+    Create<vector_t> new_vector;
+
+    // Test parameters
+    const idx_t n = GENERATE(10, 19, 30);
+    const Direction direction =
+        GENERATE(Direction::Forward, Direction::Backward);
+    const StoreV storeMode = GENERATE(StoreV::Columnwise, StoreV::Rowwise);
+    const std::string initialX = GENERATE(as<std::string>{}, "Zeros", "Random");
+    const std::string typeAlpha =
+        GENERATE(as<std::string>{}, "Real", "Complex");
+    const std::string whichLARFG =
+        GENERATE(as<std::string>{}, "direction,v", "alpha,x");
+
+    // Skip tests with invalid parameters
+    if (typeAlpha == "Complex" && !is_complex<T>::value) return;
+
+    // Vectors
+    std::vector<T> v_;
+    auto v = new_vector(v_, n);
+    std::vector<T> w_;
+    auto w = new_vector(w_, n);
+
+    // Constants
+    const real_t tol = real_t(n) * ulp<real_t>();
+    const real_t zero(0);
+    const real_t one(1);
+    const real_t two(2);
+    const T alpha =
+        (typeAlpha == "Real") ? rand_helper<real_t>() : rand_helper<T>();
+    const idx_t alphaIdx = (direction == Direction::Forward) ? 0 : n - 1;
+
+    // Print test parameters
+    INFO("Which larfg: " << whichLARFG);
+    INFO("Vector size: " << n);
+    INFO("Direction: " << direction);
+    INFO("Store mode: " << storeMode);
+    INFO("Initial x: " << initialX);
+    INFO("Type of alpha: " << typeAlpha);
+    INFO("alpha = " << alpha);
+
+    // Initialize v
+    if (initialX == "Zeros") {
+        for (idx_t i = 0; i < n; ++i) {
+            v[i] = zero;
+        }
+    }
+    else {  // initialX == 'R'
+        for (idx_t i = 0; i < n; ++i) {
+            v[i] = rand_helper<T>();
+        }
+    }
+    v[alphaIdx] = alpha;
+
+    // Copy v to w
+    for (idx_t i = 0; i < n; ++i) {
+        w[i] = v[i];
+    }
+
+    // Place to store the scalar factor of the Householder reflector
+    T tau;
+
+    if (whichLARFG == "alpha,x") {
+        auto x = slice(
+            v, (direction == Direction::Forward) ? pair(1, n) : pair(0, n - 1));
+        larfg(storeMode, v[alphaIdx], x, tau);
+    }
+    else  // whichLARFG == "direction,v"
+    {
+        larfg(direction, storeMode, v, tau);
+    }
+
+    // Post-process v and extract beta
+    const T beta = v[alphaIdx];
+    v[alphaIdx] = one;
+
+    // Check that the imaginary part of beta is zero
+    CHECK((imag(beta) == zero));
+
+    // If the elements of x are all zero and alpha is real, then tau = 0
+    if (typeAlpha == "Real" && initialX == "Zeros") {
+        CHECK(tau == zero);
+    }
+    // Otherwise  1 <= real(tau) <= 2 and abs(tau-1) <= 1.
+    else {
+        CHECK(one <= real(tau));
+        CHECK(real(tau) <= two);
+        CHECK(tlapack::abs(tau - one) <= one);
+    }
+
+    const T vHw = dot(v, w);
+    if (storeMode == StoreV::Columnwise) {
+        // Check that (id - conj(tau)*v*v^H)*[alpha x]^t = [beta 0]^t
+        for (idx_t i = 0; i < n; ++i)
+            w[i] -= v[i] * conj(tau) * vHw;
+    }
+    else {
+        // Check that [alpha x]*(id - tau*v*v^H) = [beta 0]
+        for (idx_t i = 0; i < n; ++i)
+            w[i] -= vHw * tau * v[i];
+    }
+
+    // Check that larfg returns the expected reflection
+    CHECK(tlapack::abs(real(w[alphaIdx]) - beta) / tol < tlapack::abs(beta));
+    CHECK(tlapack::abs(imag(w[alphaIdx])) / tol < one);
+    w[alphaIdx] = zero;
+    CHECK(tlapack::nrm2(w) / tol < one);
+}
+
+TEMPLATE_TEST_CASE("Application of Householder reflectors",
+                   "[larf]",
+                   TLAPACK_TYPES_TO_TEST)
+{
+    srand(1);
+    using matrix_t = TestType;
+    using vector_t = vector_type<TestType>;
+    using T = type_t<vector_t>;
+    using idx_t = size_type<vector_t>;
+    using real_t = real_type<T>;
+
+    // Functors
+    Create<vector_t> new_vector;
+    Create<matrix_t> new_matrix;
+
+    // Test parameters
+    const idx_t m = GENERATE(1, 11, 30);
+    const idx_t n = GENERATE(1, 11, 30);
+    const Side side = GENERATE(Side::Left, Side::Right);
+    const Direction direction =
+        GENERATE(Direction::Forward, Direction::Backward);
+    const StoreV storeMode = GENERATE(StoreV::Columnwise, StoreV::Rowwise);
+
+    // Print test parameters
+    INFO("Matrix size: " << m << "-by-" << n);
+    INFO("Side: " << side);
+    INFO("Direction: " << direction);
+    INFO("Store mode: " << storeMode);
+
+    // Constants
+    const idx_t k = (side == Side::Left) ? m : n;
+    const real_t tol = real_t(4 * std::max(m, n)) * ulp<real_t>();
+    const real_t one(1);
+    const idx_t oneIdx = (direction == Direction::Forward) ? 0 : k - 1;
+
+    // Vectors
+    std::vector<T> v_;
+    auto v = new_vector(v_, k);
+    std::vector<T> vH_;
+    auto vH = new_vector(vH_, k);
+    std::vector<T> w_;
+    auto w = new_vector(w_, (side == Side::Left) ? n : m);
+
+    // Build v and tau
+    for (idx_t i = 0; i < k; ++i)
+        v[i] = rand_helper<T>();
+    T tau;
+    larfg(direction, storeMode, v, tau);
+    v[oneIdx] =
+        real_t(0xDEADBEEF);  // Put trash in the element that should be one
+
+    // Initialize vH
+    for (idx_t i = 0; i < k; ++i)
+        vH[i] = conj(v[i]);
+
+    // Initialize matrix C
+    std::vector<T> C_;
+    auto C = new_matrix(C_, m, n);
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = 0; i < m; ++i)
+            C(i, j) = rand_helper<T>();
+
+    // Copy C to C0
+    std::vector<T> C0_;
+    auto C0 = new_matrix(C0_, m, n);
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = 0; i < m; ++i)
+            C0(i, j) = C(i, j);
+
+    // Apply the Householder reflector
+    larf(side, direction, storeMode, v, tau, C);
+
+    // Apply the inverse Householder reflector
+    if (side == Side::Left) {
+        if (storeMode == StoreV::Columnwise) {
+            v[oneIdx] = one;
+            gemv(conjTranspose, one, C, v, w);
+            ger(-conj(tau), v, w, C);
+        }
+        else {
+            vH[oneIdx] = one;
+            gemv(conjTranspose, one, C, vH, w);
+            ger(-conj(tau), vH, w, C);
+        }
+    }
+    else {
+        if (storeMode == StoreV::Columnwise) {
+            v[oneIdx] = one;
+            gemv(noTranspose, one, C, v, w);
+            ger(-conj(tau), w, v, C);
+        }
+        else {
+            vH[oneIdx] = one;
+            gemv(noTranspose, one, C, vH, w);
+            ger(-conj(tau), w, vH, C);
+        }
+    }
+
+    // Subtract C0 from C
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = 0; i < m; ++i)
+            C(i, j) -= C0(i, j);
+
+    // Check that larf returns the expected matrix
+    CHECK(lange(frob_norm, C) / tol < lange(frob_norm, C0));
+}


### PR DESCRIPTION
This PR adds more functionality to `larfg` and `larf` as follows:

- `larfg` now is able to store the Householder vectors in two ways: rowwise and columnwise. The latter is the functionality that is in LAPACK, used in QR, LQ and a large number of other routines. The rowwise mode is useful for RQ, QL, bidiagonalization, tridiagonalization, etc. In the rowwise mode, the conjugate of `v` is stored instead of `v` itself. See details in the documentation of `larfg`.

- `larf` has two new parameters: storeMode and direction. The first compatibilizes with the one from `larfg`. The second allows for the use of Householder vectors v = [1 x] and v = [x 1] more easily. That makes the algorithms for RQ and QL to be very similar to QR and LQ.

- `larf` has a new interface that receives `x, C0, C1` instead of `direction, v, C`. The new interface is the one that holds the logic behind the application of the Householder reflection, and the latter is basically a wrapper. The new interface generalizes the types of data one can apply a reflection. See the documentation for the details.

Additionally, we make the following changes:

- Adds a tester for LARF and LARFG.

- This PR closes #84, which is related to LARFB.

- When slicing a vector v or matrix A, allow the use of ranges (size(v),size(v)), (nrows(A),nrows(A)) and (ncols(A),ncols(A)). Notice that we still do not allow ranges like (size(v),size(v)+1), (nrows(A),nrows(A)+1). This change avoids ugly code like `(i < m) ? range(i,m) : range(0,0)` that was used just for obtaining a valid empty vector or matrix. It is worthy noticing that the matrix and vector types we support accept the new allowed ranges. 

- Adds the target `check-format-of-hpp-cpp-files` to the CMake build system. This checks if all files are correctly formatted accordingly to the rules in `.clang-format`. Mind that the check depends on the ClangFormat version installed in the system.  