### PR TITLE
Extends real_type<> for matrices

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,7 +34,7 @@ permissions:
 
 env:
   CFLAGS: "-Wall -pedantic -Wno-unused-variable -Wno-unused-function"
-  CXXFLAGS: "-Wall -pedantic -Wno-unused-variable -Wno-unused-function"
+  CXXFLAGS: "-Wall -pedantic -Wno-unused-variable -Wno-unused-function -std=c++17"
   FFLAGS: "-fimplicit-none -fcheck=all"
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -322,107 +322,7 @@ struct is_arithmetic<
 // complex_type< float >                            is complex<float>
 // complex_type< float, double >                    is complex<double>
 // complex_type< float, double, complex<float> >    is complex<double>
-
-// for zero types
-template <typename... Types>
-struct real_type_traits;
-
-/// define real_type<> type alias
-template <typename... Types>
-using real_type = typename real_type_traits<Types..., int>::type;
-
-// for one arithmetic type
-template <typename T>
-struct real_type_traits<T, std::enable_if_t<is_arithmetic_v<T>, int>> {
-    using type = typename std::decay<T>::type;
-};
-
-// for one complex type, strip complex
-template <typename T>
-struct real_type_traits<std::complex<T>, int> {
-    using type = real_type<T>;
-};
-
-// for one StrongZero type, remain StrongZero
-template <>
-struct real_type_traits<internal::StrongZero, int> {
-    using type = internal::StrongZero;
-};
-
-// pointers and references don't have a real type
-template <typename T>
-struct real_type_traits<
-    T,
-    std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
-    using type = void;
-};
-
-// for two or more types
-template <typename T1, typename T2, typename... Types>
-struct real_type_traits<T1, T2, Types...> {
-    using type =
-        std::common_type_t<typename real_type_traits<T1, int>::type,
-                           typename real_type_traits<T2, Types...>::type>;
-};
-
-// for zero types
-template <typename... Types>
-struct complex_type_traits;
-
-/// define complex_type<> type alias
-template <typename... Types>
-using complex_type = typename complex_type_traits<Types..., int>::type;
-
-// for one type
-template <typename T>
-struct complex_type_traits<T, std::enable_if_t<is_arithmetic_v<T>, int>> {
-    using type = std::complex<real_type<T>>;
-};
-
-// for one complex type, strip complex
-template <typename T>
-struct complex_type_traits<std::complex<T>, int> {
-    using type = std::complex<real_type<T>>;
-};
-
-// for one complex type, strip complex
-template <>
-struct complex_type_traits<internal::StrongZero, int> {
-    using type = internal::StrongZero;
-};
-
-// pointers and references don't have a complex type
-template <typename T>
-struct complex_type_traits<
-    T,
-    std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
-    using type = void;
-};
-
-// for two or more types
-template <typename T1, typename T2, typename... Types>
-struct complex_type_traits<T1, T2, Types...> {
-    using type =
-        complex_type<typename real_type_traits<T1, T2, Types...>::type>;
-};
-
-/// True if T is complex_type<T>
-template <typename T>
-struct is_complex {
-    static constexpr bool value =
-        std::is_same_v<complex_type<T>, typename std::decay<T>::type>;
-};
-
-/// True if T is real_type<T>
-template <typename T>
-struct is_real {
-    static constexpr bool value =
-        std::is_same_v<real_type<T>, typename std::decay<T>::type>;
-};
-
-// -----------------------------------------------------------------------------
-// Based on C++14 std::common_type implementation from
-// http://www.cplusplus.com/reference/type_traits/std::common_type/
+//
 // Adds promotion of complex types based on the common type of the associated
 // real types. This fixes various cases:
 //
