### PR TITLE
Fix BLA_VENDOR on a CMakelists.txt

### DIFF
--- a/examples/performance_eigen/CMakeLists.txt
+++ b/examples/performance_eigen/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 # Load MKL
 if( USE_MKL )
-  set( BLA_VENDOR Intel10_64lp )
+  set( $ENV{BLA_VENDOR} Intel10_64lp )
   find_package( BLAS REQUIRED )
   if( BLAS_FOUND )
     target_compile_definitions( performance_eigen PRIVATE "EIGEN_USE_MKL_ALL" )


### PR DESCRIPTION
`set( $ENV{BLA_VENDOR} Intel10_64lp )` should be used instead of `set( BLA_VENDOR Intel10_64lp )` since `BLA_VENDOR` is an environment variable.