### PR TITLE
Removes Op:Conj from gemv, trmv, trsm and larf

### DIFF
--- a/include/tlapack/blas/gemv.hpp
+++ b/include/tlapack/blas/gemv.hpp
@@ -31,8 +31,7 @@ namespace tlapack {
  *     The operation to be performed:
  *     - Op::NoTrans:   $y = \alpha A   x + \beta y$,
  *     - Op::Trans:     $y = \alpha A^T x + \beta y$,
- *     - Op::ConjTrans: $y = \alpha A^H x + \beta y$,
- *     - Op::Conj:  $y = \alpha conj(A) x + \beta y$.
+ *     - Op::ConjTrans: $y = \alpha A^H x + \beta y$.
  *
  * @param[in] alpha Scalar.
  * @param[in] A $op(A)$ is an m-by-n matrix.
@@ -66,14 +65,12 @@ void gemv(Op trans,
     using idx_t = size_type<matrixA_t>;
 
     // constants
-    const idx_t m =
-        (trans == Op::NoTrans || trans == Op::Conj) ? nrows(A) : ncols(A);
-    const idx_t n =
-        (trans == Op::NoTrans || trans == Op::Conj) ? ncols(A) : nrows(A);
+    const idx_t m = (trans == Op::NoTrans) ? nrows(A) : ncols(A);
+    const idx_t n = (trans == Op::NoTrans) ? ncols(A) : nrows(A);
 
     // check arguments
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans && trans != Op::Conj);
+                        trans != Op::ConjTrans);
     tlapack_check_false((idx_t)size(x) != n);
     tlapack_check_false((idx_t)size(y) != m);
 
@@ -93,15 +90,15 @@ void gemv(Op trans,
             }
         }
     }
-    else if (trans == Op::Conj) {
-        // form y += alpha * conj( A ) * x
-        for (idx_t j = 0; j < n; ++j) {
-            const scalar_type<alpha_t, TX> tmp = alpha * x[j];
-            for (idx_t i = 0; i < m; ++i) {
-                y[i] += tmp * conj(A(i, j));
-            }
-        }
-    }
+    // else if (trans == Op::Conj) {
+    //     // form y += alpha * conj( A ) * x
+    //     for (idx_t j = 0; j < n; ++j) {
+    //         const scalar_type<alpha_t, TX> tmp = alpha * x[j];
+    //         for (idx_t i = 0; i < m; ++i) {
+    //             y[i] += tmp * conj(A(i, j));
+    //         }
+    //     }
+    // }
     else if (trans == Op::Trans) {
         // form y += alpha * A^T * x
         for (idx_t i = 0; i < m; ++i) {
@@ -140,8 +137,7 @@ void gemv(Op trans,
  *     The operation to be performed:
  *     - Op::NoTrans:   $y = \alpha A   x$,
  *     - Op::Trans:     $y = \alpha A^T x$,
- *     - Op::ConjTrans: $y = \alpha A^H x$,
- *     - Op::Conj:  $y = \alpha conj(A) x$.
+ *     - Op::ConjTrans: $y = \alpha A^H x$.
  *
  * @param[in] alpha Scalar.
  * @param[in] A $op(A)$ is an m-by-n matrix.

--- a/include/tlapack/blas/trmv.hpp
+++ b/include/tlapack/blas/trmv.hpp
@@ -70,7 +70,7 @@ void trmv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
     // check arguments
     tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans && trans != Op::Conj);
+                        trans != Op::ConjTrans);
     tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
     tlapack_check_false(nrows(A) != ncols(A));
     tlapack_check_false((idx_t)size(x) != n);
@@ -97,28 +97,28 @@ void trmv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
             }
         }
     }
-    else if (trans == Op::Conj) {
-        // Form x := A*x
-        if (uplo == Uplo::Upper) {
-            // upper
-            for (idx_t j = 0; j < n; ++j) {
-                // note: NOT skipping if x[j] is zero, for consistent NAN
-                // handling
-                for (idx_t i = 0; i < j; ++i)
-                    x[i] += x[j] * conj(A(i, j));
-                if (nonunit) x[j] *= conj(A(j, j));
-            }
-        }
-        else {
-            // lower
-            for (idx_t j = n - 1; j != idx_t(-1); --j) {
-                // note: NOT skipping if x[j] is zero ...
-                for (idx_t i = n - 1; i >= j + 1; --i)
-                    x[i] += x[j] * conj(A(i, j));
-                if (nonunit) x[j] *= conj(A(j, j));
-            }
-        }
-    }
+    // else if (trans == Op::Conj) {
+    //     // Form x := A*x
+    //     if (uplo == Uplo::Upper) {
+    //         // upper
+    //         for (idx_t j = 0; j < n; ++j) {
+    //             // note: NOT skipping if x[j] is zero, for consistent NAN
+    //             // handling
+    //             for (idx_t i = 0; i < j; ++i)
+    //                 x[i] += x[j] * conj(A(i, j));
+    //             if (nonunit) x[j] *= conj(A(j, j));
+    //         }
+    //     }
+    //     else {
+    //         // lower
+    //         for (idx_t j = n - 1; j != idx_t(-1); --j) {
+    //             // note: NOT skipping if x[j] is zero ...
+    //             for (idx_t i = n - 1; i >= j + 1; --i)
+    //                 x[i] += x[j] * conj(A(i, j));
+    //             if (nonunit) x[j] *= conj(A(j, j));
+    //         }
+    //     }
+    // }
     else if (trans == Op::Trans) {
         // Form  x := A^T * x
 

--- a/include/tlapack/blas/trsv.hpp
+++ b/include/tlapack/blas/trsv.hpp
@@ -74,7 +74,7 @@ void trsv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
     // check arguments
     tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans && trans != Op::Conj);