@@ -432,46 +332,143 @@ struct is_real {
 // std::std::common_type_t< int, complex<long> > is not defined (compile error)
 //        scalar_type< int, complex<long> > is complex<long> (right)
 
-// for zero types
+namespace internal {
+    template <typename... Types>
+    struct real_type_traits;
+
+    template <typename... Types>
+    struct complex_type_traits;
+
+    template <typename... Types>
+    struct scalar_type_traits;
+}  // namespace internal
+
+/// define real_type<> type alias
 template <typename... Types>
-struct scalar_type_traits;
+using real_type = typename internal::real_type_traits<Types..., int>::type;
+
+/// define complex_type<> type alias
+template <typename... Types>
+using complex_type =
+    typename internal::complex_type_traits<Types..., int>::type;
 
 /// define scalar_type<> type alias
 template <typename... Types>
-using scalar_type = typename scalar_type_traits<Types..., int>::type;
+using scalar_type = typename internal::scalar_type_traits<Types..., int>::type;
 
-// for one type
+/// True if T is real_type<T>
 template <typename T>
-struct scalar_type_traits<T, int> : scalar_type_traits<T, T, int> {};
-
-// for two types, one is complex
-template <typename T1, typename T2>
-struct scalar_type_traits<
-    T1,
-    T2,
-    std::enable_if_t<is_complex<T1>::value || is_complex<T2>::value, int>> {
-    using type = complex_type<T1, T2>;
+struct is_real {
+    static constexpr bool value =
+        std::is_same_v<real_type<T>, typename std::decay<T>::type>;
 };
 
-// for two types, neither is complex
-template <typename T1, typename T2>
-struct scalar_type_traits<
-    T1,
-    T2,
-    std::enable_if_t<!is_complex<T1>::value && !is_complex<T2>::value &&
-                         is_real<T1>::value && is_real<T2>::value,
-                     int>> {
-    using type = real_type<T1, T2>;
-};
-
-// for three or more types
-template <typename T1, typename T2, typename... Types>
-struct scalar_type_traits<T1, T2, Types...> {
-    using type =
-        typename scalar_type_traits<scalar_type<T1, T2>, Types...>::type;
+/// True if T is complex_type<T>
+template <typename T>
+struct is_complex {
+    static constexpr bool value =
+        std::is_same_v<complex_type<T>, typename std::decay<T>::type>;
 };
 
 namespace internal {
+
+    // for one arithmetic type
+    template <typename T>
+    struct real_type_traits<T, std::enable_if_t<is_arithmetic_v<T>, int>> {
+        using type = typename std::decay<T>::type;
+    };
+
+    // for one complex type, strip complex
+    template <typename T>
+    struct real_type_traits<std::complex<T>, int> {
+        using type = real_type<T>;
+    };
+
+    // for one StrongZero type, remain StrongZero
+    template <>
+    struct real_type_traits<internal::StrongZero, int> {
+        using type = internal::StrongZero;
+    };
+
+    // pointers and references don't have a real type
+    template <typename T>
+    struct real_type_traits<
+        T,
+        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
+        using type = void;
+    };
+
+    // for two or more types
+    template <typename T1, typename T2, typename... Types>
+    struct real_type_traits<T1, T2, Types...> {
+        using type =
+            std::common_type_t<typename real_type_traits<T1, int>::type,
+                               typename real_type_traits<T2, Types...>::type>;
+    };
+
+    // for one type
+    template <typename T>
+    struct complex_type_traits<T, std::enable_if_t<is_arithmetic_v<T>, int>> {
+        using type = std::complex<real_type<T>>;
+    };
+
+    // for one complex type, strip complex
+    template <typename T>
+    struct complex_type_traits<std::complex<T>, int> {
+        using type = std::complex<real_type<T>>;
+    };
+
+    // for one complex type, strip complex
+    template <>
+    struct complex_type_traits<internal::StrongZero, int> {
+        using type = internal::StrongZero;
+    };
+
+    // pointers and references don't have a complex type
+    template <typename T>
+    struct complex_type_traits<
+        T,
+        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
+        using type = void;
+    };
+
+    // for two or more types
+    template <typename T1, typename T2, typename... Types>
+    struct complex_type_traits<T1, T2, Types...> {
+        using type =
+            complex_type<typename real_type_traits<T1, T2, Types...>::type>;
+    };
+
+    // for one type
+    template <typename T>
+    struct scalar_type_traits<T, int> : scalar_type_traits<T, T, int> {};
+
+    // for two types, one is complex
+    template <typename T1, typename T2>
+    struct scalar_type_traits<
+        T1,
+        T2,
+        std::enable_if_t<is_complex<T1>::value || is_complex<T2>::value, int>> {
+        using type = complex_type<T1, T2>;
+    };
+
+    // for two types, neither is complex
+    template <typename T1, typename T2>
+    struct scalar_type_traits<
+        T1,
+        T2,
+        std::enable_if_t<!is_complex<T1>::value && !is_complex<T2>::value &&
+                             is_real<T1>::value && is_real<T2>::value,
+                         int>> {
+        using type = real_type<T1, T2>;
+    };
+
+    // for three or more types
+    template <typename T1, typename T2, typename... Types>
+    struct scalar_type_traits<T1, T2, Types...> {
+        using type =
+            typename scalar_type_traits<scalar_type<T1, T2>, Types...>::type;
+    };
 
     /**
      * @brief Data type trait.

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -388,11 +388,9 @@ struct real_type_traits;
 template <typename... Types>
 using real_type = typename real_type_traits<Types..., int>::type;
 
-// for one type
+// for one arithmetic type
 template <typename T>
-struct real_type_traits<
-    T,
-    typename std::enable_if<is_arithmetic_v<T>, int>::type> {
+struct real_type_traits<T, std::enable_if_t<is_arithmetic_v<T>, int>> {
     using type = T;
 };
 
@@ -400,6 +398,14 @@ struct real_type_traits<
 template <typename T>
 struct real_type_traits<std::complex<T>, int> {
     using type = T;
+};
+
+// pointers and references don't have a real type
+template <typename T>
+struct real_type_traits<
+    T,
+    std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
+    using type = void;
 };
 
 // for two or more types

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -58,11 +58,6 @@ inline constexpr bool is_same_v = std::is_same<T, U>::value;
 #endif
 
 //------------------------------------------------------------------------------
-/// True if T is complex_type<T>
-template <typename T>
-struct is_complex {
-    static constexpr bool value = is_same_v<complex_type<T>, T>;
-};
 
 template <typename T, enable_if_t<!is_complex<T>::value, int> = 0>
 inline constexpr real_type<T> real(const T& x)

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -59,13 +59,13 @@ inline constexpr bool is_same_v = std::is_same<T, U>::value;
 
 //------------------------------------------------------------------------------
 
-template <typename T, enable_if_t<!is_complex<T>::value, int> = 0>
+template <typename T, enable_if_t<is_real<T>::value, int> = 0>
 inline constexpr real_type<T> real(const T& x)
 {
     return x;
 }
 
-template <typename T, enable_if_t<!is_complex<T>::value, int> = 0>
+template <typename T, enable_if_t<is_real<T>::value, int> = 0>
 inline constexpr real_type<T> imag(const T& x)
 {
     return real_type<T>(0);
@@ -85,8 +85,8 @@ inline constexpr real_type<T> imag(const T& x)
  * @note C++11 to C++17 returns complex<real_t> instead of real_t. @see
  * std::conj
  */
-template <typename real_t, enable_if_t<!is_complex<real_t>::value, int> = 0>
-inline constexpr real_t conj(const real_t& x)
+template <typename T, enable_if_t<is_real<T>::value, int> = 0>
+inline constexpr T conj(const T& x)
 {
     return x;
 }

--- a/include/tlapack/blas/her.hpp
+++ b/include/tlapack/blas/her.hpp
@@ -44,7 +44,7 @@ template <class matrixA_t,
           class alpha_t,
           enable_if_t<(
                           /* Requires: */
-                          !is_complex<alpha_t>::value),
+                          is_real<alpha_t>::value),
                       int> = 0,
           class T = type_t<matrixA_t>,
           disable_if_allow_optblas_t<pair<alpha_t, real_type<T> >,

--- a/include/tlapack/blas/her2k.hpp
+++ b/include/tlapack/blas/her2k.hpp
@@ -61,7 +61,7 @@ template <class matrixA_t,
           class beta_t,
           enable_if_t<(
                           /* Requires: */
-                          !is_complex<beta_t>::value),
+                          is_real<beta_t>::value),
                       int> = 0,
           class T = type_t<matrixC_t>,
           disable_if_allow_optblas_t<pair<matrixA_t, T>,
