### PR TITLE
Put all legacy code into legacy namespace

### DIFF
--- a/examples/gemm/example_gemm.cpp
+++ b/examples/gemm/example_gemm.cpp
@@ -23,9 +23,9 @@
 
 //------------------------------------------------------------------------------
 template <typename T>
-void run(tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k)
+void run(size_t m, size_t n, size_t k)
 {
-    using tlapack::idx_t;
+    using idx_t = size_t;
     using tlapack::min;
     using colmajor_matrix_t =
         tlapack::legacyMatrix<T, idx_t, tlapack::Layout::ColMajor>;
@@ -89,9 +89,9 @@ void run(tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k)
         auto start = std::chrono::high_resolution_clock::now();
 
         // C = -1.0*A*B + 1.0*C
-        tlapack::gemm(tlapack::Layout::ColMajor, tlapack::Op::NoTrans,
-                      tlapack::Op::NoTrans, m, n, k, T(-1.0), &A_[0], m, &B_[0],
-                      k, T(1.0), &C_[0], m);
+        tlapack::legacy::gemm(tlapack::Layout::ColMajor, tlapack::Op::NoTrans,
+                              tlapack::Op::NoTrans, m, n, k, T(-1.0), &A_[0], m,
+                              &B_[0], k, T(1.0), &C_[0], m);
 
         // Record end time
         auto end = std::chrono::high_resolution_clock::now();
@@ -106,7 +106,8 @@ void run(tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k)
 
     // Output
     std::cout << "Using legacy LAPACK interface:" << std::endl
-              << "||C-AB||_F = " << tlapack::nrm2(n, &C_[0], 1) << std::endl
+              << "||C-AB||_F = " << tlapack::legacy::nrm2(n, &C_[0], 1)
+              << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 
     // Using abstract interface:
@@ -138,7 +139,8 @@ void run(tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k)
 
     // Output
     std::cout << "Using abstract interface:" << std::endl
-              << "||C-AB||_F = " << tlapack::nrm2(n, &C_[0], 1) << std::endl
+              << "||C-AB||_F = " << tlapack::legacy::nrm2(n, &C_[0], 1)
+              << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 
     // Using abstract interface with row major layout:
@@ -170,7 +172,8 @@ void run(tlapack::idx_t m, tlapack::idx_t n, tlapack::idx_t k)
 
     // Output
     std::cout << "Using abstract interface with row major layout:" << std::endl
-              << "||C-AB||_F = " << tlapack::nrm2(n, &C_[0], 1) << std::endl
+              << "||C-AB||_F = " << tlapack::legacy::nrm2(n, &C_[0], 1)
+              << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 }
 

--- a/include/tlapack/lapack/potf2.hpp
+++ b/include/tlapack/lapack/potf2.hpp
@@ -161,7 +161,14 @@ int potf2(uplo_t uplo, matrix_t& A)
     // Constants to forward
     const auto& n = A_.n;
 
-    return ::lapack::potf2((::blas::Uplo)(Uplo)uplo, n, A_.ptr, A_.ldim);
+    if constexpr (layout<matrix_t> == Layout::ColMajor) {
+        return ::lapack::potf2((::blas::Uplo)(Uplo)uplo, n, A_.ptr, A_.ldim);
+    }
+    else {
+        return ::lapack::potf2(
+            ((uplo == Uplo::Lower) ? ::blas::Uplo::Upper : ::blas::Uplo::Lower),
+            n, A_.ptr, A_.ldim);
+    }
 }
 
 #endif

--- a/include/tlapack/lapack/potrf_blocked.hpp
+++ b/include/tlapack/lapack/potrf_blocked.hpp
@@ -188,7 +188,14 @@ inline int potrf_blocked(uplo_t uplo, matrix_t& A)
     // Constants to forward
     const auto& n = A_.n;
 
-    return ::lapack::potrf((::blas::Uplo)(Uplo)uplo, n, A_.ptr, A_.ldim);
+    if constexpr (layout<matrix_t> == Layout::ColMajor) {
+        return ::lapack::potrf((::blas::Uplo)(Uplo)uplo, n, A_.ptr, A_.ldim);
+    }
+    else {
+        return ::lapack::potrf(
+            ((uplo == Uplo::Lower) ? ::blas::Uplo::Upper : ::blas::Uplo::Lower),
+            n, A_.ptr, A_.ldim);
+    }
 }
 
 #endif

--- a/include/tlapack/legacy_api/base/legacyArray.hpp
+++ b/include/tlapack/legacy_api/base/legacyArray.hpp
@@ -1,4 +1,4 @@
-/// @file legacyArray.hpp
+/// @file legacy_api/base/legacyArray.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -14,67 +14,71 @@
 #include "tlapack/plugins/legacyArray.hpp"
 
 namespace tlapack {
+namespace legacy {
+    namespace internal {
 
-namespace internal {
+        template <typename T>
+        inline constexpr auto create_matrix(T* A, idx_t m, idx_t n, idx_t lda)
+        {
+            return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, lda};
+        }
 
-    template <typename T>
-    inline constexpr auto colmajor_matrix(T* A, idx_t m, idx_t n, idx_t lda)
-    {
-        return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, lda};
-    }
+        template <typename T>
+        inline constexpr auto create_matrix(T* A, idx_t m, idx_t n)
+        {
+            return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, m};
+        }
 
-    template <typename T>
-    inline constexpr auto colmajor_matrix(T* A, idx_t m, idx_t n)
-    {
-        return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, m};
-    }
+        template <typename T>
+        inline constexpr auto create_rowmajor_matrix(T* A,
+                                                     idx_t m,
+                                                     idx_t n,
+                                                     idx_t lda)
+        {
+            return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, lda};
+        }
 
-    template <typename T>
-    inline constexpr auto rowmajor_matrix(T* A, idx_t m, idx_t n, idx_t lda)
-    {
-        return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, lda};
-    }
+        template <typename T>
+        inline constexpr auto create_rowmajor_matrix(T* A, idx_t m, idx_t n)
+        {
+            return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, n};
+        }
 
-    template <typename T>
-    inline constexpr auto rowmajor_matrix(T* A, idx_t m, idx_t n)
-    {
-        return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, n};
-    }
+        template <typename T>
+        inline constexpr auto create_banded_matrix(
+            T* A, idx_t m, idx_t n, idx_t kl, idx_t ku)
+        {
+            return legacyBandedMatrix<T, idx_t>{m, n, kl, ku, A};
+        }
 
-    template <typename T>
-    inline constexpr auto banded_matrix(
-        T* A, idx_t m, idx_t n, idx_t kl, idx_t ku)
-    {
-        return legacyBandedMatrix<T, idx_t>{m, n, kl, ku, A};
-    }
+        template <typename T, typename int_t>
+        inline constexpr auto create_vector(T* x, idx_t n, int_t inc)
+        {
+            return legacyVector<T, idx_t, int_t>{n, x, inc};
+        }
 
-    template <typename T, typename int_t>
-    inline constexpr auto vector(T* x, idx_t n, int_t inc)
-    {
-        return legacyVector<T, idx_t, int_t>{n, x, inc};
-    }
+        template <typename T>
+        inline constexpr auto create_vector(T* x, idx_t n)
+        {
+            return legacyVector<T, idx_t>{n, x};
+        }
 
-    template <typename T>
-    inline constexpr auto vector(T* x, idx_t n)
-    {
-        return legacyVector<T, idx_t>{n, x};
-    }
+        template <typename T, typename int_t>
+        inline constexpr auto create_backward_vector(T* x, idx_t n, int_t inc)
+        {
+            return legacyVector<T, idx_t, int_t, Direction::Backward>{n, x,
+                                                                      inc};
+        }
 
-    template <typename T, typename int_t>
-    inline constexpr auto backward_vector(T* x, idx_t n, int_t inc)
-    {
-        return legacyVector<T, idx_t, int_t, Direction::Backward>{n, x, inc};
-    }
+        template <typename T>
+        inline constexpr auto create_backward_vector(T* x, idx_t n)
+        {
+            return legacyVector<T, idx_t, ::tlapack::internal::StrongOne,
+                                Direction::Backward>{n, x};
+        }
 
-    template <typename T>
-    inline constexpr auto backward_vector(T* x, idx_t n)
-    {
-        return legacyVector<T, idx_t, internal::StrongOne, Direction::Backward>{
-            n, x};
-    }
-
-}  // namespace internal
-
+    }  // namespace internal
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LEGACYARRAY_HH

--- a/include/tlapack/legacy_api/base/mdspan.hpp
+++ b/include/tlapack/legacy_api/base/mdspan.hpp
@@ -1,4 +1,4 @@
-/// @file mdspan.hpp
+/// @file legacy_api/base/mdspan.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -13,174 +13,179 @@
 #include <experimental/mdspan>  // Use mdspan for multidimensional arrays
 
 namespace tlapack {
+namespace legacy {
+    using std::experimental::mdspan;
 
-using std::experimental::mdspan;
+    namespace internal {
 
-namespace internal {
+        // -----------------------------------------------------------------------------
+        /** Returns a Matrix object representing a column major matrix
+         *
+         * @param A                 serial data
+         * @param m                 number of rows
+         * @param n                 number of columns
+         * @param lda               leading dimension
+         *
+         * @return mdspan< T, dextents<2>, layout_stride >
+         *      matrix object using the abstraction A(i,j) = i + j * lda
+         */
+        template <typename T, typename integral_type>
+        inline constexpr auto create_matrix(
+            T* A,
+            std::experimental::dextents<2>::size_type m,
+            std::experimental::dextents<2>::size_type n,
+            integral_type lda) noexcept
+        {
+            using std::array;
+            using std::experimental::dextents;
+            using extents_t = dextents<2>;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<extents_t>;
 
-    // -----------------------------------------------------------------------------
-    /** Returns a Matrix object representing a column major matrix
-     *
-     * @param A                 serial data
-     * @param m                 number of rows
-     * @param n                 number of columns
-     * @param lda               leading dimension
-     *
-     * @return mdspan< T, dextents<2>, layout_stride >
-     *      matrix object using the abstraction A(i,j) = i + j * lda
-     */
-    template <typename T, typename integral_type>
-    inline constexpr auto colmajor_matrix(
-        T* A,
-        std::experimental::dextents<2>::size_type m,
-        std::experimental::dextents<2>::size_type n,
-        integral_type lda) noexcept
-    {
-        using std::array;
-        using std::experimental::dextents;
-        using extents_t = dextents<2>;
-        using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping<extents_t>;
+            return mdspan<T, extents_t, layout_stride>(
+                A, mapping(extents_t(m, n), array<integral_type, 2>{1, lda}));
+        }
 
-        return mdspan<T, extents_t, layout_stride>(
-            A, mapping(extents_t(m, n), array<integral_type, 2>{1, lda}));
-    }
+        template <typename T>
+        inline constexpr auto create_matrix(
+            T* A,
+            std::experimental::dextents<2>::size_type m,
+            std::experimental::dextents<2>::size_type n) noexcept
+        {
+            using std::experimental::dextents;
+            using extents_t = dextents<2>;
+            using std::experimental::layout_left;
+            using mapping = typename layout_left::template mapping<extents_t>;
 
-    template <typename T>
-    inline constexpr auto colmajor_matrix(
-        T* A,
-        std::experimental::dextents<2>::size_type m,
-        std::experimental::dextents<2>::size_type n) noexcept
-    {
-        using std::experimental::dextents;
-        using extents_t = dextents<2>;
-        using std::experimental::layout_left;
-        using mapping = typename layout_left::template mapping<extents_t>;
+            return mdspan<T, extents_t, layout_left>(A,
+                                                     mapping(extents_t(m, n)));
+        }
 
-        return mdspan<T, extents_t, layout_left>(A, mapping(extents_t(m, n)));
-    }
+        template <typename T, typename integral_type>
+        inline constexpr auto create_rowmajor_matrix(
+            T* A,
+            std::experimental::dextents<2>::size_type m,
+            std::experimental::dextents<2>::size_type n,
+            integral_type lda) noexcept
+        {
+            using std::array;
+            using std::experimental::dextents;
+            using extents_t = dextents<2>;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<extents_t>;
 
-    template <typename T, typename integral_type>
-    inline constexpr auto rowmajor_matrix(
-        T* A,
-        std::experimental::dextents<2>::size_type m,
-        std::experimental::dextents<2>::size_type n,
-        integral_type lda) noexcept
-    {
-        using std::array;
-        using std::experimental::dextents;
-        using extents_t = dextents<2>;
-        using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping<extents_t>;
+            return mdspan<T, extents_t, layout_stride>(
+                A, mapping(extents_t(m, n), array<integral_type, 2>{lda, 1}));
+        }
 
-        return mdspan<T, extents_t, layout_stride>(
-            A, mapping(extents_t(m, n), array<integral_type, 2>{lda, 1}));
-    }
+        template <typename T>
+        inline constexpr auto create_rowmajor_matrix(
+            T* A,
+            std::experimental::dextents<2>::size_type m,
+            std::experimental::dextents<2>::size_type n) noexcept
+        {
+            using std::experimental::dextents;
+            using extents_t = dextents<2>;
+            using std::experimental::layout_right;
+            using mapping = typename layout_right::template mapping<extents_t>;
 
-    template <typename T>
-    inline constexpr auto rowmajor_matrix(
-        T* A,
-        std::experimental::dextents<2>::size_type m,
-        std::experimental::dextents<2>::size_type n) noexcept
-    {
-        using std::experimental::dextents;
-        using extents_t = dextents<2>;
-        using std::experimental::layout_right;
-        using mapping = typename layout_right::template mapping<extents_t>;
+            return mdspan<T, extents_t, layout_right>(A,
+                                                      mapping(extents_t(m, n)));
+        }
 
-        return mdspan<T, extents_t, layout_right>(A, mapping(extents_t(m, n)));
-    }
+        template <typename T, typename integral_type>
+        inline constexpr auto create_vector(
+            T* x,
+            std::experimental::dextents<1>::size_type n,
+            integral_type ldim) noexcept
+        {
+            using std::array;
+            using std::experimental::dextents;
+            using extents_t = dextents<1>;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<extents_t>;
 
-    template <typename T, typename integral_type>
-    inline constexpr auto vector(T* x,
-                                 std::experimental::dextents<1>::size_type n,
-                                 integral_type ldim) noexcept
-    {
-        using std::array;
-        using std::experimental::dextents;
-        using extents_t = dextents<1>;
-        using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping<extents_t>;
+            return mdspan<T, extents_t, layout_stride>(
+                x, mapping(extents_t(n), array<integral_type, 1>{ldim}));
+        }
 
-        return mdspan<T, extents_t, layout_stride>(
-            x, mapping(extents_t(n), array<integral_type, 1>{ldim}));
-    }
+        template <typename T>
+        inline constexpr auto create_vector(
+            T* x, std::experimental::dextents<1>::size_type n) noexcept
+        {
+            using std::experimental::dextents;
+            using extents_t = dextents<1>;
+            using std::experimental::layout_left;
+            using mapping = typename layout_left::template mapping<extents_t>;
 
-    template <typename T>
-    inline constexpr auto vector(
-        T* x, std::experimental::dextents<1>::size_type n) noexcept
-    {
-        using std::experimental::dextents;
-        using extents_t = dextents<1>;
-        using std::experimental::layout_left;
-        using mapping = typename layout_left::template mapping<extents_t>;
+            return mdspan<T, extents_t, layout_left>(x, mapping(extents_t(n)));
+        }
 
-        return mdspan<T, extents_t, layout_left>(x, mapping(extents_t(n)));
-    }
+        // Transpose
+        template <class ET, class Exts, class AP>
+        inline constexpr auto transpose(
+            const mdspan<ET, Exts, std::experimental::layout_stride, AP>&
+                A) noexcept
+        {
+            using std::array;
+            using std::experimental::layout_stride;
+            using mapping = typename layout_stride::template mapping<Exts>;
+            using size_type = typename Exts::size_type;
 
-    // Transpose
-    template <class ET, class Exts, class AP>
-    inline constexpr auto transpose(
-        const mdspan<ET, Exts, std::experimental::layout_stride, AP>&
-            A) noexcept
-    {
-        using std::array;
-        using std::experimental::layout_stride;
-        using mapping = typename layout_stride::template mapping<Exts>;
-        using size_type = typename Exts::size_type;
+            // constants
+            const size_type m = A.extent(0);
+            const size_type n = A.extent(1);
+            const size_type s0 = A.stride(0);
+            const size_type s1 = A.stride(1);
 
-        // constants
-        const size_type m = A.extent(0);
-        const size_type n = A.extent(1);
-        const size_type s0 = A.stride(0);
-        const size_type s1 = A.stride(1);
+            // return
+            return mdspan<ET, Exts, layout_stride, AP>(
+                A.data(), mapping(Exts(n, m), array<size_type, 2>{s1, s0}),
+                typename AP::offset_policy(A.accessor()));
+        }
 
-        // return
-        return mdspan<ET, Exts, layout_stride, AP>(
-            A.data(), mapping(Exts(n, m), array<size_type, 2>{s1, s0}),
-            typename AP::offset_policy(A.accessor()));
-    }
+        // Transpose
+        template <class ET, class Exts, class AP>
+        inline constexpr auto transpose(
+            const mdspan<ET, Exts, std::experimental::layout_left, AP>&
+                A) noexcept
+        {
+            using std::experimental::layout_right;
+            using mapping = typename layout_right::template mapping<Exts>;
+            using size_type = typename Exts::size_type;
 
-    // Transpose
-    template <class ET, class Exts, class AP>
-    inline constexpr auto transpose(
-        const mdspan<ET, Exts, std::experimental::layout_left, AP>& A) noexcept
-    {
-        using std::experimental::layout_right;
-        using mapping = typename layout_right::template mapping<Exts>;
-        using size_type = typename Exts::size_type;
+            // constants
+            const size_type m = A.extent(0);
+            const size_type n = A.extent(1);
 
-        // constants
-        const size_type m = A.extent(0);
-        const size_type n = A.extent(1);
+            // return
+            return mdspan<ET, Exts, layout_right, AP>(
+                A.data(), mapping(Exts(n, m)),
+                typename AP::offset_policy(A.accessor()));
+        }
 
-        // return
-        return mdspan<ET, Exts, layout_right, AP>(
-            A.data(), mapping(Exts(n, m)),
-            typename AP::offset_policy(A.accessor()));
-    }
+        // Transpose
+        template <class ET, class Exts, class AP>
+        inline constexpr auto transpose(
+            const mdspan<ET, Exts, std::experimental::layout_right, AP>&
+                A) noexcept
+        {
+            using std::experimental::layout_left;
+            using mapping = typename layout_left::template mapping<Exts>;
+            using size_type = typename Exts::size_type;
 
-    // Transpose
-    template <class ET, class Exts, class AP>
-    inline constexpr auto transpose(
-        const mdspan<ET, Exts, std::experimental::layout_right, AP>& A) noexcept
-    {
-        using std::experimental::layout_left;
-        using mapping = typename layout_left::template mapping<Exts>;
-        using size_type = typename Exts::size_type;
+            // constants
+            const size_type m = A.extent(0);
+            const size_type n = A.extent(1);
 
-        // constants
-        const size_type m = A.extent(0);
-        const size_type n = A.extent(1);
+            // return
+            return mdspan<ET, Exts, layout_left, AP>(
+                A.data(), mapping(Exts(n, m)),
+                typename AP::offset_policy(A.accessor()));
+        }
 
-        // return
-        return mdspan<ET, Exts, layout_left, AP>(
-            A.data(), mapping(Exts(n, m)),
-            typename AP::offset_policy(A.accessor()));
-    }
-
-}  // namespace internal
-
+    }  // namespace internal
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_MDSPAN_HH

--- a/include/tlapack/legacy_api/base/types.hpp
+++ b/include/tlapack/legacy_api/base/types.hpp
@@ -1,4 +1,4 @@
-/// @file types.hpp
+/// @file legacy_api/base/types.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -34,149 +34,24 @@
 // -----------------------------------------------------------------------------
 
 namespace tlapack {
+namespace legacy {
 
-using idx_t = TLAPACK_SIZE_T;
-using int_t = TLAPACK_INT_T;
+    using idx_t = TLAPACK_SIZE_T;
+    using int_t = TLAPACK_INT_T;
 
-// -----------------------------------------------------------------------------
-enum class Sides {
-    Left = 'L',
-    L = 'L',
-    Right = 'R',
-    R = 'R',
-    Both = 'B',
-    B = 'B'
-};
+    // -----------------------------------------------------------------------------
+    // lascl
+    enum class MatrixType {
+        General = 'G',
+        Lower = 'L',
+        Upper = 'U',
+        Hessenberg = 'H',
+        LowerBand = 'B',
+        UpperBand = 'Q',
+        Band = 'Z',
+    };
 
-// -----------------------------------------------------------------------------
-// Job for computing eigenvectors and singular vectors
-// # needs custom map
-enum class Job {
-    NoVec = 'N',
-    Vec = 'V',  // geev, syev, ...
-    UpdateVec =
-        'U',  // gghrd#, hbtrd, hgeqz#, hseqr#, ... (many compq or compz)
-
-    AllVec = 'A',        // gesvd, gesdd, gejsv#
-    SomeVec = 'S',       // gesvd, gesdd, gejsv#, gesvj#
-    OverwriteVec = 'O',  // gesvd, gesdd
-
-    CompactVec = 'P',  // bdsdc
-    SomeVecTol = 'C',  // gesvj
-    VecJacobi = 'J',   // gejsv
-    Workspace = 'W',   // gejsv
-};
-
-// -----------------------------------------------------------------------------
-// hseqr
-enum class JobSchur {
-    Eigenvalues = 'E',
-    Schur = 'S',
-};
-
-// -----------------------------------------------------------------------------
-// gees
-// todo: generic yes/no
-enum class Sort {
-    NotSorted = 'N',
-    Sorted = 'S',
-};
-
-// -----------------------------------------------------------------------------
-// syevx
-enum class Range {
-    All = 'A',
-    Value = 'V',
-    Index = 'I',
-};
-
-// -----------------------------------------------------------------------------
-enum class Vect {
-    Q = 'Q',     // orgbr, ormbr
-    P = 'P',     // orgbr, ormbr
-    None = 'N',  // orgbr, ormbr, gbbrd
-    Both = 'B',  // orgbr, ormbr, gbbrd
-};
-
-// -----------------------------------------------------------------------------
-// lascl
-enum class MatrixType {
-    General = 'G',
-    Lower = 'L',
-    Upper = 'U',
-    Hessenberg = 'H',
-    LowerBand = 'B',
-    UpperBand = 'Q',
-    Band = 'Z',
-};
-
-// -----------------------------------------------------------------------------
-// trevc
-enum class HowMany {
-    All = 'A',
-    Backtransform = 'B',
-    Select = 'S',
-};
-
-// -----------------------------------------------------------------------------
-// *svx, *rfsx
-enum class Equed {
-    None = 'N',
-    Row = 'R',
-    Col = 'C',
-    Both = 'B',
-    Yes = 'Y',  // porfsx
-};
-
-// -----------------------------------------------------------------------------
-// *svx
-// todo: what's good name for this?
-enum class Factored {
-    Factored = 'F',
-    NotFactored = 'N',
-    Equilibrate = 'E',
-};
-
-// -----------------------------------------------------------------------------
-// geesx, trsen
-enum class Sense {
-    None = 'N',
-    Eigenvalues = 'E',
-    Subspace = 'V',
-    Both = 'B',
-};
-
-// -----------------------------------------------------------------------------
-// disna
-enum class JobCond {
-    EigenVec = 'E',
-    LeftSingularVec = 'L',
-    RightSingularVec = 'R',
-};
-
-// -----------------------------------------------------------------------------
-// {ge,gg}{bak,bal}
-enum class Balance {
-    None = 'N',
-    Permute = 'P',
-    Scale = 'S',
-    Both = 'B',
-};
-
-// -----------------------------------------------------------------------------
-// stebz, larrd, stein docs
-enum class Order {
-    Block = 'B',
-    Entire = 'E',
-};
-
-// -----------------------------------------------------------------------------
-// check_ortho (LAPACK testing zunt01)
-enum class RowCol {
-    Col = 'C',
-    Row = 'R',
-};
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_TYPES_HH

--- a/include/tlapack/legacy_api/base/utils.hpp
+++ b/include/tlapack/legacy_api/base/utils.hpp
@@ -1,4 +1,4 @@
-/// @file utils.hpp
+/// @file legacy_api/base/utils.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -14,59 +14,59 @@
 
     #include "tlapack/legacy_api/base/legacyArray.hpp"
 
-    #define tlapack_expr_with_2vectors(x, TX, n, X, incx, ...) \
-        do {                                                   \
-            using tlapack::internal::vector;                   \
-            using tlapack::internal::backward_vector;          \
-            if (incx == 1) {                                   \
-                auto x = vector((TX*)X, n);                    \
-                tlapack_expr_with_vector(__VA_ARGS__);         \
-            }                                                  \
-            else if (incx == -1) {                             \
-                auto x = backward_vector((TX*)X, n);           \
-                tlapack_expr_with_vector(__VA_ARGS__);         \
-            }                                                  \
-            else if (incx > 1) {                               \
-                auto x = vector((TX*)X, n, incx);              \
-                tlapack_expr_with_vector(__VA_ARGS__);         \
-            }                                                  \
-            else {                                             \
-                auto x = backward_vector((TX*)X, n, -incx);    \
-                tlapack_expr_with_vector(__VA_ARGS__);         \
-            }                                                  \
+    #define tlapack_expr_with_2vectors(x, TX, n, X, incx, ...)       \
+        do {                                                         \
+            using tlapack::legacy::internal::create_vector;          \
+            using tlapack::legacy::internal::create_backward_vector; \
+            if (incx == 1) {                                         \
+                auto x = create_vector((TX*)X, n);                   \
+                tlapack_expr_with_vector(__VA_ARGS__);               \
+            }                                                        \
+            else if (incx == -1) {                                   \
+                auto x = create_backward_vector((TX*)X, n);          \
+                tlapack_expr_with_vector(__VA_ARGS__);               \
+            }                                                        \
+            else if (incx > 1) {                                     \
+                auto x = create_vector((TX*)X, n, incx);             \
+                tlapack_expr_with_vector(__VA_ARGS__);               \
+            }                                                        \
+            else {                                                   \
+                auto x = create_backward_vector((TX*)X, n, -incx);   \
+                tlapack_expr_with_vector(__VA_ARGS__);               \
+            }                                                        \
         } while (false)
 
-    #define tlapack_expr_with_vector(x, TX, n, X, incx, expr) \
-        do {                                                  \
-            using tlapack::internal::vector;                  \
-            using tlapack::internal::backward_vector;         \
-            if (incx == 1) {                                  \
-                auto x = vector((TX*)X, n);                   \
-                expr;                                         \
-            }                                                 \
-            else if (incx == -1) {                            \
-                auto x = backward_vector((TX*)X, n);          \
-                expr;                                         \
-            }                                                 \
-            else if (incx > 1) {                              \
-                auto x = vector((TX*)X, n, incx);             \
-                expr;                                         \
-            }                                                 \
-            else {                                            \
-                auto x = backward_vector((TX*)X, n, -incx);   \
-                expr;                                         \
-            }                                                 \
+    #define tlapack_expr_with_vector(x, TX, n, X, incx, expr)        \
+        do {                                                         \
+            using tlapack::legacy::internal::create_vector;          \
+            using tlapack::legacy::internal::create_backward_vector; \
+            if (incx == 1) {                                         \
+                auto x = create_vector((TX*)X, n);                   \
+                expr;                                                \
+            }                                                        \
+            else if (incx == -1) {                                   \
+                auto x = create_backward_vector((TX*)X, n);          \
+                expr;                                                \
+            }                                                        \
+            else if (incx > 1) {                                     \
+                auto x = create_vector((TX*)X, n, incx);             \
+                expr;                                                \
+            }                                                        \
+            else {                                                   \
+                auto x = create_backward_vector((TX*)X, n, -incx);   \
+                expr;                                                \
+            }                                                        \
         } while (false)
 
     #define tlapack_expr_with_vector_positiveInc(x, TX, n, X, incx, expr) \
         do {                                                              \
-            using tlapack::internal::vector;                              \
+            using tlapack::legacy::internal::create_vector;               \
             if (incx == 1) {                                              \
-                auto x = vector((TX*)X, n);                               \
+                auto x = create_vector((TX*)X, n);                        \
                 expr;                                                     \
             }                                                             \
             else {                                                        \
-                auto x = vector((TX*)X, n, incx);                         \
+                auto x = create_vector((TX*)X, n, incx);                  \
                 expr;                                                     \
             }                                                             \
         } while (false)
@@ -75,49 +75,49 @@
     #include "tlapack/legacy_api/base/mdspan.hpp"
     #include "tlapack/plugins/mdspan.hpp"  // Loads mdspan plugin
 
-    #define tlapack_expr_with_2vectors(x, TX, n, X, incx, ...)     \
-        do {                                                       \
-            using tlapack::internal::vector;                       \
-            if (incx == 1) {                                       \
-                auto x = vector((TX*)X, n);                        \
-                tlapack_expr_with_vector(__VA_ARGS__);             \
-            }                                                      \
-            else if (incx > 1) {                                   \
-                auto x = vector((TX*)X, n, incx);                  \
-                tlapack_expr_with_vector(__VA_ARGS__);             \
-            }                                                      \
-            else {                                                 \
-                auto x = vector((TX*)&X[(1 - n) * incx], n, incx); \
-                tlapack_expr_with_vector(__VA_ARGS__);             \
-            }                                                      \
+    #define tlapack_expr_with_2vectors(x, TX, n, X, incx, ...)            \
+        do {                                                              \
+            using tlapack::legacy::internal::create_vector;               \
+            if (incx == 1) {                                              \
+                auto x = create_vector((TX*)X, n);                        \
+                tlapack_expr_with_vector(__VA_ARGS__);                    \
+            }                                                             \
+            else if (incx > 1) {                                          \
+                auto x = create_vector((TX*)X, n, incx);                  \
+                tlapack_expr_with_vector(__VA_ARGS__);                    \
+            }                                                             \
+            else {                                                        \
+                auto x = create_vector((TX*)&X[(1 - n) * incx], n, incx); \
+                tlapack_expr_with_vector(__VA_ARGS__);                    \
+            }                                                             \
         } while (false)
 
-    #define tlapack_expr_with_vector(x, TX, n, X, incx, expr)      \
-        do {                                                       \
-            using tlapack::internal::vector;                       \
-            if (incx == 1) {                                       \
-                auto x = vector((TX*)X, n);                        \
-                expr;                                              \
-            }                                                      \
-            else if (incx > 1) {                                   \
-                auto x = vector((TX*)X, n, incx);                  \
-                expr;                                              \
-            }                                                      \
-            else {                                                 \
-                auto x = vector((TX*)&X[(1 - n) * incx], n, incx); \
-                expr;                                              \
-            }                                                      \
+    #define tlapack_expr_with_vector(x, TX, n, X, incx, expr)             \
+        do {                                                              \
+            using tlapack::legacy::internal::create_vector;               \
+            if (incx == 1) {                                              \
+                auto x = create_vector((TX*)X, n);                        \
+                expr;                                                     \
+            }                                                             \
+            else if (incx > 1) {                                          \
+                auto x = create_vector((TX*)X, n, incx);                  \
+                expr;                                                     \
+            }                                                             \
+            else {                                                        \
+                auto x = create_vector((TX*)&X[(1 - n) * incx], n, incx); \
+                expr;                                                     \
+            }                                                             \
         } while (false)
 
     #define tlapack_expr_with_vector_positiveInc(x, TX, n, X, incx, expr) \
         do {                                                              \
-            using tlapack::internal::vector;                              \
+            using tlapack::legacy::internal::create_vector;               \
             if (incx == 1) {                                              \
-                auto x = vector((TX*)X, n);                               \
+                auto x = create_vector((TX*)X, n);                        \
                 expr;                                                     \
             }                                                             \
             else {                                                        \
-                auto x = vector((TX*)X, n, incx);                         \
+                auto x = create_vector((TX*)X, n, incx);                  \
                 expr;                                                     \
             }                                                             \
         } while (false)

--- a/include/tlapack/legacy_api/blas/asum.hpp
+++ b/include/tlapack/legacy_api/blas/asum.hpp
@@ -1,4 +1,4 @@
-/// @file asum.hpp
+/// @file legacy_api/blas/asum.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,36 +16,39 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Wrapper to asum( vector_t const& x ).
- *
- * @return 1-norm of vector,
- *     $|| Re(x) ||_1 + || Im(x) ||_1
- *         = \sum_{i=0}^{n-1} |Re(x_i)| + |Im(x_i)|$.
- *
- * @param[in] n
- *     Number of elements in x. n >= 0.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*incx + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx > 0.
- *
- * @ingroup legacy_blas
- */
-template <typename T>
-inline real_type<T> asum(idx_t n, T const* x, int_t incx)
-{
-    tlapack_check_false(incx <= 0);
+    /**
+     * Wrapper to asum( vector_t const& x ).
+     *
+     * @return 1-norm of vector,
+     *     $|| Re(x) ||_1 + || Im(x) ||_1
+     *         = \sum_{i=0}^{n-1} |Re(x_i)| + |Im(x_i)|$.
+     *
+     * @param[in] n
+     *     Number of elements in x. n >= 0.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*incx + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx > 0.
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename T>
+    inline real_type<T> asum(idx_t n, T const* x, int_t incx)
+    {
+        tlapack_check_false(incx <= 0);
 
-    // quick return
-    if (n <= 0) return 0;
+        // quick return
+        if (n <= 0) return 0;
 
-    tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx, return asum(x_));
-}
+        tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx,
+                                             return asum(x_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_ASUM_HH

--- a/include/tlapack/legacy_api/blas/axpy.hpp
+++ b/include/tlapack/legacy_api/blas/axpy.hpp
@@ -1,4 +1,4 @@
-/// @file axpy.hpp
+/// @file legacy_api/blas/axpy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,55 +16,57 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Add scaled vector, $y = \alpha x + y$.
- *
- * Wrapper to axpy(
-    const alpha_t& alpha,
-    const vectorX_t& x, vectorY_t& y ).
- *
- * @param[in] n
- *     Number of elements in x and y. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, y is not updated.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in,out] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TX, typename TY>
-void axpy(idx_t n,
-          scalar_type<TX, TY> alpha,
-          TX const* x,
-          int_t incx,
-          TY* y,
-          int_t incy)
-{
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
-    using scalar_t = scalar_type<TX, TY>;
+    /**
+     * Add scaled vector, $y = \alpha x + y$.
+     *
+     * Wrapper to axpy(
+        const alpha_t& alpha,
+        const vectorX_t& x, vectorY_t& y ).
+     *
+     * @param[in] n
+     *     Number of elements in x and y. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, y is not updated.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in,out] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TX, typename TY>
+    void axpy(idx_t n,
+              scalar_type<TX, TY> alpha,
+              TX const* x,
+              int_t incx,
+              TY* y,
+              int_t incy)
+    {
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
+        using scalar_t = scalar_type<TX, TY>;
 
-    // quick return
-    if (n <= 0 || alpha == scalar_t(0)) return;
+        // quick return
+        if (n <= 0 || alpha == scalar_t(0)) return;
 
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return axpy(alpha, x_, y_));
-}
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return axpy(alpha, x_, y_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_AXPY_HH

--- a/include/tlapack/legacy_api/blas/copy.hpp
+++ b/include/tlapack/legacy_api/blas/copy.hpp
@@ -1,4 +1,4 @@
-/// @file copy.hpp
+/// @file legacy_api/blas/copy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,44 +16,46 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Copy vector, $y = x$.
- *
- * Wrapper to copy( const vectorX_t& x, vectorY_t& y ).
- *
- * @param[in] n
- *     Number of elements in x and y. n >= 0.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[out] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TX, typename TY>
-void copy(idx_t n, TX const* x, int_t incx, TY* y, int_t incy)
-{
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+    /**
+     * Copy vector, $y = x$.
+     *
+     * Wrapper to copy( const vectorX_t& x, vectorY_t& y ).
+     *
+     * @param[in] n
+     *     Number of elements in x and y. n >= 0.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[out] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TX, typename TY>
+    void copy(idx_t n, TX const* x, int_t incx, TY* y, int_t incy)
+    {
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (n <= 0) return;
+        // quick return
+        if (n <= 0) return;
 
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return copy(x_, y_));
-}
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return copy(x_, y_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_COPY_HH

--- a/include/tlapack/legacy_api/blas/dot.hpp
+++ b/include/tlapack/legacy_api/blas/dot.hpp
@@ -1,4 +1,4 @@
-/// @file dot.hpp
+/// @file legacy_api/blas/dot.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,46 +16,48 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * @return dot product, $x^H y$.
- * @see dotu for unconjugated version, $x^T y$.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] n
- *     Number of elements in x and y. n >= 0.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TX, typename TY>
-scalar_type<TX, TY> dot(
-    idx_t n, TX const* x, int_t incx, TY const* y, int_t incy)
-{
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+    /**
+     * @return dot product, $x^H y$.
+     * @see dotu for unconjugated version, $x^T y$.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] n
+     *     Number of elements in x and y. n >= 0.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TX, typename TY>
+    scalar_type<TX, TY> dot(
+        idx_t n, TX const* x, int_t incx, TY const* y, int_t incy)
+    {
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (n <= 0) return scalar_type<TX, TY>(0);
+        // quick return
+        if (n <= 0) return scalar_type<TX, TY>(0);
 
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return dot(x_, y_));
-}
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return dot(x_, y_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_DOT_HH

--- a/include/tlapack/legacy_api/blas/dotu.hpp
+++ b/include/tlapack/legacy_api/blas/dotu.hpp
@@ -1,4 +1,4 @@
-/// @file dotu.hpp
+/// @file legacy_api/blas/dotu.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,46 +16,48 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * @return unconjugated dot product, $x^T y$.
- * @see dot for conjugated version, $x^H y$.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] n
- *     Number of elements in x and y. n >= 0.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TX, typename TY>
-scalar_type<TX, TY> dotu(
-    idx_t n, TX const* x, int_t incx, TY const* y, int_t incy)
-{
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+    /**
+     * @return unconjugated dot product, $x^T y$.
+     * @see dot for conjugated version, $x^H y$.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] n
+     *     Number of elements in x and y. n >= 0.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TX, typename TY>
+    scalar_type<TX, TY> dotu(
+        idx_t n, TX const* x, int_t incx, TY const* y, int_t incy)
+    {
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (n <= 0) return scalar_type<TX, TY>(0);
+        // quick return
+        if (n <= 0) return scalar_type<TX, TY>(0);
 
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return dotu(x_, y_));
-}
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return dotu(x_, y_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_DOTU_HH

--- a/include/tlapack/legacy_api/blas/gemm.hpp
+++ b/include/tlapack/legacy_api/blas/gemm.hpp
@@ -1,4 +1,4 @@
-/// @file gemm.hpp
+/// @file legacy_api/blas/gemm.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,154 +16,163 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * General matrix-matrix multiply:
- * \[
- *     C = \alpha op(A) \times op(B) + \beta C,
- * \]
- * where $op(X)$ is one of
- *     $op(X) = X$,
- *     $op(X) = X^T$, or
- *     $op(X) = X^H$,
- * alpha and beta are scalars, and A, B, and C are matrices, with
- * $op(A)$ an m-by-k matrix, $op(B)$ a k-by-n matrix, and C an m-by-n matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] transA
- *     The operation $op(A)$ to be used:
- *     - Op::NoTrans:   $op(A) = A$.
- *     - Op::Trans:     $op(A) = A^T$.
- *     - Op::ConjTrans: $op(A) = A^H$.
- *
- * @param[in] transB
- *     The operation $op(B)$ to be used:
- *     - Op::NoTrans:   $op(B) = B$.
- *     - Op::Trans:     $op(B) = B^T$.
- *     - Op::ConjTrans: $op(B) = B^H$.
- *
- * @param[in] m
- *     Number of rows of the matrix C and $op(A)$. m >= 0.
- *
- * @param[in] n
- *     Number of columns of the matrix C and $op(B)$. n >= 0.
- *
- * @param[in] k
- *     Number of columns of $op(A)$ and rows of $op(B)$. k >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and B are not accessed.
- *
- * @param[in] A
- *     - If transA = NoTrans:
- *       the m-by-k matrix A, stored in an lda-by-k array [RowMajor: m-by-lda].
- *     - Otherwise:
- *       the k-by-m matrix A, stored in an lda-by-m array [RowMajor: k-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If transA = NoTrans: lda >= max(1, m) [RowMajor: lda >= max(1, k)].
- *     - Otherwise:           lda >= max(1, k) [RowMajor: lda >= max(1, m)].
- *
- * @param[in] B
- *     - If transB = NoTrans:
- *       the k-by-n matrix B, stored in an ldb-by-n array [RowMajor: k-by-ldb].
- *     - Otherwise:
- *       the n-by-k matrix B, stored in an ldb-by-k array [RowMajor: n-by-ldb].
- *
- * @param[in] ldb
- *     Leading dimension of B.
- *     - If transB = NoTrans: ldb >= max(1, k) [RowMajor: ldb >= max(1, n)].
- *     - Otherwise:           ldb >= max(1, n) [RowMajor: ldb >= max(1, k)].
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, C need not be set on input.
- *
- * @param[in] C
- *     The m-by-n matrix C, stored in an ldc-by-n array [RowMajor: m-by-ldc].
- *
- * @param[in] ldc
- *     Leading dimension of C. ldc >= max(1, m) [RowMajor: ldc >= max(1, n)].
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TB, typename TC>
-void gemm(Layout layout,
-          Op transA,
-          Op transB,
-          idx_t m,
-          idx_t n,
-          idx_t k,
-          scalar_type<TA, TB, TC> alpha,
-          TA const* A,
-          idx_t lda,
-          TB const* B,
-          idx_t ldb,
-          scalar_type<TA, TB, TC> beta,
-          TC* C,
-          idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TB, TC>;
+    /**
+     * General matrix-matrix multiply:
+     * \[
+     *     C = \alpha op(A) \times op(B) + \beta C,
+     * \]
+     * where $op(X)$ is one of
+     *     $op(X) = X$,
+     *     $op(X) = X^T$, or
+     *     $op(X) = X^H$,
+     * alpha and beta are scalars, and A, B, and C are matrices, with
+     * $op(A)$ an m-by-k matrix, $op(B)$ a k-by-n matrix, and C an m-by-n
+     * matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] transA
+     *     The operation $op(A)$ to be used:
+     *     - Op::NoTrans:   $op(A) = A$.
+     *     - Op::Trans:     $op(A) = A^T$.
+     *     - Op::ConjTrans: $op(A) = A^H$.
+     *
+     * @param[in] transB
+     *     The operation $op(B)$ to be used:
+     *     - Op::NoTrans:   $op(B) = B$.
+     *     - Op::Trans:     $op(B) = B^T$.
+     *     - Op::ConjTrans: $op(B) = B^H$.
+     *
+     * @param[in] m
+     *     Number of rows of the matrix C and $op(A)$. m >= 0.
+     *
+     * @param[in] n
+     *     Number of columns of the matrix C and $op(B)$. n >= 0.
+     *
+     * @param[in] k
+     *     Number of columns of $op(A)$ and rows of $op(B)$. k >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and B are not accessed.
+     *
+     * @param[in] A
+     *     - If transA = NoTrans:
+     *       the m-by-k matrix A, stored in an lda-by-k array [RowMajor:
+     * m-by-lda].
+     *     - Otherwise:
+     *       the k-by-m matrix A, stored in an lda-by-m array [RowMajor:
+     * k-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If transA = NoTrans: lda >= max(1, m) [RowMajor: lda >= max(1, k)].
+     *     - Otherwise:           lda >= max(1, k) [RowMajor: lda >= max(1, m)].
+     *
+     * @param[in] B
+     *     - If transB = NoTrans:
+     *       the k-by-n matrix B, stored in an ldb-by-n array [RowMajor:
+     * k-by-ldb].
+     *     - Otherwise:
+     *       the n-by-k matrix B, stored in an ldb-by-k array [RowMajor:
+     * n-by-ldb].
+     *
+     * @param[in] ldb
+     *     Leading dimension of B.
+     *     - If transB = NoTrans: ldb >= max(1, k) [RowMajor: ldb >= max(1, n)].
+     *     - Otherwise:           ldb >= max(1, n) [RowMajor: ldb >= max(1, k)].
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, C need not be set on input.
+     *
+     * @param[in] C
+     *     The m-by-n matrix C, stored in an ldc-by-n array [RowMajor:
+     * m-by-ldc].
+     *
+     * @param[in] ldc
+     *     Leading dimension of C. ldc >= max(1, m) [RowMajor: ldc >= max(1,
+     * n)].
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TB, typename TC>
+    void gemm(Layout layout,
+              Op transA,
+              Op transB,
+              idx_t m,
+              idx_t n,
+              idx_t k,
+              scalar_type<TA, TB, TC> alpha,
+              TA const* A,
+              idx_t lda,
+              TB const* B,
+              idx_t ldb,
+              scalar_type<TA, TB, TC> beta,
+              TC* C,
+              idx_t ldc)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TB, TC>;
 
-    // redirect if row major
-    if (layout == Layout::RowMajor) {
-        return gemm(Layout::ColMajor, transB, transA, n, m, k, alpha, B, ldb, A,
-                    lda, beta, C, ldc);
-    }
+        // redirect if row major
+        if (layout == Layout::RowMajor) {
+            return gemm(Layout::ColMajor, transB, transA, n, m, k, alpha, B,
+                        ldb, A, lda, beta, C, ldc);
+        }
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(transA != Op::NoTrans && transA != Op::Trans &&
-                        transA != Op::ConjTrans);
-    tlapack_check_false(transB != Op::NoTrans && transB != Op::Trans &&
-                        transB != Op::ConjTrans);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(k < 0);
-    tlapack_check_false(lda < ((transA != Op::NoTrans) ? k : m));
-    tlapack_check_false(ldb < ((transB != Op::NoTrans) ? n : k));
-    tlapack_check_false(ldc < m);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(transA != Op::NoTrans && transA != Op::Trans &&
+                            transA != Op::ConjTrans);
+        tlapack_check_false(transB != Op::NoTrans && transB != Op::Trans &&
+                            transB != Op::ConjTrans);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(k < 0);
+        tlapack_check_false(lda < ((transA != Op::NoTrans) ? k : m));
+        tlapack_check_false(ldb < ((transB != Op::NoTrans) ? n : k));
+        tlapack_check_false(ldc < m);
 
-    // quick return
-    if (m == 0 || n == 0 ||
-        ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
-        return;
+        // quick return
+        if (m == 0 || n == 0 ||
+            ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
+            return;
 
-    // Matrix views
-    const auto A_ = (transA == Op::NoTrans)
-                        ? colmajor_matrix<TA>((TA*)A, m, k, lda)
-                        : colmajor_matrix<TA>((TA*)A, k, m, lda);
-    const auto B_ = (transB == Op::NoTrans)
-                        ? colmajor_matrix<TB>((TB*)B, k, n, ldb)
-                        : colmajor_matrix<TB>((TB*)B, n, k, ldb);
-    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
+        // Matrix views
+        const auto A_ = (transA == Op::NoTrans)
+                            ? create_matrix<TA>((TA*)A, m, k, lda)
+                            : create_matrix<TA>((TA*)A, k, m, lda);
+        const auto B_ = (transB == Op::NoTrans)
+                            ? create_matrix<TB>((TB*)B, k, n, ldb)
+                            : create_matrix<TB>((TB*)B, n, k, ldb);
+        auto C_ = create_matrix<TC>(C, m, n, ldc);
 
-    if (alpha == scalar_t(0)) {
-        if (beta == scalar_t(0)) {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < m; ++i)
-                    C_(i, j) = TC(0);
+        if (alpha == scalar_t(0)) {
+            if (beta == scalar_t(0)) {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C_(i, j) = TC(0);
+            }
+            else {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C_(i, j) *= beta;
+            }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < m; ++i)
-                    C_(i, j) *= beta;
+            if (beta == scalar_t(0))
+                gemm(transA, transB, alpha, A_, B_, C_);
+            else
+                gemm(transA, transB, alpha, A_, B_, beta, C_);
         }
     }
-    else {
-        if (beta == scalar_t(0))
-            gemm(transA, transB, alpha, A_, B_, C_);
-        else
-            gemm(transA, transB, alpha, A_, B_, beta, C_);
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_GEMM_HH

--- a/include/tlapack/legacy_api/blas/gemv.hpp
+++ b/include/tlapack/legacy_api/blas/gemv.hpp
@@ -1,4 +1,4 @@
-/// @file gemv.hpp
+/// @file legacy_api/blas/gemv.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,159 +16,164 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * General matrix-vector multiply:
- * \[
- *     y = \alpha op(A) x + \beta y,
- * \]
- * where $op(A)$ is one of
- *     $op(A) = A$,
- *     $op(A) = A^T$, or
- *     $op(A) = A^H$,
- * alpha and beta are scalars, x and y are vectors,
- * and A is an m-by-n matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] trans
- *     The operation to be performed:
- *     - Op::NoTrans:   $y = \alpha A   x + \beta y$,
- *     - Op::Trans:     $y = \alpha A^T x + \beta y$,
- *     - Op::ConjTrans: $y = \alpha A^H x + \beta y$.
- *
- * @param[in] m
- *     Number of rows of the matrix A. m >= 0.
- *
- * @param[in] n
- *     Number of columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and x are not accessed.
- *
- * @param[in] A
- *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor: m-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, m) [RowMajor: lda >= max(1, n)].
- *
- * @param[in] x
- *     - If trans = NoTrans:
- *       the n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *     - Otherwise:
- *       the m-element vector x, in an array of length (m-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, y need not be set on input.
- *
- * @param[in,out] y
- *     - If trans = NoTrans:
- *       the m-element vector y, in an array of length (m-1)*abs(incy) + 1.
- *     - Otherwise:
- *       the n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX, typename TY>
-void gemv(Layout layout,
-          Op trans,
-          idx_t m,
-          idx_t n,
-          scalar_type<TA, TX, TY> alpha,
-          TA const* A,
-          idx_t lda,
-          TX const* x,
-          int_t incx,
-          scalar_type<TA, TX, TY> beta,
-          TY* y,
-          int_t incy)
-{
-    using internal::colmajor_matrix;
-    using std::abs;
-    using scalar_t = scalar_type<TA, TX, TY>;
+    /**
+     * General matrix-vector multiply:
+     * \[
+     *     y = \alpha op(A) x + \beta y,
+     * \]
+     * where $op(A)$ is one of
+     *     $op(A) = A$,
+     *     $op(A) = A^T$, or
+     *     $op(A) = A^H$,
+     * alpha and beta are scalars, x and y are vectors,
+     * and A is an m-by-n matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] trans
+     *     The operation to be performed:
+     *     - Op::NoTrans:   $y = \alpha A   x + \beta y$,
+     *     - Op::Trans:     $y = \alpha A^T x + \beta y$,
+     *     - Op::ConjTrans: $y = \alpha A^H x + \beta y$.
+     *
+     * @param[in] m
+     *     Number of rows of the matrix A. m >= 0.
+     *
+     * @param[in] n
+     *     Number of columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and x are not accessed.
+     *
+     * @param[in] A
+     *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * m-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, m) [RowMajor: lda >= max(1,
+     * n)].
+     *
+     * @param[in] x
+     *     - If trans = NoTrans:
+     *       the n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *     - Otherwise:
+     *       the m-element vector x, in an array of length (m-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, y need not be set on input.
+     *
+     * @param[in,out] y
+     *     - If trans = NoTrans:
+     *       the m-element vector y, in an array of length (m-1)*abs(incy) + 1.
+     *     - Otherwise:
+     *       the n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX, typename TY>
+    void gemv(Layout layout,
+              Op trans,
+              idx_t m,
+              idx_t n,
+              scalar_type<TA, TX, TY> alpha,
+              TA const* A,
+              idx_t lda,
+              TX const* x,
+              int_t incx,
+              scalar_type<TA, TX, TY> beta,
+              TY* y,
+              int_t incy)
+    {
+        using internal::create_matrix;
+        using std::abs;
+        using scalar_t = scalar_type<TA, TX, TY>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (m == 0 || n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
-        return;
+        // quick return
+        if (m == 0 || n == 0 ||
+            ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
+            return;
 
-    // Transpose if Row Major
-    bool doConj = false;
-    if (layout == Layout::RowMajor) {
-        // A => A^T; A^T => A; A^H => A & doConj
-        std::swap(m, n);
-        if (trans == Op::NoTrans)
-            trans = Op::Trans;
+        // Transpose if Row Major
+        bool doConj = false;
+        if (layout == Layout::RowMajor) {
+            // A => A^T; A^T => A; A^H => A & doConj
+            std::swap(m, n);
+            if (trans == Op::NoTrans)
+                trans = Op::Trans;
+            else {
+                if (trans == Op::ConjTrans) doConj = true;
+                trans = Op::NoTrans;
+            }
+        }
+
+        // Initialize indexes
+        const idx_t lenx = ((trans == Op::NoTrans) ? n : m);
+        const idx_t leny = ((trans == Op::NoTrans) ? m : n);
+
+        // Conjugate if A is row-major and initially trans is Op::ConjTrans
+        if (doConj) {
+            TX* x2 = const_cast<TX*>(x);
+            for (idx_t i = 0; i < lenx; ++i)
+                x2[i * abs(incx)] = conj(x2[i * abs(incx)]);
+            for (idx_t i = 0; i < leny; ++i)
+                y[i * abs(incy)] = conj(y[i * abs(incy)]);
+        }
+
+        // Matrix views
+        const auto A_ = create_matrix<TA>((TA*)A, m, n, lda);
+
+        if (alpha == scalar_t(0)) {
+            tlapack_expr_with_vector(
+                y_, TY, leny, y, incy,
+                if (beta == scalar_t(0)) for (idx_t i = 0; i < leny; ++i)
+                    y_[i] = TY(0);
+                else for (idx_t i = 0; i < leny; ++i) y_[i] *=
+                (doConj) ? conj(beta) : beta);
+        }
         else {
-            if (trans == Op::ConjTrans) doConj = true;
-            trans = Op::NoTrans;
+            tlapack_expr_with_2vectors(
+                x_, TX, lenx, x, incx, y_, TY, leny, y, incy,
+                if (beta == scalar_t(0))
+                    gemv(trans, (doConj) ? conj(alpha) : alpha, A_, x_, y_);
+                else gemv(trans, (doConj) ? conj(alpha) : alpha, A_, x_,
+                          (doConj) ? conj(beta) : beta, y_));
+        }
+
+        // Conjugate if A is row-major and initially trans is Op::ConjTrans
+        if (doConj) {
+            TX* x2 = const_cast<TX*>(x);
+            for (idx_t i = 0; i < lenx; ++i)
+                x2[i * abs(incx)] = conj(x2[i * abs(incx)]);
+            for (idx_t i = 0; i < leny; ++i)
+                y[i * abs(incy)] = conj(y[i * abs(incy)]);
         }
     }
 
-    // Initialize indexes
-    const idx_t lenx = ((trans == Op::NoTrans) ? n : m);
-    const idx_t leny = ((trans == Op::NoTrans) ? m : n);
-
-    // Conjugate if A is row-major and initially trans is Op::ConjTrans
-    if (doConj) {
-        TX* x2 = const_cast<TX*>(x);
-        for (idx_t i = 0; i < lenx; ++i)
-            x2[i * abs(incx)] = conj(x2[i * abs(incx)]);
-        for (idx_t i = 0; i < leny; ++i)
-            y[i * abs(incy)] = conj(y[i * abs(incy)]);
-    }
-
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
-
-    if (alpha == scalar_t(0)) {
-        tlapack_expr_with_vector(
-            y_, TY, leny, y, incy,
-            if (beta == scalar_t(0)) for (idx_t i = 0; i < leny; ++i) y_[i] =
-                TY(0);
-            else for (idx_t i = 0; i < leny; ++i) y_[i] *=
-            (doConj) ? conj(beta) : beta);
-    }
-    else {
-        tlapack_expr_with_2vectors(
-            x_, TX, lenx, x, incx, y_, TY, leny, y, incy,
-            if (beta == scalar_t(0))
-                gemv(trans, (doConj) ? conj(alpha) : alpha, A_, x_, y_);
-            else gemv(trans, (doConj) ? conj(alpha) : alpha, A_, x_,
-                      (doConj) ? conj(beta) : beta, y_));
-    }
-
-    // Conjugate if A is row-major and initially trans is Op::ConjTrans
-    if (doConj) {
-        TX* x2 = const_cast<TX*>(x);
-        for (idx_t i = 0; i < lenx; ++i)
-            x2[i * abs(incx)] = conj(x2[i * abs(incx)]);
-        for (idx_t i = 0; i < leny; ++i)
-            y[i * abs(incy)] = conj(y[i * abs(incy)]);
-    }
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_GEMV_HH

--- a/include/tlapack/legacy_api/blas/ger.hpp
+++ b/include/tlapack/legacy_api/blas/ger.hpp
@@ -1,4 +1,4 @@
-/// @file ger.hpp
+/// @file legacy_api/blas/ger.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,95 +16,99 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * General matrix rank-1 update:
- * \[
- *     A = \alpha x y^H + A,
- * \]
- * where alpha is a scalar, x and y are vectors,
- * and A is an m-by-n matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] m
- *     Number of rows of the matrix A. m >= 0.
- *
- * @param[in] n
- *     Number of columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not updated.
- *
- * @param[in] x
- *     The m-element vector x, in an array of length (m-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @param[in,out] A
- *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor: m-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, m) [RowMajor: lda >= max(1, n)].
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX, typename TY>
-void ger(Layout layout,
-         idx_t m,
-         idx_t n,
-         scalar_type<TA, TX, TY> alpha,
-         TX const* x,
-         int_t incx,
-         TY const* y,
-         int_t incy,
-         TA* A,
-         idx_t lda)
-{
-    using internal::colmajor_matrix;
-    using internal::rowmajor_matrix;
-    using scalar_t = scalar_type<TA, TX, TY>;
+    /**
+     * General matrix rank-1 update:
+     * \[
+     *     A = \alpha x y^H + A,
+     * \]
+     * where alpha is a scalar, x and y are vectors,
+     * and A is an m-by-n matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] m
+     *     Number of rows of the matrix A. m >= 0.
+     *
+     * @param[in] n
+     *     Number of columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not updated.
+     *
+     * @param[in] x
+     *     The m-element vector x, in an array of length (m-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @param[in,out] A
+     *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * m-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, m) [RowMajor: lda >= max(1,
+     * n)].
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX, typename TY>
+    void ger(Layout layout,
+             idx_t m,
+             idx_t n,
+             scalar_type<TA, TX, TY> alpha,
+             TX const* x,
+             int_t incx,
+             TY const* y,
+             int_t incy,
+             TA* A,
+             idx_t lda)
+    {
+        using internal::create_matrix;
+        using internal::create_rowmajor_matrix;
+        using scalar_t = scalar_type<TA, TX, TY>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
-    tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
+        tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
 
-    // quick return
-    if (m == 0 || n == 0 || alpha == scalar_t(0)) return;
+        // quick return
+        if (m == 0 || n == 0 || alpha == scalar_t(0)) return;
 
-    if (layout == Layout::ColMajor) {
-        // Matrix views
-        auto A_ = colmajor_matrix<TA>(A, m, n, lda);
+        if (layout == Layout::ColMajor) {
+            // Matrix views
+            auto A_ = create_matrix<TA>(A, m, n, lda);
 
-        tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
-                                   return ger(alpha, x_, y_, A_));
+            tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
+                                       return ger(alpha, x_, y_, A_));
+        }
+        else {
+            // Matrix views
+            auto A_ = create_rowmajor_matrix<TA>(A, m, n, lda);
+
+            tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
+                                       return ger(alpha, x_, y_, A_));
+        }
     }
-    else {
-        // Matrix views
-        auto A_ = rowmajor_matrix<TA>(A, m, n, lda);
 
-        tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
-                                   return ger(alpha, x_, y_, A_));
-    }
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_GER_HH

--- a/include/tlapack/legacy_api/blas/geru.hpp
+++ b/include/tlapack/legacy_api/blas/geru.hpp
@@ -1,4 +1,4 @@
-/// @file geru.hpp
+/// @file legacy_api/blas/geru.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,94 +16,98 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * General matrix rank-1 update:
- * \[
- *     A = \alpha x y^T + A,
- * \]
- * where alpha is a scalar, x and y are vectors,
- * and A is an m-by-n matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] m
- *     Number of rows of the matrix A. m >= 0.
- *
- * @param[in] n
- *     Number of columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not updated.
- *
- * @param[in] x
- *     The m-element vector x, in an array of length (m-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @param[in,out] A
- *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor: m-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, m) [RowMajor: lda >= max(1, n)].
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX, typename TY>
-void geru(Layout layout,
-          idx_t m,
-          idx_t n,
-          scalar_type<TA, TX, TY> alpha,
-          TX const* x,
-          int_t incx,
-          TY const* y,
-          int_t incy,
-          TA* A,
-          idx_t lda)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TX, TY>;
+    /**
+     * General matrix rank-1 update:
+     * \[
+     *     A = \alpha x y^T + A,
+     * \]
+     * where alpha is a scalar, x and y are vectors,
+     * and A is an m-by-n matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] m
+     *     Number of rows of the matrix A. m >= 0.
+     *
+     * @param[in] n
+     *     Number of columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not updated.
+     *
+     * @param[in] x
+     *     The m-element vector x, in an array of length (m-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @param[in,out] A
+     *     The m-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * m-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, m) [RowMajor: lda >= max(1,
+     * n)].
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX, typename TY>
+    void geru(Layout layout,
+              idx_t m,
+              idx_t n,
+              scalar_type<TA, TX, TY> alpha,
+              TX const* x,
+              int_t incx,
+              TY const* y,
+              int_t incy,
+              TA* A,
+              idx_t lda)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TX, TY>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
-    tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
+        tlapack_check_false(lda < ((layout == Layout::ColMajor) ? m : n));
 
-    // quick return
-    if (m == 0 || n == 0 || alpha == scalar_t(0)) return;
+        // quick return
+        if (m == 0 || n == 0 || alpha == scalar_t(0)) return;
 
-    if (layout == Layout::ColMajor) {
-        // Matrix views
-        auto A_ = colmajor_matrix<TA>(A, m, n, lda);
+        if (layout == Layout::ColMajor) {
+            // Matrix views
+            auto A_ = create_matrix<TA>(A, m, n, lda);
 
-        tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
-                                   return geru(alpha, x_, y_, A_));
+            tlapack_expr_with_2vectors(x_, TX, m, x, incx, y_, TY, n, y, incy,
+                                       return geru(alpha, x_, y_, A_));
+        }
+        else {
+            // Matrix views
+            auto A_ = create_matrix<TA>(A, n, m, lda);
+
+            tlapack_expr_with_2vectors(y_, TY, n, y, incy, x_, TX, m, x, incx,
+                                       return geru(alpha, y_, x_, A_));
+        }
     }
-    else {
-        // Matrix views
-        auto A_ = colmajor_matrix<TA>(A, n, m, lda);
 
-        tlapack_expr_with_2vectors(y_, TY, n, y, incy, x_, TX, m, x, incx,
-                                   return geru(alpha, y_, x_, A_));
-    }
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_GER_HH

--- a/include/tlapack/legacy_api/blas/hemm.hpp
+++ b/include/tlapack/legacy_api/blas/hemm.hpp
@@ -1,4 +1,4 @@
-/// @file hemm.hpp
+/// @file legacy_api/blas/hemm.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,146 +16,149 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Hermitian matrix-matrix multiply:
- * \[
- *     C = \alpha A B + \beta C,
- * \]
- * or
- * \[
- *     C = \alpha B A + \beta C,
- * \]
- * where alpha and beta are scalars, A is an m-by-m or n-by-n Hermitian matrix,
- * and B and C are m-by-n matrices.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] side
- *     The side the matrix A appears on:
- *     - Side::Left:  $C = \alpha A B + \beta C$,
- *     - Side::Right: $C = \alpha B A + \beta C$.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced:
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] m
- *     Number of rows of the matrices B and C.
- *
- * @param[in] n
- *     Number of columns of the matrices B and C.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and B are not accessed.
- *
- * @param[in] A
- *     - If side = Left:  the m-by-m matrix A,
- *       stored in an lda-by-m array [RowMajor: m-by-lda].
- *     - If side = Right: the n-by-n matrix A,
- *       stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If side = Left:  lda >= max(1, m).
- *     - If side = Right: lda >= max(1, n).
- *
- * @param[in] B
- *     The m-by-n matrix B,
- *     stored in ldb-by-n array [RowMajor: m-by-ldb].
- *
- * @param[in] ldb
- *     Leading dimension of B.
- *     ldb >= max(1, m) [RowMajor: ldb >= max(1, n)].
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, C need not be set on input.
- *
- * @param[in] C
- *     The m-by-n matrix C,
- *     stored in ldc-by-n array [RowMajor: m-by-ldc].
- *
- * @param[in] ldc
- *     Leading dimension of C.
- *     ldc >= max(1, m) [RowMajor: ldc >= max(1, n)].
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TB, typename TC>
-void hemm(Layout layout,
-          Side side,
-          Uplo uplo,
-          idx_t m,
-          idx_t n,
-          scalar_type<TA, TB, TC> alpha,
-          TA const* A,
-          idx_t lda,
-          TB const* B,
-          idx_t ldb,
-          scalar_type<TA, TB, TC> beta,
-          TC* C,
-          idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TB, TC>;
+    /**
+     * Hermitian matrix-matrix multiply:
+     * \[
+     *     C = \alpha A B + \beta C,
+     * \]
+     * or
+     * \[
+     *     C = \alpha B A + \beta C,
+     * \]
+     * where alpha and beta are scalars, A is an m-by-m or n-by-n Hermitian
+     * matrix, and B and C are m-by-n matrices.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] side
+     *     The side the matrix A appears on:
+     *     - Side::Left:  $C = \alpha A B + \beta C$,
+     *     - Side::Right: $C = \alpha B A + \beta C$.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced:
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] m
+     *     Number of rows of the matrices B and C.
+     *
+     * @param[in] n
+     *     Number of columns of the matrices B and C.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and B are not accessed.
+     *
+     * @param[in] A
+     *     - If side = Left:  the m-by-m matrix A,
+     *       stored in an lda-by-m array [RowMajor: m-by-lda].
+     *     - If side = Right: the n-by-n matrix A,
+     *       stored in an lda-by-n array [RowMajor: n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If side = Left:  lda >= max(1, m).
+     *     - If side = Right: lda >= max(1, n).
+     *
+     * @param[in] B
+     *     The m-by-n matrix B,
+     *     stored in ldb-by-n array [RowMajor: m-by-ldb].
+     *
+     * @param[in] ldb
+     *     Leading dimension of B.
+     *     ldb >= max(1, m) [RowMajor: ldb >= max(1, n)].
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, C need not be set on input.
+     *
+     * @param[in] C
+     *     The m-by-n matrix C,
+     *     stored in ldc-by-n array [RowMajor: m-by-ldc].
+     *
+     * @param[in] ldc
+     *     Leading dimension of C.
+     *     ldc >= max(1, m) [RowMajor: ldc >= max(1, n)].
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TB, typename TC>
+    void hemm(Layout layout,
+              Side side,
+              Uplo uplo,
+              idx_t m,
+              idx_t n,
+              scalar_type<TA, TB, TC> alpha,
+              TA const* A,
+              idx_t lda,
+              TB const* B,
+              idx_t ldb,
+              scalar_type<TA, TB, TC> beta,
+              TC* C,
+              idx_t ldc)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TB, TC>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
-    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
-    tlapack_check_false(ldc < ((layout == Layout::RowMajor) ? n : m));
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+        tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
+        tlapack_check_false(ldc < ((layout == Layout::RowMajor) ? n : m));
 
-    // quick return
-    if (m == 0 || n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
-        return;
+        // quick return
+        if (m == 0 || n == 0 ||
+            ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
+            return;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        side = (side == Side::Left) ? Side::Right : Side::Left;
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        std::swap(m, n);
-    }
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            side = (side == Side::Left) ? Side::Right : Side::Left;
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            std::swap(m, n);
+        }
 
-    // Matrix views
-    const auto A_ = (side == Side::Left)
-                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
-                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
-    const auto B_ = colmajor_matrix<TB>((TB*)B, m, n, ldb);
-    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
+        // Matrix views
+        const auto A_ = (side == Side::Left)
+                            ? create_matrix<TA>((TA*)A, m, m, lda)
+                            : create_matrix<TA>((TA*)A, n, n, lda);
+        const auto B_ = create_matrix<TB>((TB*)B, m, n, ldb);
+        auto C_ = create_matrix<TC>(C, m, n, ldc);
 
-    if (alpha == scalar_t(0)) {
-        if (beta == scalar_t(0)) {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < m; ++i)
-                    C_(i, j) = TC(0);
+        if (alpha == scalar_t(0)) {
+            if (beta == scalar_t(0)) {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C_(i, j) = TC(0);
+            }
+            else {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C_(i, j) *= beta;
+            }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < m; ++i)
-                    C_(i, j) *= beta;
+            if (beta == scalar_t(0))
+                hemm(side, uplo, alpha, A_, B_, C_);
+            else
+                hemm(side, uplo, alpha, A_, B_, beta, C_);
         }
     }
-    else {
-        if (beta == scalar_t(0))
-            hemm(side, uplo, alpha, A_, B_, C_);
-        else
-            hemm(side, uplo, alpha, A_, B_, beta, C_);
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_HEMM_HH

--- a/include/tlapack/legacy_api/blas/hemv.hpp
+++ b/include/tlapack/legacy_api/blas/hemv.hpp
@@ -1,4 +1,4 @@
-/// @file hemv.hpp
+/// @file legacy_api/blas/hemv.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,117 +16,120 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Hermitian matrix-vector multiply:
- * \[
- *     y = \alpha A x + \beta y,
- * \]
- * where alpha and beta are scalars, x and y are vectors,
- * and A is an n-by-n Hermitian matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed from symmetry.
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and x are not accessed.
- *
- * @param[in] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *     Imaginary parts of the diagonal elements need not be set,
- *     and are assumed to be zero.
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, y need not be set on input.
- *
- * @param[in,out] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX, typename TY>
-void hemv(Layout layout,
-          Uplo uplo,
-          idx_t n,
-          scalar_type<TA, TX, TY> alpha,
-          TA const* A,
-          idx_t lda,
-          TX const* x,
-          int_t incx,
-          scalar_type<TA, TX, TY> beta,
-          TY* y,
-          int_t incy)
-{
-    using internal::colmajor_matrix;
-    using internal::rowmajor_matrix;
-    using scalar_t = scalar_type<TA, TX, TY>;
+    /**
+     * Hermitian matrix-vector multiply:
+     * \[
+     *     y = \alpha A x + \beta y,
+     * \]
+     * where alpha and beta are scalars, x and y are vectors,
+     * and A is an n-by-n Hermitian matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed from symmetry.
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and x are not accessed.
+     *
+     * @param[in] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda]. Imaginary parts of the diagonal elements need not be set, and
+     * are assumed to be zero.
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, y need not be set on input.
+     *
+     * @param[in,out] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX, typename TY>
+    void hemv(Layout layout,
+              Uplo uplo,
+              idx_t n,
+              scalar_type<TA, TX, TY> alpha,
+              TA const* A,
+              idx_t lda,
+              TX const* x,
+              int_t incx,
+              scalar_type<TA, TX, TY> beta,
+              TY* y,
+              int_t incy)
+    {
+        using internal::create_matrix;
+        using internal::create_rowmajor_matrix;
+        using scalar_t = scalar_type<TA, TX, TY>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < n);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < n);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1)))) return;
+        // quick return
+        if (n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1)))) return;
 
-    if (alpha == scalar_t(0)) {
-        tlapack_expr_with_vector(
-            y_, TY, n, y, incy,
-            if (beta == scalar_t(0)) for (idx_t i = 0; i < n; ++i) y_[i] =
-                TY(0);
-            else for (idx_t i = 0; i < n; ++i) y_[i] *= beta);
+        if (alpha == scalar_t(0)) {
+            tlapack_expr_with_vector(
+                y_, TY, n, y, incy,
+                if (beta == scalar_t(0)) for (idx_t i = 0; i < n; ++i) y_[i] =
+                    TY(0);
+                else for (idx_t i = 0; i < n; ++i) y_[i] *= beta);
+        }
+        else {
+            tlapack_expr_with_2vectors(
+                x_, TX, n, x, incx, y_, TY, n, y, incy,
+                if (beta ==
+                    scalar_t(
+                        0)) if (layout ==
+                                Layout::ColMajor) return hemv(uplo, alpha,
+                                                              create_matrix<TA>(
+                                                                  (TA*)A, n, n,
+                                                                  lda),
+                                                              x_, y_);
+                else return hemv(uplo, alpha,
+                                 create_rowmajor_matrix<TA>((TA*)A, n, n, lda),
+                                 x_, y_);
+                else if (layout == Layout::ColMajor) return hemv(
+                    uplo, alpha, create_matrix<TA>((TA*)A, n, n, lda), x_, beta,
+                    y_);
+                else return hemv(uplo, alpha,
+                                 create_rowmajor_matrix<TA>((TA*)A, n, n, lda),
+                                 x_, beta, y_));
+        }
     }
-    else {
-        tlapack_expr_with_2vectors(
-            x_, TX, n, x, incx, y_, TY, n, y, incy,
-            if (beta ==
-                scalar_t(
-                    0)) if (layout ==
-                            Layout::ColMajor) return hemv(uplo, alpha,
-                                                          colmajor_matrix<TA>(
-                                                              (TA*)A, n, n,
-                                                              lda),
-                                                          x_, y_);
-            else return hemv(uplo, alpha,
-                             rowmajor_matrix<TA>((TA*)A, n, n, lda), x_, y_);
-            else if (layout == Layout::ColMajor) return hemv(
-                uplo, alpha, colmajor_matrix<TA>((TA*)A, n, n, lda), x_, beta,
-                y_);
-            else return hemv(uplo, alpha,
-                             rowmajor_matrix<TA>((TA*)A, n, n, lda), x_, beta,
-                             y_));
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_HEMV_HH

--- a/include/tlapack/legacy_api/blas/her.hpp
+++ b/include/tlapack/legacy_api/blas/her.hpp
@@ -1,4 +1,4 @@
-/// @file her.hpp
+/// @file legacy_api/blas/her.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,84 +16,86 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Hermitian matrix rank-1 update:
- * \[
- *     A = \alpha x x^H + A,
- * \]
- * where alpha is a scalar, x is a vector,
- * and A is an n-by-n Hermitian matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed from symmetry.
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not updated.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in,out] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *     Imaginary parts of the diagonal elements need not be set,
- *     are assumed to be zero on entry, and are set to zero on exit.
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX>
-void her(Layout layout,
-         Uplo uplo,
-         idx_t n,
-         real_type<TA, TX> alpha,  // zher takes double alpha; use real
-         TX const* x,
-         int_t incx,
-         TA* A,
-         idx_t lda)
-{
-    using internal::colmajor_matrix;
-    using real_t = real_type<TA, TX>;
+    /**
+     * Hermitian matrix rank-1 update:
+     * \[
+     *     A = \alpha x x^H + A,
+     * \]
+     * where alpha is a scalar, x is a vector,
+     * and A is an n-by-n Hermitian matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed from symmetry.
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not updated.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in,out] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda]. Imaginary parts of the diagonal elements need not be set, are
+     * assumed to be zero on entry, and are set to zero on exit.
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX>
+    void her(Layout layout,
+             Uplo uplo,
+             idx_t n,
+             real_type<TA, TX> alpha,  // zher takes double alpha; use real
+             TX const* x,
+             int_t incx,
+             TA* A,
+             idx_t lda)
+    {
+        using internal::create_matrix;
+        using real_t = real_type<TA, TX>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(lda < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(lda < n);
 
-    // quick return
-    if (n == 0 || alpha == real_t(0)) return;
+        // quick return
+        if (n == 0 || alpha == real_t(0)) return;
 
-    // for row major, swap lower <=> upper
-    if (layout == Layout::RowMajor) {
-        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        // for row major, swap lower <=> upper
+        if (layout == Layout::RowMajor) {
+            uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        }
+
+        // Matrix views
+        auto A_ = create_matrix<TA>(A, n, n, lda);
+
+        tlapack_expr_with_vector(x_, TX, n, x, incx, her(uplo, alpha, x_, A_));
     }
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
-
-    tlapack_expr_with_vector(x_, TX, n, x, incx, her(uplo, alpha, x_, A_));
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_HER_HH

--- a/include/tlapack/legacy_api/blas/her2.hpp
+++ b/include/tlapack/legacy_api/blas/her2.hpp
@@ -1,4 +1,4 @@
-/// @file her2.hpp
+/// @file legacy_api/blas/her2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,95 +16,97 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Hermitian matrix rank-2 update:
- * \[
- *     A = \alpha x y^H + \text{conj}(\alpha) y x^H + A,
- * \]
- * where alpha is a scalar, x and y are vectors,
- * and A is an n-by-n Hermitian matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed from symmetry.
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not updated.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @param[in,out] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *     Imaginary parts of the diagonal elements need not be set,
- *     are assumed to be zero on entry, and are set to zero on exit.
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX, typename TY>
-void her2(Layout layout,
-          Uplo uplo,
-          idx_t n,
-          scalar_type<TA, TX, TY> alpha,
-          TX const* x,
-          int_t incx,
-          TY const* y,
-          int_t incy,
-          TA* A,
-          idx_t lda)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TX>;
+    /**
+     * Hermitian matrix rank-2 update:
+     * \[
+     *     A = \alpha x y^H + \text{conj}(\alpha) y x^H + A,
+     * \]
+     * where alpha is a scalar, x and y are vectors,
+     * and A is an n-by-n Hermitian matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed from symmetry.
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not updated.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @param[in,out] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda]. Imaginary parts of the diagonal elements need not be set, are
+     * assumed to be zero on entry, and are set to zero on exit.
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX, typename TY>
+    void her2(Layout layout,
+              Uplo uplo,
+              idx_t n,
+              scalar_type<TA, TX, TY> alpha,
+              TX const* x,
+              int_t incx,
+              TY const* y,
+              int_t incy,
+              TA* A,
+              idx_t lda)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TX>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
-    tlapack_check_false(lda < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
+        tlapack_check_false(lda < n);
 
-    // quick return
-    if (n == 0 || alpha == scalar_t(0)) return;
+        // quick return
+        if (n == 0 || alpha == scalar_t(0)) return;
 
-    // for row major, swap lower <=> upper
-    if (layout == Layout::RowMajor) {
-        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        // for row major, swap lower <=> upper
+        if (layout == Layout::RowMajor) {
+            uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        }
+
+        // Matrix views
+        auto A_ = create_matrix<TA>(A, n, n, lda);
+
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return her2(uplo, alpha, x_, y_, A_));
     }
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
-
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return her2(uplo, alpha, x_, y_, A_));
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_HER2_HH

--- a/include/tlapack/legacy_api/blas/her2k.hpp
+++ b/include/tlapack/legacy_api/blas/her2k.hpp
@@ -1,4 +1,4 @@
-/// @file her2k.hpp
+/// @file legacy_api/blas/her2k.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,164 +16,170 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Hermitian rank-k update:
- * \[
- *     C = \alpha A B^H + conj(\alpha) B A^H + \beta C,
- * \]
- * or
- * \[
- *     C = \alpha A^H B + conj(\alpha) B^H A + \beta C,
- * \]
- * where alpha and beta are scalars, C is an n-by-n Hermitian matrix,
- * and A and B are n-by-k or k-by-n matrices.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix C is referenced,
- *     the opposite triangle being assumed from symmetry:
- *     - Uplo::Lower: only the lower triangular part of C is referenced.
- *     - Uplo::Upper: only the upper triangular part of C is referenced.
- *
- * @param[in] trans
- *     The operation to be performed:
- *     - Op::NoTrans:   $C = \alpha A B^H + conj(\alpha) A^H B + \beta C$.
- *     - Op::ConjTrans: $C = \alpha A^H B + conj(\alpha) B A^H + \beta C$.
- *     - In the real    case, Op::Trans is interpreted as Op::ConjTrans.
- *       In the complex case, Op::Trans is illegal (see syr2k() instead).
- *
- * @param[in] n
- *     Number of rows and columns of the matrix C. n >= 0.
- *
- * @param[in] k
- *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
- *     - Otherwise:          number of rows    of the matrix A. k >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and B are not accessed.
- *
- * @param[in] A
- *     - If trans = NoTrans:
- *       the n-by-k matrix A, stored in an lda-by-k array [RowMajor: n-by-lda].
- *     - Otherwise:
- *       the k-by-n matrix A, stored in an lda-by-n array [RowMajor: k-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
- *     - Otherwise:          lda >= max(1, k) [RowMajor: lda >= max(1, n)].
- *
- * @param[in] B
- *     - If trans = NoTrans:
- *       the n-by-k matrix B, stored in an ldb-by-k array [RowMajor: n-by-ldb].
- *     - Otherwise:
- *       the k-by-n matrix B, stored in an ldb-by-n array [RowMajor: k-by-ldb].
- *
- * @param[in] ldb
- *     Leading dimension of B.
- *     - If trans = NoTrans: ldb >= max(1, n) [RowMajor: ldb >= max(1, k)],
- *     - Otherwise:          ldb >= max(1, k) [RowMajor: ldb >= max(1, n)].
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, C need not be set on input.
- *
- * @param[in] C
- *     The n-by-n Hermitian matrix C,
- *     stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] ldc
- *     Leading dimension of C. ldc >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TB, typename TC>
-void her2k(Layout layout,
-           Uplo uplo,
-           Op trans,
-           idx_t n,
-           idx_t k,
-           scalar_type<TA, TB, TC> alpha,  // note: complex
-           TA const* A,
-           idx_t lda,
-           TB const* B,
-           idx_t ldb,
-           real_type<TA, TB, TC> beta,  // note: real
-           TC* C,
-           idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TB, TC>;
-    using real_t = real_type<TA, TB, TC>;
+    /**
+     * Hermitian rank-k update:
+     * \[
+     *     C = \alpha A B^H + conj(\alpha) B A^H + \beta C,
+     * \]
+     * or
+     * \[
+     *     C = \alpha A^H B + conj(\alpha) B^H A + \beta C,
+     * \]
+     * where alpha and beta are scalars, C is an n-by-n Hermitian matrix,
+     * and A and B are n-by-k or k-by-n matrices.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix C is referenced,
+     *     the opposite triangle being assumed from symmetry:
+     *     - Uplo::Lower: only the lower triangular part of C is referenced.
+     *     - Uplo::Upper: only the upper triangular part of C is referenced.
+     *
+     * @param[in] trans
+     *     The operation to be performed:
+     *     - Op::NoTrans:   $C = \alpha A B^H + conj(\alpha) A^H B + \beta C$.
+     *     - Op::ConjTrans: $C = \alpha A^H B + conj(\alpha) B A^H + \beta C$.
+     *     - In the real    case, Op::Trans is interpreted as Op::ConjTrans.
+     *       In the complex case, Op::Trans is illegal (see syr2k() instead).
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix C. n >= 0.
+     *
+     * @param[in] k
+     *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
+     *     - Otherwise:          number of rows    of the matrix A. k >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and B are not accessed.
+     *
+     * @param[in] A
+     *     - If trans = NoTrans:
+     *       the n-by-k matrix A, stored in an lda-by-k array [RowMajor:
+     * n-by-lda].
+     *     - Otherwise:
+     *       the k-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * k-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
+     *     - Otherwise:          lda >= max(1, k) [RowMajor: lda >= max(1, n)].
+     *
+     * @param[in] B
+     *     - If trans = NoTrans:
+     *       the n-by-k matrix B, stored in an ldb-by-k array [RowMajor:
+     * n-by-ldb].
+     *     - Otherwise:
+     *       the k-by-n matrix B, stored in an ldb-by-n array [RowMajor:
+     * k-by-ldb].
+     *
+     * @param[in] ldb
+     *     Leading dimension of B.
+     *     - If trans = NoTrans: ldb >= max(1, n) [RowMajor: ldb >= max(1, k)],
+     *     - Otherwise:          ldb >= max(1, k) [RowMajor: ldb >= max(1, n)].
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, C need not be set on input.
+     *
+     * @param[in] C
+     *     The n-by-n Hermitian matrix C,
+     *     stored in an lda-by-n array [RowMajor: n-by-lda].
+     *
+     * @param[in] ldc
+     *     Leading dimension of C. ldc >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TB, typename TC>
+    void her2k(Layout layout,
+               Uplo uplo,
+               Op trans,
+               idx_t n,
+               idx_t k,
+               scalar_type<TA, TB, TC> alpha,  // note: complex
+               TA const* A,
+               idx_t lda,
+               TB const* B,
+               idx_t ldb,
+               real_type<TA, TB, TC> beta,  // note: real
+               TC* C,
+               idx_t ldc)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TB, TC>;
+        using real_t = real_type<TA, TB, TC>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(k < 0);
-    tlapack_check_false(lda < ((layout == Layout::RowMajor)
-                                   ? ((trans == Op::NoTrans) ? k : n)
-                                   : ((trans == Op::NoTrans) ? n : k)));
-    tlapack_check_false(ldb < ((layout == Layout::RowMajor)
-                                   ? ((trans == Op::NoTrans) ? k : n)
-                                   : ((trans == Op::NoTrans) ? n : k)));
-    tlapack_check_false(ldc < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(k < 0);
+        tlapack_check_false(lda < ((layout == Layout::RowMajor)
+                                       ? ((trans == Op::NoTrans) ? k : n)
+                                       : ((trans == Op::NoTrans) ? n : k)));
+        tlapack_check_false(ldb < ((layout == Layout::RowMajor)
+                                       ? ((trans == Op::NoTrans) ? k : n)
+                                       : ((trans == Op::NoTrans) ? n : k)));
+        tlapack_check_false(ldc < n);
 
-    // quick return
-    if (n == 0 || ((alpha == scalar_t(0) || k == 0) && (beta == real_t(1))))
-        return;
+        // quick return
+        if (n == 0 || ((alpha == scalar_t(0) || k == 0) && (beta == real_t(1))))
+            return;
 
-    // This algorithm only works with Op::NoTrans or Op::ConjTrans
-    if (trans == Op::Trans) trans = Op::ConjTrans;
+        // This algorithm only works with Op::NoTrans or Op::ConjTrans
+        if (trans == Op::Trans) trans = Op::ConjTrans;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        trans = (trans == Op::NoTrans) ? Op::ConjTrans : Op::NoTrans;
-        alpha = conj(alpha);
-    }
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            trans = (trans == Op::NoTrans) ? Op::ConjTrans : Op::NoTrans;
+            alpha = conj(alpha);
+        }
 
-    // Matrix views
-    const auto A_ = (trans == Op::NoTrans)
-                        ? colmajor_matrix<TA>((TA*)A, n, k, lda)
-                        : colmajor_matrix<TA>((TA*)A, k, n, lda);
-    const auto B_ = (trans == Op::NoTrans)
-                        ? colmajor_matrix<TB>((TB*)B, n, k, ldb)
-                        : colmajor_matrix<TB>((TB*)B, k, n, ldb);
-    auto C_ = colmajor_matrix<TC>(C, n, n, ldc);
+        // Matrix views
+        const auto A_ = (trans == Op::NoTrans)
+                            ? create_matrix<TA>((TA*)A, n, k, lda)
+                            : create_matrix<TA>((TA*)A, k, n, lda);
+        const auto B_ = (trans == Op::NoTrans)
+                            ? create_matrix<TB>((TB*)B, n, k, ldb)
+                            : create_matrix<TB>((TB*)B, k, n, ldb);
+        auto C_ = create_matrix<TC>(C, n, n, ldc);
 
-    if (alpha == scalar_t(0)) {
-        if (beta == real_t(0)) {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) = TC(0);
+        if (alpha == scalar_t(0)) {
+            if (beta == real_t(0)) {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) = TC(0);
+            }
+            else {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) *= beta;
+            }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) *= beta;
+            if (beta == real_t(0))
+                her2k(uplo, trans, alpha, A_, B_, C_);
+            else
+                her2k(uplo, trans, alpha, A_, B_, beta, C_);
         }
     }
-    else {
-        if (beta == real_t(0))
-            her2k(uplo, trans, alpha, A_, B_, C_);
-        else
-            her2k(uplo, trans, alpha, A_, B_, beta, C_);
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_HER2K_HH

--- a/include/tlapack/legacy_api/blas/herk.hpp
+++ b/include/tlapack/legacy_api/blas/herk.hpp
@@ -1,4 +1,4 @@
-/// @file herk.hpp
+/// @file legacy_api/blas/herk.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,144 +16,148 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Hermitian rank-k update:
- * \[
- *     C = \alpha A A^H + \beta C,
- * \]
- * or
- * \[
- *     C = \alpha A^H A + \beta C,
- * \]
- * where alpha and beta are real scalars, C is an n-by-n Hermitian matrix,
- * and A is an n-by-k or k-by-n matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix C is referenced,
- *     the opposite triangle being assumed from symmetry:
- *     - Uplo::Lower: only the lower triangular part of C is referenced.
- *     - Uplo::Upper: only the upper triangular part of C is referenced.
- *
- * @param[in] trans
- *     The operation to be performed:
- *     - Op::NoTrans:   $C = \alpha A A^H + \beta C$.
- *     - Op::ConjTrans: $C = \alpha A^H A + \beta C$.
- *     - In the real    case, Op::Trans is interpreted as Op::ConjTrans.
- *       In the complex case, Op::Trans is illegal (see syrk() instead).
- *
- * @param[in] n
- *     Number of rows and columns of the matrix C. n >= 0.
- *
- * @param[in] k
- *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
- *     - Otherwise:          number of rows    of the matrix A. k >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not accessed.
- *
- * @param[in] A
- *     - If trans = NoTrans:
- *     the n-by-k matrix A, stored in an lda-by-k array [RowMajor: n-by-lda].
- *     - Otherwise:
- *     the k-by-n matrix A, stored in an lda-by-n array [RowMajor: k-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
- *     If Otherwise:       lda >= max(1, k) [RowMajor: lda >= max(1, n)].
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, C need not be set on input.
- *
- * @param[in] C
- *     The n-by-n Hermitian matrix C,
- *     stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] ldc
- *     Leading dimension of C. ldc >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TC>
-void herk(Layout layout,
-          Uplo uplo,
-          Op trans,
-          idx_t n,
-          idx_t k,
-          real_type<TA, TC> alpha,  // note: real
-          TA const* A,
-          idx_t lda,
-          real_type<TA, TC> beta,  // note: real
-          TC* C,
-          idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using real_t = real_type<TA, TC>;
+    /**
+     * Hermitian rank-k update:
+     * \[
+     *     C = \alpha A A^H + \beta C,
+     * \]
+     * or
+     * \[
+     *     C = \alpha A^H A + \beta C,
+     * \]
+     * where alpha and beta are real scalars, C is an n-by-n Hermitian matrix,
+     * and A is an n-by-k or k-by-n matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix C is referenced,
+     *     the opposite triangle being assumed from symmetry:
+     *     - Uplo::Lower: only the lower triangular part of C is referenced.
+     *     - Uplo::Upper: only the upper triangular part of C is referenced.
+     *
+     * @param[in] trans
+     *     The operation to be performed:
+     *     - Op::NoTrans:   $C = \alpha A A^H + \beta C$.
+     *     - Op::ConjTrans: $C = \alpha A^H A + \beta C$.
+     *     - In the real    case, Op::Trans is interpreted as Op::ConjTrans.
+     *       In the complex case, Op::Trans is illegal (see syrk() instead).
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix C. n >= 0.
+     *
+     * @param[in] k
+     *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
+     *     - Otherwise:          number of rows    of the matrix A. k >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not accessed.
+     *
+     * @param[in] A
+     *     - If trans = NoTrans:
+     *     the n-by-k matrix A, stored in an lda-by-k array [RowMajor:
+     * n-by-lda].
+     *     - Otherwise:
+     *     the k-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * k-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
+     *     If Otherwise:       lda >= max(1, k) [RowMajor: lda >= max(1, n)].
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, C need not be set on input.
+     *
+     * @param[in] C
+     *     The n-by-n Hermitian matrix C,
+     *     stored in an lda-by-n array [RowMajor: n-by-lda].
+     *
+     * @param[in] ldc
+     *     Leading dimension of C. ldc >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TC>
+    void herk(Layout layout,
+              Uplo uplo,
+              Op trans,
+              idx_t n,
+              idx_t k,
+              real_type<TA, TC> alpha,  // note: real
+              TA const* A,
+              idx_t lda,
+              real_type<TA, TC> beta,  // note: real
+              TC* C,
+              idx_t ldc)
+    {
+        using internal::create_matrix;
+        using real_t = real_type<TA, TC>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(k < 0);
-    tlapack_check_false(lda < ((layout == Layout::RowMajor)
-                                   ? ((trans == Op::NoTrans) ? k : n)
-                                   : ((trans == Op::NoTrans) ? n : k)));
-    tlapack_check_false(ldc < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(k < 0);
+        tlapack_check_false(lda < ((layout == Layout::RowMajor)
+                                       ? ((trans == Op::NoTrans) ? k : n)
+                                       : ((trans == Op::NoTrans) ? n : k)));
+        tlapack_check_false(ldc < n);
 
-    // quick return
-    if (n == 0 || ((alpha == real_t(0) || k == 0) && (beta == real_t(1))))
-        return;
+        // quick return
+        if (n == 0 || ((alpha == real_t(0) || k == 0) && (beta == real_t(1))))
+            return;
 
-    // This algorithm only works with Op::NoTrans or Op::ConjTrans
-    if (trans == Op::Trans) trans = Op::ConjTrans;
+        // This algorithm only works with Op::NoTrans or Op::ConjTrans
+        if (trans == Op::Trans) trans = Op::ConjTrans;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        trans = (trans == Op::NoTrans) ? Op::ConjTrans : Op::NoTrans;
-        alpha = conj(alpha);
-    }
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            trans = (trans == Op::NoTrans) ? Op::ConjTrans : Op::NoTrans;
+            alpha = conj(alpha);
+        }
 
-    // Matrix views
-    const auto A_ = (trans == Op::NoTrans)
-                        ? colmajor_matrix<TA>((TA*)A, n, k, lda)
-                        : colmajor_matrix<TA>((TA*)A, k, n, lda);
-    auto C_ = colmajor_matrix<TC>(C, n, n, ldc);
+        // Matrix views
+        const auto A_ = (trans == Op::NoTrans)
+                            ? create_matrix<TA>((TA*)A, n, k, lda)
+                            : create_matrix<TA>((TA*)A, k, n, lda);
+        auto C_ = create_matrix<TC>(C, n, n, ldc);
 
-    if (alpha == real_t(0)) {
-        if (beta == real_t(0)) {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) = TC(0);
+        if (alpha == real_t(0)) {
+            if (beta == real_t(0)) {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) = TC(0);
+            }
+            else {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) *= beta;
+            }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) *= beta;
+            if (beta == real_t(0))
+                herk(uplo, trans, alpha, A_, C_);
+            else
+                herk(uplo, trans, alpha, A_, beta, C_);
         }
     }
-    else {
-        if (beta == real_t(0))
-            herk(uplo, trans, alpha, A_, C_);
-        else
-            herk(uplo, trans, alpha, A_, beta, C_);
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_HERK_HH

--- a/include/tlapack/legacy_api/blas/iamax.hpp
+++ b/include/tlapack/legacy_api/blas/iamax.hpp
@@ -1,4 +1,4 @@
-/// @file iamax.hpp
+/// @file legacy_api/blas/iamax.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,42 +16,45 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * @brief Return $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$
- *
- * @param[in] n
- *     Number of elements in x.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*incx + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx > 0.
- *
- * @return In priority order:
- * 1. 0 if n <= 0,
- * 2. the index of the first `NAN` in $x$ if it exists and if `checkNAN ==
- * true`,
- * 3. the index of the first `Infinity` in $x$ if it exists,
- * 4. the Index of the infinity-norm of $x$, $|| x ||_{inf}$,
- *     $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$.
- *
- * @see iamax( const vector_t& x, const ec_opts_t& opts = {} )
- *
- * @ingroup legacy_blas
- */
-template <typename T>
-idx_t iamax(idx_t n, T const* x, int_t incx)
-{
-    tlapack_check_false(incx <= 0);
+    /**
+     * @brief Return $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$
+     *
+     * @param[in] n
+     *     Number of elements in x.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*incx + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx > 0.
+     *
+     * @return In priority order:
+     * 1. 0 if n <= 0,
+     * 2. the index of the first `NAN` in $x$ if it exists and if `checkNAN ==
+     * true`,
+     * 3. the index of the first `Infinity` in $x$ if it exists,
+     * 4. the Index of the infinity-norm of $x$, $|| x ||_{inf}$,
+     *     $\arg\max_{i=0}^{n-1} \left(|Re(x_i)| + |Im(x_i)|\right)$.
+     *
+     * @see iamax( const vector_t& x, const ec_opts_t& opts = {} )
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename T>
+    idx_t iamax(idx_t n, T const* x, int_t incx)
+    {
+        tlapack_check_false(incx <= 0);
 
-    // quick return
-    if (n <= 0) return 0;
+        // quick return
+        if (n <= 0) return 0;
 
-    tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx, return iamax(x_));
-}
+        tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx,
+                                             return iamax(x_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_IAMAX_HH

--- a/include/tlapack/legacy_api/blas/nrm2.hpp
+++ b/include/tlapack/legacy_api/blas/nrm2.hpp
@@ -1,4 +1,4 @@
-/// @file nrm2.hpp
+/// @file legacy_api/blas/nrm2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 ///
 /// Anderson E. (2017)
@@ -21,35 +21,38 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * @return 2-norm of vector,
- *     $|| x ||_2 = (\sum_{i=0}^{n-1} |x_i|^2)^{1/2}$.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] n
- *     Number of elements in x. n >= 0.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*incx + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx > 0.
- *
- * @ingroup legacy_blas
- */
-template <typename T>
-real_type<T> nrm2(idx_t n, T const* x, int_t incx)
-{
-    tlapack_check_false(incx <= 0);
+    /**
+     * @return 2-norm of vector,
+     *     $|| x ||_2 = (\sum_{i=0}^{n-1} |x_i|^2)^{1/2}$.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] n
+     *     Number of elements in x. n >= 0.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*incx + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx > 0.
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename T>
+    real_type<T> nrm2(idx_t n, T const* x, int_t incx)
+    {
+        tlapack_check_false(incx <= 0);
 
-    // quick return
-    if (n <= 0) return 0;
+        // quick return
+        if (n <= 0) return 0;
 
-    tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx, return nrm2(x_));
-}
+        tlapack_expr_with_vector_positiveInc(x_, T, n, x, incx,
+                                             return nrm2(x_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // #ifndef TLAPACK_LEGACY_NRM2_HH

--- a/include/tlapack/legacy_api/blas/rot.hpp
+++ b/include/tlapack/legacy_api/blas/rot.hpp
@@ -1,4 +1,4 @@
-/// @file rot.hpp
+/// @file legacy_api/blas/rot.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,64 +16,66 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Apply plane rotation:
- * \[
- *       \begin{bmatrix} x^T   \\ y^T    \end{bmatrix}
- *     = \begin{bmatrix} c & s \\ -s & c \end{bmatrix}
- *       \begin{bmatrix} x^T   \\ y^T    \end{bmatrix}.
- * \]
- *
- * @see rotg to generate the rotation.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] n
- *     Number of elements in x and y. n >= 0.
- *
- * @param[in,out] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in,out] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @param[in] c
- *     Cosine of rotation; real.
- *
- * @param[in] s
- *     Sine of rotation; complex.
- *
- * @ingroup legacy_blas
- */
-template <typename TX, typename TY>
-void rot(idx_t n,
-         TX* x,
-         int_t incx,
-         TY* y,
-         int_t incy,
-         const real_type<TX, TY>& c,
-         const scalar_type<TX, TY>& s)
-{
-    // check arguments
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+    /**
+     * Apply plane rotation:
+     * \[
+     *       \begin{bmatrix} x^T   \\ y^T    \end{bmatrix}
+     *     = \begin{bmatrix} c & s \\ -s & c \end{bmatrix}
+     *       \begin{bmatrix} x^T   \\ y^T    \end{bmatrix}.
+     * \]
+     *
+     * @see rotg to generate the rotation.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] n
+     *     Number of elements in x and y. n >= 0.
+     *
+     * @param[in,out] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in,out] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @param[in] c
+     *     Cosine of rotation; real.
+     *
+     * @param[in] s
+     *     Sine of rotation; complex.
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TX, typename TY>
+    void rot(idx_t n,
+             TX* x,
+             int_t incx,
+             TY* y,
+             int_t incy,
+             const real_type<TX, TY>& c,
+             const scalar_type<TX, TY>& s)
+    {
+        // check arguments
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (n <= 0) return;
+        // quick return
+        if (n <= 0) return;
 
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return rot(x_, y_, c, s));
-}
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return rot(x_, y_, c, s));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_ROT_HH

--- a/include/tlapack/legacy_api/blas/rotg.hpp
+++ b/include/tlapack/legacy_api/blas/rotg.hpp
@@ -1,4 +1,4 @@
-/// @file rotg.hpp
+/// @file legacy_api/blas/rotg.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,44 +16,46 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Construct plane rotation that eliminates b, such that:
- * \[
- *       \begin{bmatrix} r     \\ 0      \end{bmatrix}
- *     = \begin{bmatrix} c & s \\ -s & c \end{bmatrix}
- *       \begin{bmatrix} a     \\ b      \end{bmatrix}.
- * \]
- *
- * @see rot to apply the rotation.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in,out] a
- *     On entry, scalar a. On exit, set to r.
- *
- * @param[in,out] b
- *     On entry, scalar b. On exit, set to s, 1/c, or 0.
- *
- * @param[out] c
- *     Cosine of rotation; real.
- *
- * @param[out] s
- *     Sine of rotation; scalar.
- *
- * @details
- *
- * Anderson E (2017) Algorithm 978: Safe scaling in the level 1 BLAS.
- * ACM Trans Math Softw 44:. https://doi.org/10.1145/3061665
- *
- * @ingroup legacy_blas
- */
-template <typename T>
-inline void rotg(T* a, T* b, real_type<T>* c, T* s)
-{
-    return rotg(*a, *b, *c, *s);
-}
+    /**
+     * Construct plane rotation that eliminates b, such that:
+     * \[
+     *       \begin{bmatrix} r     \\ 0      \end{bmatrix}
+     *     = \begin{bmatrix} c & s \\ -s & c \end{bmatrix}
+     *       \begin{bmatrix} a     \\ b      \end{bmatrix}.
+     * \]
+     *
+     * @see rot to apply the rotation.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in,out] a
+     *     On entry, scalar a. On exit, set to r.
+     *
+     * @param[in,out] b
+     *     On entry, scalar b. On exit, set to s, 1/c, or 0.
+     *
+     * @param[out] c
+     *     Cosine of rotation; real.
+     *
+     * @param[out] s
+     *     Sine of rotation; scalar.
+     *
+     * @details
+     *
+     * Anderson E (2017) Algorithm 978: Safe scaling in the level 1 BLAS.
+     * ACM Trans Math Softw 44:. https://doi.org/10.1145/3061665
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename T>
+    inline void rotg(T* a, T* b, real_type<T>* c, T* s)
+    {
+        return ::tlapack::rotg(*a, *b, *c, *s);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_ROTG_HH

--- a/include/tlapack/legacy_api/blas/rotm.hpp
+++ b/include/tlapack/legacy_api/blas/rotm.hpp
@@ -1,4 +1,4 @@
-/// @file rotm.hpp
+/// @file legacy_api/blas/rotm.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,68 +16,71 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Apply modified (fast) plane rotation, H:
- * \[
- *       \begin{bmatrix} x^T \\ y^T \end{bmatrix}
- *     = H
- *       \begin{bmatrix} x^T \\ y^T \end{bmatrix}.
- * \]
- *
- * @see rotmg to generate the rotation, and for fuller description.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] n
- *     Number of elements in x and y. n >= 0.
- *
- * @param[in,out] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in,out] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @param[in] param
- *     Array of length 5 giving parameters of modified plane rotation.
- *
- * @ingroup legacy_blas
- */
-template <typename TX, typename TY>
-void rotm(idx_t n,
-          TX* x,
-          int_t incx,
-          TY* y,
-          int_t incy,
-          scalar_type<TX, TY> const param[5])
-{
-    // constants
-    const int flag = (int)param[0];
-    const scalar_type<TX, TY>* h = &param[1];
+    /**
+     * Apply modified (fast) plane rotation, H:
+     * \[
+     *       \begin{bmatrix} x^T \\ y^T \end{bmatrix}
+     *     = H
+     *       \begin{bmatrix} x^T \\ y^T \end{bmatrix}.
+     * \]
+     *
+     * @see rotmg to generate the rotation, and for fuller description.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] n
+     *     Number of elements in x and y. n >= 0.
+     *
+     * @param[in,out] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in,out] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @param[in] param
+     *     Array of length 5 giving parameters of modified plane rotation.
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TX, typename TY>
+    void rotm(idx_t n,
+              TX* x,
+              int_t incx,
+              TY* y,
+              int_t incy,
+              scalar_type<TX, TY> const param[5])
+    {
+        // constants
+        const int flag = (int)param[0];
+        const scalar_type<TX, TY>* h = &param[1];
 
-    // check arguments
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
-    tlapack_check_false(flag < -2 && flag > 1);
+        // check arguments
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
+        tlapack_check_false(flag < -2 && flag > 1);
 
-    // quick return
-    if (n <= 0) return;
+        // quick return
+        if (n <= 0) return;
 
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               if (flag == -2) return rotm<-2>(x_, y_, h);
-                               else if (flag == -1) return rotm<-1>(x_, y_, h);
-                               else if (flag == 0) return rotm<0>(x_, y_, h);
-                               else return rotm<1>(x_, y_, h););
-}
+        tlapack_expr_with_2vectors(
+            x_, TX, n, x, incx, y_, TY, n, y, incy,
+            if (flag == -2) return rotm<-2>(x_, y_, h);
+            else if (flag == -1) return rotm<-1>(x_, y_, h);
+            else if (flag == 0) return rotm<0>(x_, y_, h);
+            else return rotm<1>(x_, y_, h););
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_ROTM_HH

--- a/include/tlapack/legacy_api/blas/rotmg.hpp
+++ b/include/tlapack/legacy_api/blas/rotmg.hpp
@@ -1,4 +1,4 @@
-/// @file rotmg.hpp
+/// @file legacy_api/blas/rotmg.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,99 +16,102 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Construct modified (fast) plane rotation, H, that eliminates b, such that
- * \[
- *       \begin{bmatrix} z \\ 0 \end{bmatrix}
- *     = H
- *       \begin{bmatrix} \sqrt{d_1} & 0 \\ 0 & \sqrt{d_2} \end{bmatrix}
- *       \begin{bmatrix} a \\ b \end{bmatrix}.
- * \]
- *
- * @see rotm to apply the rotation.
- *
- * With modified plane rotations, vectors u and v are held in factored form as
- * \[
- *     \begin{bmatrix} u^T \\ v^T \end{bmatrix} =
- *     \begin{bmatrix} \sqrt{d_1} & 0 \\ 0 & \sqrt{d_2} \end{bmatrix}
- *     \begin{bmatrix} x^T \\ y^T \end{bmatrix}.
- * \]
- *
- * Application of H to vectors x and y requires 4n flops (2n mul, 2n add)
- * instead of 6n flops (4n mul, 2n add) as in standard plane rotations.
- *
- * Let param = [ flag, $h_{11}, h_{21}, h_{12}, h_{22}$ ].
- * Then H has one of the following forms:
- *
- * - For flag = -1,
- *     \[
- *         H = \begin{bmatrix}
- *             h_{11}  &  h_{12}
- *         \\  h_{21}  &  h_{22}
- *         \end{bmatrix}
- *     \]
- *
- * - For flag = 0,
- *     \[
- *         H = \begin{bmatrix}
- *             1       &  h_{12}
- *         \\  h_{21}  &  1
- *         \end{bmatrix}
- *     \]
- *
- * - For flag = 1,
- *     \[
- *         H = \begin{bmatrix}
- *             h_{11}  &  1
- *         \\  -1      &  h_{22}
- *         \end{bmatrix}
- *     \]
- *
- * - For flag = -2,
- *     \[
- *         H = \begin{bmatrix}
- *             1  &  0
- *         \\  0  &  1
- *         \end{bmatrix}
- *     \]
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in,out] d1
- *     sqrt(d1) is scaling factor for vector x.
- *
- * @param[in,out] d2
- *     sqrt(d2) is scaling factor for vector y.
- *
- * @param[in,out] a
- *     On entry, scalar a. On exit, set to z.
- *
- * @param[in] b
- *     On entry, scalar b.
- *
- * @param[out] param
- *     Array of length 5 giving parameters of modified plane rotation,
- *     as described above.
- *
- * @details
- *
- * Hammarling, Sven. A note on modifications to the Givens plane rotation.
- * IMA Journal of Applied Mathematics, 13:215-218, 1974.
- * http://dx.doi.org/10.1093/imamat/13.2.215
- * (Note the notation swaps u <=> x, v <=> y, d_i -> l_i.)
- *
- * @ingroup legacy_blas
- */
-template <typename real_t>
-void rotmg(real_t* d1, real_t* d2, real_t* a, real_t b, real_t param[5])
-{
-    // check arguments
-    tlapack_check_false(*d1 <= 0);
+    /**
+     * Construct modified (fast) plane rotation, H, that eliminates b, such that
+     * \[
+     *       \begin{bmatrix} z \\ 0 \end{bmatrix}
+     *     = H
+     *       \begin{bmatrix} \sqrt{d_1} & 0 \\ 0 & \sqrt{d_2} \end{bmatrix}
+     *       \begin{bmatrix} a \\ b \end{bmatrix}.
+     * \]
+     *
+     * @see rotm to apply the rotation.
+     *
+     * With modified plane rotations, vectors u and v are held in factored form
+     * as
+     * \[
+     *     \begin{bmatrix} u^T \\ v^T \end{bmatrix} =
+     *     \begin{bmatrix} \sqrt{d_1} & 0 \\ 0 & \sqrt{d_2} \end{bmatrix}
+     *     \begin{bmatrix} x^T \\ y^T \end{bmatrix}.
+     * \]
+     *
+     * Application of H to vectors x and y requires 4n flops (2n mul, 2n add)
+     * instead of 6n flops (4n mul, 2n add) as in standard plane rotations.
+     *
+     * Let param = [ flag, $h_{11}, h_{21}, h_{12}, h_{22}$ ].
+     * Then H has one of the following forms:
+     *
+     * - For flag = -1,
+     *     \[
+     *         H = \begin{bmatrix}
+     *             h_{11}  &  h_{12}
+     *         \\  h_{21}  &  h_{22}
+     *         \end{bmatrix}
+     *     \]
+     *
+     * - For flag = 0,
+     *     \[
+     *         H = \begin{bmatrix}
+     *             1       &  h_{12}
+     *         \\  h_{21}  &  1
+     *         \end{bmatrix}
+     *     \]
+     *
+     * - For flag = 1,
+     *     \[
+     *         H = \begin{bmatrix}
+     *             h_{11}  &  1
+     *         \\  -1      &  h_{22}
+     *         \end{bmatrix}
+     *     \]
+     *
+     * - For flag = -2,
+     *     \[
+     *         H = \begin{bmatrix}
+     *             1  &  0
+     *         \\  0  &  1
+     *         \end{bmatrix}
+     *     \]
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in,out] d1
+     *     sqrt(d1) is scaling factor for vector x.
+     *
+     * @param[in,out] d2
+     *     sqrt(d2) is scaling factor for vector y.
+     *
+     * @param[in,out] a
+     *     On entry, scalar a. On exit, set to z.
+     *
+     * @param[in] b
+     *     On entry, scalar b.
+     *
+     * @param[out] param
+     *     Array of length 5 giving parameters of modified plane rotation,
+     *     as described above.
+     *
+     * @details
+     *
+     * Hammarling, Sven. A note on modifications to the Givens plane rotation.
+     * IMA Journal of Applied Mathematics, 13:215-218, 1974.
+     * http://dx.doi.org/10.1093/imamat/13.2.215
+     * (Note the notation swaps u <=> x, v <=> y, d_i -> l_i.)
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename real_t>
+    void rotmg(real_t* d1, real_t* d2, real_t* a, real_t b, real_t param[5])
+    {
+        // check arguments
+        tlapack_check_false(*d1 <= 0);
 
-    param[0] = rotmg(*d1, *d2, *a, b, &param[1]);
-}
+        param[0] = ::tlapack::rotmg(*d1, *d2, *a, b, &param[1]);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_ROTMG_HH

--- a/include/tlapack/legacy_api/blas/scal.hpp
+++ b/include/tlapack/legacy_api/blas/scal.hpp
@@ -1,4 +1,4 @@
-/// @file scal.hpp
+/// @file legacy_api/blas/scal.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,38 +16,40 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Scale vector by constant, $x = \alpha x$.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] n
- *     Number of elements in x. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*incx + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx > 0.
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX>
-void scal(idx_t n, const TA& alpha, TX* x, int_t incx)
-{
-    tlapack_check_false(incx <= 0);
+    /**
+     * Scale vector by constant, $x = \alpha x$.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] n
+     *     Number of elements in x. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*incx + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx > 0.
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX>
+    void scal(idx_t n, const TA& alpha, TX* x, int_t incx)
+    {
+        tlapack_check_false(incx <= 0);
 
-    // quick return
-    if (n <= 0) return;
+        // quick return
+        if (n <= 0) return;
 
-    tlapack_expr_with_vector_positiveInc(x_, TX, n, x, incx,
-                                         return scal(alpha, x_));
-}
+        tlapack_expr_with_vector_positiveInc(x_, TX, n, x, incx,
+                                             return scal(alpha, x_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SCAL_HH

--- a/include/tlapack/legacy_api/blas/swap.hpp
+++ b/include/tlapack/legacy_api/blas/swap.hpp
@@ -1,4 +1,4 @@
-/// @file swap.hpp
+/// @file legacy_api/blas/swap.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,45 +16,47 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Swap vectors, $x <=> y$.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] n
- *     Number of elements in x and y. n >= 0.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in,out] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TX, typename TY>
-void swap(idx_t n, TX* x, int_t incx, TY* y, int_t incy)
-{
-    // check arguments
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+    /**
+     * Swap vectors, $x <=> y$.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] n
+     *     Number of elements in x and y. n >= 0.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in,out] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TX, typename TY>
+    void swap(idx_t n, TX* x, int_t incx, TY* y, int_t incy)
+    {
+        // check arguments
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (n <= 0) return;
+        // quick return
+        if (n <= 0) return;
 
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return tlapack::swap(x_, y_););
-}
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return tlapack::swap(x_, y_););
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SWAP_HH

--- a/include/tlapack/legacy_api/blas/symm.hpp
+++ b/include/tlapack/legacy_api/blas/symm.hpp
@@ -1,4 +1,4 @@
-/// @file symm.hpp
+/// @file legacy_api/blas/symm.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,140 +16,143 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Symmetric matrix-matrix multiply:
- * \[
- *     C = \alpha A B + \beta C,
- * \]
- * or
- * \[
- *     C = \alpha B A + \beta C,
- * \]
- * where alpha and beta are scalars, A is an m-by-m or n-by-n symmetric matrix,
- * and B and C are m-by-n matrices.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] side
- *     The side the matrix A appears on:
- *     - Side::Left:  $C = \alpha A B + \beta C$,
- *     - Side::Right: $C = \alpha B A + \beta C$.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced:
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] m
- *     Number of rows of the matrices B and C.
- *
- * @param[in] n
- *     Number of columns of the matrices B and C.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and B are not accessed.
- *
- * @param[in] A
- *     - If side = Left:  The m-by-m matrix A, stored in an lda-by-m array.
- *     - If side = Right: The n-by-n matrix A, stored in an lda-by-n array.
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If side = Left:  lda >= max(1, m).
- *     - If side = Right: lda >= max(1, n).
- *
- * @param[in] B
- *     The m-by-n matrix B, stored in an ldb-by-n array.
- *
- * @param[in] ldb
- *     Leading dimension of B. ldb >= max(1, n).
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, C need not be set on input.
- *
- * @param[in] C
- *     The m-by-n matrix C, stored in an lda-by-n array.
- *
- * @param[in] ldc
- *     Leading dimension of C. ldc >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TB, typename TC>
-void symm(Layout layout,
-          Side side,
-          Uplo uplo,
-          idx_t m,
-          idx_t n,
-          scalar_type<TA, TB, TC> alpha,
-          TA const* A,
-          idx_t lda,
-          TB const* B,
-          idx_t ldb,
-          scalar_type<TA, TB, TC> beta,
-          TC* C,
-          idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TB, TC>;
+    /**
+     * Symmetric matrix-matrix multiply:
+     * \[
+     *     C = \alpha A B + \beta C,
+     * \]
+     * or
+     * \[
+     *     C = \alpha B A + \beta C,
+     * \]
+     * where alpha and beta are scalars, A is an m-by-m or n-by-n symmetric
+     * matrix, and B and C are m-by-n matrices.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] side
+     *     The side the matrix A appears on:
+     *     - Side::Left:  $C = \alpha A B + \beta C$,
+     *     - Side::Right: $C = \alpha B A + \beta C$.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced:
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] m
+     *     Number of rows of the matrices B and C.
+     *
+     * @param[in] n
+     *     Number of columns of the matrices B and C.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and B are not accessed.
+     *
+     * @param[in] A
+     *     - If side = Left:  The m-by-m matrix A, stored in an lda-by-m array.
+     *     - If side = Right: The n-by-n matrix A, stored in an lda-by-n array.
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If side = Left:  lda >= max(1, m).
+     *     - If side = Right: lda >= max(1, n).
+     *
+     * @param[in] B
+     *     The m-by-n matrix B, stored in an ldb-by-n array.
+     *
+     * @param[in] ldb
+     *     Leading dimension of B. ldb >= max(1, n).
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, C need not be set on input.
+     *
+     * @param[in] C
+     *     The m-by-n matrix C, stored in an lda-by-n array.
+     *
+     * @param[in] ldc
+     *     Leading dimension of C. ldc >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TB, typename TC>
+    void symm(Layout layout,
+              Side side,
+              Uplo uplo,
+              idx_t m,
+              idx_t n,
+              scalar_type<TA, TB, TC> alpha,
+              TA const* A,
+              idx_t lda,
+              TB const* B,
+              idx_t ldb,
+              scalar_type<TA, TB, TC> beta,
+              TC* C,
+              idx_t ldc)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TB, TC>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
-    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
-    tlapack_check_false(ldc < ((layout == Layout::RowMajor) ? n : m));
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+        tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
+        tlapack_check_false(ldc < ((layout == Layout::RowMajor) ? n : m));
 
-    // quick return
-    if (m == 0 || n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
-        return;
+        // quick return
+        if (m == 0 || n == 0 ||
+            ((alpha == scalar_t(0)) && (beta == scalar_t(1))))
+            return;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        side = (side == Side::Left) ? Side::Right : Side::Left;
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        std::swap(m, n);
-    }
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            side = (side == Side::Left) ? Side::Right : Side::Left;
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            std::swap(m, n);
+        }
 
-    // Matrix views
-    const auto A_ = (side == Side::Left)
-                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
-                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
-    const auto B_ = colmajor_matrix<TB>((TB*)B, m, n, ldb);
-    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
+        // Matrix views
+        const auto A_ = (side == Side::Left)
+                            ? create_matrix<TA>((TA*)A, m, m, lda)
+                            : create_matrix<TA>((TA*)A, n, n, lda);
+        const auto B_ = create_matrix<TB>((TB*)B, m, n, ldb);
+        auto C_ = create_matrix<TC>(C, m, n, ldc);
 
-    if (alpha == scalar_t(0)) {
-        if (beta == scalar_t(0)) {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < m; ++i)
-                    C_(i, j) = TC(0);
+        if (alpha == scalar_t(0)) {
+            if (beta == scalar_t(0)) {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C_(i, j) = TC(0);
+            }
+            else {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < m; ++i)
+                        C_(i, j) *= beta;
+            }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < m; ++i)
-                    C_(i, j) *= beta;
+            if (beta == scalar_t(0))
+                symm(side, uplo, alpha, A_, B_, C_);
+            else
+                symm(side, uplo, alpha, A_, B_, beta, C_);
         }
     }
-    else {
-        if (beta == scalar_t(0))
-            symm(side, uplo, alpha, A_, B_, C_);
-        else
-            symm(side, uplo, alpha, A_, B_, beta, C_);
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/tlapack/legacy_api/blas/symv.hpp
+++ b/include/tlapack/legacy_api/blas/symv.hpp
@@ -1,4 +1,4 @@
-/// @file symv.hpp
+/// @file legacy_api/blas/symv.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,108 +16,111 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Symmetric matrix-vector multiply:
- * \[
- *     y = \alpha A x + \beta y,
- * \]
- * where alpha and beta are scalars, x and y are vectors,
- * and A is an n-by-n symmetric matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed from symmetry.
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and x are not accessed.
- *
- * @param[in] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, y need not be set on input.
- *
- * @param[in,out] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX, typename TY>
-void symv(Layout layout,
-          Uplo uplo,
-          idx_t n,
-          scalar_type<TA, TX, TY> alpha,
-          TA const* A,
-          idx_t lda,
-          TX const* x,
-          int_t incx,
-          scalar_type<TA, TX, TY> beta,
-          TY* y,
-          int_t incy)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TX, TY>;
+    /**
+     * Symmetric matrix-vector multiply:
+     * \[
+     *     y = \alpha A x + \beta y,
+     * \]
+     * where alpha and beta are scalars, x and y are vectors,
+     * and A is an n-by-n symmetric matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed from symmetry.
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and x are not accessed.
+     *
+     * @param[in] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, y need not be set on input.
+     *
+     * @param[in,out] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX, typename TY>
+    void symv(Layout layout,
+              Uplo uplo,
+              idx_t n,
+              scalar_type<TA, TX, TY> alpha,
+              TA const* A,
+              idx_t lda,
+              TX const* x,
+              int_t incx,
+              scalar_type<TA, TX, TY> beta,
+              TY* y,
+              int_t incy)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TX, TY>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < n);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < n);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
 
-    // quick return
-    if (n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1)))) return;
+        // quick return
+        if (n == 0 || ((alpha == scalar_t(0)) && (beta == scalar_t(1)))) return;
 
-    // for row major, swap lower <=> upper
-    if (layout == Layout::RowMajor) {
-        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        // for row major, swap lower <=> upper
+        if (layout == Layout::RowMajor) {
+            uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        }
+
+        // Views
+        const auto A_ = create_matrix<TA>((TA*)A, n, n, lda);
+
+        if (alpha == scalar_t(0)) {
+            tlapack_expr_with_vector(
+                y_, TY, n, y, incy,
+                if (beta == scalar_t(0)) for (idx_t i = 0; i < n; ++i) y_[i] =
+                    TY(0);
+                else for (idx_t i = 0; i < n; ++i) y_[i] *= beta);
+        }
+        else {
+            tlapack_expr_with_2vectors(
+                x_, TX, n, x, incx, y_, TY, n, y, incy,
+                if (beta == scalar_t(0)) return symv(uplo, alpha, A_, x_, y_);
+                else return symv(uplo, alpha, A_, x_, beta, y_));
+        }
     }
 
-    // Views
-    const auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
-
-    if (alpha == scalar_t(0)) {
-        tlapack_expr_with_vector(
-            y_, TY, n, y, incy,
-            if (beta == scalar_t(0)) for (idx_t i = 0; i < n; ++i) y_[i] =
-                TY(0);
-            else for (idx_t i = 0; i < n; ++i) y_[i] *= beta);
-    }
-    else {
-        tlapack_expr_with_2vectors(
-            x_, TX, n, x, incx, y_, TY, n, y, incy,
-            if (beta == scalar_t(0)) return symv(uplo, alpha, A_, x_, y_);
-            else return symv(uplo, alpha, A_, x_, beta, y_));
-    }
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SYMV_HH

--- a/include/tlapack/legacy_api/blas/syr.hpp
+++ b/include/tlapack/legacy_api/blas/syr.hpp
@@ -1,4 +1,4 @@
-/// @file syr.hpp
+/// @file legacy_api/blas/syr.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,82 +16,85 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Symmetric matrix rank-1 update:
- * \[
- *     A = \alpha x x^T + A,
- * \]
- * where alpha is a scalar, x is a vector,
- * and A is an n-by-n symmetric matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed from symmetry.
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not updated.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in,out] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX>
-void syr(Layout layout,
-         Uplo uplo,
-         idx_t n,
-         scalar_type<TA, TX> alpha,
-         TX const* x,
-         int_t incx,
-         TA* A,
-         idx_t lda)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TX>;
+    /**
+     * Symmetric matrix rank-1 update:
+     * \[
+     *     A = \alpha x x^T + A,
+     * \]
+     * where alpha is a scalar, x is a vector,
+     * and A is an n-by-n symmetric matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed from symmetry.
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not updated.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in,out] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX>
+    void syr(Layout layout,
+             Uplo uplo,
+             idx_t n,
+             scalar_type<TA, TX> alpha,
+             TX const* x,
+             int_t incx,
+             TA* A,
+             idx_t lda)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TX>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(lda < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(lda < n);
 
-    // quick return
-    if (n == 0 || alpha == scalar_t(0)) return;
+        // quick return
+        if (n == 0 || alpha == scalar_t(0)) return;
 
-    // for row major, swap lower <=> upper
-    if (layout == Layout::RowMajor) {
-        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        // for row major, swap lower <=> upper
+        if (layout == Layout::RowMajor) {
+            uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        }
+
+        // Matrix views
+        auto A_ = create_matrix<TA>(A, n, n, lda);
+
+        tlapack_expr_with_vector(x_, TX, n, x, incx, syr(uplo, alpha, x_, A_));
     }
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
-
-    tlapack_expr_with_vector(x_, TX, n, x, incx, syr(uplo, alpha, x_, A_));
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SYR_HH

--- a/include/tlapack/legacy_api/blas/syr2.hpp
+++ b/include/tlapack/legacy_api/blas/syr2.hpp
@@ -1,4 +1,4 @@
-/// @file syr2.hpp
+/// @file legacy_api/blas/syr2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,93 +16,96 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Symmetric matrix rank-2 update:
- * \[
- *     A = \alpha x y^T + \alpha y x^T + A,
- * \]
- * where alpha is a scalar, x and y are vectors,
- * and A is an n-by-n symmetric matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed from symmetry.
- *     - Uplo::Lower: only the lower triangular part of A is referenced.
- *     - Uplo::Upper: only the upper triangular part of A is referenced.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not updated.
- *
- * @param[in] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @param[in] y
- *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
- *
- * @param[in] incy
- *     Stride between elements of y. incy must not be zero.
- *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
- *
- * @param[in,out] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX, typename TY>
-void syr2(Layout layout,
-          Uplo uplo,
-          idx_t n,
-          scalar_type<TA, TX, TY> alpha,
-          TX const* x,
-          int_t incx,
-          TY const* y,
-          int_t incy,
-          TA* A,
-          idx_t lda)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TX>;
+    /**
+     * Symmetric matrix rank-2 update:
+     * \[
+     *     A = \alpha x y^T + \alpha y x^T + A,
+     * \]
+     * where alpha is a scalar, x and y are vectors,
+     * and A is an n-by-n symmetric matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed from symmetry.
+     *     - Uplo::Lower: only the lower triangular part of A is referenced.
+     *     - Uplo::Upper: only the upper triangular part of A is referenced.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not updated.
+     *
+     * @param[in] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @param[in] y
+     *     The n-element vector y, in an array of length (n-1)*abs(incy) + 1.
+     *
+     * @param[in] incy
+     *     Stride between elements of y. incy must not be zero.
+     *     If incy < 0, uses elements of y in reverse order: y(n-1), ..., y(0).
+     *
+     * @param[in,out] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX, typename TY>
+    void syr2(Layout layout,
+              Uplo uplo,
+              idx_t n,
+              scalar_type<TA, TX, TY> alpha,
+              TX const* x,
+              int_t incx,
+              TY const* y,
+              int_t incy,
+              TA* A,
+              idx_t lda)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TX>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(incx == 0);
-    tlapack_check_false(incy == 0);
-    tlapack_check_false(lda < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(incx == 0);
+        tlapack_check_false(incy == 0);
+        tlapack_check_false(lda < n);
 
-    // quick return
-    if (n == 0 || alpha == scalar_t(0)) return;
+        // quick return
+        if (n == 0 || alpha == scalar_t(0)) return;
 
-    // for row major, swap lower <=> upper
-    if (layout == Layout::RowMajor) {
-        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        // for row major, swap lower <=> upper
+        if (layout == Layout::RowMajor) {
+            uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        }
+
+        // Matrix views
+        auto A_ = create_matrix<TA>(A, n, n, lda);
+
+        tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
+                                   return syr2(uplo, alpha, x_, y_, A_));
     }
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>(A, n, n, lda);
-
-    tlapack_expr_with_2vectors(x_, TX, n, x, incx, y_, TY, n, y, incy,
-                               return syr2(uplo, alpha, x_, y_, A_));
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SYR2_HH

--- a/include/tlapack/legacy_api/blas/syr2k.hpp
+++ b/include/tlapack/legacy_api/blas/syr2k.hpp
@@ -1,4 +1,4 @@
-/// @file syr2k.hpp
+/// @file legacy_api/blas/syr2k.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,163 +16,170 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Symmetric rank-k update:
- * \[
- *     C = \alpha A B^T + \alpha B A^T + \beta C,
- * \]
- * or
- * \[
- *     C = \alpha A^T B + \alpha B^T A + \beta C,
- * \]
- * where alpha and beta are scalars, C is an n-by-n symmetric matrix,
- * and A and B are n-by-k or k-by-n matrices.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix C is referenced,
- *     the opposite triangle being assumed from symmetry:
- *     - Uplo::Lower: only the lower triangular part of C is referenced.
- *     - Uplo::Upper: only the upper triangular part of C is referenced.
- *
- * @param[in] trans
- *     The operation to be performed:
- *     - Op::NoTrans: $C = \alpha A B^T + \alpha B A^T + \beta C$.
- *     - Op::Trans:   $C = \alpha A^T B + \alpha B^T A + \beta C$.
- *     - In the real    case, Op::ConjTrans is interpreted as Op::Trans.
- *       In the complex case, Op::ConjTrans is illegal (see her2k()
- * instead).
- *
- * @param[in] n
- *     Number of rows and columns of the matrix C. n >= 0.
- *
- * @param[in] k
- *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
- *     - Otherwise:          number of rows    of the matrix A. k >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A and B are not accessed.
- *
- * @param[in] A
- *     - If trans = NoTrans:
- *       the n-by-k matrix A, stored in an lda-by-k array [RowMajor: n-by-lda].
- *     - Otherwise:
- *       the k-by-n matrix A, stored in an lda-by-n array [RowMajor: k-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
- *     - Otherwise:          lda >= max(1, k) [RowMajor: lda >= max(1, n)].
- *
- * @param[in] B
- *     - If trans = NoTrans:
- *       the n-by-k matrix B, stored in an ldb-by-k array [RowMajor: n-by-ldb].
- *     - Otherwise:
- *       the k-by-n matrix B, stored in an ldb-by-n array [RowMajor: k-by-ldb].
- *
- * @param[in] ldb
- *     Leading dimension of B.
- *     - If trans = NoTrans: ldb >= max(1, n) [RowMajor: ldb >= max(1, k)],
- *     - Otherwise:          ldb >= max(1, k) [RowMajor: ldb >= max(1, n)].
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, C need not be set on input.
- *
- * @param[in] C
- *     The n-by-n symmetric matrix C,
- *     stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] ldc
- *     Leading dimension of C. ldc >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TB, typename TC>
-void syr2k(Layout layout,
-           Uplo uplo,
-           Op trans,
-           idx_t n,
-           idx_t k,
-           scalar_type<TA, TB, TC> alpha,
-           TA const* A,
-           idx_t lda,
-           TB const* B,
-           idx_t ldb,
-           scalar_type<TA, TB, TC> beta,
-           TC* C,
-           idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TB, TC>;
+    /**
+     * Symmetric rank-k update:
+     * \[
+     *     C = \alpha A B^T + \alpha B A^T + \beta C,
+     * \]
+     * or
+     * \[
+     *     C = \alpha A^T B + \alpha B^T A + \beta C,
+     * \]
+     * where alpha and beta are scalars, C is an n-by-n symmetric matrix,
+     * and A and B are n-by-k or k-by-n matrices.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix C is referenced,
+     *     the opposite triangle being assumed from symmetry:
+     *     - Uplo::Lower: only the lower triangular part of C is referenced.
+     *     - Uplo::Upper: only the upper triangular part of C is referenced.
+     *
+     * @param[in] trans
+     *     The operation to be performed:
+     *     - Op::NoTrans: $C = \alpha A B^T + \alpha B A^T + \beta C$.
+     *     - Op::Trans:   $C = \alpha A^T B + \alpha B^T A + \beta C$.
+     *     - In the real    case, Op::ConjTrans is interpreted as Op::Trans.
+     *       In the complex case, Op::ConjTrans is illegal (see her2k()
+     * instead).
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix C. n >= 0.
+     *
+     * @param[in] k
+     *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
+     *     - Otherwise:          number of rows    of the matrix A. k >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A and B are not accessed.
+     *
+     * @param[in] A
+     *     - If trans = NoTrans:
+     *       the n-by-k matrix A, stored in an lda-by-k array [RowMajor:
+     * n-by-lda].
+     *     - Otherwise:
+     *       the k-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * k-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
+     *     - Otherwise:          lda >= max(1, k) [RowMajor: lda >= max(1, n)].
+     *
+     * @param[in] B
+     *     - If trans = NoTrans:
+     *       the n-by-k matrix B, stored in an ldb-by-k array [RowMajor:
+     * n-by-ldb].
+     *     - Otherwise:
+     *       the k-by-n matrix B, stored in an ldb-by-n array [RowMajor:
+     * k-by-ldb].
+     *
+     * @param[in] ldb
+     *     Leading dimension of B.
+     *     - If trans = NoTrans: ldb >= max(1, n) [RowMajor: ldb >= max(1, k)],
+     *     - Otherwise:          ldb >= max(1, k) [RowMajor: ldb >= max(1, n)].
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, C need not be set on input.
+     *
+     * @param[in] C
+     *     The n-by-n symmetric matrix C,
+     *     stored in an lda-by-n array [RowMajor: n-by-lda].
+     *
+     * @param[in] ldc
+     *     Leading dimension of C. ldc >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TB, typename TC>
+    void syr2k(Layout layout,
+               Uplo uplo,
+               Op trans,
+               idx_t n,
+               idx_t k,
+               scalar_type<TA, TB, TC> alpha,
+               TA const* A,
+               idx_t lda,
+               TB const* B,
+               idx_t ldb,
+               scalar_type<TA, TB, TC> beta,
+               TC* C,
+               idx_t ldc)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TB, TC>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(is_complex<TA>::value && trans == Op::ConjTrans);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(k < 0);
-    tlapack_check_false(lda < ((layout == Layout::RowMajor)
-                                   ? ((trans == Op::NoTrans) ? k : n)
-                                   : ((trans == Op::NoTrans) ? n : k)));
-    tlapack_check_false(ldb < ((layout == Layout::RowMajor)
-                                   ? ((trans == Op::NoTrans) ? k : n)
-                                   : ((trans == Op::NoTrans) ? n : k)));
-    tlapack_check_false(ldc < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(is_complex<TA>::value && trans == Op::ConjTrans);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(k < 0);
+        tlapack_check_false(lda < ((layout == Layout::RowMajor)
+                                       ? ((trans == Op::NoTrans) ? k : n)
+                                       : ((trans == Op::NoTrans) ? n : k)));
+        tlapack_check_false(ldb < ((layout == Layout::RowMajor)
+                                       ? ((trans == Op::NoTrans) ? k : n)
+                                       : ((trans == Op::NoTrans) ? n : k)));
+        tlapack_check_false(ldc < n);
 
-    // quick return
-    if (n == 0 || ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
-        return;
+        // quick return
+        if (n == 0 ||
+            ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
+            return;
 
-    // This algorithm only works with Op::NoTrans or Op::Trans
-    if (trans == Op::ConjTrans) trans = Op::Trans;
+        // This algorithm only works with Op::NoTrans or Op::Trans
+        if (trans == Op::ConjTrans) trans = Op::Trans;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        trans = (trans == Op::NoTrans) ? Op::Trans : Op::NoTrans;
-    }
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            trans = (trans == Op::NoTrans) ? Op::Trans : Op::NoTrans;
+        }
 
-    // Matrix views
-    const auto A_ = (trans == Op::NoTrans)
-                        ? colmajor_matrix<TA>((TA*)A, n, k, lda)
-                        : colmajor_matrix<TA>((TA*)A, k, n, lda);
-    const auto B_ = (trans == Op::NoTrans)
-                        ? colmajor_matrix<TB>((TB*)B, n, k, ldb)
-                        : colmajor_matrix<TB>((TB*)B, k, n, ldb);
-    auto C_ = colmajor_matrix<TC>(C, n, n, ldc);
+        // Matrix views
+        const auto A_ = (trans == Op::NoTrans)
+                            ? create_matrix<TA>((TA*)A, n, k, lda)
+                            : create_matrix<TA>((TA*)A, k, n, lda);
+        const auto B_ = (trans == Op::NoTrans)
+                            ? create_matrix<TB>((TB*)B, n, k, ldb)
+                            : create_matrix<TB>((TB*)B, k, n, ldb);
+        auto C_ = create_matrix<TC>(C, n, n, ldc);
 
-    if (alpha == scalar_t(0)) {
-        if (beta == scalar_t(0)) {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) = TC(0);
+        if (alpha == scalar_t(0)) {
+            if (beta == scalar_t(0)) {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) = TC(0);
+            }
+            else {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) *= beta;
+            }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) *= beta;
+            if (beta == scalar_t(0))
+                syr2k(uplo, trans, alpha, A_, B_, C_);
+            else
+                syr2k(uplo, trans, alpha, A_, B_, beta, C_);
         }
     }
-    else {
-        if (beta == scalar_t(0))
-            syr2k(uplo, trans, alpha, A_, B_, C_);
-        else
-            syr2k(uplo, trans, alpha, A_, B_, beta, C_);
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/tlapack/legacy_api/blas/syrk.hpp
+++ b/include/tlapack/legacy_api/blas/syrk.hpp
@@ -1,4 +1,4 @@
-/// @file syrk.hpp
+/// @file legacy_api/blas/syrk.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,144 +16,150 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Symmetric rank-k update:
- * \[
- *     C = \alpha A A^T + \beta C,
- * \]
- * or
- * \[
- *     C = \alpha A^T A + \beta C,
- * \]
- * where alpha and beta are scalars, C is an n-by-n symmetric matrix,
- * and A is an n-by-k or k-by-n matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix C is referenced,
- *     the opposite triangle being assumed from symmetry:
- *     - Uplo::Lower: only the lower triangular part of C is referenced.
- *     - Uplo::Upper: only the upper triangular part of C is referenced.
- *
- * @param[in] trans
- *     The operation to be performed:
- *     - Op::NoTrans: $C = \alpha A A^T + \beta C$.
- *     - Op::Trans:   $C = \alpha A^T A + \beta C$.
- *     - In the real    case, Op::ConjTrans is interpreted as Op::Trans.
- *       In the complex case, Op::ConjTrans is illegal (see herk()
- * instead).
- *
- * @param[in] n
- *     Number of rows and columns of the matrix C. n >= 0.
- *
- * @param[in] k
- *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
- *     - Otherwise:          number of rows    of the matrix A. k >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not accessed.
- *
- * @param[in] A
- *     - If trans = NoTrans:
- *       the n-by-k matrix A, stored in an lda-by-k array [RowMajor: n-by-lda].
- *     - Otherwise:
- *       the k-by-n matrix A, stored in an lda-by-n array [RowMajor: k-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
- *     - Otherwise:              lda >= max(1, k) [RowMajor: lda >= max(1, n)].
- *
- * @param[in] beta
- *     Scalar beta. If beta is zero, C need not be set on input.
- *
- * @param[in] C
- *     The n-by-n symmetric matrix C,
- *     stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] ldc
- *     Leading dimension of C. ldc >= max(1, n).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TC>
-void syrk(Layout layout,
-          Uplo uplo,
-          Op trans,
-          idx_t n,
-          idx_t k,
-          scalar_type<TA, TC> alpha,
-          TA const* A,
-          idx_t lda,
-          scalar_type<TA, TC> beta,
-          TC* C,
-          idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TC>;
+    /**
+     * Symmetric rank-k update:
+     * \[
+     *     C = \alpha A A^T + \beta C,
+     * \]
+     * or
+     * \[
+     *     C = \alpha A^T A + \beta C,
+     * \]
+     * where alpha and beta are scalars, C is an n-by-n symmetric matrix,
+     * and A is an n-by-k or k-by-n matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix C is referenced,
+     *     the opposite triangle being assumed from symmetry:
+     *     - Uplo::Lower: only the lower triangular part of C is referenced.
+     *     - Uplo::Upper: only the upper triangular part of C is referenced.
+     *
+     * @param[in] trans
+     *     The operation to be performed:
+     *     - Op::NoTrans: $C = \alpha A A^T + \beta C$.
+     *     - Op::Trans:   $C = \alpha A^T A + \beta C$.
+     *     - In the real    case, Op::ConjTrans is interpreted as Op::Trans.
+     *       In the complex case, Op::ConjTrans is illegal (see herk()
+     * instead).
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix C. n >= 0.
+     *
+     * @param[in] k
+     *     - If trans = NoTrans: number of columns of the matrix A. k >= 0.
+     *     - Otherwise:          number of rows    of the matrix A. k >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not accessed.
+     *
+     * @param[in] A
+     *     - If trans = NoTrans:
+     *       the n-by-k matrix A, stored in an lda-by-k array [RowMajor:
+     * n-by-lda].
+     *     - Otherwise:
+     *       the k-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * k-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If trans = NoTrans: lda >= max(1, n) [RowMajor: lda >= max(1, k)],
+     *     - Otherwise:              lda >= max(1, k) [RowMajor: lda >= max(1,
+     * n)].
+     *
+     * @param[in] beta
+     *     Scalar beta. If beta is zero, C need not be set on input.
+     *
+     * @param[in] C
+     *     The n-by-n symmetric matrix C,
+     *     stored in an lda-by-n array [RowMajor: n-by-lda].
+     *
+     * @param[in] ldc
+     *     Leading dimension of C. ldc >= max(1, n).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TC>
+    void syrk(Layout layout,
+              Uplo uplo,
+              Op trans,
+              idx_t n,
+              idx_t k,
+              scalar_type<TA, TC> alpha,
+              TA const* A,
+              idx_t lda,
+              scalar_type<TA, TC> beta,
+              TC* C,
+              idx_t ldc)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TC>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(is_complex<TA>::value && trans == Op::ConjTrans);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(k < 0);
-    tlapack_check_false(lda < ((layout == Layout::RowMajor)
-                                   ? ((trans == Op::NoTrans) ? k : n)
-                                   : ((trans == Op::NoTrans) ? n : k)));
-    tlapack_check_false(ldc < n);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(is_complex<TA>::value && trans == Op::ConjTrans);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(k < 0);
+        tlapack_check_false(lda < ((layout == Layout::RowMajor)
+                                       ? ((trans == Op::NoTrans) ? k : n)
+                                       : ((trans == Op::NoTrans) ? n : k)));
+        tlapack_check_false(ldc < n);
 
-    // quick return
-    if (n == 0 || ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
-        return;
+        // quick return
+        if (n == 0 ||
+            ((alpha == scalar_t(0) || k == 0) && (beta == scalar_t(1))))
+            return;
 
-    // This algorithm only works with Op::NoTrans or Op::Trans
-    if (trans == Op::ConjTrans) trans = Op::Trans;
+        // This algorithm only works with Op::NoTrans or Op::Trans
+        if (trans == Op::ConjTrans) trans = Op::Trans;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        trans = (trans == Op::NoTrans) ? Op::Trans : Op::NoTrans;
-    }
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            trans = (trans == Op::NoTrans) ? Op::Trans : Op::NoTrans;
+        }
 
-    // Matrix views
-    const auto A_ = (trans == Op::NoTrans)
-                        ? colmajor_matrix<TA>((TA*)A, n, k, lda)
-                        : colmajor_matrix<TA>((TA*)A, k, n, lda);
-    auto C_ = colmajor_matrix<TC>(C, n, n, ldc);
+        // Matrix views
+        const auto A_ = (trans == Op::NoTrans)
+                            ? create_matrix<TA>((TA*)A, n, k, lda)
+                            : create_matrix<TA>((TA*)A, k, n, lda);
+        auto C_ = create_matrix<TC>(C, n, n, ldc);
 
-    if (alpha == scalar_t(0)) {
-        if (beta == scalar_t(0)) {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) = TC(0);
+        if (alpha == scalar_t(0)) {
+            if (beta == scalar_t(0)) {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) = TC(0);
+            }
+            else {
+                for (idx_t j = 0; j < n; ++j)
+                    for (idx_t i = 0; i < n; ++i)
+                        C_(i, j) *= beta;
+            }
         }
         else {
-            for (idx_t j = 0; j < n; ++j)
-                for (idx_t i = 0; i < n; ++i)
-                    C_(i, j) *= beta;
+            if (beta == scalar_t(0))
+                syrk(uplo, trans, alpha, A_, C_);
+            else
+                syrk(uplo, trans, alpha, A_, beta, C_);
         }
     }
-    else {
-        if (beta == scalar_t(0))
-            syrk(uplo, trans, alpha, A_, C_);
-        else
-            syrk(uplo, trans, alpha, A_, beta, C_);
-    }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_SYMM_HH

--- a/include/tlapack/legacy_api/blas/trmm.hpp
+++ b/include/tlapack/legacy_api/blas/trmm.hpp
@@ -1,4 +1,4 @@
-/// @file trmm.hpp
+/// @file legacy_api/blas/trmm.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,136 +16,142 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Triangular matrix-matrix multiply:
- * \[
- *     B = \alpha op(A) B,
- * \]
- * or
- * \[
- *     B = \alpha B op(A),
- * \]
- * where $op(A)$ is one of
- *     $op(A) = A$,
- *     $op(A) = A^T$, or
- *     $op(A) = A^H$,
- * B is an m-by-n matrix, and A is an m-by-m or n-by-n, unit or non-unit,
- * upper or lower triangular matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] side
- *     Whether $op(A)$ is on the left or right of B:
- *     - Side::Left:  $B = \alpha op(A) B$.
- *     - Side::Right: $B = \alpha B op(A)$.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed to be zero:
- *     - Uplo::Lower: A is lower triangular.
- *     - Uplo::Upper: A is upper triangular.
- *     - Uplo::General is illegal (see gemm() instead).
- *
- * @param[in] trans
- *     The form of $op(A)$:
- *     - Op::NoTrans:   $op(A) = A$.
- *     - Op::Trans:     $op(A) = A^T$.
- *     - Op::ConjTrans: $op(A) = A^H$.
- *
- * @param[in] diag
- *     Whether A has a unit or non-unit diagonal:
- *     - Diag::Unit:    A is assumed to be unit triangular.
- *     - Diag::NonUnit: A is not assumed to be unit triangular.
- *
- * @param[in] m
- *     Number of rows of matrix B. m >= 0.
- *
- * @param[in] n
- *     Number of columns of matrix B. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not accessed.
- *
- * @param[in] A
- *     - If side = Left:
- *       the m-by-m matrix A, stored in an lda-by-m array [RowMajor: m-by-lda].
- *     - If side = Right:
- *       the n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If side = left:  lda >= max(1, m).
- *     - If side = right: lda >= max(1, n).
- *
- * @param[in,out] B
- *     The m-by-n matrix B, stored in an ldb-by-n array [RowMajor: m-by-ldb].
- *
- * @param[in] ldb
- *     Leading dimension of B. ldb >= max(1, m) [RowMajor: ldb >= max(1, n)].
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TB>
-void trmm(Layout layout,
-          Side side,
-          Uplo uplo,
-          Op trans,
-          Diag diag,
-          idx_t m,
-          idx_t n,
-          scalar_type<TA, TB> alpha,
-          TA const* A,
-          idx_t lda,
-          TB* B,
-          idx_t ldb)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TB>;
+    /**
+     * Triangular matrix-matrix multiply:
+     * \[
+     *     B = \alpha op(A) B,
+     * \]
+     * or
+     * \[
+     *     B = \alpha B op(A),
+     * \]
+     * where $op(A)$ is one of
+     *     $op(A) = A$,
+     *     $op(A) = A^T$, or
+     *     $op(A) = A^H$,
+     * B is an m-by-n matrix, and A is an m-by-m or n-by-n, unit or non-unit,
+     * upper or lower triangular matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] side
+     *     Whether $op(A)$ is on the left or right of B:
+     *     - Side::Left:  $B = \alpha op(A) B$.
+     *     - Side::Right: $B = \alpha B op(A)$.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed to be zero:
+     *     - Uplo::Lower: A is lower triangular.
+     *     - Uplo::Upper: A is upper triangular.
+     *     - Uplo::General is illegal (see gemm() instead).
+     *
+     * @param[in] trans
+     *     The form of $op(A)$:
+     *     - Op::NoTrans:   $op(A) = A$.
+     *     - Op::Trans:     $op(A) = A^T$.
+     *     - Op::ConjTrans: $op(A) = A^H$.
+     *
+     * @param[in] diag
+     *     Whether A has a unit or non-unit diagonal:
+     *     - Diag::Unit:    A is assumed to be unit triangular.
+     *     - Diag::NonUnit: A is not assumed to be unit triangular.
+     *
+     * @param[in] m
+     *     Number of rows of matrix B. m >= 0.
+     *
+     * @param[in] n
+     *     Number of columns of matrix B. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not accessed.
+     *
+     * @param[in] A
+     *     - If side = Left:
+     *       the m-by-m matrix A, stored in an lda-by-m array [RowMajor:
+     * m-by-lda].
+     *     - If side = Right:
+     *       the n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If side = left:  lda >= max(1, m).
+     *     - If side = right: lda >= max(1, n).
+     *
+     * @param[in,out] B
+     *     The m-by-n matrix B, stored in an ldb-by-n array [RowMajor:
+     * m-by-ldb].
+     *
+     * @param[in] ldb
+     *     Leading dimension of B. ldb >= max(1, m) [RowMajor: ldb >= max(1,
+     * n)].
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TB>
+    void trmm(Layout layout,
+              Side side,
+              Uplo uplo,
+              Op trans,
+              Diag diag,
+              idx_t m,
+              idx_t n,
+              scalar_type<TA, TB> alpha,
+              TA const* A,
+              idx_t lda,
+              TB* B,
+              idx_t ldb)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TB>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
-    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+        tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
 
-    // quick return
-    if (m == 0 || n == 0) return;
+        // quick return
+        if (m == 0 || n == 0) return;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        side = (side == Side::Left) ? Side::Right : Side::Left;
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        std::swap(m, n);
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            side = (side == Side::Left) ? Side::Right : Side::Left;
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            std::swap(m, n);
+        }
+
+        // Matrix views
+        const auto A_ = (side == Side::Left)
+                            ? create_matrix<TA>((TA*)A, m, m, lda)
+                            : create_matrix<TA>((TA*)A, n, n, lda);
+        auto B_ = create_matrix<TB>(B, m, n, ldb);
+
+        if (alpha == scalar_t(0))
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    B_(i, j) = TB(0);
+        else
+            trmm(side, uplo, trans, diag, alpha, A_, B_);
     }
 
-    // Matrix views
-    const auto A_ = (side == Side::Left)
-                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
-                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
-    auto B_ = colmajor_matrix<TB>(B, m, n, ldb);
-
-    if (alpha == scalar_t(0))
-        for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < m; ++i)
-                B_(i, j) = TB(0);
-    else
-        trmm(side, uplo, trans, diag, alpha, A_, B_);
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_TRMM_HH

--- a/include/tlapack/legacy_api/blas/trmv.hpp
+++ b/include/tlapack/legacy_api/blas/trmv.hpp
@@ -1,4 +1,4 @@
-/// @file trmv.hpp
+/// @file legacy_api/blas/trmv.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,120 +16,123 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Triangular matrix-vector multiply:
- * \[
- *     x = op(A) x,
- * \]
- * where $op(A)$ is one of
- *     $op(A) = A$,
- *     $op(A) = A^T$, or
- *     $op(A) = A^H$,
- * x is a vector,
- * and A is an n-by-n, unit or non-unit, upper or lower triangular matrix.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed to be zero.
- *     - Uplo::Lower: A is lower triangular.
- *     - Uplo::Upper: A is upper triangular.
- *
- * @param[in] trans
- *     The operation to be performed:
- *     - Op::NoTrans:   $x = A   x$,
- *     - Op::Trans:     $x = A^T x$,
- *     - Op::ConjTrans: $x = A^H x$.
- *
- * @param[in] diag
- *     Whether A has a unit or non-unit diagonal:
- *     - Diag::Unit:    A is assumed to be unit triangular.
- *                      The diagonal elements of A are not referenced.
- *     - Diag::NonUnit: A is not assumed to be unit triangular.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @param[in,out] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX>
-void trmv(Layout layout,
-          Uplo uplo,
-          Op trans,
-          Diag diag,
-          idx_t n,
-          TA const* A,
-          idx_t lda,
-          TX* x,
-          int_t incx)
-{
-    using internal::colmajor_matrix;
-    using std::abs;
+    /**
+     * Triangular matrix-vector multiply:
+     * \[
+     *     x = op(A) x,
+     * \]
+     * where $op(A)$ is one of
+     *     $op(A) = A$,
+     *     $op(A) = A^T$, or
+     *     $op(A) = A^H$,
+     * x is a vector,
+     * and A is an n-by-n, unit or non-unit, upper or lower triangular matrix.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed to be zero.
+     *     - Uplo::Lower: A is lower triangular.
+     *     - Uplo::Upper: A is upper triangular.
+     *
+     * @param[in] trans
+     *     The operation to be performed:
+     *     - Op::NoTrans:   $x = A   x$,
+     *     - Op::Trans:     $x = A^T x$,
+     *     - Op::ConjTrans: $x = A^H x$.
+     *
+     * @param[in] diag
+     *     Whether A has a unit or non-unit diagonal:
+     *     - Diag::Unit:    A is assumed to be unit triangular.
+     *                      The diagonal elements of A are not referenced.
+     *     - Diag::NonUnit: A is not assumed to be unit triangular.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @param[in,out] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX>
+    void trmv(Layout layout,
+              Uplo uplo,
+              Op trans,
+              Diag diag,
+              idx_t n,
+              TA const* A,
+              idx_t lda,
+              TX* x,
+              int_t incx)
+    {
+        using internal::create_matrix;
+        using std::abs;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < n);
-    tlapack_check_false(incx == 0);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < n);
+        tlapack_check_false(incx == 0);
 
-    // quick return
-    if (n == 0) return;
+        // quick return
+        if (n == 0) return;
 
-    // for row major, swap lower <=> upper and
-    // A => A^T; A^T => A; A^H => A & doConj
-    bool doConj = false;
-    if (layout == Layout::RowMajor) {
-        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
-        if (trans == Op::NoTrans)
-            trans = Op::Trans;
-        else {
-            if (trans == Op::ConjTrans) doConj = true;
-            trans = Op::NoTrans;
+        // for row major, swap lower <=> upper and
+        // A => A^T; A^T => A; A^H => A & doConj
+        bool doConj = false;
+        if (layout == Layout::RowMajor) {
+            uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+            if (trans == Op::NoTrans)
+                trans = Op::Trans;
+            else {
+                if (trans == Op::ConjTrans) doConj = true;
+                trans = Op::NoTrans;
+            }
+        }
+
+        // Conjugate if A is row-major and initially trans is Op::ConjTrans
+        if (doConj) {
+            for (idx_t i = 0; i < n; ++i)
+                x[i * abs(incx)] = conj(x[i * abs(incx)]);
+        }
+
+        // Matrix views
+        const auto A_ = create_matrix<TA>((TA*)A, n, n, lda);
+
+        tlapack_expr_with_vector(x_, TX, n, x, incx,
+                                 trmv(uplo, trans, diag, A_, x_));
+
+        // Conjugate if A is row-major and initially trans is Op::ConjTrans
+        if (doConj) {
+            for (idx_t i = 0; i < n; ++i)
+                x[i * abs(incx)] = conj(x[i * abs(incx)]);
         }
     }
 
-    // Conjugate if A is row-major and initially trans is Op::ConjTrans
-    if (doConj) {
-        for (idx_t i = 0; i < n; ++i)
-            x[i * abs(incx)] = conj(x[i * abs(incx)]);
-    }
-
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
-
-    tlapack_expr_with_vector(x_, TX, n, x, incx,
-                             trmv(uplo, trans, diag, A_, x_));
-
-    // Conjugate if A is row-major and initially trans is Op::ConjTrans
-    if (doConj) {
-        for (idx_t i = 0; i < n; ++i)
-            x[i * abs(incx)] = conj(x[i * abs(incx)]);
-    }
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_TRMV_HH

--- a/include/tlapack/legacy_api/blas/trsm.hpp
+++ b/include/tlapack/legacy_api/blas/trsm.hpp
@@ -1,4 +1,4 @@
-/// @file trsm.hpp
+/// @file legacy_api/blas/trsm.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,141 +16,146 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Solve the triangular matrix-vector equation
- * \[
- *     op(A) X = \alpha B,
- * \]
- * or
- * \[
- *     X op(A) = \alpha B,
- * \]
- * where $op(A)$ is one of
- *     $op(A) = A$,
- *     $op(A) = A^T$, or
- *     $op(A) = A^H$,
- * X and B are m-by-n matrices, and A is an m-by-m or n-by-n, unit or non-unit,
- * upper or lower triangular matrix.
- *
- * No test for singularity or near-singularity is included in this
- * routine. Such tests must be performed before calling this routine.
- * @see latrs for a more numerically robust implementation.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] side
- *     Whether $op(A)$ is on the left or right of X:
- *     - Side::Left:  $op(A) X = B$.
- *     - Side::Right: $X op(A) = B$.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed to be zero:
- *     - Uplo::Lower: A is lower triangular.
- *     - Uplo::Upper: A is upper triangular.
- *
- * @param[in] trans
- *     The form of $op(A)$:
- *     - Op::NoTrans:   $op(A) = A$.
- *     - Op::Trans:     $op(A) = A^T$.
- *     - Op::ConjTrans: $op(A) = A^H$.
- *
- * @param[in] diag
- *     Whether A has a unit or non-unit diagonal:
- *     - Diag::Unit:    A is assumed to be unit triangular.
- *     - Diag::NonUnit: A is not assumed to be unit triangular.
- *
- * @param[in] m
- *     Number of rows of matrices B and X. m >= 0.
- *
- * @param[in] n
- *     Number of columns of matrices B and X. n >= 0.
- *
- * @param[in] alpha
- *     Scalar alpha. If alpha is zero, A is not accessed.
- *
- * @param[in] A
- *     - If side = Left:
- *       the m-by-m matrix A, stored in an lda-by-m array [RowMajor: m-by-lda].
- *     - If side = Right:
- *       the n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A.
- *     - If side = left:  lda >= max(1, m).
- *     - If side = right: lda >= max(1, n).
- *
- * @param[in,out] B
- *     On entry,
- *     the m-by-n matrix B, stored in an ldb-by-n array [RowMajor: m-by-ldb].
- *     On exit, overwritten by the solution matrix X.
- *
- * @param[in] ldb
- *     Leading dimension of B. ldb >= max(1, m) [RowMajor: ldb >= max(1, n)].
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TB>
-void trsm(Layout layout,
-          Side side,
-          Uplo uplo,
-          Op trans,
-          Diag diag,
-          idx_t m,
-          idx_t n,
-          scalar_type<TA, TB> alpha,
-          TA const* A,
-          idx_t lda,
-          TB* B,
-          idx_t ldb)
-{
-    using internal::colmajor_matrix;
-    using scalar_t = scalar_type<TA, TB>;
+    /**
+     * Solve the triangular matrix-vector equation
+     * \[
+     *     op(A) X = \alpha B,
+     * \]
+     * or
+     * \[
+     *     X op(A) = \alpha B,
+     * \]
+     * where $op(A)$ is one of
+     *     $op(A) = A$,
+     *     $op(A) = A^T$, or
+     *     $op(A) = A^H$,
+     * X and B are m-by-n matrices, and A is an m-by-m or n-by-n, unit or
+     * non-unit, upper or lower triangular matrix.
+     *
+     * No test for singularity or near-singularity is included in this
+     * routine. Such tests must be performed before calling this routine.
+     * @see latrs for a more numerically robust implementation.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] side
+     *     Whether $op(A)$ is on the left or right of X:
+     *     - Side::Left:  $op(A) X = B$.
+     *     - Side::Right: $X op(A) = B$.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed to be zero:
+     *     - Uplo::Lower: A is lower triangular.
+     *     - Uplo::Upper: A is upper triangular.
+     *
+     * @param[in] trans
+     *     The form of $op(A)$:
+     *     - Op::NoTrans:   $op(A) = A$.
+     *     - Op::Trans:     $op(A) = A^T$.
+     *     - Op::ConjTrans: $op(A) = A^H$.
+     *
+     * @param[in] diag
+     *     Whether A has a unit or non-unit diagonal:
+     *     - Diag::Unit:    A is assumed to be unit triangular.
+     *     - Diag::NonUnit: A is not assumed to be unit triangular.
+     *
+     * @param[in] m
+     *     Number of rows of matrices B and X. m >= 0.
+     *
+     * @param[in] n
+     *     Number of columns of matrices B and X. n >= 0.
+     *
+     * @param[in] alpha
+     *     Scalar alpha. If alpha is zero, A is not accessed.
+     *
+     * @param[in] A
+     *     - If side = Left:
+     *       the m-by-m matrix A, stored in an lda-by-m array [RowMajor:
+     * m-by-lda].
+     *     - If side = Right:
+     *       the n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A.
+     *     - If side = left:  lda >= max(1, m).
+     *     - If side = right: lda >= max(1, n).
+     *
+     * @param[in,out] B
+     *     On entry,
+     *     the m-by-n matrix B, stored in an ldb-by-n array [RowMajor:
+     * m-by-ldb]. On exit, overwritten by the solution matrix X.
+     *
+     * @param[in] ldb
+     *     Leading dimension of B. ldb >= max(1, m) [RowMajor: ldb >= max(1,
+     * n)].
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TB>
+    void trsm(Layout layout,
+              Side side,
+              Uplo uplo,
+              Op trans,
+              Diag diag,
+              idx_t m,
+              idx_t n,
+              scalar_type<TA, TB> alpha,
+              TA const* A,
+              idx_t lda,
+              TB* B,
+              idx_t ldb)
+    {
+        using internal::create_matrix;
+        using scalar_t = scalar_type<TA, TB>;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < ((side == Side::Left) ? m : n));
-    tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < ((side == Side::Left) ? m : n));
+        tlapack_check_false(ldb < ((layout == Layout::RowMajor) ? n : m));
 
-    // quick return
-    if (m == 0 || n == 0) return;
+        // quick return
+        if (m == 0 || n == 0) return;
 
-    // adapt if row major
-    if (layout == Layout::RowMajor) {
-        side = (side == Side::Left) ? Side::Right : Side::Left;
-        if (uplo == Uplo::Lower)
-            uplo = Uplo::Upper;
-        else if (uplo == Uplo::Upper)
-            uplo = Uplo::Lower;
-        std::swap(m, n);
+        // adapt if row major
+        if (layout == Layout::RowMajor) {
+            side = (side == Side::Left) ? Side::Right : Side::Left;
+            if (uplo == Uplo::Lower)
+                uplo = Uplo::Upper;
+            else if (uplo == Uplo::Upper)
+                uplo = Uplo::Lower;
+            std::swap(m, n);
+        }
+
+        // Matrix views
+        const auto A_ = (side == Side::Left)
+                            ? create_matrix<TA>((TA*)A, m, m, lda)
+                            : create_matrix<TA>((TA*)A, n, n, lda);
+        auto B_ = create_matrix<TB>(B, m, n, ldb);
+
+        if (alpha == scalar_t(0))
+            for (idx_t j = 0; j < n; ++j)
+                for (idx_t i = 0; i < m; ++i)
+                    B_(i, j) = TB(0);
+        else
+            trsm(side, uplo, trans, diag, alpha, A_, B_);
     }
 
-    // Matrix views
-    const auto A_ = (side == Side::Left)
-                        ? colmajor_matrix<TA>((TA*)A, m, m, lda)
-                        : colmajor_matrix<TA>((TA*)A, n, n, lda);
-    auto B_ = colmajor_matrix<TB>(B, m, n, ldb);
-
-    if (alpha == scalar_t(0))
-        for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < m; ++i)
-                B_(i, j) = TB(0);
-    else
-        trsm(side, uplo, trans, diag, alpha, A_, B_);
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_TRSM_HH

--- a/include/tlapack/legacy_api/blas/trsv.hpp
+++ b/include/tlapack/legacy_api/blas/trsv.hpp
@@ -1,4 +1,4 @@
-/// @file trsv.hpp
+/// @file legacy_api/blas/trsv.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
@@ -16,124 +16,127 @@
 #include "tlapack/legacy_api/base/utils.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * Solve the triangular matrix-vector equation
- * \[
- *     op(A) x = b,
- * \]
- * where $op(A)$ is one of
- *     $op(A) = A$,
- *     $op(A) = A^T$, or
- *     $op(A) = A^H$,
- * x and b are vectors,
- * and A is an n-by-n, unit or non-unit, upper or lower triangular matrix.
- *
- * No test for singularity or near-singularity is included in this
- * routine. Such tests must be performed before calling this routine.
- * @see LAPACK's latrs for a more numerically robust implementation.
- *
- * Generic implementation for arbitrary data types.
- *
- * @param[in] layout
- *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
- *
- * @param[in] uplo
- *     What part of the matrix A is referenced,
- *     the opposite triangle being assumed to be zero.
- *     - Uplo::Lower: A is lower triangular.
- *     - Uplo::Upper: A is upper triangular.
- *
- * @param[in] trans
- *     The equation to be solved:
- *     - Op::NoTrans:   $A   x = b$,
- *     - Op::Trans:     $A^T x = b$,
- *     - Op::ConjTrans: $A^H x = b$.
- *
- * @param[in] diag
- *     Whether A has a unit or non-unit diagonal:
- *     - Diag::Unit:    A is assumed to be unit triangular.
- *                      The diagonal elements of A are not referenced.
- *     - Diag::NonUnit: A is not assumed to be unit triangular.
- *
- * @param[in] n
- *     Number of rows and columns of the matrix A. n >= 0.
- *
- * @param[in] A
- *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor: n-by-lda].
- *
- * @param[in] lda
- *     Leading dimension of A. lda >= max(1, n).
- *
- * @param[in,out] x
- *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
- *
- * @param[in] incx
- *     Stride between elements of x. incx must not be zero.
- *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
- *
- * @ingroup legacy_blas
- */
-template <typename TA, typename TX>
-void trsv(Layout layout,
-          Uplo uplo,
-          Op trans,
-          Diag diag,
-          idx_t n,
-          TA const* A,
-          idx_t lda,
-          TX* x,
-          int_t incx)
-{
-    using internal::colmajor_matrix;
-    using std::abs;
+    /**
+     * Solve the triangular matrix-vector equation
+     * \[
+     *     op(A) x = b,
+     * \]
+     * where $op(A)$ is one of
+     *     $op(A) = A$,
+     *     $op(A) = A^T$, or
+     *     $op(A) = A^H$,
+     * x and b are vectors,
+     * and A is an n-by-n, unit or non-unit, upper or lower triangular matrix.
+     *
+     * No test for singularity or near-singularity is included in this
+     * routine. Such tests must be performed before calling this routine.
+     * @see LAPACK's latrs for a more numerically robust implementation.
+     *
+     * Generic implementation for arbitrary data types.
+     *
+     * @param[in] layout
+     *     Matrix storage, Layout::ColMajor or Layout::RowMajor.
+     *
+     * @param[in] uplo
+     *     What part of the matrix A is referenced,
+     *     the opposite triangle being assumed to be zero.
+     *     - Uplo::Lower: A is lower triangular.
+     *     - Uplo::Upper: A is upper triangular.
+     *
+     * @param[in] trans
+     *     The equation to be solved:
+     *     - Op::NoTrans:   $A   x = b$,
+     *     - Op::Trans:     $A^T x = b$,
+     *     - Op::ConjTrans: $A^H x = b$.
+     *
+     * @param[in] diag
+     *     Whether A has a unit or non-unit diagonal:
+     *     - Diag::Unit:    A is assumed to be unit triangular.
+     *                      The diagonal elements of A are not referenced.
+     *     - Diag::NonUnit: A is not assumed to be unit triangular.
+     *
+     * @param[in] n
+     *     Number of rows and columns of the matrix A. n >= 0.
+     *
+     * @param[in] A
+     *     The n-by-n matrix A, stored in an lda-by-n array [RowMajor:
+     * n-by-lda].
+     *
+     * @param[in] lda
+     *     Leading dimension of A. lda >= max(1, n).
+     *
+     * @param[in,out] x
+     *     The n-element vector x, in an array of length (n-1)*abs(incx) + 1.
+     *
+     * @param[in] incx
+     *     Stride between elements of x. incx must not be zero.
+     *     If incx < 0, uses elements of x in reverse order: x(n-1), ..., x(0).
+     *
+     * @ingroup legacy_blas
+     */
+    template <typename TA, typename TX>
+    void trsv(Layout layout,
+              Uplo uplo,
+              Op trans,
+              Diag diag,
+              idx_t n,
+              TA const* A,
+              idx_t lda,
+              TX* x,
+              int_t incx)
+    {
+        using internal::create_matrix;
+        using std::abs;
 
-    // check arguments
-    tlapack_check_false(layout != Layout::ColMajor &&
-                        layout != Layout::RowMajor);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < n);
-    tlapack_check_false(incx == 0);
+        // check arguments
+        tlapack_check_false(layout != Layout::ColMajor &&
+                            layout != Layout::RowMajor);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < n);
+        tlapack_check_false(incx == 0);
 
-    // quick return
-    if (n == 0) return;
+        // quick return
+        if (n == 0) return;
 
-    // for row major, swap lower <=> upper and
-    // A => A^T; A^T => A; A^H => A & doConj
-    bool doConj = false;
-    if (layout == Layout::RowMajor) {
-        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
-        if (trans == Op::NoTrans)
-            trans = Op::Trans;
-        else {
-            if (trans == Op::ConjTrans) doConj = true;
-            trans = Op::NoTrans;
+        // for row major, swap lower <=> upper and
+        // A => A^T; A^T => A; A^H => A & doConj
+        bool doConj = false;
+        if (layout == Layout::RowMajor) {
+            uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+            if (trans == Op::NoTrans)
+                trans = Op::Trans;
+            else {
+                if (trans == Op::ConjTrans) doConj = true;
+                trans = Op::NoTrans;
+            }
+        }
+
+        // Conjugate if A is row-major and initially trans is Op::ConjTrans
+        if (doConj) {
+            for (idx_t i = 0; i < n; ++i)
+                x[i * abs(incx)] = conj(x[i * abs(incx)]);
+        }
+
+        // Matrix views
+        const auto A_ = create_matrix<TA>((TA*)A, n, n, lda);
+
+        tlapack_expr_with_vector(x_, TX, n, x, incx,
+                                 trsv(uplo, trans, diag, A_, x_));
+
+        // Conjugate if A is row-major and initially trans is Op::ConjTrans
+        if (doConj) {
+            for (idx_t i = 0; i < n; ++i)
+                x[i * abs(incx)] = conj(x[i * abs(incx)]);
         }
     }
 
-    // Conjugate if A is row-major and initially trans is Op::ConjTrans
-    if (doConj) {
-        for (idx_t i = 0; i < n; ++i)
-            x[i * abs(incx)] = conj(x[i * abs(incx)]);
-    }
-
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
-
-    tlapack_expr_with_vector(x_, TX, n, x, incx,
-                             trsv(uplo, trans, diag, A_, x_));
-
-    // Conjugate if A is row-major and initially trans is Op::ConjTrans
-    if (doConj) {
-        for (idx_t i = 0; i < n; ++i)
-            x[i * abs(incx)] = conj(x[i * abs(incx)]);
-    }
-}
-
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  //  #ifndef TLAPACK_LEGACY_TRSV_HH

--- a/include/tlapack/legacy_api/lapack/geqr2.hpp
+++ b/include/tlapack/legacy_api/lapack/geqr2.hpp
@@ -1,4 +1,4 @@
-/// @file geqr2.hpp
+/// @file legacy_api/lapack/geqr2.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/geqr2.h
@@ -15,47 +15,49 @@
 #include "tlapack/lapack/geqr2.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Computes a QR factorization of a matrix A.
- *
- * @param[in] m The number of rows of the matrix A.
- * @param[in] n The number of columns of the matrix A.
- * @param[in,out] A m-by-n matrix.
- *      On exit, the elements on and above the diagonal of the array
- *      contain the min(m,n)-by-n upper trapezoidal matrix R
- *      (R is upper triangular if m >= n); the elements below the diagonal,
- *      with the array tau, represent the unitary matrix Q as a
- *      product of elementary reflectors.
- * @param[in] lda The leading dimension of A. lda >= max(1,m).
- * @param[out] tau Real vector of length min(m,n).
- *      The scalar factors of the elementary reflectors.
- *      The subarray tau[1:n-1] is used as the workspace.
- *
- * @see geqr2( matrix_t& A, vector_t &tau, vector_t &work )
- *
- * @ingroup legacy_lapack
- */
-template <typename TA, typename TT>
-inline int geqr2(idx_t m, idx_t n, TA* A, idx_t lda, TT* tau)
-{
-    using internal::colmajor_matrix;
-    using internal::vector;
+    /** Computes a QR factorization of a matrix A.
+     *
+     * @param[in] m The number of rows of the matrix A.
+     * @param[in] n The number of columns of the matrix A.
+     * @param[in,out] A m-by-n matrix.
+     *      On exit, the elements on and above the diagonal of the array
+     *      contain the min(m,n)-by-n upper trapezoidal matrix R
+     *      (R is upper triangular if m >= n); the elements below the diagonal,
+     *      with the array tau, represent the unitary matrix Q as a
+     *      product of elementary reflectors.
+     * @param[in] lda The leading dimension of A. lda >= max(1,m).
+     * @param[out] tau Real vector of length min(m,n).
+     *      The scalar factors of the elementary reflectors.
+     *      The subarray tau[1:n-1] is used as the workspace.
+     *
+     * @see geqr2( matrix_t& A, vector_t &tau, vector_t &work )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <typename TA, typename TT>
+    inline int geqr2(idx_t m, idx_t n, TA* A, idx_t lda, TT* tau)
+    {
+        using internal::create_matrix;
+        using internal::create_vector;
 
-    // check arguments
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(lda < m);
+        // check arguments
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(lda < m);
 
-    // quick return
-    if (n <= 0) return 0;
+        // quick return
+        if (n <= 0) return 0;
 
-    // Matrix views
-    auto A_ = colmajor_matrix(A, m, n, lda);
-    auto tau_ = vector(tau, std::min(m, n));
+        // Matrix views
+        auto A_ = create_matrix(A, m, n, lda);
+        auto tau_ = create_vector(tau, std::min(m, n));
 
-    return geqr2(A_, tau_);
-}
+        return geqr2(A_, tau_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_GEQR2_HH

--- a/include/tlapack/legacy_api/lapack/lacpy.hpp
+++ b/include/tlapack/legacy_api/lapack/lacpy.hpp
@@ -1,4 +1,4 @@
-/// @file lacpy.hpp
+/// @file legacy_api/lapack/lacpy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/lacpy.h
@@ -15,82 +15,85 @@
 #include "tlapack/lapack/lacpy.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * @brief Copies a matrix from A to B.
- *
- * @tparam uplo_t
- *      Either Uplo or any class that implements `operator Uplo()`.
- *
- * @param[in] uplo
- *      - Uplo::Upper:   Upper triangle of A and B are referenced;
- *      - Uplo::Lower:   Lower triangle of A and B are referenced;
- *      - Uplo::General: All entries of A are referenced; the first m rows of B
- *                          and first n columns of B are referenced.
- * @param[in] m Number of rows of A.
- * @param[in] n Number of columns of A.
- * @param[in] A m-by-n matrix.
- * @param[in] lda Leading dimension of A.
- * @param[out] B Matrix with at least m rows and at least n columns.
- * @param[in] ldb Leading dimension of B.
- */
-template <class uplo_t, typename TA, typename TB>
-void lacpy(
-    uplo_t uplo, idx_t m, idx_t n, const TA* A, idx_t lda, TB* B, idx_t ldb)
-{
-    using internal::colmajor_matrix;
+    /**
+     * @brief Copies a matrix from A to B.
+     *
+     * @tparam uplo_t
+     *      Either Uplo or any class that implements `operator Uplo()`.
+     *
+     * @param[in] uplo
+     *      - Uplo::Upper:   Upper triangle of A and B are referenced;
+     *      - Uplo::Lower:   Lower triangle of A and B are referenced;
+     *      - Uplo::General: All entries of A are referenced; the first m rows
+     * of B and first n columns of B are referenced.
+     * @param[in] m Number of rows of A.
+     * @param[in] n Number of columns of A.
+     * @param[in] A m-by-n matrix.
+     * @param[in] lda Leading dimension of A.
+     * @param[out] B Matrix with at least m rows and at least n columns.
+     * @param[in] ldb Leading dimension of B.
+     */
+    template <class uplo_t, typename TA, typename TB>
+    void lacpy(
+        uplo_t uplo, idx_t m, idx_t n, const TA* A, idx_t lda, TB* B, idx_t ldb)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
+        // check arguments
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
 
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
-    auto B_ = colmajor_matrix<TB>(B, m, n, ldb);
+        // Matrix views
+        const auto A_ = create_matrix<TA>((TA*)A, m, n, lda);
+        auto B_ = create_matrix<TB>(B, m, n, ldb);
 
-    lacpy(uplo, A_, B_);
-}
-
-/** Copies a real matrix from A to B where A is either a full, upper triangular
- * or lower triangular matrix.
- *
- * @param[in] matrixtype :
- *
- *        'U': A is assumed to be upper triangular; elements below the diagonal
- * are not referenced. 'L': A is assumed to be lower triangular; elements above
- * the diagonal are not referenced. otherwise, A is assumed to be a full matrix.
- *
- * @param[in] m Number of rows of A.
- * @param[in] n Number of columns of A.
- * @param[in] A m-by-n matrix.
- * @param[in] lda Leading dimension of A.
- * @param[out] B Matrix with at least m rows and at least n columns.
- * @param[in] ldb Leading dimension of B.
- *
- * @see lacpy( uplo_t, idx_t, idx_t, const TA*, idx_t, TB* B, idx_t )
- *
- * @ingroup legacy_lapack
- */
-template <typename TA, typename TB>
-void inline lacpy(MatrixType matrixtype,
-                  idx_t m,
-                  idx_t n,
-                  const TA* A,
-                  idx_t lda,
-                  TB* B,
-                  idx_t ldb)
-{
-    if (matrixtype == MatrixType::Upper) {
-        lacpy(Uplo::Upper, m, n, A, lda, B, ldb);
+        lacpy(uplo, A_, B_);
     }
-    else if (matrixtype == MatrixType::Lower) {
-        lacpy(Uplo::Lower, m, n, A, lda, B, ldb);
-    }
-    else {
-        lacpy(Uplo::General, m, n, A, lda, B, ldb);
-    }
-}
 
+    /** Copies a real matrix from A to B where A is either a full, upper
+     * triangular or lower triangular matrix.
+     *
+     * @param[in] matrixtype :
+     *
+     *        'U': A is assumed to be upper triangular; elements below the
+     * diagonal are not referenced. 'L': A is assumed to be lower triangular;
+     * elements above the diagonal are not referenced. otherwise, A is assumed
+     * to be a full matrix.
+     *
+     * @param[in] m Number of rows of A.
+     * @param[in] n Number of columns of A.
+     * @param[in] A m-by-n matrix.
+     * @param[in] lda Leading dimension of A.
+     * @param[out] B Matrix with at least m rows and at least n columns.
+     * @param[in] ldb Leading dimension of B.
+     *
+     * @see lacpy( uplo_t, idx_t, idx_t, const TA*, idx_t, TB* B, idx_t )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <typename TA, typename TB>
+    void inline lacpy(MatrixType matrixtype,
+                      idx_t m,
+                      idx_t n,
+                      const TA* A,
+                      idx_t lda,
+                      TB* B,
+                      idx_t ldb)
+    {
+        if (matrixtype == MatrixType::Upper) {
+            lacpy(Uplo::Upper, m, n, A, lda, B, ldb);
+        }
+        else if (matrixtype == MatrixType::Lower) {
+            lacpy(Uplo::Lower, m, n, A, lda, B, ldb);
+        }
+        else {
+            lacpy(Uplo::General, m, n, A, lda, B, ldb);
+        }
+    }
+
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LACPY_HH

--- a/include/tlapack/legacy_api/lapack/lange.hpp
+++ b/include/tlapack/legacy_api/lapack/lange.hpp
@@ -1,4 +1,4 @@
-/// @file lange.hpp
+/// @file legacy_api/lapack/lange.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/lange.h
@@ -15,47 +15,49 @@
 #include "tlapack/lapack/lange.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
- *element of largest absolute value
- *
- * @return Calculated norm value for the specified type.
- *
- * @param normType Type should be specified as follows:
- *
- *     Norm::Max = maximum absolute value over all elements in A.
- *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of
- *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
- *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
- *the square root of the sum of the squares of each element in A.
- *
- * @param m Number of rows to be included in the norm. m >= 0
- * @param n Number of columns to be included in the norm. n >= 0
- * @param A matrix size m-by-n.
- * @param lda Column length of the matrix A.  ldA >= m
- *
- * @ingroup legacy_lapack
- **/
-template <class norm_t, typename TA>
-inline real_type<TA> lange(
-    norm_t normType, idx_t m, idx_t n, const TA* A, idx_t lda)
-{
-    using internal::colmajor_matrix;
+    /** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+     *element of largest absolute value
+     *
+     * @return Calculated norm value for the specified type.
+     *
+     * @param normType Type should be specified as follows:
+     *
+     *     Norm::Max = maximum absolute value over all elements in A.
+     *         Note: this is not a consistent matrix norm.
+     *     Norm::One = one norm of the matrix A, the maximum value of the sums
+     *of each column. Norm::Inf = the infinity norm of the matrix A, the maximum
+     *value of the sum of each row. Norm::Fro = the Frobenius norm of the matrix
+     *A. This the square root of the sum of the squares of each element in A.
+     *
+     * @param m Number of rows to be included in the norm. m >= 0
+     * @param n Number of columns to be included in the norm. n >= 0
+     * @param A matrix size m-by-n.
+     * @param lda Column length of the matrix A.  ldA >= m
+     *
+     * @ingroup legacy_lapack
+     **/
+    template <class norm_t, typename TA>
+    inline real_type<TA> lange(
+        norm_t normType, idx_t m, idx_t n, const TA* A, idx_t lda)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
-                        normType != Norm::Max && normType != Norm::One);
+        // check arguments
+        tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                            normType != Norm::Max && normType != Norm::One);
 
-    // quick return
-    if (m == 0 || n == 0) return 0;
+        // quick return
+        if (m == 0 || n == 0) return 0;
 
-    // Views
-    auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
+        // Views
+        auto A_ = create_matrix<TA>((TA*)A, m, n, lda);
 
-    return lange(normType, A_);
-}
+        return lange(normType, A_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LANGE_HH

--- a/include/tlapack/legacy_api/lapack/lanhe.hpp
+++ b/include/tlapack/legacy_api/lapack/lanhe.hpp
@@ -1,4 +1,4 @@
-/// @file lanhe.hpp
+/// @file legacy_api/lapack/lanhe.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -14,49 +14,52 @@
 #include "tlapack/lapack/lanhe.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
- *element of largest absolute value of a symmetric matrix
- *
- * @return Calculated norm value for the specified type.
- *
- * @param normType Type should be specified as follows:
- *
- *     Norm::Max = maximum absolute value over all elements in A.
- *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of
- *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
- *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
- *the square root of the sum of the squares of each element in A.
- *
- * @param uplo Indicates whether the symmetric matrix A is stored as upper
- *triangular or lower triangular. The other strict triangular part of A is not
- *referenced.
- * @param n Number of columns to be included in the norm. n >= 0
- * @param A symmetric matrix size lda-by-n.
- * @param lda Leading dimension of matrix A.  ldA >= m
- *
- * @ingroup legacy_lapack
- **/
-template <class norm_t, typename TA>
-real_type<TA> lanhe(norm_t normType, Uplo uplo, idx_t n, const TA* A, idx_t lda)
-{
-    using internal::colmajor_matrix;
+    /** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+     *element of largest absolute value of a symmetric matrix
+     *
+     * @return Calculated norm value for the specified type.
+     *
+     * @param normType Type should be specified as follows:
+     *
+     *     Norm::Max = maximum absolute value over all elements in A.
+     *         Note: this is not a consistent matrix norm.
+     *     Norm::One = one norm of the matrix A, the maximum value of the sums
+     *of each column. Norm::Inf = the infinity norm of the matrix A, the maximum
+     *value of the sum of each row. Norm::Fro = the Frobenius norm of the matrix
+     *A. This the square root of the sum of the squares of each element in A.
+     *
+     * @param uplo Indicates whether the symmetric matrix A is stored as upper
+     *triangular or lower triangular. The other strict triangular part of A is
+     *not referenced.
+     * @param n Number of columns to be included in the norm. n >= 0
+     * @param A symmetric matrix size lda-by-n.
+     * @param lda Leading dimension of matrix A.  ldA >= m
+     *
+     * @ingroup legacy_lapack
+     **/
+    template <class norm_t, typename TA>
+    real_type<TA> lanhe(
+        norm_t normType, Uplo uplo, idx_t n, const TA* A, idx_t lda)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
-                        normType != Norm::Max && normType != Norm::One);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        // check arguments
+        tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                            normType != Norm::Max && normType != Norm::One);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
-    // quick return
-    if (n == 0) return 0;
+        // quick return
+        if (n == 0) return 0;
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
+        // Matrix views
+        auto A_ = create_matrix<TA>((TA*)A, n, n, lda);
 
-    return lanhe(normType, uplo, A_);
-}
+        return lanhe(normType, uplo, A_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LANHE_HH

--- a/include/tlapack/legacy_api/lapack/lansy.hpp
+++ b/include/tlapack/legacy_api/lapack/lansy.hpp
@@ -1,4 +1,4 @@
-/// @file lansy.hpp
+/// @file legacy_api/lapack/lansy.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -14,49 +14,52 @@
 #include "tlapack/lapack/lansy.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
- *element of largest absolute value of a symmetric matrix
- *
- * @return Calculated norm value for the specified type.
- *
- * @param normType Type should be specified as follows:
- *
- *     Norm::Max = maximum absolute value over all elements in A.
- *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of
- *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
- *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
- *the square root of the sum of the squares of each element in A.
- *
- * @param uplo Indicates whether the symmetric matrix A is stored as upper
- *triangular or lower triangular. The other triangular part of A is not
- *referenced.
- * @param n Number of columns to be included in the norm. n >= 0
- * @param A symmetric matrix size lda-by-n.
- * @param lda Leading dimension of matrix A.  ldA >= m
- *
- * @ingroup legacy_lapack
- **/
-template <class norm_t, typename TA>
-real_type<TA> lansy(norm_t normType, Uplo uplo, idx_t n, const TA* A, idx_t lda)
-{
-    using internal::colmajor_matrix;
+    /** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+     *element of largest absolute value of a symmetric matrix
+     *
+     * @return Calculated norm value for the specified type.
+     *
+     * @param normType Type should be specified as follows:
+     *
+     *     Norm::Max = maximum absolute value over all elements in A.
+     *         Note: this is not a consistent matrix norm.
+     *     Norm::One = one norm of the matrix A, the maximum value of the sums
+     *of each column. Norm::Inf = the infinity norm of the matrix A, the maximum
+     *value of the sum of each row. Norm::Fro = the Frobenius norm of the matrix
+     *A. This the square root of the sum of the squares of each element in A.
+     *
+     * @param uplo Indicates whether the symmetric matrix A is stored as upper
+     *triangular or lower triangular. The other triangular part of A is not
+     *referenced.
+     * @param n Number of columns to be included in the norm. n >= 0
+     * @param A symmetric matrix size lda-by-n.
+     * @param lda Leading dimension of matrix A.  ldA >= m
+     *
+     * @ingroup legacy_lapack
+     **/
+    template <class norm_t, typename TA>
+    real_type<TA> lansy(
+        norm_t normType, Uplo uplo, idx_t n, const TA* A, idx_t lda)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
-                        normType != Norm::Max && normType != Norm::One);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        // check arguments
+        tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                            normType != Norm::Max && normType != Norm::One);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
-    // quick return
-    if (n == 0) return 0;
+        // quick return
+        if (n == 0) return 0;
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>((TA*)A, n, n, lda);
+        // Matrix views
+        auto A_ = create_matrix<TA>((TA*)A, n, n, lda);
 
-    return lansy(normType, uplo, A_);
-}
+        return lansy(normType, uplo, A_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LANSY_HH

--- a/include/tlapack/legacy_api/lapack/lantr.hpp
+++ b/include/tlapack/legacy_api/lapack/lantr.hpp
@@ -1,4 +1,4 @@
-/// @file lantr.hpp
+/// @file legacy_api/lapack/lantr.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -14,62 +14,64 @@
 #include "tlapack/lapack/lantr.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Calculates the value of the one norm, Frobenius norm, infinity norm, or
- *element of largest absolute value of a triangular matrix
- *
- * @return Calculated norm value for the specified type.
- *
- * @param normType Type should be specified as follows:
- *
- *     Norm::Max = maximum absolute value over all elements in A.
- *         Note: this is not a consistent matrix norm.
- *     Norm::One = one norm of the matrix A, the maximum value of the sums of
- *each column. Norm::Inf = the infinity norm of the matrix A, the maximum value
- *of the sum of each row. Norm::Fro = the Frobenius norm of the matrix A. This
- *the square root of the sum of the squares of each element in A.
- *
- * @param uplo Indicates whether A is upper or lower triangular.
- *      The other strict triangular part of A is not referenced.
- *
- * @param[in] diag
- *     Whether A has a unit or non-unit diagonal:
- *     - Diag::Unit:    A is assumed to be unit triangular.
- *     - Diag::NonUnit: A is not assumed to be unit triangular.
- *
- * @param m Number of rows to be included in the norm. m >= 0
- * @param n Number of columns to be included in the norm. n >= 0
- * @param A symmetric matrix size lda-by-n.
- * @param lda Leading dimension of matrix A.  ldA >= m
- *
- * @ingroup legacy_lapack
- **/
-template <typename TA>
-real_type<TA> lantr(Norm normType,
-                    Uplo uplo,
-                    Diag diag,
-                    idx_t m,
-                    idx_t n,
-                    const TA* A,
-                    idx_t lda)
-{
-    using internal::colmajor_matrix;
+    /** Calculates the value of the one norm, Frobenius norm, infinity norm, or
+     *element of largest absolute value of a triangular matrix
+     *
+     * @return Calculated norm value for the specified type.
+     *
+     * @param normType Type should be specified as follows:
+     *
+     *     Norm::Max = maximum absolute value over all elements in A.
+     *         Note: this is not a consistent matrix norm.
+     *     Norm::One = one norm of the matrix A, the maximum value of the sums
+     *of each column. Norm::Inf = the infinity norm of the matrix A, the maximum
+     *value of the sum of each row. Norm::Fro = the Frobenius norm of the matrix
+     *A. This the square root of the sum of the squares of each element in A.
+     *
+     * @param uplo Indicates whether A is upper or lower triangular.
+     *      The other strict triangular part of A is not referenced.
+     *
+     * @param[in] diag
+     *     Whether A has a unit or non-unit diagonal:
+     *     - Diag::Unit:    A is assumed to be unit triangular.
+     *     - Diag::NonUnit: A is not assumed to be unit triangular.
+     *
+     * @param m Number of rows to be included in the norm. m >= 0
+     * @param n Number of columns to be included in the norm. n >= 0
+     * @param A symmetric matrix size lda-by-n.
+     * @param lda Leading dimension of matrix A.  ldA >= m
+     *
+     * @ingroup legacy_lapack
+     **/
+    template <typename TA>
+    real_type<TA> lantr(Norm normType,
+                        Uplo uplo,
+                        Diag diag,
+                        idx_t m,
+                        idx_t n,
+                        const TA* A,
+                        idx_t lda)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
-                        normType != Norm::Max && normType != Norm::One);
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
-    tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
+        // check arguments
+        tlapack_check_false(normType != Norm::Fro && normType != Norm::Inf &&
+                            normType != Norm::Max && normType != Norm::One);
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        tlapack_check_false(diag != Diag::NonUnit && diag != Diag::Unit);
 
-    // quick return
-    if (m == 0 || n == 0) return 0;
+        // quick return
+        if (m == 0 || n == 0) return 0;
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>((TA*)A, m, n, lda);
+        // Matrix views
+        auto A_ = create_matrix<TA>((TA*)A, m, n, lda);
 
-    return lantr(normType, uplo, diag, A_);
-}
+        return lantr(normType, uplo, diag, A_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LANTR_HH

--- a/include/tlapack/legacy_api/lapack/larf.hpp
+++ b/include/tlapack/legacy_api/lapack/larf.hpp
@@ -1,4 +1,4 @@
-/// @file larf.hpp
+/// @file legacy_api/lapack/larf.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/larf.h
@@ -15,44 +15,46 @@
 #include "tlapack/lapack/larf.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Applies an elementary reflector H to a m-by-n matrix C.
- *
- * @see larf( Side side, idx_t m, idx_t n, TV const *v, int_t incv, scalar_type<
- * TV, TC , TW > tau, TC *C, idx_t ldC, TW *work )
- *
- * @ingroup legacy_lapack
- */
-template <class side_t, typename TV, typename TC>
-inline void larf(side_t side,
-                 idx_t m,
-                 idx_t n,
-                 TV const* v,
-                 int_t incv,
-                 scalar_type<TV, TC> tau,
-                 TC* C,
-                 idx_t ldC)
-{
-    using internal::colmajor_matrix;
+    /** Applies an elementary reflector H to a m-by-n matrix C.
+     *
+     * @see larf( Side side, idx_t m, idx_t n, TV const *v, int_t incv,
+     * scalar_type< TV, TC , TW > tau, TC *C, idx_t ldC, TW *work )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <class side_t, typename TV, typename TC>
+    inline void larf(side_t side,
+                     idx_t m,
+                     idx_t n,
+                     TV const* v,
+                     int_t incv,
+                     scalar_type<TV, TC> tau,
+                     TC* C,
+                     idx_t ldC)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(incv == 0);
-    tlapack_check_false(ldC < m);
+        // check arguments
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(incv == 0);
+        tlapack_check_false(ldC < m);
 
-    // Initialize indexes
-    idx_t lenv = ((side == Side::Left) ? m : n);
+        // Initialize indexes
+        idx_t lenv = ((side == Side::Left) ? m : n);
 
-    // Matrix views
-    auto C_ = colmajor_matrix<TC>(C, m, n, ldC);
+        // Matrix views
+        auto C_ = create_matrix<TC>(C, m, n, ldC);
 
-    tlapack_expr_with_vector(
-        v_, TV, lenv, v, incv,
-        return larf(side, forward, columnwise_storage, v_, tau, C_));
-}
+        tlapack_expr_with_vector(
+            v_, TV, lenv, v, incv,
+            return larf(side, forward, columnwise_storage, v_, tau, C_));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LARF_HH

--- a/include/tlapack/legacy_api/lapack/larfb.hpp
+++ b/include/tlapack/legacy_api/lapack/larfb.hpp
@@ -1,4 +1,5 @@
-/// @file larfb.hpp Applies a Householder block reflector to a matrix.
+/// @file legacy_api/lapack/larfb.hpp Applies a Householder block reflector to a
+/// matrix.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/larfb.h
@@ -15,149 +16,156 @@
 #include "tlapack/lapack/larfb.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Applies a block reflector $H$ or its conjugate transpose $H^H$ to a
- * m-by-n matrix C, from either the left or the right.
- *
- * @param[in] side
- *     - Side::Left:  apply $H$ or $H^H$ from the Left
- *     - Side::Right: apply $H$ or $H^H$ from the Right
- *
- * @param[in] trans
- *     - Op::NoTrans:   apply $H  $ (No transpose)
- *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of H is
- * Real)
- *     - Op::ConjTrans: apply $H^H$ (Conjugate transpose)
- *
- * @param[in] direction
- *     Indicates how H is formed from a product of elementary
- *     reflectors
- *     - Direction::Forward:  $H = H(1) H(2) \dots H(k)$
- *     - Direction::Backward: $H = H(k) \dots H(2) H(1)$
- *
- * @param[in] storev
- *     Indicates how the vectors which define the elementary
- *     reflectors are stored:
- *     - StoreV::Columnwise
- *     - StoreV::Rowwise
- *
- * @param[in] m
- *     The number of rows of the matrix C.
- *
- * @param[in] n
- *     The number of columns of the matrix C.
- *
- * @param[in] k
- *     The order of the matrix T (= the number of elementary
- *     reflectors whose product defines the block reflector).
- *     - If side = Left,  m >= k >= 0;
- *     - if side = Right, n >= k >= 0.
- *
- * @param[in] V
- *     - If storev = Columnwise:
- *       - if side = Left,  the m-by-k matrix V, stored in an ldv-by-k array;
- *       - if side = Right, the n-by-k matrix V, stored in an ldv-by-k array.
- *     - If storev = Rowwise:
- *       - if side = Left,  the k-by-m matrix V, stored in an ldv-by-m array;
- *       - if side = Right, the k-by-n matrix V, stored in an ldv-by-n array.
- *     - See Further Details.
- *
- * @param[in] ldv
- *     The leading dimension of the array V.
- *     - If storev = Columnwise and side = Left,  ldv >= max(1,m);
- *     - if storev = Columnwise and side = Right, ldv >= max(1,n);
- *     - if storev = Rowwise, ldv >= k.
- *
- * @param[in] T
- *     The k-by-k matrix T, stored in an ldt-by-k array.
- *     The triangular k-by-k matrix T in the representation of the
- *     block reflector.
- *
- * @param[in] ldt
- *     The leading dimension of the array T. ldt >= k.
- *
- * @param[in,out] C
- *     The m-by-n matrix C, stored in an ldc-by-n array.
- *     On entry, the m-by-n matrix C.
- *     On exit, C is overwritten by
- *     $H C$ or $H^H C$ or $C H$ or $C H^H$.
- *
- * @param[in] ldc
- *     The leading dimension of the array C. ldc >= max(1,m).
- *
- * @par Further Details
- *
- * The shape of the matrix V and the storage of the vectors which define
- * the H(i) is best illustrated by the following example with n = 5 and
- * k = 3. The elements equal to 1 are not stored. The rest of the
- * array is not used.
- *
- *     direction = Forward and          direction = Forward and
- *     storev = Columnwise:             storev = Rowwise:
- *
- *     V = (  1       )                 V = (  1 v1 v1 v1 v1 )
- *         ( v1  1    )                     (     1 v2 v2 v2 )
- *         ( v1 v2  1 )                     (        1 v3 v3 )
- *         ( v1 v2 v3 )
- *         ( v1 v2 v3 )
- *
- *     direction = Backward and         direction = Backward and
- *     storev = Columnwise:             storev = Rowwise:
- *
- *     V = ( v1 v2 v3 )                 V = ( v1 v1  1       )
- *         ( v1 v2 v3 )                     ( v2 v2 v2  1    )
- *         (  1 v2 v3 )                     ( v3 v3 v3 v3  1 )
- *         (     1 v3 )
- *         (        1 )
- *
- * @ingroup legacy_lapack
- */
+    /** Applies a block reflector $H$ or its conjugate transpose $H^H$ to a
+     * m-by-n matrix C, from either the left or the right.
+     *
+     * @param[in] side
+     *     - Side::Left:  apply $H$ or $H^H$ from the Left
+     *     - Side::Right: apply $H$ or $H^H$ from the Right
+     *
+     * @param[in] trans
+     *     - Op::NoTrans:   apply $H  $ (No transpose)
+     *     - Op::Trans:     apply $H^T$ (Transpose, only allowed if the type of
+     * H is Real)
+     *     - Op::ConjTrans: apply $H^H$ (Conjugate transpose)
+     *
+     * @param[in] direction
+     *     Indicates how H is formed from a product of elementary
+     *     reflectors
+     *     - Direction::Forward:  $H = H(1) H(2) \dots H(k)$
+     *     - Direction::Backward: $H = H(k) \dots H(2) H(1)$
+     *
+     * @param[in] storev
+     *     Indicates how the vectors which define the elementary
+     *     reflectors are stored:
+     *     - StoreV::Columnwise
+     *     - StoreV::Rowwise
+     *
+     * @param[in] m
+     *     The number of rows of the matrix C.
+     *
+     * @param[in] n
+     *     The number of columns of the matrix C.
+     *
+     * @param[in] k
+     *     The order of the matrix T (= the number of elementary
+     *     reflectors whose product defines the block reflector).
+     *     - If side = Left,  m >= k >= 0;
+     *     - if side = Right, n >= k >= 0.
+     *
+     * @param[in] V
+     *     - If storev = Columnwise:
+     *       - if side = Left,  the m-by-k matrix V, stored in an ldv-by-k
+     * array;
+     *       - if side = Right, the n-by-k matrix V, stored in an ldv-by-k
+     * array.
+     *     - If storev = Rowwise:
+     *       - if side = Left,  the k-by-m matrix V, stored in an ldv-by-m
+     * array;
+     *       - if side = Right, the k-by-n matrix V, stored in an ldv-by-n
+     * array.
+     *     - See Further Details.
+     *
+     * @param[in] ldv
+     *     The leading dimension of the array V.
+     *     - If storev = Columnwise and side = Left,  ldv >= max(1,m);
+     *     - if storev = Columnwise and side = Right, ldv >= max(1,n);
+     *     - if storev = Rowwise, ldv >= k.
+     *
+     * @param[in] T
+     *     The k-by-k matrix T, stored in an ldt-by-k array.
+     *     The triangular k-by-k matrix T in the representation of the
+     *     block reflector.
+     *
+     * @param[in] ldt
+     *     The leading dimension of the array T. ldt >= k.
+     *
+     * @param[in,out] C
+     *     The m-by-n matrix C, stored in an ldc-by-n array.
+     *     On entry, the m-by-n matrix C.
+     *     On exit, C is overwritten by
+     *     $H C$ or $H^H C$ or $C H$ or $C H^H$.
+     *
+     * @param[in] ldc
+     *     The leading dimension of the array C. ldc >= max(1,m).
+     *
+     * @par Further Details
+     *
+     * The shape of the matrix V and the storage of the vectors which define
+     * the H(i) is best illustrated by the following example with n = 5 and
+     * k = 3. The elements equal to 1 are not stored. The rest of the
+     * array is not used.
+     *
+     *     direction = Forward and          direction = Forward and
+     *     storev = Columnwise:             storev = Rowwise:
+     *
+     *     V = (  1       )                 V = (  1 v1 v1 v1 v1 )
+     *         ( v1  1    )                     (     1 v2 v2 v2 )
+     *         ( v1 v2  1 )                     (        1 v3 v3 )
+     *         ( v1 v2 v3 )
+     *         ( v1 v2 v3 )
+     *
+     *     direction = Backward and         direction = Backward and
+     *     storev = Columnwise:             storev = Rowwise:
+     *
+     *     V = ( v1 v2 v3 )                 V = ( v1 v1  1       )
+     *         ( v1 v2 v3 )                     ( v2 v2 v2  1    )
+     *         (  1 v2 v3 )                     ( v3 v3 v3 v3  1 )
+     *         (     1 v3 )
+     *         (        1 )
+     *
+     * @ingroup legacy_lapack
+     */
 
-template <class side_t,
-          class trans_t,
-          class direction_t,
-          class storeV_t,
-          typename TV,
-          typename TC>
-int larfb(side_t side,
-          trans_t trans,
-          direction_t direction,
-          storeV_t storev,
-          idx_t m,
-          idx_t n,
-          idx_t k,
-          TV const* V,
-          idx_t ldv,
-          TV const* T,
-          idx_t ldt,
-          TC* C,
-          idx_t ldc)
-{
-    using internal::colmajor_matrix;
+    template <class side_t,
+              class trans_t,
+              class direction_t,
+              class storeV_t,
+              typename TV,
+              typename TC>
+    int larfb(side_t side,
+              trans_t trans,
+              direction_t direction,
+              storeV_t storev,
+              idx_t m,
+              idx_t n,
+              idx_t k,
+              TV const* V,
+              idx_t ldv,
+              TV const* T,
+              idx_t ldt,
+              TC* C,
+              idx_t ldc)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::ConjTrans &&
-                        ((trans != Op::Trans) || is_complex<TV>::value));
-    tlapack_check_false(direction != Direction::Backward &&
-                        direction != Direction::Forward);
-    tlapack_check_false(storev != StoreV::Columnwise &&
-                        storev != StoreV::Rowwise);
+        // check arguments
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::ConjTrans &&
+                            ((trans != Op::Trans) || is_complex<TV>::value));
+        tlapack_check_false(direction != Direction::Backward &&
+                            direction != Direction::Forward);
+        tlapack_check_false(storev != StoreV::Columnwise &&
+                            storev != StoreV::Rowwise);
 
-    // Quick return
-    if (m <= 0 || n <= 0) return 0;
+        // Quick return
+        if (m <= 0 || n <= 0) return 0;
 
-    // Views
-    const auto V_ =
-        (storev == StoreV::Columnwise)
-            ? colmajor_matrix<TV>((TV*)V, (side == Side::Left) ? m : n, k, ldv)
-            : colmajor_matrix<TV>((TV*)V, k, (side == Side::Left) ? m : n, ldv);
-    const auto T_ = colmajor_matrix<TV>((TV*)T, k, k, ldt);
-    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
+        // Views
+        const auto V_ = (storev == StoreV::Columnwise)
+                            ? create_matrix<TV>(
+                                  (TV*)V, (side == Side::Left) ? m : n, k, ldv)
+                            : create_matrix<TV>(
+                                  (TV*)V, k, (side == Side::Left) ? m : n, ldv);
+        const auto T_ = create_matrix<TV>((TV*)T, k, k, ldt);
+        auto C_ = create_matrix<TC>(C, m, n, ldc);
 
-    return larfb(side, trans, direction, storev, V_, T_, C_);
-}
+        return larfb(side, trans, direction, storev, V_, T_, C_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LARFB_HH

--- a/include/tlapack/legacy_api/lapack/larfg.hpp
+++ b/include/tlapack/legacy_api/lapack/larfg.hpp
@@ -1,4 +1,4 @@
-/// @file larfg.hpp
+/// @file legacy_api/lapack/larfg.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/larfg.h
@@ -15,26 +15,29 @@
 #include "tlapack/lapack/larfg.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-template <typename T>
-void inline larfg(idx_t n, T& alpha, T* x, int_t incx, T& tau)
-{
-    tlapack_expr_with_vector(x_, T, n - 1, x, incx,
-                             return larfg(columnwise_storage, alpha, x_, tau));
-}
+    template <typename T>
+    void inline larfg(idx_t n, T& alpha, T* x, int_t incx, T& tau)
+    {
+        tlapack_expr_with_vector(
+            x_, T, n - 1, x, incx,
+            return larfg(columnwise_storage, alpha, x_, tau));
+    }
 
-/** Generates a elementary Householder reflection.
- *
- * @see larfg( idx_t, T &, T *, int_t, T & )
- *
- * @ingroup legacy_lapack
- */
-template <typename T>
-void inline larfg(idx_t n, T* alpha, T* x, int_t incx, T* tau)
-{
-    larfg(n, *alpha, x, incx, *tau);
-}
+    /** Generates a elementary Householder reflection.
+     *
+     * @see larfg( idx_t, T &, T *, int_t, T & )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <typename T>
+    void inline larfg(idx_t n, T* alpha, T* x, int_t incx, T* tau)
+    {
+        larfg(n, *alpha, x, incx, *tau);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LARFG_HH

--- a/include/tlapack/legacy_api/lapack/larft.hpp
+++ b/include/tlapack/legacy_api/lapack/larft.hpp
@@ -1,4 +1,5 @@
-/// @file larft.hpp Forms the triangular factor T of a block reflector.
+/// @file legacy_api/lapack/larft.hpp Forms the triangular factor T of a block
+/// reflector.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/larft.h
@@ -15,116 +16,118 @@
 #include "tlapack/lapack/larft.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Forms the triangular factor T of a block reflector H of order n,
- * which is defined as a product of k elementary reflectors.
- *
- *               If direction = Direction::Forward, H = H_1 H_2 . . . H_k and T
- * is upper triangular. If direction = Direction::Backward, H = H_k . . . H_2
- * H_1 and T is lower triangular.
- *
- *  If storev = StoreV::Columnwise, the vector which defines the elementary
- * reflector H(i) is stored in the i-th column of the array V, and
- *
- *               H  =  I - V * T * V'
- *
- *  If storev = StoreV::Rowwise, the vector which defines the elementary
- * reflector H(i) is stored in the i-th row of the array V, and
- *
- *               H  =  I - V' * T * V
- *
- *  The shape of the matrix V and the storage of the vectors which define
- *  the H(i) is best illustrated by the following example with n = 5 and
- *  k = 3. The elements equal to 1 are not stored.
- *
- *               direction=Direction::Forward & storev=StoreV::Columnwise
- * direction=Direction::Forward & storev=StoreV::Rowwise
- *               -----------------------          -----------------------
- *               V = (  1       )                 V = (  1 v1 v1 v1 v1 )
- *                   ( v1  1    )                     (     1 v2 v2 v2 )
- *                   ( v1 v2  1 )                     (        1 v3 v3 )
- *                   ( v1 v2 v3 )
- *                   ( v1 v2 v3 )
- *
- *               direction=Direction::Backward & storev=StoreV::Columnwise
- * direction=Direction::Backward & storev=StoreV::Rowwise
- *               -----------------------          -----------------------
- *               V = ( v1 v2 v3 )                 V = ( v1 v1  1       )
- *                   ( v1 v2 v3 )                     ( v2 v2 v2  1    )
- *                   (  1 v2 v3 )                     ( v3 v3 v3 v3  1 )
- *                   (     1 v3 )
- *                   (        1 )
- *
- * @return 0 if success.
- * @return -i if the ith argument is invalid.
- *
- * @param direction Specifies the direction in which the elementary reflectors
- * are multiplied to form the block reflector.
- *
- *               Direction::Forward
- *               Direction::Backward
- *
- * @param storev Specifies how the vectors which define the elementary
- * reflectors are stored.
- *
- *               StoreV::Columnwise
- *               StoreV::Rowwise
- *
- * @param n The order of the block reflector H. n >= 0.
- * @param k The order of the triangular factor T, or the number of elementary
- * reflectors. k >= 1.
- * @param[in] V Real matrix containing the vectors defining the elementary
- * reflector H. If stored columnwise, V is n-by-k.  If stored rowwise, V is
- * k-by-n.
- * @param ldV Column length of the matrix V.  If stored columnwise, ldV >= n.
- * If stored rowwise, ldV >= k.
- * @param[in] tau Real vector of length k containing the scalar factors of the
- * elementary reflectors H.
- * @param[out] T Real matrix of size k-by-k containing the triangular factor of
- * the block reflector. If the direction of the elementary reflectors is
- * forward, T is upper triangular; if the direction of the elementary reflectors
- * is backward, T is lower triangular.
- * @param ldT Column length of the matrix T.  ldT >= k.
- *
- * @ingroup legacy_lapack
- */
-template <class direction_t, class storeV_t, typename scalar_t>
-int larft(direction_t direction,
-          storeV_t storev,
-          idx_t n,
-          idx_t k,
-          const scalar_t* V,
-          idx_t ldV,
-          const scalar_t* tau,
-          scalar_t* T,
-          idx_t ldT)
-{
-    using internal::colmajor_matrix;
-    using internal::vector;
+    /** Forms the triangular factor T of a block reflector H of order n,
+     * which is defined as a product of k elementary reflectors.
+     *
+     *               If direction = Direction::Forward, H = H_1 H_2 . . . H_k
+     * and T is upper triangular. If direction = Direction::Backward, H = H_k .
+     * . . H_2 H_1 and T is lower triangular.
+     *
+     *  If storev = StoreV::Columnwise, the vector which defines the elementary
+     * reflector H(i) is stored in the i-th column of the array V, and
+     *
+     *               H  =  I - V * T * V'
+     *
+     *  If storev = StoreV::Rowwise, the vector which defines the elementary
+     * reflector H(i) is stored in the i-th row of the array V, and
+     *
+     *               H  =  I - V' * T * V
+     *
+     *  The shape of the matrix V and the storage of the vectors which define
+     *  the H(i) is best illustrated by the following example with n = 5 and
+     *  k = 3. The elements equal to 1 are not stored.
+     *
+     *               direction=Direction::Forward & storev=StoreV::Columnwise
+     * direction=Direction::Forward & storev=StoreV::Rowwise
+     *               -----------------------          -----------------------
+     *               V = (  1       )                 V = (  1 v1 v1 v1 v1 )
+     *                   ( v1  1    )                     (     1 v2 v2 v2 )
+     *                   ( v1 v2  1 )                     (        1 v3 v3 )
+     *                   ( v1 v2 v3 )
+     *                   ( v1 v2 v3 )
+     *
+     *               direction=Direction::Backward & storev=StoreV::Columnwise
+     * direction=Direction::Backward & storev=StoreV::Rowwise
+     *               -----------------------          -----------------------
+     *               V = ( v1 v2 v3 )                 V = ( v1 v1  1       )
+     *                   ( v1 v2 v3 )                     ( v2 v2 v2  1    )
+     *                   (  1 v2 v3 )                     ( v3 v3 v3 v3  1 )
+     *                   (     1 v3 )
+     *                   (        1 )
+     *
+     * @return 0 if success.
+     * @return -i if the ith argument is invalid.
+     *
+     * @param direction Specifies the direction in which the elementary
+     * reflectors are multiplied to form the block reflector.
+     *
+     *               Direction::Forward
+     *               Direction::Backward
+     *
+     * @param storev Specifies how the vectors which define the elementary
+     * reflectors are stored.
+     *
+     *               StoreV::Columnwise
+     *               StoreV::Rowwise
+     *
+     * @param n The order of the block reflector H. n >= 0.
+     * @param k The order of the triangular factor T, or the number of
+     * elementary reflectors. k >= 1.
+     * @param[in] V Real matrix containing the vectors defining the elementary
+     * reflector H. If stored columnwise, V is n-by-k.  If stored rowwise, V is
+     * k-by-n.
+     * @param ldV Column length of the matrix V.  If stored columnwise, ldV >=
+     * n. If stored rowwise, ldV >= k.
+     * @param[in] tau Real vector of length k containing the scalar factors of
+     * the elementary reflectors H.
+     * @param[out] T Real matrix of size k-by-k containing the triangular factor
+     * of the block reflector. If the direction of the elementary reflectors is
+     * forward, T is upper triangular; if the direction of the elementary
+     * reflectors is backward, T is lower triangular.
+     * @param ldT Column length of the matrix T.  ldT >= k.
+     *
+     * @ingroup legacy_lapack
+     */
+    template <class direction_t, class storeV_t, typename scalar_t>
+    int larft(direction_t direction,
+              storeV_t storev,
+              idx_t n,
+              idx_t k,
+              const scalar_t* V,
+              idx_t ldV,
+              const scalar_t* tau,
+              scalar_t* T,
+              idx_t ldT)
+    {
+        using internal::create_matrix;
+        using internal::create_vector;
 
-    // check arguments
-    tlapack_check_false(direction != Direction::Forward &&
-                        direction != Direction::Backward);
-    tlapack_check_false(storev != StoreV::Columnwise &&
-                        storev != StoreV::Rowwise);
-    tlapack_check_false(n < 0);
-    tlapack_check_false(k < 1);
-    tlapack_check_false(ldV < ((storev == StoreV::Columnwise) ? n : k));
-    tlapack_check_false(ldT < k);
+        // check arguments
+        tlapack_check_false(direction != Direction::Forward &&
+                            direction != Direction::Backward);
+        tlapack_check_false(storev != StoreV::Columnwise &&
+                            storev != StoreV::Rowwise);
+        tlapack_check_false(n < 0);
+        tlapack_check_false(k < 1);
+        tlapack_check_false(ldV < ((storev == StoreV::Columnwise) ? n : k));
+        tlapack_check_false(ldT < k);
 
-    // Quick return
-    if (n == 0 || k == 0) return 0;
+        // Quick return
+        if (n == 0 || k == 0) return 0;
 
-    // Matrix views
-    auto V_ = (storev == StoreV::Columnwise)
-                  ? colmajor_matrix<scalar_t>((scalar_t*)V, n, k, ldV)
-                  : colmajor_matrix<scalar_t>((scalar_t*)V, k, n, ldV);
-    auto tau_ = vector((scalar_t*)tau, k);
-    auto T_ = colmajor_matrix<scalar_t>(T, k, k, ldT);
+        // Matrix views
+        auto V_ = (storev == StoreV::Columnwise)
+                      ? create_matrix<scalar_t>((scalar_t*)V, n, k, ldV)
+                      : create_matrix<scalar_t>((scalar_t*)V, k, n, ldV);
+        auto tau_ = create_vector((scalar_t*)tau, k);
+        auto T_ = create_matrix<scalar_t>(T, k, k, ldT);
 
-    return larft(direction, storev, V_, tau_, T_);
-}
+        return larft(direction, storev, V_, tau_, T_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LARFT_HH

--- a/include/tlapack/legacy_api/lapack/larnv.hpp
+++ b/include/tlapack/legacy_api/lapack/larnv.hpp
@@ -1,5 +1,5 @@
-/// @file larnv.hpp Returns a vector of random numbers from a uniform or normal
-/// distribution.
+/// @file legacy_api/lapack/larnv.hpp Returns a vector of random numbers from a
+/// uniform or normal distribution.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// Adapted from @see https://github.com/langou/latl/blob/mastUSA
 /// @note Adapted
@@ -16,51 +16,55 @@
 #include "tlapack/legacy_api/base/types.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * @brief Returns a vector of n random numbers from a uniform or normal
- * distribution.
- *
- * This implementation uses the Mersenne Twister 19937 generator (class
- * std::mt19937), which is a Mersenne Twister pseudo-random generator of 32-bit
- * numbers with a state size of 19937 bits.
- *
- * Requires ISO C++ 2011 random number generators.
- *
- * @param[in] idist Specifies the distribution:
- *
- *        1:  real and imaginary parts each uniform (0,1)
- *        2:  real and imaginary parts each uniform (-1,1)
- *        3:  real and imaginary parts each normal (0,1)
- *        4:  uniformly distributed on the disc abs(z) < 1
- *        5:  uniformly distributed on the circle abs(z) = 1
- *
- * @param[in,out] iseed Seed for the random number generator.
- *      The seed is updated inside the routine ( Currently: seed_out := seed_in
- * + 1 )
- * @param[in] n Length of vector x.
- * @param[out] x Pointer to real vector of length n.
- *
- * @ingroup legacy_lapack
- */
-template <typename T>
-inline void larnv(idx_t idist, idx_t* iseed, idx_t n, T* x)
-{
-    using internal::vector;
-    auto x_ = vector(x, n);
+    /**
+     * @brief Returns a vector of n random numbers from a uniform or normal
+     * distribution.
+     *
+     * This implementation uses the Mersenne Twister 19937 generator (class
+     * std::mt19937), which is a Mersenne Twister pseudo-random generator of
+     * 32-bit numbers with a state size of 19937 bits.
+     *
+     * Requires ISO C++ 2011 random number generators.
+     *
+     * @param[in] idist Specifies the distribution:
+     *
+     *        1:  real and imaginary parts each uniform (0,1)
+     *        2:  real and imaginary parts each uniform (-1,1)
+     *        3:  real and imaginary parts each normal (0,1)
+     *        4:  uniformly distributed on the disc abs(z) < 1
+     *        5:  uniformly distributed on the circle abs(z) = 1
+     *
+     * @param[in,out] iseed Seed for the random number generator.
+     *      The seed is updated inside the routine ( Currently: seed_out :=
+     * seed_in
+     * + 1 )
+     * @param[in] n Length of vector x.
+     * @param[out] x Pointer to real vector of length n.
+     *
+     * @ingroup legacy_lapack
+     */
+    template <typename T>
+    inline void larnv(idx_t idist, idx_t* iseed, idx_t n, T* x)
+    {
+        using internal::create_vector;
 
-    if (idist == 1)
-        return larnv<1>(*iseed, x_);
-    else if (idist == 2)
-        return larnv<2>(*iseed, x_);
-    else if (idist == 3)
-        return larnv<3>(*iseed, x_);
-    else if (idist == 4)
-        return larnv<4>(*iseed, x_);
-    else if (idist == 5)
-        return larnv<5>(*iseed, x_);
-}
+        auto x_ = create_vector(x, n);
 
+        if (idist == 1)
+            return larnv<1>(*iseed, x_);
+        else if (idist == 2)
+            return larnv<2>(*iseed, x_);
+        else if (idist == 3)
+            return larnv<3>(*iseed, x_);
+        else if (idist == 4)
+            return larnv<4>(*iseed, x_);
+        else if (idist == 5)
+            return larnv<5>(*iseed, x_);
+    }
+
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LARNV_HH

--- a/include/tlapack/legacy_api/lapack/lascl.hpp
+++ b/include/tlapack/legacy_api/lapack/lascl.hpp
@@ -1,4 +1,4 @@
-/// @file lascl.hpp Multiplies a matrix by a scalar.
+/// @file legacy_api/lapack/lascl.hpp Multiplies a matrix by a scalar.
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -14,124 +14,128 @@
 #include "tlapack/lapack/lascl.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** @brief  Multiplies a matrix A by the real scalar a/b.
- *
- * Multiplication of a matrix A by scalar a/b is done without over/underflow as
- * long as the final result $a A/b$ does not over/underflow. The parameter type
- * specifies that A may be full, upper triangular, lower triangular, upper
- * Hessenberg, or banded.
- *
- * @return 0 if success.
- * @return -i if the ith argument is invalid.
- *
- * @param[in] matrixtype Specifies the type of matrix A.
- *
- *        MatrixType::General:
- *          A is a full matrix.
- *        MatrixType::Lower:
- *          A is a lower triangular matrix.
- *        MatrixType::Upper:
- *          A is an upper triangular matrix.
- *        MatrixType::Hessenberg:
- *          A is an upper Hessenberg matrix.
- *        MatrixType::LowerBand:
- *          A is a symmetric band matrix with lower bandwidth kl and upper
- * bandwidth ku and with the only the lower half stored. MatrixType::UpperBand:
- *          A is a symmetric band matrix with lower bandwidth kl and upper
- * bandwidth ku and with the only the upper half stored. MatrixType::Band: A is
- * a band matrix with lower bandwidth kl and upper bandwidth ku.
- *
- * @param[in] kl The lower bandwidth of A, used only for banded matrix types B,
- * Q and Z.
- * @param[in] ku The upper bandwidth of A, used only for banded matrix types B,
- * Q and Z.
- * @param[in] b The denominator of the scalar a/b.
- * @param[in] a The numerator of the scalar a/b.
- * @param[in] m The number of rows of the matrix A. m>=0
- * @param[in] n The number of columns of the matrix A. n>=0
- * @param[in,out] A Pointer to the matrix A [in/out].
- * @param[in] lda The column length of the matrix A.
- *
- * @ingroup legacy_lapack
- */
-template <class matrixType_t, typename T>
-int lascl(matrixType_t matrixtype,
-          idx_t kl,
-          idx_t ku,
-          const real_type<T>& b,
-          const real_type<T>& a,
-          idx_t m,
-          idx_t n,
-          T* A,
-          idx_t lda)
-{
-    using internal::banded_matrix;
-    using internal::colmajor_matrix;
-    using std::max;
+    /** @brief  Multiplies a matrix A by the real scalar a/b.
+     *
+     * Multiplication of a matrix A by scalar a/b is done without over/underflow
+     * as long as the final result $a A/b$ does not over/underflow. The
+     * parameter type specifies that A may be full, upper triangular, lower
+     * triangular, upper Hessenberg, or banded.
+     *
+     * @return 0 if success.
+     * @return -i if the ith argument is invalid.
+     *
+     * @param[in] matrixtype Specifies the type of matrix A.
+     *
+     *        MatrixType::General:
+     *          A is a full matrix.
+     *        MatrixType::Lower:
+     *          A is a lower triangular matrix.
+     *        MatrixType::Upper:
+     *          A is an upper triangular matrix.
+     *        MatrixType::Hessenberg:
+     *          A is an upper Hessenberg matrix.
+     *        MatrixType::LowerBand:
+     *          A is a symmetric band matrix with lower bandwidth kl and upper
+     * bandwidth ku and with the only the lower half stored.
+     * MatrixType::UpperBand: A is a symmetric band matrix with lower bandwidth
+     * kl and upper bandwidth ku and with the only the upper half stored.
+     * MatrixType::Band: A is a band matrix with lower bandwidth kl and upper
+     * bandwidth ku.
+     *
+     * @param[in] kl The lower bandwidth of A, used only for banded matrix types
+     * B, Q and Z.
+     * @param[in] ku The upper bandwidth of A, used only for banded matrix types
+     * B, Q and Z.
+     * @param[in] b The denominator of the scalar a/b.
+     * @param[in] a The numerator of the scalar a/b.
+     * @param[in] m The number of rows of the matrix A. m>=0
+     * @param[in] n The number of columns of the matrix A. n>=0
+     * @param[in,out] A Pointer to the matrix A [in/out].
+     * @param[in] lda The column length of the matrix A.
+     *
+     * @ingroup legacy_lapack
+     */
+    template <class matrixType_t, typename T>
+    int lascl(matrixType_t matrixtype,
+              idx_t kl,
+              idx_t ku,
+              const real_type<T>& b,
+              const real_type<T>& a,
+              idx_t m,
+              idx_t n,
+              T* A,
+              idx_t lda)
+    {
+        using internal::create_banded_matrix;
+        using internal::create_matrix;
+        using std::max;
 
-    // check arguments
-    tlapack_check_false((matrixtype != MatrixType::General) &&
-                        (matrixtype != MatrixType::Lower) &&
-                        (matrixtype != MatrixType::Upper) &&
-                        (matrixtype != MatrixType::Hessenberg) &&
-                        (matrixtype != MatrixType::LowerBand) &&
-                        (matrixtype != MatrixType::UpperBand) &&
-                        (matrixtype != MatrixType::Band));
-    tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
-                         (matrixtype == MatrixType::UpperBand) ||
-                         (matrixtype == MatrixType::Band)) &&
-                        ((kl < 0) || (kl > max(m - 1, idx_t(0)))));
-    tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
-                         (matrixtype == MatrixType::UpperBand) ||
-                         (matrixtype == MatrixType::Band)) &&
-                        ((ku < 0) || (ku > max(n - 1, idx_t(0)))));
-    tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
-                         (matrixtype == MatrixType::UpperBand)) &&
-                        (kl != ku));
-    tlapack_check_false(m < 0);
-    tlapack_check_false((lda < m) && ((matrixtype == MatrixType::General) ||
-                                      (matrixtype == MatrixType::Lower) ||
-                                      (matrixtype == MatrixType::Upper) ||
-                                      (matrixtype == MatrixType::Hessenberg)));
-    tlapack_check_false((matrixtype == MatrixType::LowerBand) &&
-                        (lda < kl + 1));
-    tlapack_check_false((matrixtype == MatrixType::UpperBand) &&
-                        (lda < ku + 1));
-    tlapack_check_false((matrixtype == MatrixType::Band) &&
-                        (lda < 2 * kl + ku + 1));
+        // check arguments
+        tlapack_check_false((matrixtype != MatrixType::General) &&
+                            (matrixtype != MatrixType::Lower) &&
+                            (matrixtype != MatrixType::Upper) &&
+                            (matrixtype != MatrixType::Hessenberg) &&
+                            (matrixtype != MatrixType::LowerBand) &&
+                            (matrixtype != MatrixType::UpperBand) &&
+                            (matrixtype != MatrixType::Band));
+        tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
+                             (matrixtype == MatrixType::UpperBand) ||
+                             (matrixtype == MatrixType::Band)) &&
+                            ((kl < 0) || (kl > max(m - 1, idx_t(0)))));
+        tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
+                             (matrixtype == MatrixType::UpperBand) ||
+                             (matrixtype == MatrixType::Band)) &&
+                            ((ku < 0) || (ku > max(n - 1, idx_t(0)))));
+        tlapack_check_false(((matrixtype == MatrixType::LowerBand) ||
+                             (matrixtype == MatrixType::UpperBand)) &&
+                            (kl != ku));
+        tlapack_check_false(m < 0);
+        tlapack_check_false((lda < m) &&
+                            ((matrixtype == MatrixType::General) ||
+                             (matrixtype == MatrixType::Lower) ||
+                             (matrixtype == MatrixType::Upper) ||
+                             (matrixtype == MatrixType::Hessenberg)));
+        tlapack_check_false((matrixtype == MatrixType::LowerBand) &&
+                            (lda < kl + 1));
+        tlapack_check_false((matrixtype == MatrixType::UpperBand) &&
+                            (lda < ku + 1));
+        tlapack_check_false((matrixtype == MatrixType::Band) &&
+                            (lda < 2 * kl + ku + 1));
 
-    if (matrixtype == MatrixType::LowerBand) {
-        auto A_ = banded_matrix<T>(A, m, n, kl, 0);
-        return lascl(band_t(kl, 0), b, a, A_);
-    }
-    else if (matrixtype == MatrixType::UpperBand) {
-        auto A_ = banded_matrix<T>(A, m, n, 0, ku);
-        return lascl(band_t(0, ku), b, a, A_);
-    }
-    else if (matrixtype == MatrixType::Band) {
-        auto A_ = banded_matrix<T>(A, m, n, kl, ku);
-        return lascl(band_t(kl, ku), b, a, A_);
-    }
-    else {
-        auto A_ = colmajor_matrix<T>(A, m, n, lda);
-
-        if (matrixtype == MatrixType::General) {
-            return lascl(MatrixAccessPolicy::Dense, b, a, A_);
+        if (matrixtype == MatrixType::LowerBand) {
+            auto A_ = create_banded_matrix<T>(A, m, n, kl, 0);
+            return lascl(band_t(kl, 0), b, a, A_);
         }
-        else if (matrixtype == MatrixType::Lower) {
-            return lascl(MatrixAccessPolicy::LowerTriangle, b, a, A_);
+        else if (matrixtype == MatrixType::UpperBand) {
+            auto A_ = create_banded_matrix<T>(A, m, n, 0, ku);
+            return lascl(band_t(0, ku), b, a, A_);
         }
-        else if (matrixtype == MatrixType::Upper) {
-            return lascl(MatrixAccessPolicy::UpperTriangle, b, a, A_);
+        else if (matrixtype == MatrixType::Band) {
+            auto A_ = create_banded_matrix<T>(A, m, n, kl, ku);
+            return lascl(band_t(kl, ku), b, a, A_);
         }
-        else  // if (matrixtype == MatrixType::Hessenberg)
-        {
-            return lascl(MatrixAccessPolicy::UpperHessenberg, b, a, A_);
+        else {
+            auto A_ = create_matrix<T>(A, m, n, lda);
+
+            if (matrixtype == MatrixType::General) {
+                return lascl(MatrixAccessPolicy::Dense, b, a, A_);
+            }
+            else if (matrixtype == MatrixType::Lower) {
+                return lascl(MatrixAccessPolicy::LowerTriangle, b, a, A_);
+            }
+            else if (matrixtype == MatrixType::Upper) {
+                return lascl(MatrixAccessPolicy::UpperTriangle, b, a, A_);
+            }
+            else  // if (matrixtype == MatrixType::Hessenberg)
+            {
+                return lascl(MatrixAccessPolicy::UpperHessenberg, b, a, A_);
+            }
         }
     }
-}
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LASCL_HH

--- a/include/tlapack/legacy_api/lapack/laset.hpp
+++ b/include/tlapack/legacy_api/lapack/laset.hpp
@@ -1,4 +1,4 @@
-/// @file laset.hpp
+/// @file legacy_api/lapack/laset.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/laset.h
@@ -15,81 +15,85 @@
 #include "tlapack/lapack/laset.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/**
- * @brief Initializes a matrix to diagonal and off-diagonal values
- *
- * @tparam uplo_t
- *      Either Uplo or any class that implements `operator Uplo()`.
- *
- * @param[in] uplo
- *      - Uplo::Upper:   Upper triangle of A and B are referenced;
- *      - Uplo::Lower:   Lower triangle of A and B are referenced;
- *      - Uplo::General: All entries of A are referenced; the first m rows of B
- *                          and first n columns of B are referenced.
- * @param[in] m Number of rows of A.
- * @param[in] n Number of columns of A.
- * @param[in] alpha Value to be assigned to the off-diagonal elements of A.
- * @param[in] beta Value to assign to the diagonal elements of A.
- * @param[in] A m-by-n matrix.
- * @param[in] lda Leading dimension of A.
- */
-template <class uplo_t, typename TA>
-void laset(uplo_t uplo, idx_t m, idx_t n, TA alpha, TA beta, TA* A, idx_t lda)
-{
-    using internal::colmajor_matrix;
+    /**
+     * @brief Initializes a matrix to diagonal and off-diagonal values
+     *
+     * @tparam uplo_t
+     *      Either Uplo or any class that implements `operator Uplo()`.
+     *
+     * @param[in] uplo
+     *      - Uplo::Upper:   Upper triangle of A and B are referenced;
+     *      - Uplo::Lower:   Lower triangle of A and B are referenced;
+     *      - Uplo::General: All entries of A are referenced; the first m rows
+     * of B and first n columns of B are referenced.
+     * @param[in] m Number of rows of A.
+     * @param[in] n Number of columns of A.
+     * @param[in] alpha Value to be assigned to the off-diagonal elements of A.
+     * @param[in] beta Value to assign to the diagonal elements of A.
+     * @param[in] A m-by-n matrix.
+     * @param[in] lda Leading dimension of A.
+     */
+    template <class uplo_t, typename TA>
+    void laset(
+        uplo_t uplo, idx_t m, idx_t n, TA alpha, TA beta, TA* A, idx_t lda)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
-                        uplo != Uplo::General);
+        // check arguments
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper &&
+                            uplo != Uplo::General);
 
-    // quick return
-    if (m <= 0 || n <= 0) return;
+        // quick return
+        if (m <= 0 || n <= 0) return;
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>(A, m, n, lda);
+        // Matrix views
+        auto A_ = create_matrix<TA>(A, m, n, lda);
 
-    return laset(uplo, alpha, beta, A_);
-}
-
-/** Initializes a matrix to diagonal and off-diagonal values
- *
- * @param[in] matrixtype :
- *
- *        'U': A is assumed to be upper triangular; elements below the diagonal
- * are not referenced. 'L': A is assumed to be lower triangular; elements above
- * the diagonal are not referenced. otherwise, A is assumed to be a full matrix.
- * @param[in] m Number of rows of A.
- * @param[in] n Number of columns of A.
- * @param[in] alpha Value to be assigned to the off-diagonal elements of A.
- * @param[in] beta Value to assign to the diagonal elements of A.
- * @param[in] A m-by-n matrix.
- * @param[in] lda Leading dimension of A.
- *
- * @see laset( Uplo, idx_t, idx_t, TA, TA, TA*, idx_t )
- *
- * @ingroup legacy_lapack
- */
-template <typename TA>
-void inline laset(MatrixType matrixtype,
-                  idx_t m,
-                  idx_t n,
-                  TA alpha,
-                  TA beta,
-                  TA* A,
-                  idx_t lda)
-{
-    if (matrixtype == MatrixType::Upper) {
-        laset(Uplo::Upper, m, n, alpha, beta, A, lda);
+        return laset(uplo, alpha, beta, A_);
     }
-    else if (matrixtype == MatrixType::Lower) {
-        laset(Uplo::Lower, m, n, alpha, beta, A, lda);
-    }
-    else {
-        laset(Uplo::General, m, n, alpha, beta, A, lda);
-    }
-}
 
+    /** Initializes a matrix to diagonal and off-diagonal values
+     *
+     * @param[in] matrixtype :
+     *
+     *        'U': A is assumed to be upper triangular; elements below the
+     * diagonal are not referenced. 'L': A is assumed to be lower triangular;
+     * elements above the diagonal are not referenced. otherwise, A is assumed
+     * to be a full matrix.
+     * @param[in] m Number of rows of A.
+     * @param[in] n Number of columns of A.
+     * @param[in] alpha Value to be assigned to the off-diagonal elements of A.
+     * @param[in] beta Value to assign to the diagonal elements of A.
+     * @param[in] A m-by-n matrix.
+     * @param[in] lda Leading dimension of A.
+     *
+     * @see laset( Uplo, idx_t, idx_t, TA, TA, TA*, idx_t )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <typename TA>
+    void inline laset(MatrixType matrixtype,
+                      idx_t m,
+                      idx_t n,
+                      TA alpha,
+                      TA beta,
+                      TA* A,
+                      idx_t lda)
+    {
+        if (matrixtype == MatrixType::Upper) {
+            laset(Uplo::Upper, m, n, alpha, beta, A, lda);
+        }
+        else if (matrixtype == MatrixType::Lower) {
+            laset(Uplo::Lower, m, n, alpha, beta, A, lda);
+        }
+        else {
+            laset(Uplo::General, m, n, alpha, beta, A, lda);
+        }
+    }
+
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LASET_HH

--- a/include/tlapack/legacy_api/lapack/lassq.hpp
+++ b/include/tlapack/legacy_api/lapack/lassq.hpp
@@ -1,4 +1,4 @@
-/// @file lassq.hpp
+/// @file legacy_api/lapack/lassq.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 ///
 /// Anderson E. (2017)
@@ -18,50 +18,56 @@
 #include "tlapack/lapack/lassq.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Updates a sum of squares represented in scaled form.
- * \[
- *      scl_{[OUT]}^2 sumsq_{[OUT]} = \sum_{i = 0}^n x_i^2 + scl_{[IN]}^2
- * sumsq_{[IN]},
- * \]
- * The value of  sumsq  is assumed to be non-negative.
- *
- * If (scale * sqrt( sumsq )) > tbig on entry then
- *    we require:   scale >= sqrt( TINY*EPS ) / sbig   on entry,
- * and if 0 < (scale * sqrt( sumsq )) < tsml on entry then
- *    we require:   scale <= sqrt( HUGE ) / ssml       on entry,
- * where
- *    tbig -- upper threshold for values whose square is representable;
- *    sbig -- scaling constant for big numbers; @see base/constants.hpp
- *    tsml -- lower threshold for values whose square is representable;
- *    ssml -- scaling constant for small numbers; @see base/constants.hpp
- * and
- *    TINY*EPS -- tiniest representable number;
- *    HUGE     -- biggest representable number.
- *
- * @param[in] n The number of elements to be used from the vector x.
- * @param[in] x Array of dimension $(1+(n-1)*|incx|)$.
- * @param[in] incx The increment between successive values of the vector x.
- *          If incx > 0, X(i*incx) = x_i for 0 <= i < n
- *          If incx < 0, X((n-i-1)*(-incx)) = x_i for 0 <= i < n
- *          If incx = 0, x isn't a vector so there is no need to call
- *          this subroutine.  If you call it anyway, it will count x_0
- *          in the vector norm n times.
- * @param[in] scl
- * @param[in] sumsq
- *
- * @ingroup legacy_lapack
- */
-template <typename TX>
-void lassq(
-    idx_t n, TX const* x, int_t incx, real_type<TX>& scl, real_type<TX>& sumsq)
-{
-    // quick return
-    if (isnan(scl) || isnan(sumsq) || n <= 0) return;
+    /** Updates a sum of squares represented in scaled form.
+     * \[
+     *      scl_{[OUT]}^2 sumsq_{[OUT]} = \sum_{i = 0}^n x_i^2 + scl_{[IN]}^2
+     * sumsq_{[IN]},
+     * \]
+     * The value of  sumsq  is assumed to be non-negative.
+     *
+     * If (scale * sqrt( sumsq )) > tbig on entry then
+     *    we require:   scale >= sqrt( TINY*EPS ) / sbig   on entry,
+     * and if 0 < (scale * sqrt( sumsq )) < tsml on entry then
+     *    we require:   scale <= sqrt( HUGE ) / ssml       on entry,
+     * where
+     *    tbig -- upper threshold for values whose square is representable;
+     *    sbig -- scaling constant for big numbers; @see base/constants.hpp
+     *    tsml -- lower threshold for values whose square is representable;
+     *    ssml -- scaling constant for small numbers; @see base/constants.hpp
+     * and
+     *    TINY*EPS -- tiniest representable number;
+     *    HUGE     -- biggest representable number.
+     *
+     * @param[in] n The number of elements to be used from the vector x.
+     * @param[in] x Array of dimension $(1+(n-1)*|incx|)$.
+     * @param[in] incx The increment between successive values of the vector x.
+     *          If incx > 0, X(i*incx) = x_i for 0 <= i < n
+     *          If incx < 0, X((n-i-1)*(-incx)) = x_i for 0 <= i < n
+     *          If incx = 0, x isn't a vector so there is no need to call
+     *          this subroutine.  If you call it anyway, it will count x_0
+     *          in the vector norm n times.
+     * @param[in] scl
+     * @param[in] sumsq
+     *
+     * @ingroup legacy_lapack
+     */
+    template <typename TX>
+    void lassq(idx_t n,
+               TX const* x,
+               int_t incx,
+               real_type<TX>& scl,
+               real_type<TX>& sumsq)
+    {
+        // quick return
+        if (isnan(scl) || isnan(sumsq) || n <= 0) return;
 
-    tlapack_expr_with_vector(x_, TX, n, x, incx, return lassq(x_, scl, sumsq));
-}
+        tlapack_expr_with_vector(x_, TX, n, x, incx,
+                                 return lassq(x_, scl, sumsq));
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_LASSQ_HH

--- a/include/tlapack/legacy_api/lapack/potrf.hpp
+++ b/include/tlapack/legacy_api/lapack/potrf.hpp
@@ -1,4 +1,4 @@
-/// @file potrf.hpp
+/// @file legacy_api/lapack/potrf.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -13,29 +13,32 @@
 #include "tlapack/lapack/potrf.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Computes the Cholesky factorization of a Hermitian
- * positive definite matrix A using a blocked algorithm.
- *
- * @see potrf( uplo_t uplo, matrix_t& A, const potrf_opts_t< size_type<matrix_t>
- * >& opts = {} )
- *
- * @ingroup legacy_lapack
- */
-template <class uplo_t, typename T>
-inline int potrf(uplo_t uplo, idx_t n, T* A, idx_t lda)
-{
-    using internal::colmajor_matrix;
+    /** Computes the Cholesky factorization of a Hermitian
+     * positive definite matrix A using a blocked algorithm.
+     *
+     * @see potrf( uplo_t uplo, matrix_t& A, const potrf_opts_t<
+     * size_type<matrix_t>
+     * >& opts = {} )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <class uplo_t, typename T>
+    inline int potrf(uplo_t uplo, idx_t n, T* A, idx_t lda)
+    {
+        using internal::create_matrix;
 
-    // check arguments
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        // check arguments
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
-    // Matrix views
-    auto A_ = colmajor_matrix(A, n, n, lda);
+        // Matrix views
+        auto A_ = create_matrix(A, n, n, lda);
 
-    return potrf_blocked(uplo, A_);
-}
+        return potrf_blocked(uplo, A_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_POTRF_HH

--- a/include/tlapack/legacy_api/lapack/potrs.hpp
+++ b/include/tlapack/legacy_api/lapack/potrs.hpp
@@ -1,4 +1,4 @@
-/// @file potrs.hpp
+/// @file legacy_api/lapack/potrs.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -13,29 +13,36 @@
 #include "tlapack/lapack/potrs.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Apply the Cholesky factorization to solve a linear system.
- *
- * @see potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
- *
- * @ingroup legacy_lapack
- */
-template <class uplo_t, typename T>
-inline int potrs(
-    uplo_t uplo, idx_t n, idx_t nrhs, const T* A, idx_t lda, T* B, idx_t ldb)
-{
-    using internal::colmajor_matrix;
+    /** Apply the Cholesky factorization to solve a linear system.
+     *
+     * @see potrs( uplo_t uplo, const matrixA_t& A, matrixB_t& B )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <class uplo_t, typename T>
+    inline int potrs(uplo_t uplo,
+                     idx_t n,
+                     idx_t nrhs,
+                     const T* A,
+                     idx_t lda,
+                     T* B,
+                     idx_t ldb)
+    {
+        using internal::create_matrix;
 
-    // Check arguments
-    tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
+        // Check arguments
+        tlapack_check_false(uplo != Uplo::Lower && uplo != Uplo::Upper);
 
-    // Matrix views
-    const auto A_ = colmajor_matrix<T>((T*)A, n, n, lda);
-    auto B_ = colmajor_matrix<T>(B, n, nrhs, ldb);
+        // Matrix views
+        const auto A_ = create_matrix<T>((T*)A, n, n, lda);
+        auto B_ = create_matrix<T>(B, n, nrhs, ldb);
 
-    return potrs(uplo, A_, B_);
-}
+        return potrs(uplo, A_, B_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_POTRS_HH

--- a/include/tlapack/legacy_api/lapack/ung2r.hpp
+++ b/include/tlapack/legacy_api/lapack/ung2r.hpp
@@ -1,4 +1,4 @@
-/// @file ung2r.hpp
+/// @file legacy_api/lapack/ung2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/ung2r.h
@@ -15,52 +15,54 @@
 #include "tlapack/lapack/ung2r.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Generates a m-by-n matrix Q with orthogonal columns.
- * \[
- *     Q  =  H_1 H_2 ... H_k
- * \]
- *
- * @return  0 if success
- * @return -i if the ith argument is invalid
- *
- * @param[in] m The number of rows of the matrix A. m>=0
- * @param[in] n The number of columns of the matrix A. n>=0
- * @param[in] k The number of elementary reflectors whose product defines the
- * matrix Q. n>=k>=0
- * @param[in,out] A m-by-n matrix.
- *      On entry, the i-th column must contains the vector which defines the
- *      elementary reflector $H_i$, for $i=0,1,...,k-1$, as returned by GEQRF in
- * the first k columns of its array argument A. On exit, the m-by-n matrix $Q  =
- * H_1 H_2 ... H_k$.
- * @param[in] lda The leading dimension of A. lda >= max(1,m).
- * @param[in] tau Real vector of length min(m,n).
- *      The scalar factors of the elementary reflectors.
- *
- * @ingroup legacy_lapack
- */
-template <typename TA, typename TT>
-inline int ung2r(idx_t m, idx_t n, idx_t k, TA* A, idx_t lda, const TT* tau)
-{
-    using internal::colmajor_matrix;
-    using internal::vector;
+    /** Generates a m-by-n matrix Q with orthogonal columns.
+     * \[
+     *     Q  =  H_1 H_2 ... H_k
+     * \]
+     *
+     * @return  0 if success
+     * @return -i if the ith argument is invalid
+     *
+     * @param[in] m The number of rows of the matrix A. m>=0
+     * @param[in] n The number of columns of the matrix A. n>=0
+     * @param[in] k The number of elementary reflectors whose product defines
+     * the matrix Q. n>=k>=0
+     * @param[in,out] A m-by-n matrix.
+     *      On entry, the i-th column must contains the vector which defines the
+     *      elementary reflector $H_i$, for $i=0,1,...,k-1$, as returned by
+     * GEQRF in the first k columns of its array argument A. On exit, the m-by-n
+     * matrix $Q  = H_1 H_2 ... H_k$.
+     * @param[in] lda The leading dimension of A. lda >= max(1,m).
+     * @param[in] tau Real vector of length min(m,n).
+     *      The scalar factors of the elementary reflectors.
+     *
+     * @ingroup legacy_lapack
+     */
+    template <typename TA, typename TT>
+    inline int ung2r(idx_t m, idx_t n, idx_t k, TA* A, idx_t lda, const TT* tau)
+    {
+        using internal::create_matrix;
+        using internal::create_vector;
 
-    // check arguments
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0 || n > m);
-    tlapack_check_false(k < 0 || k > n);
-    tlapack_check_false(lda < m);
+        // check arguments
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0 || n > m);
+        tlapack_check_false(k < 0 || k > n);
+        tlapack_check_false(lda < m);
 
-    // quick return
-    if (n <= 0) return 0;
+        // quick return
+        if (n <= 0) return 0;
 
-    // Matrix views
-    auto A_ = colmajor_matrix<TA>(A, m, n, lda);
-    auto tau_ = vector((TT*)tau, std::min<idx_t>(m, n));
+        // Matrix views
+        auto A_ = create_matrix<TA>(A, m, n, lda);
+        auto tau_ = create_vector((TT*)tau, std::min<idx_t>(m, n));
 
-    return ung2r(A_, tau_);
-}
+        return ung2r(A_, tau_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_UNG2R_HH

--- a/include/tlapack/legacy_api/lapack/unm2r.hpp
+++ b/include/tlapack/legacy_api/lapack/unm2r.hpp
@@ -1,4 +1,4 @@
-/// @file unm2r.hpp
+/// @file legacy_api/lapack/unm2r.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @note Adapted from @see
 /// https://github.com/langou/latl/blob/master/include/ormr2.h
@@ -15,75 +15,77 @@
 #include "tlapack/lapack/unm2r.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Applies unitary matrix Q to a matrix C.
- *
- * @return  0 if success
- * @return -i if the ith argument is invalid
- *
- * @param[in] side Specifies which side Q is to be applied.
- *                 'L': apply Q or Q' from the Left;
- *                 'R': apply Q or Q' from the Right.
- * @param[in] trans Specifies whether Q or Q' is applied.
- *                 'N':  No transpose, apply Q;
- *                 'T':  Transpose, apply Q'.
- * @param[in] m The number of rows of the matrix C.
- * @param[in] n The number of columns of the matrix C.
- * @param[in] k The number of elementary reflectors whose product defines the
- * matrix Q. If side='L', m>=k>=0; if side='R', n>=k>=0.
- * @param[in] A Matrix containing the elementary reflectors H.
- *                 If side='L', A is k-by-m;
- *                 if side='R', A is k-by-n.
- * @param[in] lda The column length of the matrix A.  ldA>=k.
- * @param[in] tau Real vector of length k containing the scalar factors of the
- * elementary reflectors.
- * @param[in,out] C m-by-n matrix.
- *     On exit, C is replaced by one of the following:
- *                 If side='L' & trans='N':  C <- Q * C
- *                 If side='L' & trans='T':  C <- Q'* C
- *                 If side='R' & trans='T':  C <- C * Q'
- *                 If side='R' & trans='N':  C <- C * Q
- * @param ldc The column length the matrix C. ldC>=m.
- *
- * @ingroup legacy_lapack
- */
-template <class side_t, class trans_t, typename TA, typename TC>
-inline int unm2r(side_t side,
-                 trans_t trans,
-                 idx_t m,
-                 idx_t n,
-                 idx_t k,
-                 TA* A,
-                 idx_t lda,
-                 const real_type<TA, TC>* tau,
-                 TC* C,
-                 idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using internal::vector;
+    /** Applies unitary matrix Q to a matrix C.
+     *
+     * @return  0 if success
+     * @return -i if the ith argument is invalid
+     *
+     * @param[in] side Specifies which side Q is to be applied.
+     *                 'L': apply Q or Q' from the Left;
+     *                 'R': apply Q or Q' from the Right.
+     * @param[in] trans Specifies whether Q or Q' is applied.
+     *                 'N':  No transpose, apply Q;
+     *                 'T':  Transpose, apply Q'.
+     * @param[in] m The number of rows of the matrix C.
+     * @param[in] n The number of columns of the matrix C.
+     * @param[in] k The number of elementary reflectors whose product defines
+     * the matrix Q. If side='L', m>=k>=0; if side='R', n>=k>=0.
+     * @param[in] A Matrix containing the elementary reflectors H.
+     *                 If side='L', A is k-by-m;
+     *                 if side='R', A is k-by-n.
+     * @param[in] lda The column length of the matrix A.  ldA>=k.
+     * @param[in] tau Real vector of length k containing the scalar factors of
+     * the elementary reflectors.
+     * @param[in,out] C m-by-n matrix.
+     *     On exit, C is replaced by one of the following:
+     *                 If side='L' & trans='N':  C <- Q * C
+     *                 If side='L' & trans='T':  C <- Q'* C
+     *                 If side='R' & trans='T':  C <- C * Q'
+     *                 If side='R' & trans='N':  C <- C * Q
+     * @param ldc The column length the matrix C. ldC>=m.
+     *
+     * @ingroup legacy_lapack
+     */
+    template <class side_t, class trans_t, typename TA, typename TC>
+    inline int unm2r(side_t side,
+                     trans_t trans,
+                     idx_t m,
+                     idx_t n,
+                     idx_t k,
+                     TA* A,
+                     idx_t lda,
+                     const real_type<TA, TC>* tau,
+                     TC* C,
+                     idx_t ldc)
+    {
+        using internal::create_matrix;
+        using internal::create_vector;
 
-    // check arguments
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
-    tlapack_check_false(m < 0);
-    tlapack_check_false(n < 0);
-    const idx_t q = (side == Side::Left) ? m : n;
-    tlapack_check_false(k < 0 || k > q);
-    tlapack_check_false(lda < q);
-    tlapack_check_false(ldc < m);
+        // check arguments
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
+        tlapack_check_false(m < 0);
+        tlapack_check_false(n < 0);
+        const idx_t q = (side == Side::Left) ? m : n;
+        tlapack_check_false(k < 0 || k > q);
+        tlapack_check_false(lda < q);
+        tlapack_check_false(ldc < m);
 
-    // quick return
-    if ((m == 0) || (n == 0) || (k == 0)) return 0;
+        // quick return
+        if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
-    // Matrix views
-    const auto A_ = colmajor_matrix<TA>((TA*)A, q, k, lda);
-    const auto tau_ = vector((TA*)tau, k);
-    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
+        // Matrix views
+        const auto A_ = create_matrix<TA>((TA*)A, q, k, lda);
+        const auto tau_ = create_vector((TA*)tau, k);
+        auto C_ = create_matrix<TC>(C, m, n, ldc);
 
-    return unm2r(side, trans, A, tau_, C_);
-}
+        return unm2r(side, trans, A, tau_, C_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_UNM2R_HH

--- a/include/tlapack/legacy_api/lapack/unmqr.hpp
+++ b/include/tlapack/legacy_api/lapack/unmqr.hpp
@@ -1,4 +1,5 @@
-/// @file unmqr.hpp Multiplies the general m-by-n matrix C by Q from geqrf()
+/// @file legacy_api/lapack/unmqr.hpp Multiplies the general m-by-n matrix C by
+/// Q from geqrf()
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -13,94 +14,96 @@
 #include "tlapack/lapack/unmqr.hpp"
 
 namespace tlapack {
+namespace legacy {
 
-/** Multiplies the general m-by-n matrix C by Q from geqrf() using a blocked
- code as follows:
- *
- * @param[in] side
- *     - Side::Left:  apply $Q$ or $Q^H$ from the Left;
- *     - Side::Right: apply $Q$ or $Q^H$ from the Right.
- *
- * @param[in] trans
- *     - Op::NoTrans:   No transpose, apply $Q$;
- *     - Op::ConjTrans: Conjugate transpose, apply $Q^H$.
- *
- * @param[in] m
- *     The number of rows of the matrix C. m >= 0.
- *
- * @param[in] n
- *     The number of columns of the matrix C. n >= 0.
- *
- * @param[in] k
- *     The number of elementary reflectors whose product defines
- *     the matrix Q.
- *     - If side = Left,  m >= k >= 0;
- *     - if side = Right, n >= k >= 0.
- *
- * @param[in] A
- *     - If side = Left,  the m-by-k matrix A, stored in an lda-by-k array;
- *     - if side = Right, the n-by-k matrix A, stored in an lda-by-k array.
- *     \n
- *     The i-th column must contain the vector which defines the
- *     elementary reflector H(i), for i = 1, 2, ..., k, as returned by
- *     geqrf() in the first k columns of its array argument A.
- *
- * @param[in] lda
- *     The leading dimension of the array A.
- *     - If side = Left,  lda >= max(1,m);
- *     - if side = Right, lda >= max(1,n).
- *
- * @param[in] tau
- *     The vector tau of length k.
- *     tau[i] must contain the scalar factor of the elementary
- *     reflector H(i), as returned by geqrf().
- *
- * @param[in,out] C
- *     The m-by-n matrix C, stored in an ldc-by-n array.
- *     On entry, the m-by-n matrix C.
- *     On exit, C is overwritten by
- *     $Q C$ or $Q^H C$ or $C Q^H$ or $C Q$.
- *
- * @param[in] ldc
- *     The leading dimension of the array C. ldc >= max(1,m).
- *
- * @see unmqr(
-    side_t side, trans_t trans,
-    const matrixA_t& A, const tau_t& tau,
-    matrixC_t& C, const unmqr_opts_t<workT_t>& opts = {} )
- *
- * @ingroup legacy_lapack
- */
-template <class side_t, class trans_t, typename TA, typename TC>
-inline int unmqr(side_t side,
-                 trans_t trans,
-                 idx_t m,
-                 idx_t n,
-                 idx_t k,
-                 TA const* A,
-                 idx_t lda,
-                 TA const* tau,
-                 TC* C,
-                 idx_t ldc)
-{
-    using internal::colmajor_matrix;
-    using internal::vector;
+    /** Multiplies the general m-by-n matrix C by Q from geqrf() using a blocked
+     code as follows:
+     *
+     * @param[in] side
+     *     - Side::Left:  apply $Q$ or $Q^H$ from the Left;
+     *     - Side::Right: apply $Q$ or $Q^H$ from the Right.
+     *
+     * @param[in] trans
+     *     - Op::NoTrans:   No transpose, apply $Q$;
+     *     - Op::ConjTrans: Conjugate transpose, apply $Q^H$.
+     *
+     * @param[in] m
+     *     The number of rows of the matrix C. m >= 0.
+     *
+     * @param[in] n
+     *     The number of columns of the matrix C. n >= 0.
+     *
+     * @param[in] k
+     *     The number of elementary reflectors whose product defines
+     *     the matrix Q.
+     *     - If side = Left,  m >= k >= 0;
+     *     - if side = Right, n >= k >= 0.
+     *
+     * @param[in] A
+     *     - If side = Left,  the m-by-k matrix A, stored in an lda-by-k array;
+     *     - if side = Right, the n-by-k matrix A, stored in an lda-by-k array.
+     *     \n
+     *     The i-th column must contain the vector which defines the
+     *     elementary reflector H(i), for i = 1, 2, ..., k, as returned by
+     *     geqrf() in the first k columns of its array argument A.
+     *
+     * @param[in] lda
+     *     The leading dimension of the array A.
+     *     - If side = Left,  lda >= max(1,m);
+     *     - if side = Right, lda >= max(1,n).
+     *
+     * @param[in] tau
+     *     The vector tau of length k.
+     *     tau[i] must contain the scalar factor of the elementary
+     *     reflector H(i), as returned by geqrf().
+     *
+     * @param[in,out] C
+     *     The m-by-n matrix C, stored in an ldc-by-n array.
+     *     On entry, the m-by-n matrix C.
+     *     On exit, C is overwritten by
+     *     $Q C$ or $Q^H C$ or $C Q^H$ or $C Q$.
+     *
+     * @param[in] ldc
+     *     The leading dimension of the array C. ldc >= max(1,m).
+     *
+     * @see unmqr(
+        side_t side, trans_t trans,
+        const matrixA_t& A, const tau_t& tau,
+        matrixC_t& C, const unmqr_opts_t<workT_t>& opts = {} )
+     *
+     * @ingroup legacy_lapack
+     */
+    template <class side_t, class trans_t, typename TA, typename TC>
+    inline int unmqr(side_t side,
+                     trans_t trans,
+                     idx_t m,
+                     idx_t n,
+                     idx_t k,
+                     TA const* A,
+                     idx_t lda,
+                     TA const* tau,
+                     TC* C,
+                     idx_t ldc)
+    {
+        using internal::create_matrix;
+        using internal::create_vector;
 
-    // check arguments
-    tlapack_check_false(side != Side::Left && side != Side::Right);
-    tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
-                        trans != Op::ConjTrans);
+        // check arguments
+        tlapack_check_false(side != Side::Left && side != Side::Right);
+        tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
+                            trans != Op::ConjTrans);
 
-    // Matrix views
-    const auto A_ = (side == Side::Left)
-                        ? colmajor_matrix<TA>((TA*)A, m, k, lda)
-                        : colmajor_matrix<TA>((TA*)A, n, k, lda);
-    const auto tau_ = vector((TA*)tau, k);
-    auto C_ = colmajor_matrix<TC>(C, m, n, ldc);
+        // Matrix views
+        const auto A_ = (side == Side::Left)
+                            ? create_matrix<TA>((TA*)A, m, k, lda)
+                            : create_matrix<TA>((TA*)A, n, k, lda);
+        const auto tau_ = create_vector((TA*)tau, k);
+        auto C_ = create_matrix<TC>(C, m, n, ldc);
 
-    return unmqr(side, trans, A_, tau_, C_);
-}
+        return unmqr(side, trans, A_, tau_, C_);
+    }
 
+}  // namespace legacy
 }  // namespace tlapack
 
 #endif  // TLAPACK_LEGACY_UNMQR_HH

--- a/include/tlapack/starpu/functions.hpp
+++ b/include/tlapack/starpu/functions.hpp
@@ -60,9 +60,9 @@ namespace starpu {
             // call gemm
             if constexpr (mode == 0) {
                 using T = scalar_type<TC, beta_t>;
-                gemm(Layout::ColMajor, transA, transB, m, n, k, alpha,
-                     (const TA*)A, lda, (const TB*)B, ldb, (T)beta, (TC*)C,
-                     ldc);
+                legacy::gemm(Layout::ColMajor, transA, transB, m, n, k, alpha,
+                             (const TA*)A, lda, (const TB*)B, ldb, (T)beta,
+                             (TC*)C, ldc);
             }
 #ifdef STARPU_USE_CUDA
             else if constexpr (mode == 1) {
@@ -142,8 +142,9 @@ namespace starpu {
 
             // call symm
             using T = scalar_type<TC, beta_t>;
-            symm(Layout::ColMajor, side, uplo, m, n, alpha, (const TA*)A, lda,
-                 (const TB*)B, ldb, (T)beta, (TC*)C, ldc);
+            legacy::symm(Layout::ColMajor, side, uplo, m, n, alpha,
+                         (const TA*)A, lda, (const TB*)B, ldb, (T)beta, (TC*)C,
+                         ldc);
         }
 
         template <class TA,
@@ -177,8 +178,9 @@ namespace starpu {
 
             // call hemm
             using T = scalar_type<TC, beta_t>;
-            hemm(Layout::ColMajor, side, uplo, m, n, alpha, (const TA*)A, lda,
-                 (const TB*)B, ldb, (T)beta, (TC*)C, ldc);
+            legacy::hemm(Layout::ColMajor, side, uplo, m, n, alpha,
+                         (const TA*)A, lda, (const TB*)B, ldb, (T)beta, (TC*)C,
+                         ldc);
         }
 
         template <class TA, class TC, class alpha_t, class beta_t, int mode = 0>
@@ -207,8 +209,8 @@ namespace starpu {
 
             // call syrk
             using T = scalar_type<TC, beta_t>;
-            syrk(Layout::ColMajor, uplo, op, n, k, alpha, (const TA*)A, lda,
-                 (T)beta, (TC*)C, ldc);
+            legacy::syrk(Layout::ColMajor, uplo, op, n, k, alpha, (const TA*)A,
+                         lda, (T)beta, (TC*)C, ldc);
         }
 
         template <class TA, class TC, class alpha_t, class beta_t, int mode = 0>
@@ -238,8 +240,8 @@ namespace starpu {
             // call herk
             if constexpr (mode == 0) {
                 using real_t = real_type<scalar_type<TC, beta_t>>;
-                herk(Layout::ColMajor, uplo, op, n, k, alpha, (const TA*)A, lda,
-                     (real_t)beta, (TC*)C, ldc);
+                legacy::herk(Layout::ColMajor, uplo, op, n, k, alpha,
+                             (const TA*)A, lda, (real_t)beta, (TC*)C, ldc);
             }
 #ifdef STARPU_USE_CUDA
             else if constexpr (mode == 1) {
@@ -316,8 +318,8 @@ namespace starpu {
 
             // call syr2k
             using T = scalar_type<TC, beta_t>;
-            syr2k(Layout::ColMajor, uplo, op, n, k, alpha, (const TA*)A, lda,
-                  (const TB*)B, ldb, (T)beta, (TC*)C, ldc);
+            legacy::syr2k(Layout::ColMajor, uplo, op, n, k, alpha, (const TA*)A,
+                          lda, (const TB*)B, ldb, (T)beta, (TC*)C, ldc);
         }
 
         template <class TA,
@@ -353,8 +355,8 @@ namespace starpu {
 
             // call her2k
             using real_t = real_type<scalar_type<TC, beta_t>>;
-            her2k(Layout::ColMajor, uplo, op, n, k, alpha, (const TA*)A, lda,
-                  (const TB*)B, ldb, (real_t)beta, (TC*)C, ldc);
+            legacy::her2k(Layout::ColMajor, uplo, op, n, k, alpha, (const TA*)A,
+                          lda, (const TB*)B, ldb, (real_t)beta, (TC*)C, ldc);
         }
 
         template <class TA, class TB, class alpha_t, int mode = 0>
@@ -381,8 +383,8 @@ namespace starpu {
             const uintptr_t& B = STARPU_MATRIX_GET_PTR(buffers[1]);
 
             // call trmm
-            trmm(Layout::ColMajor, side, uplo, op, diag, m, n, alpha,
-                 (const TA*)A, lda, (TB*)B, ldb);
+            legacy::trmm(Layout::ColMajor, side, uplo, op, diag, m, n, alpha,
+                         (const TA*)A, lda, (TB*)B, ldb);
         }
 
         template <class TA, class TB, class alpha_t, int mode = 0>
@@ -410,8 +412,8 @@ namespace starpu {
 
             // call trsm
             if constexpr (mode == 0)
-                trsm(Layout::ColMajor, side, uplo, op, diag, m, n, alpha,
-                     (const TA*)A, lda, (TB*)B, ldb);
+                legacy::trsm(Layout::ColMajor, side, uplo, op, diag, m, n,
+                             alpha, (const TA*)A, lda, (TB*)B, ldb);
 #ifdef STARPU_USE_CUDA
             else if constexpr (mode == 1) {
                 using T = scalar_type<TA, TB, alpha_t>;
@@ -482,9 +484,9 @@ namespace starpu {
             // call potrf
             if constexpr (mode == 0) {
                 if constexpr (has_info)
-                    *info = potrf(uplo, n, (T*)A, lda);
+                    *info = legacy::potrf(uplo, n, (T*)A, lda);
                 else
-                    potrf(uplo, n, (T*)A, lda);
+                    legacy::potrf(uplo, n, (T*)A, lda);
             }
 #ifdef STARPU_HAVE_LIBCUSOLVER
             if constexpr (mode == 1) {

--- a/src/tlapack_cwrappers.cpp
+++ b/src/tlapack_cwrappers.cpp
@@ -127,25 +127,27 @@ extern "C" {
 #define _sasum BLAS_FUNCTION(sasum)
 float _sasum(blas_idx_t n, float const* x, blas_int_t incx)
 {
-    return tlapack::asum<float>(n, x, incx);
+    return tlapack::legacy::asum<float>(n, x, incx);
 }
 
 #define _dasum BLAS_FUNCTION(dasum)
 double _dasum(blas_idx_t n, double const* x, blas_int_t incx)
 {
-    return tlapack::asum<double>(n, x, incx);
+    return tlapack::legacy::asum<double>(n, x, incx);
 }
 
 #define _casum BLAS_FUNCTION(casum)
 float _casum(blas_idx_t n, complexFloat const* x, blas_int_t incx)
 {
-    return tlapack::asum<tlapack_complexFloat>(n, tlapack_cteC(x), incx);
+    return tlapack::legacy::asum<tlapack_complexFloat>(n, tlapack_cteC(x),
+                                                       incx);
 }
 
 #define _zasum BLAS_FUNCTION(zasum)
 double _zasum(blas_idx_t n, complexDouble const* x, blas_int_t incx)
 {
-    return tlapack::asum<tlapack_complexDouble>(n, tlapack_cteZ(x), incx);
+    return tlapack::legacy::asum<tlapack_complexDouble>(n, tlapack_cteZ(x),
+                                                        incx);
 }
 
 #define _saxpy BLAS_FUNCTION(saxpy)
@@ -156,7 +158,7 @@ void _saxpy(blas_idx_t n,
             float* y,
             blas_int_t incy)
 {
-    return tlapack::axpy<float, float>(n, alpha, x, incx, y, incy);
+    return tlapack::legacy::axpy<float, float>(n, alpha, x, incx, y, incy);
 }
 
 #define _daxpy BLAS_FUNCTION(daxpy)
@@ -167,7 +169,7 @@ void _daxpy(blas_idx_t n,
             double* y,
             blas_int_t incy)
 {
-    return tlapack::axpy<double, double>(n, alpha, x, incx, y, incy);
+    return tlapack::legacy::axpy<double, double>(n, alpha, x, incx, y, incy);
 }
 
 #define _caxpy BLAS_FUNCTION(caxpy)
@@ -178,7 +180,7 @@ void _caxpy(blas_idx_t n,
             complexFloat* y,
             blas_int_t incy)
 {
-    return tlapack::axpy<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::axpy<tlapack_complexFloat, tlapack_complexFloat>(
         n, *tlapack_C(&alpha), tlapack_cteC(x), incx, tlapack_C(y), incy);
 }
 
@@ -190,7 +192,7 @@ void _zaxpy(blas_idx_t n,
             complexDouble* y,
             blas_int_t incy)
 {
-    return tlapack::axpy<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::axpy<tlapack_complexDouble, tlapack_complexDouble>(
         n, *tlapack_Z(&alpha), tlapack_cteZ(x), incx, tlapack_Z(y), incy);
 }
 
@@ -198,14 +200,14 @@ void _zaxpy(blas_idx_t n,
 void _scopy(
     blas_idx_t n, float const* x, blas_int_t incx, float* y, blas_int_t incy)
 {
-    return tlapack::copy<float, float>(n, x, incx, y, incy);
+    return tlapack::legacy::copy<float, float>(n, x, incx, y, incy);
 }
 
 #define _dcopy BLAS_FUNCTION(dcopy)
 void _dcopy(
     blas_idx_t n, double const* x, blas_int_t incx, double* y, blas_int_t incy)
 {
-    return tlapack::copy<double, double>(n, x, incx, y, incy);
+    return tlapack::legacy::copy<double, double>(n, x, incx, y, incy);
 }
 
 #define _ccopy BLAS_FUNCTION(ccopy)
@@ -215,7 +217,7 @@ void _ccopy(blas_idx_t n,
             complexFloat* y,
             blas_int_t incy)
 {
-    return tlapack::copy<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::copy<tlapack_complexFloat, tlapack_complexFloat>(
         n, tlapack_cteC(x), incx, tlapack_C(y), incy);
 }
 
@@ -226,7 +228,7 @@ void _zcopy(blas_idx_t n,
             complexDouble* y,
             blas_int_t incy)
 {
-    return tlapack::copy<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::copy<tlapack_complexDouble, tlapack_complexDouble>(
         n, tlapack_cteZ(x), incx, tlapack_Z(y), incy);
 }
 
@@ -237,7 +239,7 @@ float _sdot(blas_idx_t n,
             float const* y,
             blas_int_t incy)
 {
-    return tlapack::dot<float, float>(n, x, incx, y, incy);
+    return tlapack::legacy::dot<float, float>(n, x, incx, y, incy);
 }
 
 #define _ddot BLAS_FUNCTION(ddot)
@@ -247,7 +249,7 @@ double _ddot(blas_idx_t n,
              double const* y,
              blas_int_t incy)
 {
-    return tlapack::dot<double, double>(n, x, incx, y, incy);
+    return tlapack::legacy::dot<double, double>(n, x, incx, y, incy);
 }
 
 #define _cdot BLAS_FUNCTION(cdot)
@@ -258,7 +260,7 @@ complexFloat _cdot(blas_idx_t n,
                    blas_int_t incy)
 {
     tlapack_complexFloat c =
-        tlapack::dot<tlapack_complexFloat, tlapack_complexFloat>(
+        tlapack::legacy::dot<tlapack_complexFloat, tlapack_complexFloat>(
             n, tlapack_cteC(x), incx, tlapack_cteC(y), incy);
     return *reinterpret_cast<complexFloat*>(&c);
 }
@@ -271,7 +273,7 @@ complexDouble _zdot(blas_idx_t n,
                     blas_int_t incy)
 {
     tlapack_complexDouble z =
-        tlapack::dot<tlapack_complexDouble, tlapack_complexDouble>(
+        tlapack::legacy::dot<tlapack_complexDouble, tlapack_complexDouble>(
             n, tlapack_cteZ(x), incx, tlapack_cteZ(y), incy);
     return *reinterpret_cast<complexDouble*>(&z);
 }
@@ -283,7 +285,7 @@ float _sdotu(blas_idx_t n,
              float const* y,
              blas_int_t incy)
 {
-    return tlapack::dotu<float, float>(n, x, incx, y, incy);
+    return tlapack::legacy::dotu<float, float>(n, x, incx, y, incy);
 }
 
 #define _ddotu BLAS_FUNCTION(ddotu)
@@ -293,7 +295,7 @@ double _ddotu(blas_idx_t n,
               double const* y,
               blas_int_t incy)
 {
-    return tlapack::dotu<double, double>(n, x, incx, y, incy);
+    return tlapack::legacy::dotu<double, double>(n, x, incx, y, incy);
 }
 
 #define _cdotu BLAS_FUNCTION(cdotu)
@@ -304,7 +306,7 @@ complexFloat _cdotu(blas_idx_t n,
                     blas_int_t incy)
 {
     tlapack_complexFloat c =
-        tlapack::dotu<tlapack_complexFloat, tlapack_complexFloat>(
+        tlapack::legacy::dotu<tlapack_complexFloat, tlapack_complexFloat>(
             n, tlapack_cteC(x), incx, tlapack_cteC(y), incy);
     return *reinterpret_cast<complexFloat*>(&c);
 }
@@ -317,7 +319,7 @@ complexDouble _zdotu(blas_idx_t n,
                      blas_int_t incy)
 {
     tlapack_complexDouble z =
-        tlapack::dotu<tlapack_complexDouble, tlapack_complexDouble>(
+        tlapack::legacy::dotu<tlapack_complexDouble, tlapack_complexDouble>(
             n, tlapack_cteZ(x), incx, tlapack_cteZ(y), incy);
     return *reinterpret_cast<complexDouble*>(&z);
 }
@@ -325,51 +327,53 @@ complexDouble _zdotu(blas_idx_t n,
 #define _isamax BLAS_FUNCTION(isamax)
 blas_iamax_t _isamax(blas_idx_t n, float const* x, blas_int_t incx)
 {
-    return (blas_iamax_t)tlapack::iamax<float>(n, x, incx);
+    return (blas_iamax_t)tlapack::legacy::iamax<float>(n, x, incx);
 }
 
 #define _idamax BLAS_FUNCTION(idamax)
 blas_iamax_t _idamax(blas_idx_t n, double const* x, blas_int_t incx)
 {
-    return (blas_iamax_t)tlapack::iamax<double>(n, x, incx);
+    return (blas_iamax_t)tlapack::legacy::iamax<double>(n, x, incx);
 }
 
 #define _icamax BLAS_FUNCTION(icamax)
 blas_iamax_t _icamax(blas_idx_t n, complexFloat const* x, blas_int_t incx)
 {
-    return (blas_iamax_t)tlapack::iamax<tlapack_complexFloat>(
+    return (blas_iamax_t)tlapack::legacy::iamax<tlapack_complexFloat>(
         n, tlapack_cteC(x), incx);
 }
 
 #define _izamax BLAS_FUNCTION(izamax)
 blas_iamax_t _izamax(blas_idx_t n, complexDouble const* x, blas_int_t incx)
 {
-    return (blas_iamax_t)tlapack::iamax<tlapack_complexDouble>(
+    return (blas_iamax_t)tlapack::legacy::iamax<tlapack_complexDouble>(
         n, tlapack_cteZ(x), incx);
 }
 
 #define _snrm2 BLAS_FUNCTION(snrm2)
 float _snrm2(blas_idx_t n, float const* x, blas_int_t incx)
 {
-    return tlapack::nrm2<float>(n, x, incx);
+    return tlapack::legacy::nrm2<float>(n, x, incx);
 }
 
 #define _dnrm2 BLAS_FUNCTION(dnrm2)
 double _dnrm2(blas_idx_t n, double const* x, blas_int_t incx)
 {
-    return tlapack::nrm2<double>(n, x, incx);
+    return tlapack::legacy::nrm2<double>(n, x, incx);
 }
 
 #define _cnrm2 BLAS_FUNCTION(cnrm2)
 float _cnrm2(blas_idx_t n, complexFloat const* x, blas_int_t incx)
 {
-    return tlapack::nrm2<tlapack_complexFloat>(n, tlapack_cteC(x), incx);
+    return tlapack::legacy::nrm2<tlapack_complexFloat>(n, tlapack_cteC(x),
+                                                       incx);
 }
 
 #define _znrm2 BLAS_FUNCTION(znrm2)
 double _znrm2(blas_idx_t n, complexDouble const* x, blas_int_t incx)
 {
-    return tlapack::nrm2<tlapack_complexDouble>(n, tlapack_cteZ(x), incx);
+    return tlapack::legacy::nrm2<tlapack_complexDouble>(n, tlapack_cteZ(x),
+                                                        incx);
 }
 
 #define _srot BLAS_FUNCTION(srot)
@@ -381,7 +385,7 @@ void _srot(blas_idx_t n,
            float c,
            float s)
 {
-    return tlapack::rot<float, float>(n, x, incx, y, incy, c, s);
+    return tlapack::legacy::rot<float, float>(n, x, incx, y, incy, c, s);
 }
 
 #define _drot BLAS_FUNCTION(drot)
@@ -393,7 +397,7 @@ void _drot(blas_idx_t n,
            double c,
            double s)
 {
-    return tlapack::rot<double, double>(n, x, incx, y, incy, c, s);
+    return tlapack::legacy::rot<double, double>(n, x, incx, y, incy, c, s);
 }
 
 #define _csrot BLAS_FUNCTION(csrot)
@@ -405,7 +409,8 @@ void _csrot(blas_idx_t n,
             float c,
             float s)
 {
-    return tlapack::rot(n, tlapack_C(x), incx, tlapack_C(y), incy, c, s);
+    return tlapack::legacy::rot(n, tlapack_C(x), incx, tlapack_C(y), incy, c,
+                                s);
 }
 
 #define _zdrot BLAS_FUNCTION(zdrot)
@@ -417,7 +422,8 @@ void _zdrot(blas_idx_t n,
             double c,
             double s)
 {
-    return tlapack::rot(n, tlapack_Z(x), incx, tlapack_Z(y), incy, c, s);
+    return tlapack::legacy::rot(n, tlapack_Z(x), incx, tlapack_Z(y), incy, c,
+                                s);
 }
 
 #define _crot BLAS_FUNCTION(crot)
@@ -429,7 +435,7 @@ void _crot(blas_idx_t n,
            float c,
            complexFloat s)
 {
-    return tlapack::rot<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::rot<tlapack_complexFloat, tlapack_complexFloat>(
         n, tlapack_C(x), incx, tlapack_C(y), incy, c, *tlapack_C(&s));
 }
 
@@ -442,20 +448,20 @@ void _zrot(blas_idx_t n,
            double c,
            complexDouble s)
 {
-    return tlapack::rot<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::rot<tlapack_complexDouble, tlapack_complexDouble>(
         n, tlapack_Z(x), incx, tlapack_Z(y), incy, c, *tlapack_Z(&s));
 }
 
 #define _srotg BLAS_FUNCTION(srotg)
 void _srotg(float* a, float* b, float* c, float* s)
 {
-    return tlapack::rotg<float>(*a, *b, *c, *s);
+    return tlapack::legacy::rotg<float>(a, b, c, s);
 }
 
 #define _drotg BLAS_FUNCTION(drotg)
 void _drotg(double* a, double* b, double* c, double* s)
 {
-    return tlapack::rotg<double>(*a, *b, *c, *s);
+    return tlapack::legacy::rotg<double>(a, b, c, s);
 }
 
 #define _crotg BLAS_FUNCTION(crotg)
@@ -480,7 +486,7 @@ void _srotm(blas_idx_t n,
             blas_int_t incy,
             float const* param)
 {
-    return tlapack::rotm<float, float>(n, x, incx, y, incy, param);
+    return tlapack::legacy::rotm<float, float>(n, x, incx, y, incy, param);
 }
 
 #define _drotm BLAS_FUNCTION(drotm)
@@ -491,38 +497,38 @@ void _drotm(blas_idx_t n,
             blas_int_t incy,
             double const* param)
 {
-    return tlapack::rotm<double, double>(n, x, incx, y, incy, param);
+    return tlapack::legacy::rotm<double, double>(n, x, incx, y, incy, param);
 }
 
 #define _srotmg BLAS_FUNCTION(srotmg)
 void _srotmg(float* d1, float* d2, float* a, float b, float* param)
 {
-    return tlapack::rotmg<float>(d1, d2, a, b, param);
+    return tlapack::legacy::rotmg<float>(d1, d2, a, b, param);
 }
 
 #define _drotmg BLAS_FUNCTION(drotmg)
 void _drotmg(double* d1, double* d2, double* a, double b, double* param)
 {
-    return tlapack::rotmg<double>(d1, d2, a, b, param);
+    return tlapack::legacy::rotmg<double>(d1, d2, a, b, param);
 }
 
 #define _sscal BLAS_FUNCTION(sscal)
 void _sscal(blas_idx_t n, float alpha, float* x, blas_int_t incx)
 {
-    return tlapack::scal<float>(n, alpha, x, incx);
+    return tlapack::legacy::scal<float>(n, alpha, x, incx);
 }
 
 #define _dscal BLAS_FUNCTION(dscal)
 void _dscal(blas_idx_t n, double alpha, double* x, blas_int_t incx)
 {
-    return tlapack::scal<double>(n, alpha, x, incx);
+    return tlapack::legacy::scal<double>(n, alpha, x, incx);
 }
 
 #define _cscal BLAS_FUNCTION(cscal)
 void _cscal(blas_idx_t n, complexFloat alpha, complexFloat* x, blas_int_t incx)
 {
-    return tlapack::scal<tlapack_complexFloat>(n, *tlapack_C(&alpha),
-                                               tlapack_C(x), incx);
+    return tlapack::legacy::scal<tlapack_complexFloat>(n, *tlapack_C(&alpha),
+                                                       tlapack_C(x), incx);
 }
 
 #define _zscal BLAS_FUNCTION(zscal)
@@ -531,21 +537,21 @@ void _zscal(blas_idx_t n,
             complexDouble* x,
             blas_int_t incx)
 {
-    return tlapack::scal<tlapack_complexDouble>(n, *tlapack_Z(&alpha),
-                                                tlapack_Z(x), incx);
+    return tlapack::legacy::scal<tlapack_complexDouble>(n, *tlapack_Z(&alpha),
+                                                        tlapack_Z(x), incx);
 }
 
 #define _sswap BLAS_FUNCTION(sswap)
 void _sswap(blas_idx_t n, float* x, blas_int_t incx, float* y, blas_int_t incy)
 {
-    return tlapack::swap<float, float>(n, x, incx, y, incy);
+    return tlapack::legacy::swap<float, float>(n, x, incx, y, incy);
 }
 
 #define _dswap BLAS_FUNCTION(dswap)
 void _dswap(
     blas_idx_t n, double* x, blas_int_t incx, double* y, blas_int_t incy)
 {
-    return tlapack::swap<double, double>(n, x, incx, y, incy);
+    return tlapack::legacy::swap<double, double>(n, x, incx, y, incy);
 }
 
 #define _cswap BLAS_FUNCTION(cswap)
@@ -555,7 +561,7 @@ void _cswap(blas_idx_t n,
             complexFloat* y,
             blas_int_t incy)
 {
-    return tlapack::swap<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::swap<tlapack_complexFloat, tlapack_complexFloat>(
         n, tlapack_C(x), incx, tlapack_C(y), incy);
 }
 
@@ -566,7 +572,7 @@ void _zswap(blas_idx_t n,
             complexDouble* y,
             blas_int_t incy)
 {
-    return tlapack::swap<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::swap<tlapack_complexDouble, tlapack_complexDouble>(
         n, tlapack_Z(x), incx, tlapack_Z(y), incy);
 }
 
@@ -584,9 +590,9 @@ void _sgemv(Layout layout,
             float* y,
             blas_int_t incy)
 {
-    return tlapack::gemv<float, float, float>(toTLAPACKlayout(layout),
-                                              toTLAPACKop(trans), m, n, alpha,
-                                              A, lda, x, incx, beta, y, incy);
+    return tlapack::legacy::gemv<float, float, float>(
+        toTLAPACKlayout(layout), toTLAPACKop(trans), m, n, alpha, A, lda, x,
+        incx, beta, y, incy);
 }
 
 #define _dgemv BLAS_FUNCTION(dgemv)
@@ -603,7 +609,7 @@ void _dgemv(Layout layout,
             double* y,
             blas_int_t incy)
 {
-    return tlapack::gemv<double, double, double>(
+    return tlapack::legacy::gemv<double, double, double>(
         toTLAPACKlayout(layout), toTLAPACKop(trans), m, n, alpha, A, lda, x,
         incx, beta, y, incy);
 }
@@ -622,8 +628,8 @@ void _cgemv(Layout layout,
             complexFloat* y,
             blas_int_t incy)
 {
-    return tlapack::gemv<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::gemv<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKop(trans), m, n, *tlapack_C(&alpha),
         tlapack_cteC(A), lda, tlapack_cteC(x), incx, *tlapack_C(&beta),
         tlapack_C(y), incy);
@@ -643,8 +649,8 @@ void _zgemv(Layout layout,
             complexDouble* y,
             blas_int_t incy)
 {
-    return tlapack::gemv<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::gemv<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKop(trans), m, n, *tlapack_Z(&alpha),
         tlapack_cteZ(A), lda, tlapack_cteZ(x), incx, *tlapack_Z(&beta),
         tlapack_Z(y), incy);
@@ -662,8 +668,8 @@ void _sger(Layout layout,
            float* A,
            blas_idx_t lda)
 {
-    return tlapack::ger<float, float, float>(toTLAPACKlayout(layout), m, n,
-                                             alpha, x, incx, y, incy, A, lda);
+    return tlapack::legacy::ger<float, float, float>(
+        toTLAPACKlayout(layout), m, n, alpha, x, incx, y, incy, A, lda);
 }
 
 #define _dger BLAS_FUNCTION(dger)
@@ -678,7 +684,7 @@ void _dger(Layout layout,
            double* A,
            blas_idx_t lda)
 {
-    return tlapack::ger<double, double, double>(
+    return tlapack::legacy::ger<double, double, double>(
         toTLAPACKlayout(layout), m, n, alpha, x, incx, y, incy, A, lda);
 }
 
@@ -694,8 +700,8 @@ void _cger(Layout layout,
            complexFloat* A,
            blas_idx_t lda)
 {
-    return tlapack::ger<tlapack_complexFloat, tlapack_complexFloat,
-                        tlapack_complexFloat>(
+    return tlapack::legacy::ger<tlapack_complexFloat, tlapack_complexFloat,
+                                tlapack_complexFloat>(
         toTLAPACKlayout(layout), m, n, *tlapack_C(&alpha), tlapack_cteC(x),
         incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
@@ -712,8 +718,8 @@ void _zger(Layout layout,
            complexDouble* A,
            blas_idx_t lda)
 {
-    return tlapack::ger<tlapack_complexDouble, tlapack_complexDouble,
-                        tlapack_complexDouble>(
+    return tlapack::legacy::ger<tlapack_complexDouble, tlapack_complexDouble,
+                                tlapack_complexDouble>(
         toTLAPACKlayout(layout), m, n, *tlapack_Z(&alpha), tlapack_cteZ(x),
         incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
@@ -730,8 +736,8 @@ void _sgeru(Layout layout,
             float* A,
             blas_idx_t lda)
 {
-    return tlapack::geru<float, float, float>(toTLAPACKlayout(layout), m, n,
-                                              alpha, x, incx, y, incy, A, lda);
+    return tlapack::legacy::geru<float, float, float>(
+        toTLAPACKlayout(layout), m, n, alpha, x, incx, y, incy, A, lda);
 }
 
 #define _dgeru BLAS_FUNCTION(dgeru)
@@ -746,7 +752,7 @@ void _dgeru(Layout layout,
             double* A,
             blas_idx_t lda)
 {
-    return tlapack::geru<double, double, double>(
+    return tlapack::legacy::geru<double, double, double>(
         toTLAPACKlayout(layout), m, n, alpha, x, incx, y, incy, A, lda);
 }
 
@@ -762,8 +768,8 @@ void _cgeru(Layout layout,
             complexFloat* A,
             blas_idx_t lda)
 {
-    return tlapack::geru<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::geru<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), m, n, *tlapack_C(&alpha), tlapack_cteC(x),
         incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
@@ -780,8 +786,8 @@ void _zgeru(Layout layout,
             complexDouble* A,
             blas_idx_t lda)
 {
-    return tlapack::geru<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::geru<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), m, n, *tlapack_Z(&alpha), tlapack_cteZ(x),
         incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
@@ -799,9 +805,9 @@ void _shemv(Layout layout,
             float* y,
             blas_int_t incy)
 {
-    return tlapack::hemv<float, float, float>(toTLAPACKlayout(layout),
-                                              toTLAPACKuplo(uplo), n, alpha, A,
-                                              lda, x, incx, beta, y, incy);
+    return tlapack::legacy::hemv<float, float, float>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, A, lda, x, incx,
+        beta, y, incy);
 }
 
 #define _dhemv BLAS_FUNCTION(dhemv)
@@ -817,7 +823,7 @@ void _dhemv(Layout layout,
             double* y,
             blas_int_t incy)
 {
-    return tlapack::hemv<double, double, double>(
+    return tlapack::legacy::hemv<double, double, double>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, A, lda, x, incx,
         beta, y, incy);
 }
@@ -835,8 +841,8 @@ void _chemv(Layout layout,
             complexFloat* y,
             blas_int_t incy)
 {
-    return tlapack::hemv<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::hemv<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
         tlapack_cteC(A), lda, tlapack_cteC(x), incx, *tlapack_C(&beta),
         tlapack_C(y), incy);
@@ -855,8 +861,8 @@ void _zhemv(Layout layout,
             complexDouble* y,
             blas_int_t incy)
 {
-    return tlapack::hemv<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::hemv<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
         tlapack_cteZ(A), lda, tlapack_cteZ(x), incx, *tlapack_Z(&beta),
         tlapack_Z(y), incy);
@@ -872,9 +878,9 @@ void _sher(Layout layout,
            float* A,
            blas_idx_t lda)
 {
-    return tlapack::her<float, float>(toTLAPACKlayout(layout),
-                                      toTLAPACKuplo(uplo), n, alpha, x, incx, A,
-                                      lda);
+    return tlapack::legacy::her<float, float>(toTLAPACKlayout(layout),
+                                              toTLAPACKuplo(uplo), n, alpha, x,
+                                              incx, A, lda);
 }
 
 #define _dher BLAS_FUNCTION(dher)
@@ -887,9 +893,9 @@ void _dher(Layout layout,
            double* A,
            blas_idx_t lda)
 {
-    return tlapack::her<double, double>(toTLAPACKlayout(layout),
-                                        toTLAPACKuplo(uplo), n, alpha, x, incx,
-                                        A, lda);
+    return tlapack::legacy::her<double, double>(toTLAPACKlayout(layout),
+                                                toTLAPACKuplo(uplo), n, alpha,
+                                                x, incx, A, lda);
 }
 
 #define _cher BLAS_FUNCTION(cher)
@@ -902,7 +908,7 @@ void _cher(Layout layout,
            complexFloat* A,
            blas_idx_t lda)
 {
-    return tlapack::her<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::her<tlapack_complexFloat, tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, tlapack_cteC(x),
         incx, tlapack_C(A), lda);
 }
@@ -917,7 +923,7 @@ void _zher(Layout layout,
            complexDouble* A,
            blas_idx_t lda)
 {
-    return tlapack::her<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::her<tlapack_complexDouble, tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, tlapack_cteZ(x),
         incx, tlapack_Z(A), lda);
 }
@@ -934,9 +940,9 @@ void _sher2(Layout layout,
             float* A,
             blas_idx_t lda)
 {
-    return tlapack::her2<float, float, float>(toTLAPACKlayout(layout),
-                                              toTLAPACKuplo(uplo), n, alpha, x,
-                                              incx, y, incy, A, lda);
+    return tlapack::legacy::her2<float, float, float>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, x, incx, y,
+        incy, A, lda);
 }
 
 #define _dher2 BLAS_FUNCTION(dher2)
@@ -951,9 +957,9 @@ void _dher2(Layout layout,
             double* A,
             blas_idx_t lda)
 {
-    return tlapack::her2<double, double, double>(toTLAPACKlayout(layout),
-                                                 toTLAPACKuplo(uplo), n, alpha,
-                                                 x, incx, y, incy, A, lda);
+    return tlapack::legacy::her2<double, double, double>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, x, incx, y,
+        incy, A, lda);
 }
 
 #define _cher2 BLAS_FUNCTION(cher2)
@@ -968,8 +974,8 @@ void _cher2(Layout layout,
             complexFloat* A,
             blas_idx_t lda)
 {
-    return tlapack::her2<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::her2<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
         tlapack_cteC(x), incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
@@ -986,8 +992,8 @@ void _zher2(Layout layout,
             complexDouble* A,
             blas_idx_t lda)
 {
-    return tlapack::her2<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::her2<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
         tlapack_cteZ(x), incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
@@ -1005,9 +1011,9 @@ void _ssymv(Layout layout,
             float* y,
             blas_int_t incy)
 {
-    return tlapack::symv<float, float, float>(toTLAPACKlayout(layout),
-                                              toTLAPACKuplo(uplo), n, alpha, A,
-                                              lda, x, incx, beta, y, incy);
+    return tlapack::legacy::symv<float, float, float>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, A, lda, x, incx,
+        beta, y, incy);
 }
 
 #define _dsymv BLAS_FUNCTION(dsymv)
@@ -1023,7 +1029,7 @@ void _dsymv(Layout layout,
             double* y,
             blas_int_t incy)
 {
-    return tlapack::symv<double, double, double>(
+    return tlapack::legacy::symv<double, double, double>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, A, lda, x, incx,
         beta, y, incy);
 }
@@ -1041,8 +1047,8 @@ void _csymv(Layout layout,
             complexFloat* y,
             blas_int_t incy)
 {
-    return tlapack::symv<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::symv<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
         tlapack_cteC(A), lda, tlapack_cteC(x), incx, *tlapack_C(&beta),
         tlapack_C(y), incy);
@@ -1061,8 +1067,8 @@ void _zsymv(Layout layout,
             complexDouble* y,
             blas_int_t incy)
 {
-    return tlapack::symv<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::symv<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
         tlapack_cteZ(A), lda, tlapack_cteZ(x), incx, *tlapack_Z(&beta),
         tlapack_Z(y), incy);
@@ -1078,9 +1084,9 @@ void _ssyr(Layout layout,
            float* A,
            blas_idx_t lda)
 {
-    return tlapack::syr<float, float>(toTLAPACKlayout(layout),
-                                      toTLAPACKuplo(uplo), n, alpha, x, incx, A,
-                                      lda);
+    return tlapack::legacy::syr<float, float>(toTLAPACKlayout(layout),
+                                              toTLAPACKuplo(uplo), n, alpha, x,
+                                              incx, A, lda);
 }
 
 #define _dsyr BLAS_FUNCTION(dsyr)
@@ -1093,9 +1099,9 @@ void _dsyr(Layout layout,
            double* A,
            blas_idx_t lda)
 {
-    return tlapack::syr<double, double>(toTLAPACKlayout(layout),
-                                        toTLAPACKuplo(uplo), n, alpha, x, incx,
-                                        A, lda);
+    return tlapack::legacy::syr<double, double>(toTLAPACKlayout(layout),
+                                                toTLAPACKuplo(uplo), n, alpha,
+                                                x, incx, A, lda);
 }
 
 #define _ssyr2 BLAS_FUNCTION(ssyr2)
@@ -1110,9 +1116,9 @@ void _ssyr2(Layout layout,
             float* A,
             blas_idx_t lda)
 {
-    return tlapack::syr2<float, float, float>(toTLAPACKlayout(layout),
-                                              toTLAPACKuplo(uplo), n, alpha, x,
-                                              incx, y, incy, A, lda);
+    return tlapack::legacy::syr2<float, float, float>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, x, incx, y,
+        incy, A, lda);
 }
 
 #define _dsyr2 BLAS_FUNCTION(dsyr2)
@@ -1127,9 +1133,9 @@ void _dsyr2(Layout layout,
             double* A,
             blas_idx_t lda)
 {
-    return tlapack::syr2<double, double, double>(toTLAPACKlayout(layout),
-                                                 toTLAPACKuplo(uplo), n, alpha,
-                                                 x, incx, y, incy, A, lda);
+    return tlapack::legacy::syr2<double, double, double>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, alpha, x, incx, y,
+        incy, A, lda);
 }
 
 #define _csyr2 BLAS_FUNCTION(csyr2)
@@ -1144,8 +1150,8 @@ void _csyr2(Layout layout,
             complexFloat* A,
             blas_idx_t lda)
 {
-    return tlapack::syr2<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::syr2<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_C(&alpha),
         tlapack_cteC(x), incx, tlapack_cteC(y), incy, tlapack_C(A), lda);
 }
@@ -1162,8 +1168,8 @@ void _zsyr2(Layout layout,
             complexDouble* A,
             blas_idx_t lda)
 {
-    return tlapack::syr2<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::syr2<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), n, *tlapack_Z(&alpha),
         tlapack_cteZ(x), incx, tlapack_cteZ(y), incy, tlapack_Z(A), lda);
 }
@@ -1179,9 +1185,9 @@ void _strmv(Layout layout,
             float* x,
             blas_int_t incx)
 {
-    return tlapack::trmv<float, float>(toTLAPACKlayout(layout),
-                                       toTLAPACKuplo(uplo), toTLAPACKop(trans),
-                                       toTLAPACKdiag(diag), n, A, lda, x, incx);
+    return tlapack::legacy::trmv<float, float>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
 
 #define _dtrmv BLAS_FUNCTION(dtrmv)
@@ -1195,7 +1201,7 @@ void _dtrmv(Layout layout,
             double* x,
             blas_int_t incx)
 {
-    return tlapack::trmv<double, double>(
+    return tlapack::legacy::trmv<double, double>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
         toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
@@ -1211,7 +1217,7 @@ void _ctrmv(Layout layout,
             complexFloat* x,
             blas_int_t incx)
 {
-    return tlapack::trmv<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::trmv<tlapack_complexFloat, tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
         toTLAPACKdiag(diag), n, tlapack_cteC(A), lda, tlapack_C(x), incx);
 }
@@ -1227,7 +1233,7 @@ void _ztrmv(Layout layout,
             complexDouble* x,
             blas_int_t incx)
 {
-    return tlapack::trmv<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::trmv<tlapack_complexDouble, tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
         toTLAPACKdiag(diag), n, tlapack_cteZ(A), lda, tlapack_Z(x), incx);
 }
@@ -1243,9 +1249,9 @@ void _strsv(Layout layout,
             float* x,
             blas_int_t incx)
 {
-    return tlapack::trsv<float, float>(toTLAPACKlayout(layout),
-                                       toTLAPACKuplo(uplo), toTLAPACKop(trans),
-                                       toTLAPACKdiag(diag), n, A, lda, x, incx);
+    return tlapack::legacy::trsv<float, float>(
+        toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
+        toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
 
 #define _dtrsv BLAS_FUNCTION(dtrsv)
@@ -1259,7 +1265,7 @@ void _dtrsv(Layout layout,
             double* x,
             blas_int_t incx)
 {
-    return tlapack::trsv<double, double>(
+    return tlapack::legacy::trsv<double, double>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
         toTLAPACKdiag(diag), n, A, lda, x, incx);
 }
@@ -1275,7 +1281,7 @@ void _ctrsv(Layout layout,
             complexFloat* x,
             blas_int_t incx)
 {
-    return tlapack::trsv<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::trsv<tlapack_complexFloat, tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
         toTLAPACKdiag(diag), n, tlapack_cteC(A), lda, tlapack_C(x), incx);
 }
@@ -1291,7 +1297,7 @@ void _ztrsv(Layout layout,
             complexDouble* x,
             blas_int_t incx)
 {
-    return tlapack::trsv<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::trsv<tlapack_complexDouble, tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans),
         toTLAPACKdiag(diag), n, tlapack_cteZ(A), lda, tlapack_Z(x), incx);
 }
@@ -1312,9 +1318,9 @@ void _sgemm(Layout layout,
             float* C,
             blas_idx_t ldc)
 {
-    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
-                         (tlapack::Op)transB, m, n, k, alpha, A, lda, B, ldb,
-                         beta, C, ldc);
+    return tlapack::legacy::gemm(toTLAPACKlayout(layout), toTLAPACKop(transA),
+                                 toTLAPACKop(transB), m, n, k, alpha, A, lda, B,
+                                 ldb, beta, C, ldc);
 }
 
 #define _dgemm BLAS_FUNCTION(dgemm)
@@ -1333,9 +1339,9 @@ void _dgemm(Layout layout,
             double* C,
             blas_idx_t ldc)
 {
-    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
-                         (tlapack::Op)transB, m, n, k, alpha, A, lda, B, ldb,
-                         beta, C, ldc);
+    return tlapack::legacy::gemm(toTLAPACKlayout(layout), toTLAPACKop(transA),
+                                 toTLAPACKop(transB), m, n, k, alpha, A, lda, B,
+                                 ldb, beta, C, ldc);
 }
 
 #define _cgemm BLAS_FUNCTION(cgemm)
@@ -1354,10 +1360,10 @@ void _cgemm(Layout layout,
             complexFloat* C,
             blas_idx_t ldc)
 {
-    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
-                         (tlapack::Op)transB, m, n, k, *tlapack_C(&alpha),
-                         tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
-                         *tlapack_C(&beta), tlapack_C(C), ldc);
+    return tlapack::legacy::gemm(
+        toTLAPACKlayout(layout), toTLAPACKop(transA), toTLAPACKop(transB), m, n,
+        k, *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
+        *tlapack_C(&beta), tlapack_C(C), ldc);
 }
 
 #define _zgemm BLAS_FUNCTION(zgemm)
@@ -1376,10 +1382,10 @@ void _zgemm(Layout layout,
             complexDouble* C,
             blas_idx_t ldc)
 {
-    return tlapack::gemm(toTLAPACKlayout(layout), (tlapack::Op)transA,
-                         (tlapack::Op)transB, m, n, k, *tlapack_Z(&alpha),
-                         tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
-                         *tlapack_Z(&beta), tlapack_Z(C), ldc);
+    return tlapack::legacy::gemm(
+        toTLAPACKlayout(layout), toTLAPACKop(transA), toTLAPACKop(transB), m, n,
+        k, *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
+        *tlapack_Z(&beta), tlapack_Z(C), ldc);
 }
 
 #define _shemm BLAS_FUNCTION(shemm)
@@ -1397,7 +1403,7 @@ void _shemm(Layout layout,
             float* C,
             blas_idx_t ldc)
 {
-    return tlapack::hemm<float, float, float>(
+    return tlapack::legacy::hemm<float, float, float>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1417,7 +1423,7 @@ void _dhemm(Layout layout,
             double* C,
             blas_idx_t ldc)
 {
-    return tlapack::hemm<double, double, double>(
+    return tlapack::legacy::hemm<double, double, double>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1437,8 +1443,8 @@ void _chemm(Layout layout,
             complexFloat* C,
             blas_idx_t ldc)
 {
-    return tlapack::hemm<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::hemm<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
         *tlapack_C(&beta), tlapack_C(C), ldc);
@@ -1459,8 +1465,8 @@ void _zhemm(Layout layout,
             complexDouble* C,
             blas_idx_t ldc)
 {
-    return tlapack::hemm<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::hemm<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
         *tlapack_Z(&beta), tlapack_Z(C), ldc);
@@ -1481,7 +1487,7 @@ void _sher2k(Layout layout,
              float* C,
              blas_idx_t ldc)
 {
-    return tlapack::her2k<float, float, float>(
+    return tlapack::legacy::her2k<float, float, float>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1501,7 +1507,7 @@ void _dher2k(Layout layout,
              double* C,
              blas_idx_t ldc)
 {
-    return tlapack::her2k<double, double, double>(
+    return tlapack::legacy::her2k<double, double, double>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1521,8 +1527,8 @@ void _cher2k(Layout layout,
              complexFloat* C,
              blas_idx_t ldc)
 {
-    return tlapack::her2k<tlapack_complexFloat, tlapack_complexFloat,
-                          tlapack_complexFloat>(
+    return tlapack::legacy::her2k<tlapack_complexFloat, tlapack_complexFloat,
+                                  tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb, beta,
         tlapack_C(C), ldc);
@@ -1543,8 +1549,8 @@ void _zher2k(Layout layout,
              complexDouble* C,
              blas_idx_t ldc)
 {
-    return tlapack::her2k<tlapack_complexDouble, tlapack_complexDouble,
-                          tlapack_complexDouble>(
+    return tlapack::legacy::her2k<tlapack_complexDouble, tlapack_complexDouble,
+                                  tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb, beta,
         tlapack_Z(C), ldc);
@@ -1563,8 +1569,9 @@ void _sherk(Layout layout,
             float* C,
             blas_idx_t ldc)
 {
-    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
+    return tlapack::legacy::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, alpha, A, lda, beta,
+                                 C, ldc);
 }
 
 #define _dherk BLAS_FUNCTION(dherk)
@@ -1580,8 +1587,9 @@ void _dherk(Layout layout,
             double* C,
             blas_idx_t ldc)
 {
-    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
+    return tlapack::legacy::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, alpha, A, lda, beta,
+                                 C, ldc);
 }
 
 #define _cherk BLAS_FUNCTION(cherk)
@@ -1597,9 +1605,9 @@ void _cherk(Layout layout,
             complexFloat* C,
             blas_idx_t ldc)
 {
-    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, alpha, tlapack_cteC(A), lda,
-                         beta, tlapack_C(C), ldc);
+    return tlapack::legacy::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, alpha,
+                                 tlapack_cteC(A), lda, beta, tlapack_C(C), ldc);
 }
 
 #define _zherk BLAS_FUNCTION(zherk)
@@ -1615,9 +1623,9 @@ void _zherk(Layout layout,
             complexDouble* C,
             blas_idx_t ldc)
 {
-    return tlapack::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, alpha, tlapack_cteZ(A), lda,
-                         beta, tlapack_Z(C), ldc);
+    return tlapack::legacy::herk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, alpha,
+                                 tlapack_cteZ(A), lda, beta, tlapack_Z(C), ldc);
 }
 
 #define _ssymm BLAS_FUNCTION(ssymm)
@@ -1635,7 +1643,7 @@ void _ssymm(Layout layout,
             float* C,
             blas_idx_t ldc)
 {
-    return tlapack::symm<float, float, float>(
+    return tlapack::legacy::symm<float, float, float>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1655,7 +1663,7 @@ void _dsymm(Layout layout,
             double* C,
             blas_idx_t ldc)
 {
-    return tlapack::symm<double, double, double>(
+    return tlapack::legacy::symm<double, double, double>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1675,8 +1683,8 @@ void _csymm(Layout layout,
             complexFloat* C,
             blas_idx_t ldc)
 {
-    return tlapack::symm<tlapack_complexFloat, tlapack_complexFloat,
-                         tlapack_complexFloat>(
+    return tlapack::legacy::symm<tlapack_complexFloat, tlapack_complexFloat,
+                                 tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
         *tlapack_C(&beta), tlapack_C(C), ldc);
@@ -1697,8 +1705,8 @@ void _zsymm(Layout layout,
             complexDouble* C,
             blas_idx_t ldc)
 {
-    return tlapack::symm<tlapack_complexDouble, tlapack_complexDouble,
-                         tlapack_complexDouble>(
+    return tlapack::legacy::symm<tlapack_complexDouble, tlapack_complexDouble,
+                                 tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo), m, n,
         *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
         *tlapack_Z(&beta), tlapack_Z(C), ldc);
@@ -1719,7 +1727,7 @@ void _ssyr2k(Layout layout,
              float* C,
              blas_idx_t ldc)
 {
-    return tlapack::syr2k<float, float, float>(
+    return tlapack::legacy::syr2k<float, float, float>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1739,7 +1747,7 @@ void _dsyr2k(Layout layout,
              double* C,
              blas_idx_t ldc)
 {
-    return tlapack::syr2k<double, double, double>(
+    return tlapack::legacy::syr2k<double, double, double>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -1759,8 +1767,8 @@ void _csyr2k(Layout layout,
              complexFloat* C,
              blas_idx_t ldc)
 {
-    return tlapack::syr2k<tlapack_complexFloat, tlapack_complexFloat,
-                          tlapack_complexFloat>(
+    return tlapack::legacy::syr2k<tlapack_complexFloat, tlapack_complexFloat,
+                                  tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         *tlapack_C(&alpha), tlapack_cteC(A), lda, tlapack_cteC(B), ldb,
         *tlapack_C(&beta), tlapack_C(C), ldc);
@@ -1781,8 +1789,8 @@ void _zsyr2k(Layout layout,
              complexDouble* C,
              blas_idx_t ldc)
 {
-    return tlapack::syr2k<tlapack_complexDouble, tlapack_complexDouble,
-                          tlapack_complexDouble>(
+    return tlapack::legacy::syr2k<tlapack_complexDouble, tlapack_complexDouble,
+                                  tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKuplo(uplo), toTLAPACKop(trans), n, k,
         *tlapack_Z(&alpha), tlapack_cteZ(A), lda, tlapack_cteZ(B), ldb,
         *tlapack_Z(&beta), tlapack_Z(C), ldc);
@@ -1801,8 +1809,9 @@ void _ssyrk(Layout layout,
             float* C,
             blas_idx_t ldc)
 {
-    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
+    return tlapack::legacy::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, alpha, A, lda, beta,
+                                 C, ldc);
 }
 
 #define _dsyrk BLAS_FUNCTION(dsyrk)
@@ -1818,8 +1827,9 @@ void _dsyrk(Layout layout,
             double* C,
             blas_idx_t ldc)
 {
-    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, alpha, A, lda, beta, C, ldc);
+    return tlapack::legacy::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, alpha, A, lda, beta,
+                                 C, ldc);
 }
 
 #define _csyrk BLAS_FUNCTION(csyrk)
@@ -1835,10 +1845,10 @@ void _csyrk(Layout layout,
             complexFloat* C,
             blas_idx_t ldc)
 {
-    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, *tlapack_C(&alpha),
-                         tlapack_cteC(A), lda, *tlapack_C(&beta), tlapack_C(C),
-                         ldc);
+    return tlapack::legacy::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, *tlapack_C(&alpha),
+                                 tlapack_cteC(A), lda, *tlapack_C(&beta),
+                                 tlapack_C(C), ldc);
 }
 
 #define _zsyrk BLAS_FUNCTION(zsyrk)
@@ -1854,10 +1864,10 @@ void _zsyrk(Layout layout,
             complexDouble* C,
             blas_idx_t ldc)
 {
-    return tlapack::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
-                         toTLAPACKop(trans), n, k, *tlapack_Z(&alpha),
-                         tlapack_cteZ(A), lda, *tlapack_Z(&beta), tlapack_Z(C),
-                         ldc);
+    return tlapack::legacy::syrk(toTLAPACKlayout(layout), toTLAPACKuplo(uplo),
+                                 toTLAPACKop(trans), n, k, *tlapack_Z(&alpha),
+                                 tlapack_cteZ(A), lda, *tlapack_Z(&beta),
+                                 tlapack_Z(C), ldc);
 }
 
 #define _strmm BLAS_FUNCTION(strmm)
@@ -1874,7 +1884,7 @@ void _strmm(Layout layout,
             float* B,
             blas_idx_t ldb)
 {
-    return tlapack::trmm<float, float>(
+    return tlapack::legacy::trmm<float, float>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
         toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
@@ -1893,7 +1903,7 @@ void _dtrmm(Layout layout,
             double* B,
             blas_idx_t ldb)
 {
-    return tlapack::trmm<double, double>(
+    return tlapack::legacy::trmm<double, double>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
         toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
@@ -1912,7 +1922,7 @@ void _ctrmm(Layout layout,
             complexFloat* B,
             blas_idx_t ldb)
 {
-    return tlapack::trmm<tlapack_complexFloat, tlapack_complexFloat>(
+    return tlapack::legacy::trmm<tlapack_complexFloat, tlapack_complexFloat>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
         toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, *tlapack_C(&alpha),
         tlapack_cteC(A), lda, tlapack_C(B), ldb);
@@ -1932,7 +1942,7 @@ void _ztrmm(Layout layout,
             complexDouble* B,
             blas_idx_t ldb)
 {
-    return tlapack::trmm<tlapack_complexDouble, tlapack_complexDouble>(
+    return tlapack::legacy::trmm<tlapack_complexDouble, tlapack_complexDouble>(
         toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
         toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, *tlapack_Z(&alpha),
         tlapack_cteZ(A), lda, tlapack_Z(B), ldb);
@@ -1952,9 +1962,9 @@ void _strsm(Layout layout,
             float* B,
             blas_idx_t ldb)
 {
-    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
-                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
-                         toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
+    return tlapack::legacy::trsm(
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
+        toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
 
 #define _dtrsm BLAS_FUNCTION(dtrsm)
@@ -1971,9 +1981,9 @@ void _dtrsm(Layout layout,
             double* B,
             blas_idx_t ldb)
 {
-    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
-                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
-                         toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
+    return tlapack::legacy::trsm(
+        toTLAPACKlayout(layout), toTLAPACKside(side), toTLAPACKuplo(uplo),
+        toTLAPACKop(trans), toTLAPACKdiag(diag), m, n, alpha, A, lda, B, ldb);
 }
 
 #define _ctrsm BLAS_FUNCTION(ctrsm)
@@ -1990,10 +2000,10 @@ void _ctrsm(Layout layout,
             complexFloat* B,
             blas_idx_t ldb)
 {
-    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
-                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
-                         toTLAPACKdiag(diag), m, n, *tlapack_C(&alpha),
-                         tlapack_cteC(A), lda, tlapack_C(B), ldb);
+    return tlapack::legacy::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
+                                 toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                                 toTLAPACKdiag(diag), m, n, *tlapack_C(&alpha),
+                                 tlapack_cteC(A), lda, tlapack_C(B), ldb);
 }
 
 #define _ztrsm BLAS_FUNCTION(ztrsm)
@@ -2010,10 +2020,10 @@ void _ztrsm(Layout layout,
             complexDouble* B,
             blas_idx_t ldb)
 {
-    return tlapack::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
-                         toTLAPACKuplo(uplo), toTLAPACKop(trans),
-                         toTLAPACKdiag(diag), m, n, *tlapack_Z(&alpha),
-                         tlapack_cteZ(A), lda, tlapack_Z(B), ldb);
+    return tlapack::legacy::trsm(toTLAPACKlayout(layout), toTLAPACKside(side),
+                                 toTLAPACKuplo(uplo), toTLAPACKop(trans),
+                                 toTLAPACKdiag(diag), m, n, *tlapack_Z(&alpha),
+                                 tlapack_cteZ(A), lda, tlapack_Z(B), ldb);
 }
 
 }  // extern "C"

--- a/test/blaspp/blas.hh
+++ b/test/blaspp/blas.hh
@@ -12,7 +12,66 @@
 #include "tlapack/legacy_api/blas.hpp"
 
 namespace blas {
-    using namespace tlapack;
-}
 
-#endif // BLAS_HH
+// using std::min;
+// using std::max;
+
+// using tlapack::real_type;
+// using tlapack::complex_type;
+// using tlapack::scalar_type;
+// using tlapack::is_complex;
+
+using tlapack::Diag;
+using tlapack::Layout;
+using tlapack::Op;
+using tlapack::Side;
+using tlapack::Uplo;
+
+// =============================================================================
+// Level 1 BLAS template implementations
+
+using tlapack::legacy::asum;
+using tlapack::legacy::axpy;
+using tlapack::legacy::copy;
+using tlapack::legacy::dot;
+using tlapack::legacy::dotu;
+using tlapack::legacy::iamax;
+using tlapack::legacy::nrm2;
+using tlapack::legacy::rot;
+using tlapack::legacy::rotg;
+using tlapack::legacy::rotm;
+using tlapack::legacy::rotmg;
+using tlapack::legacy::scal;
+using tlapack::legacy::swap;
+
+// =============================================================================
+// Level 2 BLAS template implementations
+
+using tlapack::legacy::gemv;
+using tlapack::legacy::ger;
+using tlapack::legacy::geru;
+using tlapack::legacy::hemv;
+using tlapack::legacy::her;
+using tlapack::legacy::her2;
+using tlapack::legacy::symv;
+using tlapack::legacy::syr;
+using tlapack::legacy::syr2;
+using tlapack::legacy::trmv;
+using tlapack::legacy::trsv;
+
+// =============================================================================
+// Level 3 BLAS template implementations
+
+using tlapack::legacy::gemm;
+using tlapack::legacy::hemm;
+using tlapack::legacy::her2k;
+using tlapack::legacy::herk;
+using tlapack::legacy::symm;
+using tlapack::legacy::syr2k;
+using tlapack::legacy::syrk;
+using tlapack::legacy::trmm;
+using tlapack::legacy::trsm;
+
+}  // namespace blas
+
+#endif  // BLAS_HH

--- a/test/lapackpp/lapack.hh
+++ b/test/lapackpp/lapack.hh
@@ -12,7 +12,32 @@
 #include "tlapack/legacy_api/lapack.hpp"
 
 namespace lapack {
-    using namespace tlapack;
-}
 
-#endif // LAPACK_HH
+using tlapack::ladiv;
+using tlapack::lapy2;
+using tlapack::lapy3;
+
+using tlapack::legacy::lacpy;
+using tlapack::legacy::lange;
+using tlapack::legacy::lanhe;
+using tlapack::legacy::lansy;
+using tlapack::legacy::lantr;
+using tlapack::legacy::larf;
+using tlapack::legacy::larfb;
+using tlapack::legacy::larfg;
+using tlapack::legacy::larft;
+using tlapack::legacy::larnv;
+using tlapack::legacy::lascl;
+using tlapack::legacy::laset;
+using tlapack::legacy::lassq;
+
+using tlapack::legacy::geqr2;
+using tlapack::legacy::potrf;
+using tlapack::legacy::potrs;
+using tlapack::legacy::ung2r;
+using tlapack::legacy::unm2r;
+using tlapack::legacy::unmqr;
+
+}  // namespace lapack
+
+#endif  // LAPACK_HH

--- a/test/lapackpp/lapack/util.hh
+++ b/test/lapackpp/lapack/util.hh
@@ -20,6 +20,135 @@ namespace lapack {
     using namespace tlapack;
     using blas::Error;
 
+    using tlapack::legacy::MatrixType;
+
+    // -----------------------------------------------------------------------------
+    enum class Sides {
+        Left = 'L',
+        L = 'L',
+        Right = 'R',
+        R = 'R',
+        Both = 'B',
+        B = 'B'
+    };
+
+    // -----------------------------------------------------------------------------
+    // Job for computing eigenvectors and singular vectors
+    // # needs custom map
+    enum class Job {
+        NoVec = 'N',
+        Vec = 'V',  // geev, syev, ...
+        UpdateVec =
+            'U',  // gghrd#, hbtrd, hgeqz#, hseqr#, ... (many compq or compz)
+
+        AllVec = 'A',        // gesvd, gesdd, gejsv#
+        SomeVec = 'S',       // gesvd, gesdd, gejsv#, gesvj#
+        OverwriteVec = 'O',  // gesvd, gesdd
+
+        CompactVec = 'P',  // bdsdc
+        SomeVecTol = 'C',  // gesvj
+        VecJacobi = 'J',   // gejsv
+        Workspace = 'W',   // gejsv
+    };
+
+    // -----------------------------------------------------------------------------
+    // hseqr
+    enum class JobSchur {
+        Eigenvalues = 'E',
+        Schur = 'S',
+    };
+
+    // -----------------------------------------------------------------------------
+    // gees
+    // todo: generic yes/no
+    enum class Sort {
+        NotSorted = 'N',
+        Sorted = 'S',
+    };
+
+    // -----------------------------------------------------------------------------
+    // syevx
+    enum class Range {
+        All = 'A',
+        Value = 'V',
+        Index = 'I',
+    };
+
+    // -----------------------------------------------------------------------------
+    enum class Vect {
+        Q = 'Q',     // orgbr, ormbr
+        P = 'P',     // orgbr, ormbr
+        None = 'N',  // orgbr, ormbr, gbbrd
+        Both = 'B',  // orgbr, ormbr, gbbrd
+    };
+
+    // -----------------------------------------------------------------------------
+    // trevc
+    enum class HowMany {
+        All = 'A',
+        Backtransform = 'B',
+        Select = 'S',
+    };
+
+    // -----------------------------------------------------------------------------
+    // *svx, *rfsx
+    enum class Equed {
+        None = 'N',
+        Row = 'R',
+        Col = 'C',
+        Both = 'B',
+        Yes = 'Y',  // porfsx
+    };
+
+    // -----------------------------------------------------------------------------
+    // *svx
+    // todo: what's good name for this?
+    enum class Factored {
+        Factored = 'F',
+        NotFactored = 'N',
+        Equilibrate = 'E',
+    };
+
+    // -----------------------------------------------------------------------------
+    // geesx, trsen
+    enum class Sense {
+        None = 'N',
+        Eigenvalues = 'E',
+        Subspace = 'V',
+        Both = 'B',
+    };
+
+    // -----------------------------------------------------------------------------
+    // disna
+    enum class JobCond {
+        EigenVec = 'E',
+        LeftSingularVec = 'L',
+        RightSingularVec = 'R',
+    };
+
+    // -----------------------------------------------------------------------------
+    // {ge,gg}{bak,bal}
+    enum class Balance {
+        None = 'N',
+        Permute = 'P',
+        Scale = 'S',
+        Both = 'B',
+    };
+
+    // -----------------------------------------------------------------------------
+    // stebz, larrd, stein docs
+    enum class Order {
+        Block = 'B',
+        Entire = 'E',
+    };
+
+    // -----------------------------------------------------------------------------
+    // check_ortho (LAPACK testing zunt01)
+    enum class RowCol {
+        Col = 'C',
+        Row = 'R',
+    };
+
     inline char sides2char( Sides sides )
     {
         return char(sides);


### PR DESCRIPTION
This is one step in order to clean up the namespace `tlapack`. Now we have `tlapack::legacy::gemm()` and `tlapack::gemm()`. It should be clear for users and programmers whether they are using legacy or abstract interface. Also, the Doxygen documentation becomes more organized.