### PR TITLE
Naming conventions

### DIFF
--- a/examples/lu/example_lu.cpp
+++ b/examples/lu/example_lu.cpp
@@ -45,7 +45,7 @@ void run(size_t n)
     real_t normA = tlapack::lange(tlapack::Norm::Fro, A);
 
     // Allocate space for the LU decomposition
-    std::vector<size_t> Piv(n);
+    std::vector<size_t> piv(n);
     std::vector<T> LU_(n * n);
     tlapack::legacyMatrix<T, idx_t, L> LU(n, n, LU_.data(), n);
 
@@ -53,7 +53,7 @@ void run(size_t n)
     tlapack::lacpy(tlapack::dense, A, LU);
 
     // Computing the LU decomposition of A
-    int info = tlapack::getrf(LU, Piv);
+    int info = tlapack::getrf(LU, piv);
     if (info != 0) {
         std::cerr << "Matrix could not be factorized!" << std::endl;
         return;
@@ -76,11 +76,11 @@ void run(size_t n)
                   tlapack::Op::NoTrans, tlapack::Diag::NonUnit, real_t(1), LU,
                   X);
 
-    // X <----- U^{-1}L^{-1}P; swapping columns of X according to Piv
+    // X <----- U^{-1}L^{-1}P; swapping columns of X according to piv
     for (idx_t i = n; i-- > 0;) {
-        if (Piv[i] != i) {
+        if (piv[i] != i) {
             auto vect1 = tlapack::col(X, i);
-            auto vect2 = tlapack::col(X, Piv[i]);
+            auto vect2 = tlapack::col(X, piv[i]);
             tlapack::swap(vect1, vect2);
         }
     }

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -76,8 +76,8 @@ inline constexpr real_type<T> imag(const T& x)
  * Usage:
  *
  *     using tlapack::conj;
- *     scalar_t x = ...
- *     scalar_t y = conj( x );
+ *     T x = ...
+ *     T y = conj( x );
  *
  * @param[in] x Real number
  * @return x
@@ -160,10 +160,10 @@ struct MakeScalarTraits<std::complex<real_t>> {
     }
 };
 
-template <typename scalar_t>
-inline scalar_t make_scalar(real_type<scalar_t> re, real_type<scalar_t> im = 0)
+template <typename T>
+inline T make_scalar(real_type<T> re, real_type<T> im = 0)
 {
-    return MakeScalarTraits<scalar_t>::make(re, im);
+    return MakeScalarTraits<T>::make(re, im);
 }
 
 // -----------------------------------------------------------------------------