@@ -269,7 +269,7 @@ template <class matrixA_t,
           class beta_t,
           enable_if_t<(
                           /* Requires: */
-                          !is_complex<beta_t>::value),
+                          is_real<beta_t>::value),
                       int> = 0,
           class T = type_t<matrixC_t>,
           enable_if_allow_optblas_t<pair<matrixA_t, T>,

--- a/include/tlapack/blas/herk.hpp
+++ b/include/tlapack/blas/herk.hpp
@@ -52,20 +52,19 @@ namespace tlapack {
  *
  * @ingroup blas3
  */
-template <
-    class matrixA_t,
-    class matrixC_t,
-    class alpha_t,
-    class beta_t,
-    enable_if_t<(
-                    /* Requires: */
-                    is_real<alpha_t>::value && !is_complex<beta_t>::value),
-                int> = 0,
-    class T = type_t<matrixC_t>,
-    disable_if_allow_optblas_t<pair<matrixA_t, T>,
-                               pair<matrixC_t, T>,
-                               pair<alpha_t, real_type<T> >,
-                               pair<beta_t, real_type<T> > > = 0>
+template <class matrixA_t,
+          class matrixC_t,
+          class alpha_t,
+          class beta_t,
+          enable_if_t<(
+                          /* Requires: */
+                          is_real<alpha_t>::value && is_real<beta_t>::value),
+                      int> = 0,
+          class T = type_t<matrixC_t>,
+          disable_if_allow_optblas_t<pair<matrixA_t, T>,
+                                     pair<matrixC_t, T>,
+                                     pair<alpha_t, real_type<T> >,
+                                     pair<beta_t, real_type<T> > > = 0>
 void herk(Uplo uplo,
           Op trans,
           const alpha_t& alpha,
@@ -207,7 +206,7 @@ template <class matrixA_t,
           class alpha_t,
           enable_if_t<(
                           /* Requires: */
-                          !is_complex<alpha_t>::value),
+                          is_real<alpha_t>::value),
                       int> = 0,
           class T = type_t<matrixC_t>,
           disable_if_allow_optblas_t<pair<matrixA_t, T>,

--- a/include/tlapack/blas/herk.hpp
+++ b/include/tlapack/blas/herk.hpp
@@ -59,7 +59,7 @@ template <
     class beta_t,
     enable_if_t<(
                     /* Requires: */
-                    !is_complex<alpha_t>::value && !is_complex<beta_t>::value),
+                    is_real<alpha_t>::value && !is_complex<beta_t>::value),
                 int> = 0,
     class T = type_t<matrixC_t>,
     disable_if_allow_optblas_t<pair<matrixA_t, T>,