+                        trans != Op::ConjTrans);
     tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
     tlapack_check_false(nrows(A) != ncols(A));
     tlapack_check_false(size(x) != n);
@@ -107,34 +107,34 @@ void trsv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
             }
         }
     }
-    else if (trans == Op::Conj) {
-        // Form x := A^{-1} * x
-        if (uplo == Uplo::Upper) {
-            // upper
-            for (idx_t j = n - 1; j != idx_t(-1); --j) {
-                // note: NOT skipping if x[j] is zero, for consistent NAN
-                // handling
-                if (nonunit) {
-                    x[j] /= conj(A(j, j));
-                }
-                for (idx_t i = j - 1; i != idx_t(-1); --i) {
-                    x[i] -= x[j] * conj(A(i, j));
-                }
-            }
-        }
-        else {
-            // lower
-            for (idx_t j = 0; j < n; ++j) {
-                // note: NOT skipping if x[j] is zero ...
-                if (nonunit) {
-                    x[j] /= conj(A(j, j));
-                }
-                for (idx_t i = j + 1; i < n; ++i) {
-                    x[i] -= x[j] * conj(A(i, j));
-                }
-            }
-        }
-    }
+    // else if (trans == Op::Conj) {
+    //     // Form x := A^{-1} * x
+    //     if (uplo == Uplo::Upper) {
+    //         // upper
+    //         for (idx_t j = n - 1; j != idx_t(-1); --j) {
+    //             // note: NOT skipping if x[j] is zero, for consistent NAN
+    //             // handling
+    //             if (nonunit) {
+    //                 x[j] /= conj(A(j, j));
+    //             }
+    //             for (idx_t i = j - 1; i != idx_t(-1); --i) {
+    //                 x[i] -= x[j] * conj(A(i, j));
+    //             }
+    //         }
+    //     }
+    //     else {
+    //         // lower
+    //         for (idx_t j = 0; j < n; ++j) {
+    //             // note: NOT skipping if x[j] is zero ...
+    //             if (nonunit) {
+    //                 x[j] /= conj(A(j, j));
+    //             }
+    //             for (idx_t i = j + 1; i < n; ++i) {
+    //                 x[i] -= x[j] * conj(A(i, j));
+    //             }
+    //         }
+    //     }
+    // }
     else if (trans == Op::Trans) {
         // Form  x := A^{-T} * x
 

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -169,6 +169,7 @@ void larf(side_t side,
     tlapack_check(storeMode == StoreV::Columnwise ||
                   storeMode == StoreV::Rowwise);
     tlapack_check((idx_t)size(x) == (side == Side::Left) ? m : n);
+    tlapack_check(k == ((side == Side::Left) ? n : m));
 
     // Quick return if possible
     if (m == 0 || n == 0) {
@@ -232,9 +233,11 @@ void larf(side_t side,
         }
         else {
             // w := C0 + C1*conj(x)
-            gemv(Op::Conj, one, C1, x, w);
             for (idx_t i = 0; i < k; ++i)
-                w[i] = C0[i] + conj(w[i]);
+                w[i] = C0[i];
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    w[i] += C1(i, j) * conj(x[j]);
 
             // C1 := C1 - tau*w*x^t
             geru(-tau, w, x, C1);

--- a/include/tlapack/legacy_api/blas/trsv.hpp
+++ b/include/tlapack/legacy_api/blas/trsv.hpp
@@ -86,6 +86,7 @@ void trsv(Layout layout,
           int_t incx)
 {
     using internal::colmajor_matrix;
+    using std::abs;
 
     // check arguments
     tlapack_check_false(layout != Layout::ColMajor &&
@@ -102,19 +103,35 @@ void trsv(Layout layout,
     if (n == 0) return;
 
     // for row major, swap lower <=> upper and
-    // A => A^T; A^T => A; A^H => A & conj
+    // A => A^T; A^T => A; A^H => A & doConj
+    bool doConj = false;
     if (layout == Layout::RowMajor) {
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
-        trans = (trans == Op::NoTrans)
-                    ? Op::Trans
-                    : ((trans == Op::Trans) ? Op::NoTrans : Op::Conj);
+        if (trans == Op::NoTrans)
+            trans = Op::Trans;
+        else {
+            if (trans == Op::ConjTrans) doConj = true;
+            trans = Op::NoTrans;
+        }
+    }
+
+    // Conjugate if A is row-major and initially trans is Op::ConjTrans
+    if (doConj) {
+        for (idx_t i = 0; i < n; ++i)
+            x[i * abs(incx)] = conj(x[i * abs(incx)]);
     }
 
     // Matrix views
     const auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
 
     tlapack_expr_with_vector(x_, TX, n, x, incx,
-                             return trsv(uplo, trans, diag, A_, x_));
+                             trsv(uplo, trans, diag, A_, x_));
+
+    // Conjugate if A is row-major and initially trans is Op::ConjTrans
+    if (doConj) {
+        for (idx_t i = 0; i < n; ++i)
+            x[i * abs(incx)] = conj(x[i * abs(incx)]);
+    }
 }
 
 }  // namespace tlapack


### PR DESCRIPTION
This PR removes `Op::Conj` from gemv, trmv and trsm.

`Op::Conj` was used to indicate "transpose without conjugate". It may look like a good idea to have those functionalities in BLAS. However, this creates issues when linking with optimized BLAS, since the new flags aren't part of the standard.

More specifically, the issue is that the call `tlapack::gemv(Op::Conj, ... )` sometimes ends up in the wrapper for the optimized BLAS gemv which does not accept `Op::Conj`. We could as well make the wrapper call the C++ implementation of gemv if `trans == Op::Conj`, I think this could be too smart for a wrapper. The wrapper was designed to be just a call for the optimized implementation.