--- a/include/tlapack/blas/rotg.hpp
+++ b/include/tlapack/blas/rotg.hpp
@@ -104,8 +104,7 @@ template <typename T,
           disable_if_allow_optblas_t<T> = 0>
 void rotg(T& a, const T& b, real_type<T>& c, T& s)
 {
-    typedef real_type<T> real_t;
-    typedef T scalar_t;
+    using real_t = real_type<T>;
 
     // Constants
     const real_t one(1);
@@ -138,7 +137,7 @@ void rotg(T& a, const T& b, real_type<T>& c, T& s)
             // Use scaled algorithm
             real_t u = min(safmax, max(safmin, g1));
             real_t uu = one / u;
-            scalar_t gs = b * uu;
+            T gs = b * uu;
             real_t g2 = real(gs) * real(gs) + imag(gs) * imag(gs);
             real_t d = sqrt(g2);
             s = conj(gs) / d;
@@ -164,10 +163,10 @@ void rotg(T& a, const T& b, real_type<T>& c, T& s)
             // Use scaled algorithm
             real_t u = min(safmax, max(safmin, f1, g1));
             real_t uu = one / u;
-            scalar_t gs = b * uu;
+            T gs = b * uu;
             real_t g2 = real(gs) * real(gs) + imag(gs) * imag(gs);
             real_t f2, h2, w;
-            scalar_t fs;
+            T fs;
             if (f1 * uu < rtmin) {
                 // a is not well-scaled when scaled by g1.
                 real_t v = min(safmax, max(safmin, f1));

--- a/include/tlapack/lapack/getrf.hpp
+++ b/include/tlapack/lapack/getrf.hpp
@@ -29,7 +29,7 @@ struct getrf_opts_t {
  * \[
  *   P A = L U
  * \]
- *  where P is a permutation matrix constructed from our Piv vector, L is lower
+ *  where P is a permutation matrix constructed from our piv vector, L is lower
  * triangular with unit diagonal elements (lower trapezoidal if m > n), and U is
  * upper triangular (upper trapezoidal if m < n).
  *
@@ -40,8 +40,8 @@ struct getrf_opts_t {
  *      On exit, the factors L and U from the factorization A=PLU;
  *      the unit diagonal elements of L are not stored.
  *
- * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
- * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
+ * @param[in,out] piv is a k-by-1 integer vector where k=min(m,n)
+ * and piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
  * algorithm, the j-th row needs to be swapped with i
  *
  * @param[in] opts Options.
@@ -58,14 +58,14 @@ struct getrf_opts_t {
  *
  * @ingroup computational
  */
-template <class matrix_t, class vector_t>
-inline int getrf(matrix_t& A, vector_t& Piv, const getrf_opts_t& opts = {})
+template <class matrix_t, class piv_t>
+inline int getrf(matrix_t& A, piv_t& piv, const getrf_opts_t& opts = {})
 {
     // Call variant
     if (opts.variant == GetrfVariant::Recursive)
-        return getrf_recursive(A, Piv);
+        return getrf_recursive(A, piv);
     else
-        return getrf_level0(A, Piv);
+        return getrf_level0(A, piv);
 }
 
 }  // namespace tlapack

--- a/include/tlapack/lapack/getrf_level0.hpp
+++ b/include/tlapack/lapack/getrf_level0.hpp
@@ -22,7 +22,7 @@ namespace tlapack {
  * \[
  *   P A = L U
  * \]
- *  where P is a permutation matrix constructed from our Piv vector, L is lower
+ *  where P is a permutation matrix constructed from our piv vector, L is lower
  * triangular with unit diagonal elements (lower trapezoidal if m > n), and U is
  * upper triangular (upper trapezoidal if m < n).
  *
@@ -37,8 +37,8 @@ namespace tlapack {
  *      On exit, the factors L and U from the factorization A=PLU;
  *      the unit diagonal elements of L are not stored.
  *
- * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
- * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
+ * @param[in,out] piv is a k-by-1 integer vector where k=min(m,n)
+ * and piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
  * algorithm, the j-th row needs to be swapped with i
  *
  * @note To construct L and U, one proceeds as in the following steps
@@ -50,8 +50,8 @@ namespace tlapack {
  *
  * @ingroup computational
  */
-template <class matrix_t, class vector_t>
-int getrf_level0(matrix_t& A, vector_t& Piv)
+template <class matrix_t, class piv_t>
+int getrf_level0(matrix_t& A, piv_t& piv)
 {
     using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
@@ -63,27 +63,27 @@ int getrf_level0(matrix_t& A, vector_t& Piv)
     const idx_t end = std::min<idx_t>(m, n);
 
     // check arguments
-    tlapack_check((idx_t)size(Piv) >= end);
+    tlapack_check((idx_t)size(piv) >= end);
 
     // quick return
     if (m <= 0 || n <= 0) return 0;
 
     for (idx_t j = 0; j < end; j++) {
         // find pivot and swap the row with pivot row
-        Piv[j] = j + iamax(tlapack::slice(A, tlapack::range<idx_t>(j, m), j));
+        piv[j] = j + iamax(tlapack::slice(A, tlapack::range<idx_t>(j, m), j));
 
         // if nonzero pivot does not exist, return
-        if (A(Piv[j], j) == real_t(0)) {
+        if (A(piv[j], j) == real_t(0)) {
             return j + 1;
         }
 
-        // if the pivot happens to be a Piv[j]>j(Piv[j] not equal to j), then
-        // swap j-th row and Piv[j] row of A
-        if (Piv[j] != j) {
+        // if the pivot happens to be a piv[j]>j(piv[j] not equal to j), then
+        // swap j-th row and piv[j] row of A
+        if (piv[j] != j) {
             for (idx_t i = 0; i < n; i++) {
                 T tmp = A(j, i);
-                A(j, i) = A(Piv[j], i);
-                A(Piv[j], i) = tmp;
+                A(j, i) = A(piv[j], i);
+                A(piv[j], i) = tmp;
             }
         }
 

--- a/include/tlapack/lapack/getrf_recursive.hpp
+++ b/include/tlapack/lapack/getrf_recursive.hpp
@@ -26,7 +26,7 @@ namespace tlapack {
  * \[
  *   P A = L U
  * \]
- *  where P is a permutation matrix constructed from our Piv vector, L is lower
+ *  where P is a permutation matrix constructed from our piv vector, L is lower
  * triangular with unit diagonal elements (lower trapezoidal if m > n), and U is
  * upper triangular (upper trapezoidal if m < n).
  *
@@ -39,8 +39,8 @@ namespace tlapack {
  *      On exit, the factors L and U from the factorization A=PLU;
  *      the unit diagonal elements of L are not stored.
  *
- * @param[in,out] Piv is a k-by-1 integer vector where k=min(m,n)
- * and Piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
+ * @param[in,out] piv is a k-by-1 integer vector where k=min(m,n)
+ * and piv[i]=j where i<=j<=k-1, which means in the i-th iteration of the
  * algorithm, the j-th row needs to be swapped with i
  *
  * @note To construct L and U, one proceeds as in the following steps
@@ -52,8 +52,8 @@ namespace tlapack {
  *
  * @ingroup computational
  */
-template <class matrix_t, class vector_t>
-int getrf_recursive(matrix_t& A, vector_t& Piv)
+template <class matrix_t, class piv_t>
+int getrf_recursive(matrix_t& A, piv_t& piv)
 {
     using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
@@ -76,7 +76,7 @@ int getrf_recursive(matrix_t& A, vector_t& Piv)
     const idx_t k = std::min<idx_t>(m, n);
 
     // check arguments
-    tlapack_check((idx_t)size(Piv) >= k);
+    tlapack_check((idx_t)size(piv) >= k);
 
     // quick return
     if (m <= 0 || n <= 0) return 0;
@@ -84,9 +84,9 @@ int getrf_recursive(matrix_t& A, vector_t& Piv)
     // base case of recursion; one column matrices or one row matrices
     // one-row matrices
     if (m == 1) {
-        // Piv has one element
-        Piv[0] = 0;
-        if (A(Piv[0], 0) == real_t(0)) {
+        // piv has one element
+        piv[0] = 0;
+        if (A(piv[0], 0) == real_t(0)) {
             // in case which A(0,0) is zero, then we return 1 since in the first
             // iteration we stopped
             return 1;
@@ -97,15 +97,15 @@ int getrf_recursive(matrix_t& A, vector_t& Piv)
 
     // one-column matrices
     else if (n == 1) {
-        // when n==1, Piv has one element, Piv[0] needs to be swapped by the
+        // when n==1, piv has one element, piv[0] needs to be swapped by the
         // first row
-        Piv[0] = iamax(col(A, 0), optsIamax);
+        piv[0] = iamax(col(A, 0), optsIamax);
 
         // in the following case all elements are zero, and we return 1
-        if (A(Piv[0], 0) == real_t(0)) return 1;
+        if (A(piv[0], 0) == real_t(0)) return 1;
 
-        // in this case, we can safely swap since A(Piv[0],0) is not zero
-        if (Piv[0] != 0) std::swap(A(Piv[0], 0), A(0, 0));
+        // in this case, we can safely swap since A(piv[0],0) is not zero
+        if (piv[0] != 0) std::swap(A(piv[0], 0), A(0, 0));
 
         // by the previous comment, we can safely scale all elements of 0th
         // column by 1/A(0,0)
@@ -121,14 +121,14 @@ int getrf_recursive(matrix_t& A, vector_t& Piv)
         auto A0 = tlapack::cols(A, tlapack::range<idx_t>(0, m));
         auto A1 = tlapack::cols(A, tlapack::range<idx_t>(m, n));
 
-        int info = getrf_recursive(A0, Piv);
+        int info = getrf_recursive(A0, piv);
         if (info != 0) return info;
 
-        // swap the rows of A1 according to Piv
+        // swap the rows of A1 according to piv
         for (idx_t j = 0; j < k; j++) {
-            if (Piv[j] != j) {
+            if (piv[j] != j) {
                 auto vect1 = tlapack::row(A1, j);
-                auto vect2 = tlapack::row(A1, Piv[j]);
+                auto vect2 = tlapack::row(A1, piv[j]);
                 tlapack::swap(vect1, vect2);
             }
         }
@@ -146,18 +146,18 @@ int getrf_recursive(matrix_t& A, vector_t& Piv)
         auto A0 = tlapack::cols(A, tlapack::range<idx_t>(0, k0));
         auto A1 = tlapack::cols(A, tlapack::range<idx_t>(k0, n));
 
-        // Piv0 is the first k0 elements of Piv
-        auto Piv0 = tlapack::slice(Piv, tlapack::range<idx_t>(0, k0));
+        // piv0 is the first k0 elements of piv
+        auto piv0 = tlapack::slice(piv, tlapack::range<idx_t>(0, k0));
 
         // Apply getrf on the left of half of the matrix
-        int info = getrf_recursive(A0, Piv0);
+        int info = getrf_recursive(A0, piv0);
         if (info != 0) return info;
 
         // swap the rows of A1
         for (idx_t j = 0; j < k0; j++) {
-            if (Piv0[j] != j) {
+            if (piv0[j] != j) {
                 auto vect1 = tlapack::row(A1, j);
-                auto vect2 = tlapack::row(A1, Piv0[j]);
+                auto vect2 = tlapack::row(A1, piv0[j]);
                 tlapack::swap(vect1, vect2);
             }
         }
@@ -172,8 +172,8 @@ int getrf_recursive(matrix_t& A, vector_t& Piv)
         auto A11 = tlapack::slice(A, tlapack::range<idx_t>(k0, m),
                                   tlapack::range<idx_t>(k0, n));
 
-        // Take Piv1 to be the second slice of of Piv, meaning Piv= [Piv0, Piv1]
-        auto Piv1 = tlapack::slice(Piv, tlapack::range<idx_t>(k0, k));
+        // Take piv1 to be the second slice of of piv, meaning piv= [piv0, piv1]
+        auto piv1 = tlapack::slice(piv, tlapack::range<idx_t>(k0, k));
 
         // Solve the triangular system of equations given by A00 X = A01
         trsm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, T(1), A00, A01);
@@ -182,23 +182,23 @@ int getrf_recursive(matrix_t& A, vector_t& Piv)
         gemm(Op::NoTrans, Op::NoTrans, real_t(-1), A10, A01, real_t(1), A11);
 
         // Finding LU factorization of A11 in place
-        info = getrf_recursive(A11, Piv1);
+        info = getrf_recursive(A11, piv1);
         if (info != 0) return info + k0;
 
         // swap the rows of A10 according to the swapped rows of A11 by refering
-        // to Piv1
+        // to piv1
         for (idx_t j = 0; j < k - k0; j++) {
-            if (Piv1[j] != j) {
+            if (piv1[j] != j) {
                 auto vect1 = tlapack::row(A10, j);
-                auto vect2 = tlapack::row(A10, Piv1[j]);
+                auto vect2 = tlapack::row(A10, piv1[j]);
                 tlapack::swap(vect1, vect2);
             }
         }
 
-        // Shift Piv1, so Piv will have the accurate representation of overall
+        // Shift piv1, so piv will have the accurate representation of overall
         // pivots
         for (idx_t i = 0; i < k - k0; i++) {
-            Piv1[i] += k0;
+            piv1[i] += k0;
         }
 
         return 0;

--- a/include/tlapack/lapack/getri.hpp
+++ b/include/tlapack/lapack/getri.hpp
@@ -33,7 +33,7 @@ struct getri_opts_t : public workspace_opts_t<> {
  *
  * @param[in] A n-by-n matrix.
  *
- * @param[in] Piv pivot vector of size at least n.
+ * @param[in] piv pivot vector of size at least n.
  *
  * @param[in] opts Options.
  *      - @c opts.variant:
@@ -44,9 +44,9 @@ struct getri_opts_t : public workspace_opts_t<> {
  *
  * @ingroup workspace_query
  */
-template <class matrix_t, class vector_t>
+template <class matrix_t, class piv_t>
 inline constexpr workinfo_t getri_worksize(const matrix_t& A,
-                                           const vector_t& Piv,
+                                           const piv_t& piv,
                                            const getri_opts_t& opts = {})
 {
     if (opts.variant == GetriVariant::UXLI) return getri_uxli_worksize(A, opts);
@@ -66,7 +66,7 @@ inline constexpr workinfo_t getri_worksize(const matrix_t& A,
  * of L are not stored. U is stored in the upper triangle of A. On exit, inverse
  * of A is overwritten on A.
  *
- * @param[in] Piv pivot vector of size at least n.
+ * @param[in] piv pivot vector of size at least n.
  *
  * @param[in] opts Options.
  *      - @c opts.variant:
@@ -77,8 +77,8 @@ inline constexpr workinfo_t getri_worksize(const matrix_t& A,
  *
  * @ingroup computational
  */
-template <class matrix_t, class vector_t>
-int getri(matrix_t& A, const vector_t& Piv, const getri_opts_t& opts = {})
+template <class matrix_t, class piv_t>
+int getri(matrix_t& A, const piv_t& piv, const getri_opts_t& opts = {})
 {
     using idx_t = size_type<matrix_t>;
 
@@ -100,9 +100,9 @@ int getri(matrix_t& A, const vector_t& Piv, const getri_opts_t& opts = {})
 
     // swap columns of X to find A^{-1} since A^{-1}=X P
     for (idx_t j = n; j-- > 0;) {
-        if (Piv[j] != j) {
+        if (piv[j] != j) {
             auto vect1 = tlapack::col(A, j);
-            auto vect2 = tlapack::col(A, Piv[j]);
+            auto vect2 = tlapack::col(A, piv[j]);
             tlapack::swap(vect1, vect2);
         }
     }

--- a/include/tlapack/lapack/labrd.hpp
+++ b/include/tlapack/lapack/labrd.hpp
@@ -59,14 +59,18 @@ namespace tlapack {
  *
  * @ingroup auxiliary
  */
-template <class A_t, class vector_t, class r_vector_t, class X_t, class Y_t>
+template <class A_t,
+          class vector_t,
+          class r_vector_t,
+          class X_t,
+          class matrixY_t>
 int labrd(A_t& A,
           r_vector_t& d,
           r_vector_t& e,
           vector_t& tauq,
           vector_t& taup,
           X_t& X,
-          Y_t& Y)
+          matrixY_t& Y)
 {
     using TA = type_t<A_t>;
     using idx_t = size_type<A_t>;

--- a/include/tlapack/lapack/lahr2.hpp
+++ b/include/tlapack/lapack/lahr2.hpp
@@ -53,13 +53,13 @@ namespace tlapack {
  *
  * @ingroup auxiliary
  */
-template <class matrix_t, class vector_t, class T_t, class Y_t>
+template <class matrix_t, class vector_t, class matrixT_t, class matrixY_t>
 int lahr2(size_type<matrix_t> k,
           size_type<matrix_t> nb,
           matrix_t& A,
           vector_t& tau,
-          T_t& T,
-          Y_t& Y)
+          matrixT_t& T,
+          matrixY_t& Y)
 {
     using TA = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;

--- a/include/tlapack/legacy_api/lapack/geqr2.hpp
+++ b/include/tlapack/legacy_api/lapack/geqr2.hpp
@@ -35,8 +35,8 @@ namespace tlapack {
  *
  * @ingroup legacy_lapack
  */
-template <typename TA, typename Ttau>
-inline int geqr2(idx_t m, idx_t n, TA* A, idx_t lda, Ttau* tau)
+template <typename TA, typename TT>
+inline int geqr2(idx_t m, idx_t n, TA* A, idx_t lda, TT* tau)
 {
     using internal::colmajor_matrix;
     using internal::vector;

--- a/include/tlapack/legacy_api/lapack/ung2r.hpp
+++ b/include/tlapack/legacy_api/lapack/ung2r.hpp
@@ -39,8 +39,8 @@ namespace tlapack {
  *
  * @ingroup legacy_lapack
  */
-template <typename TA, typename Ttau>
-inline int ung2r(idx_t m, idx_t n, idx_t k, TA* A, idx_t lda, const Ttau* tau)
+template <typename TA, typename TT>
+inline int ung2r(idx_t m, idx_t n, idx_t k, TA* A, idx_t lda, const TT* tau)
 {
     using internal::colmajor_matrix;
     using internal::vector;
@@ -56,7 +56,7 @@ inline int ung2r(idx_t m, idx_t n, idx_t k, TA* A, idx_t lda, const Ttau* tau)
 
     // Matrix views
     auto A_ = colmajor_matrix<TA>(A, m, n, lda);
-    auto tau_ = vector((Ttau*)tau, std::min<idx_t>(m, n));
+    auto tau_ = vector((TT*)tau, std::min<idx_t>(m, n));
 
     return ung2r(A_, tau_);
 }

--- a/test/src/test_getrf.cpp
+++ b/test/src/test_getrf.cpp
@@ -75,10 +75,10 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
         lacpy(Uplo::General, A, A_copy);
 
         real_t norma = tlapack::lange(tlapack::Norm::Max, A);
-        // Initialize Piv vector to all zeros
-        std::vector<idx_t> Piv(k, idx_t(0));
-        // Run getrf and both A and Piv will be update
-        getrf(A, Piv, getrf_opts_t{variant});
+        // Initialize piv vector to all zeros
+        std::vector<idx_t> piv(k, idx_t(0));
+        // Run getrf and both A and piv will be update
+        getrf(A, piv, getrf_opts_t{variant});
 
         // A contains L and U now, then form A <--- LU
         if (m > n) {
@@ -102,11 +102,11 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
         else
             lu_mult(A);
 
-        // Now that Piv is updated, we work our way backwards in Piv and switch
+        // Now that piv is updated, we work our way backwards in piv and switch
         // rows of LU
         for (idx_t j = k - idx_t(1); j != idx_t(-1); j--) {
             auto vect1 = tlapack::row(A, j);
-            auto vect2 = tlapack::row(A, Piv[j]);
+            auto vect2 = tlapack::row(A, piv[j]);
             tlapack::swap(vect1, vect2);
         }
 

--- a/test/src/test_getri.cpp
+++ b/test/src/test_getri.cpp
@@ -70,13 +70,13 @@ TEMPLATE_TEST_CASE("Inversion of a general m-by-n matrix",
         real_t norma = tlapack::lange(tlapack::Norm::Max, A);
 
         // LU factorize Pivoted A
-        std::vector<idx_t> Piv(n, idx_t(0));
-        getrf(invA, Piv);
+        std::vector<idx_t> piv(n, idx_t(0));
+        getrf(invA, piv);
 
         // run inverse function, this could test any inverse function of choice
         getri_opts_t opts;
         opts.variant = variant;
-        getri(invA, Piv, opts);
+        getri(invA, piv, opts);
 
         // building error matrix E
         std::vector<T> E_;


### PR DESCRIPTION
Establishes some naming conventions for function arguments and template parameters. See the proposal on `CONTRIBUTING.md` at https://github.com/weslleyspereira/tlapack/blob/try-naming-conventions/CONTRIBUTING.md.

Closes #182.