--- a/include/tlapack/blas/iamax.hpp
+++ b/include/tlapack/blas/iamax.hpp
@@ -102,7 +102,7 @@ size_type<vector_t> iamax_ec(const vector_t& x, abs_f absf)
             return i;
         }
         else {  // still no Inf found yet
-            if (!is_complex<T>::value) {
+            if (is_real<T>::value) {
                 real_t a = absf(x[i]);
                 if (a > smax) {
                     smax = a;
@@ -179,7 +179,7 @@ size_type<vector_t> iamax_nc(const vector_t& x, abs_f absf)
             return i;
         }
         else {  // still no Inf found yet
-            if (!is_complex<T>::value) {
+            if (is_real<T>::value) {
                 real_t a = absf(x[i]);
                 if (a > smax) {
                     smax = a;

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -288,7 +288,7 @@ void agressive_early_deflation(bool want_t,
     idx_t ilst = infqr;
     while (ilst < ns) {
         bool bulge = false;
-        if (!is_complex<T>::value)
+        if (is_real<T>::value)
             if (ns > 1)
                 if (TW(ns - 1, ns - 2) != zero) bulge = true;
 
@@ -358,7 +358,7 @@ void agressive_early_deflation(bool want_t,
         while (i1 + 1 < sorting_window_size) {
             // Size of the first block
             idx_t n1 = 1;
-            if (!is_complex<T>::value)
+            if (is_real<T>::value)
                 if (TW(i1 + 1, i1) != zero) n1 = 2;
 
             // Check if there is a next block
@@ -372,7 +372,7 @@ void agressive_early_deflation(bool want_t,
 
             // Size of the second block
             idx_t n2 = 1;
-            if (!is_complex<T>::value)
+            if (is_real<T>::value)
                 if (i2 + 1 < jw)
                     if (TW(i2 + 1, i2) != zero) n2 = 2;
 
@@ -410,7 +410,7 @@ void agressive_early_deflation(bool want_t,
     idx_t i = 0;
     while (i < jw) {
         idx_t n1 = 1;
-        if (!is_complex<T>::value)
+        if (is_real<T>::value)
             if (i + 1 < jw)
                 if (TW(i + 1, i) != zero) n1 = 2;
 

--- a/include/tlapack/lapack/gebrd.hpp
+++ b/include/tlapack/lapack/gebrd.hpp
@@ -168,10 +168,6 @@ int gebrd(matrix_t& A,
         return alloc_workspace(localworkdata, workinfo, opts.work);
     }();
 
-    // Options to forward
-    auto&& larfbOpts = workspace_opts_t<transpose_type<work_t> >{work};
-    auto&& gehd2Opts = workspace_opts_t<>{work};
-
     // Matrix X
     Workspace workMatrixY;
     auto X = new_matrix(work, m, nb, workMatrixY);

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -35,7 +35,7 @@ namespace tlapack {
 template <typename real_t,
           enable_if_t<(
                           /* Requires: */
-                          !is_complex<real_t>::value),
+                          is_real<real_t>::value),
                       int> = 0>
 void ladiv(const real_t& a,
            const real_t& b,

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -70,7 +70,7 @@ namespace tlapack {
 template <class matrix_t,
           class vector_t,
           enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true,
-          enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_real<type_t<matrix_t>>::value, bool> = true>
 int lahqr(bool want_t,
           bool want_z,
           size_type<matrix_t> ilo,
@@ -213,7 +213,7 @@ int lahqr(bool want_t,
                 istart = ilo;
                 continue;
             }
-            if (!is_complex<TA>::value && istart + 2 == istop) {
+            if (is_real<TA>::value && istart + 2 == istop) {
                 // 2x2 block, normalize the block
                 real_t cs;
                 TA sn;

--- a/include/tlapack/lapack/lahqr_schur22.hpp
+++ b/include/tlapack/lapack/lahqr_schur22.hpp
@@ -47,7 +47,7 @@ namespace tlapack {
  *
  * @ingroup auxiliary
  */
-template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
+template <typename T, enable_if_t<is_real<T>::value, bool> = true>
 int lahqr_schur22(T& a,
                   T& b,
                   T& c,

--- a/include/tlapack/lapack/lahqr_shiftcolumn.hpp
+++ b/include/tlapack/lapack/lahqr_shiftcolumn.hpp
@@ -37,7 +37,7 @@ namespace tlapack {
  */
 template <class matrix_t,
           class vector_t,
-          enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_real<type_t<matrix_t>>::value, bool> = true>
 int lahqr_shiftcolumn(const matrix_t& H,
                       vector_t& v,
                       complex_type<type_t<matrix_t>> s1,

--- a/include/tlapack/lapack/lapy2.hpp
+++ b/include/tlapack/lapack/lapy2.hpp
@@ -27,7 +27,7 @@ template <class TX,
           class TY,
           enable_if_t<(
                           /* Requires: */
-                          !is_complex<TX>::value && !is_complex<TY>::value),
+                          is_real<TX>::value && is_real<TY>::value),
                       int> = 0>
 real_type<TX, TY> lapy2(const TX& x, const TY& y)
 {

--- a/include/tlapack/lapack/lapy3.hpp
+++ b/include/tlapack/lapack/lapy3.hpp
@@ -33,8 +33,8 @@ template <class TX,
           class TZ,
           enable_if_t<(
                           /* Requires: */
-                          !is_complex<TX>::value && !is_complex<TY>::value &&
-                          !is_complex<TZ>::value),
+                          is_real<TX>::value && is_real<TY>::value &&
+                          is_real<TZ>::value),
                       int> = 0>
 real_type<TX, TY, TZ> lapy3(const TX& x, const TY& y, const TZ& z)
 {

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -96,7 +96,7 @@ void larfg(storage_t storeMode,
 
     if (xnorm > zero || (imag(alpha) != zero)) {
         // First estimate of beta
-        real_t temp = (!is_complex<T>::value)
+        real_t temp = (is_real<T>::value)
                           ? lapy2(real(alpha), xnorm)
                           : lapy3(real(alpha), imag(alpha), xnorm);
         real_t beta = (real(alpha) < zero) ? temp : -temp;
@@ -111,9 +111,8 @@ void larfg(storage_t storeMode,
                 alpha *= rsafemin;
             }
             xnorm = nrm2(x);
-            temp = (!is_complex<T>::value)
-                       ? lapy2(real(alpha), xnorm)
-                       : lapy3(real(alpha), imag(alpha), xnorm);
+            temp = (is_real<T>::value) ? lapy2(real(alpha), xnorm)
+                                       : lapy3(real(alpha), imag(alpha), xnorm);
             beta = (real(alpha) < zero) ? temp : -temp;
         }
 

--- a/include/tlapack/lapack/lascl.hpp
+++ b/include/tlapack/lapack/lascl.hpp
@@ -50,15 +50,14 @@ namespace tlapack {
  *
  * @ingroup auxiliary
  */
-template <
-    class access_t,
-    class matrix_t,
-    class a_type,
-    class b_type,
-    enable_if_t<(
-                    /* Requires: */
-                    !is_complex<a_type>::value && !is_complex<b_type>::value),
-                int> = 0>
+template <class access_t,
+          class matrix_t,
+          class a_type,
+          class b_type,
+          enable_if_t<(
+                          /* Requires: */
+                          is_real<a_type>::value && is_real<b_type>::value),
+                      int> = 0>
 int lascl(access_t accessType, const b_type& b, const a_type& a, matrix_t& A)
 {
     // data traits
@@ -190,14 +189,13 @@ int lascl(access_t accessType, const b_type& b, const a_type& a, matrix_t& A)
  *
  * @ingroup auxiliary
  */
-template <
-    class matrix_t,
-    class a_type,
-    class b_type,
-    enable_if_t<(
-                    /* Requires: */
-                    !is_complex<a_type>::value && !is_complex<b_type>::value),
-                int> = 0>
+template <class matrix_t,
+          class a_type,
+          class b_type,
+          enable_if_t<(
+                          /* Requires: */
+                          is_real<a_type>::value && is_real<b_type>::value),
+                      int> = 0>
 int lascl(band_t accessType,
           const b_type& b,
           const a_type& a,

--- a/include/tlapack/lapack/lasy2.hpp
+++ b/include/tlapack/lapack/lasy2.hpp
@@ -29,7 +29,7 @@ namespace tlapack {
  * @ingroup auxiliary
  */
 template <typename matrix_t,
-          enable_if_t<!is_complex<type_t<matrix_t> >::value, bool> = true>
+          enable_if_t<is_real<type_t<matrix_t> >::value, bool> = true>
 int lasy2(Op trans_l,
           Op trans_r,
           int isign,

--- a/include/tlapack/lapack/multishift_qr.hpp
+++ b/include/tlapack/lapack/multishift_qr.hpp
@@ -421,7 +421,7 @@ int multishift_qr(bool want_t,
 
         // If there are only two shifts and both are real
         // then use only one (helps avoid interference)
-        if (!is_complex<TA>::value) {
+        if (is_real<TA>::value) {
             if (ns == 2) {
                 if (imag(w[i_shifts]) == zero) {
                     if (tlapack::abs(real(w[i_shifts]) -

--- a/include/tlapack/lapack/schur_move.hpp
+++ b/include/tlapack/lapack/schur_move.hpp
@@ -61,24 +61,24 @@ int schur_move(bool want_q,
     if (n == 0) return 0;
 
     // Check if ifst points to the middle of a 2x2 block
-    if (!is_complex<T>::value)
+    if (is_real<T>::value)
         if (ifst > 0)
             if (A(ifst, ifst - 1) != zero) ifst = ifst - 1;
 
     // Size of the current block, can be either 1, 2
     idx_t nbf = 1;
-    if (!is_complex<T>::value)
+    if (is_real<T>::value)
         if (ifst < n - 1)
             if (A(ifst + 1, ifst) != zero) nbf = 2;
 
     // Check if ilst points to the middle of a 2x2 block
-    if (!is_complex<T>::value)
+    if (is_real<T>::value)
         if (ilst > 0)
             if (A(ilst, ilst - 1) != zero) ilst = ilst - 1;
 
     // Size of the final block, can be either 1, 2
     idx_t nbl = 1;
-    if (!is_complex<T>::value)
+    if (is_real<T>::value)
         if (ilst < n - 1)
             if (A(ilst + 1, ilst) != zero) nbl = 2;
 
@@ -90,7 +90,7 @@ int schur_move(bool want_q,
         while (here != ilst) {
             // Size of the next eigenvalue block
             idx_t nbnext = 1;
-            if (!is_complex<T>::value)
+            if (is_real<T>::value)
                 if (here + nbf + 1 < n)
                     if (A(here + nbf + 1, here + nbf) != zero) nbnext = 2;
 
@@ -107,7 +107,7 @@ int schur_move(bool want_q,
         while (here != ilst) {
             // Size of the next eigenvalue block
             idx_t nbnext = 1;
-            if (!is_complex<T>::value)
+            if (is_real<T>::value)
                 if (here > 1)
                     if (A(here - 1, here - 2) != zero) nbnext = 2;
 

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -45,7 +45,7 @@ namespace tlapack {
  * @ingroup auxiliary
  */
 template <typename matrix_t,
-          enable_if_t<!is_complex<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_real<type_t<matrix_t>>::value, bool> = true>
 int schur_swap(bool want_q,
                matrix_t& A,
                matrix_t& Q,

--- a/include/tlapack/lapack/ungbr.hpp
+++ b/include/tlapack/lapack/ungbr.hpp
@@ -166,7 +166,6 @@ int ungbr_q(const size_type<matrix_t> k,
     const real_t zero(0);
     const real_t one(1);
     const idx_t m = nrows(A);
-    const idx_t n = ncols(A);
 
     ungqr_opts_t<matrix_t> ungqrOpts;
     ungqrOpts.nb = opts.nb;
@@ -244,7 +243,6 @@ int ungbr_p(const size_type<matrix_t> k,
     // constants
     const real_t zero(0);
     const real_t one(1);
-    const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     unglq_opts_t<matrix_t> unglqOpts;

--- a/include/tlapack/lapack/unm2l.hpp
+++ b/include/tlapack/lapack/unm2l.hpp
@@ -127,6 +127,7 @@ int unm2l(side_t side,
           matrixC_t& C,
           const workspace_opts_t<>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixA_t>;
     using pair = std::pair<idx_t, idx_t>;
 
@@ -140,7 +141,7 @@ int unm2l(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -139,6 +139,7 @@ int unm2r(side_t side,
           matrixC_t& C,
           const workspace_opts_t<>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixA_t>;
     using pair = std::pair<idx_t, idx_t>;
 
@@ -152,7 +153,7 @@ int unm2r(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/lapack/unml2.hpp
+++ b/include/tlapack/lapack/unml2.hpp
@@ -126,6 +126,7 @@ int unml2(side_t side,
           matrixC_t& C,
           const workspace_opts_t<>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixA_t>;
     using pair = std::pair<idx_t, idx_t>;
 
@@ -139,7 +140,7 @@ int unml2(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/lapack/unmlq.hpp
+++ b/include/tlapack/lapack/unmlq.hpp
@@ -177,6 +177,7 @@ int unmlq(side_t side,
           matrixC_t& C,
           const unmlq_opts_t<workT_t>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
 
@@ -198,7 +199,7 @@ int unmlq(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/lapack/unmql.hpp
+++ b/include/tlapack/lapack/unmql.hpp
@@ -190,6 +190,7 @@ int unmql(side_t side,
           matrixC_t& C,
           const unmql_opts_t<workT_t>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
 
@@ -211,7 +212,7 @@ int unmql(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/lapack/unmqr.hpp
+++ b/include/tlapack/lapack/unmqr.hpp
@@ -177,6 +177,7 @@ int unmqr(side_t side,
           matrixC_t& C,
           const unmqr_opts_t<workT_t>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
 
@@ -198,7 +199,7 @@ int unmqr(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/lapack/unmr2.hpp
+++ b/include/tlapack/lapack/unmr2.hpp
@@ -127,6 +127,7 @@ int unmr2(side_t side,
           matrixC_t& C,
           const workspace_opts_t<>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixA_t>;
     using pair = std::pair<idx_t, idx_t>;
 
@@ -140,7 +141,7 @@ int unmr2(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/lapack/unmrq.hpp
+++ b/include/tlapack/lapack/unmrq.hpp
@@ -177,6 +177,7 @@ int unmrq(side_t side,
           matrixC_t& C,
           const unmrq_opts_t<workT_t>& opts = {})
 {
+    using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
 
@@ -198,7 +199,7 @@ int unmrq(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<matrixA_t>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -259,6 +259,34 @@ namespace internal {
             }
         }
     };
+
+    template <class matrix_t>
+    struct real_type_traits<
+        matrix_t,
+        typename std::enable_if<internal::is_eigen_dense<matrix_t>,
+                                int>::type> {
+        using type = Eigen::Matrix<real_type<typename matrix_t::Scalar>,
+                                   matrix_t::RowsAtCompileTime,
+                                   matrix_t::ColsAtCompileTime,
+                                   matrix_t::IsRowMajor ? Eigen::RowMajor
+                                                        : Eigen::ColMajor,
+                                   matrix_t::MaxRowsAtCompileTime,
+                                   matrix_t::MaxColsAtCompileTime>;
+    };
+
+    template <class matrix_t>
+    struct complex_type_traits<
+        matrix_t,
+        typename std::enable_if<internal::is_eigen_dense<matrix_t>,
+                                int>::type> {
+        using type = Eigen::Matrix<complex_type<typename matrix_t::Scalar>,
+                                   matrix_t::RowsAtCompileTime,
+                                   matrix_t::ColsAtCompileTime,
+                                   matrix_t::IsRowMajor ? Eigen::RowMajor
+                                                        : Eigen::ColMajor,
+                                   matrix_t::MaxRowsAtCompileTime,
+                                   matrix_t::MaxColsAtCompileTime>;
+    };
 }  // namespace internal
 
 // -----------------------------------------------------------------------------

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -18,6 +18,11 @@
 
 namespace tlapack {
 
+template <>
+struct is_arithmetic<Eigen::half, int> {
+    static constexpr bool value = true;
+};
+
 // Forward declarations
 template <typename T>
 T abs(const T& x);

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -142,6 +142,16 @@ namespace internal {
     };
 }  // namespace internal
 
+template <class T, class idx_t, typename int_t, Direction D>
+struct real_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
+    using type = legacyVector<real_type<T>, idx_t, int_t, D>;
+};
+
+template <typename T, class idx_t, Layout layout>
+struct real_type_traits<legacyMatrix<T, idx_t, layout>, int> {
+    using type = legacyMatrix<real_type<T>, idx_t, layout>;
+};
+
 // -----------------------------------------------------------------------------
 // Data descriptors
 

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -140,27 +140,27 @@ namespace internal {
                        : vector_t(m, (T*)W.data(), W.getLdim() / sizeof(T));
         }
     };
+
+    template <class T, class idx_t, typename int_t, Direction D>
+    struct real_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
+        using type = legacyVector<real_type<T>, idx_t, int_t, D>;
+    };
+
+    template <typename T, class idx_t, Layout layout>
+    struct real_type_traits<legacyMatrix<T, idx_t, layout>, int> {
+        using type = legacyMatrix<real_type<T>, idx_t, layout>;
+    };
+
+    template <class T, class idx_t, typename int_t, Direction D>
+    struct complex_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
+        using type = legacyVector<complex_type<T>, idx_t, int_t, D>;
+    };
+
+    template <typename T, class idx_t, Layout layout>
+    struct complex_type_traits<legacyMatrix<T, idx_t, layout>, int> {
+        using type = legacyMatrix<complex_type<T>, idx_t, layout>;
+    };
 }  // namespace internal
-
-template <class T, class idx_t, typename int_t, Direction D>
-struct real_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
-    using type = legacyVector<real_type<T>, idx_t, int_t, D>;
-};
-
-template <typename T, class idx_t, Layout layout>
-struct real_type_traits<legacyMatrix<T, idx_t, layout>, int> {
-    using type = legacyMatrix<real_type<T>, idx_t, layout>;
-};
-
-template <class T, class idx_t, typename int_t, Direction D>
-struct complex_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
-    using type = legacyVector<complex_type<T>, idx_t, int_t, D>;
-};
-
-template <typename T, class idx_t, Layout layout>
-struct complex_type_traits<legacyMatrix<T, idx_t, layout>, int> {
-    using type = legacyMatrix<complex_type<T>, idx_t, layout>;
-};
 
 // -----------------------------------------------------------------------------
 // Data descriptors

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -152,6 +152,16 @@ struct real_type_traits<legacyMatrix<T, idx_t, layout>, int> {
     using type = legacyMatrix<real_type<T>, idx_t, layout>;
 };
 
+template <class T, class idx_t, typename int_t, Direction D>
+struct complex_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
+    using type = legacyVector<complex_type<T>, idx_t, int_t, D>;
+};
+
+template <typename T, class idx_t, Layout layout>
+struct complex_type_traits<legacyMatrix<T, idx_t, layout>, int> {
+    using type = legacyMatrix<complex_type<T>, idx_t, layout>;
+};
+
 // -----------------------------------------------------------------------------
 // Data descriptors
 

--- a/include/tlapack/plugins/mdspan.hpp
+++ b/include/tlapack/plugins/mdspan.hpp
@@ -226,6 +226,17 @@ namespace internal {
             return matrix_t((ET*)W.data(), std::move(map));
         }
     };
+
+    template <class ET, class Exts, class LP, class AP>
+    struct real_type_traits<std::experimental::mdspan<ET, Exts, LP, AP>, int> {
+        using type = std::experimental::mdspan<real_type<ET>, Exts, LP, AP>;
+    };
+
+    template <class ET, class Exts, class LP, class AP>
+    struct complex_type_traits<std::experimental::mdspan<ET, Exts, LP, AP>,
+                               int> {
+        using type = std::experimental::mdspan<complex_type<ET>, Exts, LP, AP>;
+    };
 }  // namespace internal
 
 // -----------------------------------------------------------------------------

--- a/include/tlapack/plugins/mpreal.hpp
+++ b/include/tlapack/plugins/mpreal.hpp
@@ -17,12 +17,19 @@
 namespace tlapack {
 
 // Forward declarations
+template <class T, class>
+struct is_arithmetic;
 template <typename T>
 T abs(const T& x);
 template <typename T>
 bool isnan(const std::complex<T>& x);
 template <typename T>
 bool isinf(const std::complex<T>& x);
+
+template <>
+struct is_arithmetic<mpfr::mpreal, int> {
+    static constexpr bool value = true;
+};
 
 /// Absolute value
 template <>

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -48,7 +48,7 @@ class rand_generator {
     }
 };
 
-template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
+template <typename T, enable_if_t<is_real<T>::value, bool> = true>
 T rand_helper(rand_generator& gen)
 {
     return T(static_cast<float>(gen()) / static_cast<float>(gen.max()));
@@ -63,7 +63,7 @@ T rand_helper(rand_generator& gen)
     return complex_type<real_t>(r1, r2);
 }
 
-template <typename T, enable_if_t<!is_complex<T>::value, bool> = true>
+template <typename T, enable_if_t<is_real<T>::value, bool> = true>
 T rand_helper()
 {
     return T(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -165,7 +165,7 @@ TEMPLATE_TEST_CASE("Multishift QR",
         idx_t i = ilo;
         while (i < ihi) {
             int nb = 1;
-            if (!is_complex<T>::value)
+            if (is_real<T>::value)
                 if (i + 1 < ihi)
                     if (H(i + 1, i) != zero) nb = 2;
 

--- a/test/src/test_gebd2.cpp
+++ b/test/src/test_gebd2.cpp
@@ -46,7 +46,6 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
     Create<matrix_t> new_matrix;
 
     const real_t zero(0);
-    const real_t one(1);
 
     idx_t m, n;
 

--- a/test/src/test_gebrd.cpp
+++ b/test/src/test_gebrd.cpp
@@ -45,7 +45,6 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
     Create<matrix_t> new_matrix;
 
     const real_t zero(0);
-    const real_t one(1);
 
     idx_t m, n, nb;
 

--- a/test/src/test_larf.cpp
+++ b/test/src/test_larf.cpp
@@ -50,7 +50,7 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
         GENERATE(as<std::string>{}, "direction,v", "alpha,x");
 
     // Skip tests with invalid parameters
-    if (typeAlpha == "Complex" && !is_complex<T>::value) return;
+    if (typeAlpha == "Complex" && is_real<T>::value) return;
 
     // Vectors
     std::vector<T> v_;

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results",
     idx_t n1 = GENERATE(1, 2);
     idx_t n2 = GENERATE(1, 2);
 
-    if (!is_complex<T>::value || (n1 == 1 && n2 == 1)) {
+    if (is_real<T>::value || (n1 == 1 && n2 == 1)) {
         // ifst and ilst point to the same block, n1 must be equal to n2 for
         // the test to make sense.
         if (ifst == ilst and n1 != n2) n2 = n1;
@@ -83,7 +83,7 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results",
                 A(ilst, ilst - 1) = rand_helper<T>();
         }
 
-        if (!is_complex<T>::value) {
+        if (is_real<T>::value) {
             // Put a 2x2 block in the middle
             A(5, 4) = rand_helper<T>();
         }

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -45,7 +45,7 @@ TEMPLATE_TEST_CASE("schur swap gives correct result",
     const idx_t n1 = GENERATE(1, 2);
     const idx_t n2 = GENERATE(1, 2);
 
-    if (!is_complex<T>::value || (n1 == 1 && n2 == 1)) {
+    if (is_real<T>::value || (n1 == 1 && n2 == 1)) {
         const real_t eps = uroundoff<real_t>();
         const real_t tol = real_t(1.0e2 * n) * eps;
 

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -122,7 +122,7 @@ TEMPLATE_TEST_CASE("Double shift QR",
         idx_t i = ilo;
         while (i < ihi) {
             int nb = 1;
-            if (!is_complex<T>::value)
+            if (is_real<T>::value)
                 if (i + 1 < ihi)
                     if (H(i + 1, i) != zero) nb = 2;
 


### PR DESCRIPTION
Closes #219.

This PR:
- Creates `tlapack::is_real<T>` in addition to the `tlapack::is_complex<T>`. Why? We now may have real types, complex types and non-real non-complex types. Before, we were assuming everything that wasn't complex, was a real type. Moreover, matrices and vectors can now be identified as real or complex.
- Creates `tlapack::is_arithmetic<T>` that helps to separate scalar types from matrices and vectors.
- Updates the plugins so that they reflect the changes.
- Removed a couple of unused variables.