### PR TITLE
New concepts and other improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ int m = 1;
 int n = m + m;
 ```
 
-are equivalent, and deduce the type `int` for `n`. The former is very useful and allows us to write generic functions and classes templated by other abstract classes. We suggest avoiding the usage of `auto` in the following cases:
+are equivalent, and deduce the type `int` for `n`. We suggest avoiding the usage of `auto` in the following cases:
 
 1. When the type is known, like in [nrm2](include/tlapack/blas/nrm2.hpp):
 
@@ -89,7 +89,7 @@ We recommend the usage of `auto` in the following cases:
 
    a. `tlapack::legacy_matrix` and `tlapack::legacy_vector` when writing wrappers to optimized BLAS and LAPACK.
 
-   b. slicing matrices and vectors using `tlapack::slice`, `tlapack::rows`, `tlapack::col`, etc. See [abstractArray](include/tlapack/plugins/abstractArray.hpp) for more details.
+   b. slicing matrices and vectors using `tlapack::slice`, `tlapack::rows`, `tlapack::col`, etc. See [concepts](include/tlapack/base/concepts.hpp) for more details.
 
    c. the functor `tlapack::Create< >(...)`. See [arrayTraits.hpp](include/tlapack/base/arrayTraits.hpp) for more details.
 

--- a/examples/access_types/example_accessTypes.cpp
+++ b/examples/access_types/example_accessTypes.cpp
@@ -106,22 +106,22 @@ int main(int argc, char** argv)
     std::cout << std::endl;
 
     std::cout << std::endl << "Scale Matrix2 by 3:";
-    lascl(band_t(n / 2, n - n / 2 - 1), 1.0, 3.0, A2);
+    lascl(BandAccess(n / 2, n - n / 2 - 1), 1.0, 3.0, A2);
     printBandedMatrix(A2);
     std::cout << std::endl;
 
     std::cout << std::endl << "Scale lower band of Matrix2 by 1/3:";
-    lascl(band_t(n / 2, 0), 3.0, 1.0, A2);
+    lascl(BandAccess(n / 2, 0), 3.0, 1.0, A2);
     printBandedMatrix(A2);
     std::cout << std::endl;
 
     std::cout << std::endl << "Scale main diagonal of Matrix2 by 3:";
-    lascl(band_t(0, 0), 1.0, 3.0, A2);
+    lascl(BandAccess(0, 0), 1.0, 3.0, A2);
     printBandedMatrix(A2);
     std::cout << std::endl;
 
     std::cout << std::endl << "Scale upper band of Matrix2 by 1/3:";
-    lascl(band_t(0, n - n / 2 - 1), 3.0, 1.0, A2);
+    lascl(BandAccess(0, n - n / 2 - 1), 3.0, 1.0, A2);
     printBandedMatrix(A2);
     std::cout << std::endl;
 

--- a/examples/cwrapper_gemm/example_cwrapper_gemm.c
+++ b/examples/cwrapper_gemm/example_cwrapper_gemm.c
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     // Generate a random matrix in a submatrix of A
     for (TLAPACK_SIZE_T j = 0; j < min(k, n); ++j)
         for (TLAPACK_SIZE_T i = 0; i < m; ++i)
-            A(i, j) = ((float)rand()) / RAND_MAX;
+            A(i, j) = ((float)rand()) / ((float)RAND_MAX);
 
     // Set C using A
     for (TLAPACK_SIZE_T j = 0; j < min(k, n); ++j)

--- a/examples/eigen/example_eigen.cpp
+++ b/examples/eigen/example_eigen.cpp
@@ -29,7 +29,7 @@
 int main(int argc, char** argv)
 {
     using std::size_t;
-    using pair = std::pair<size_t, size_t>;
+    using range = std::pair<size_t, size_t>;
     using namespace tlapack;
     using Eigen::Matrix;
 
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
     // Compute QR decomposision in place
     geqr2(Q, tau);
     // Copy the upper triangle to R
-    lacpy(upperTriangle, slice(Q, pair{0, n}, pair{0, n}), R);
+    lacpy(upperTriangle, slice(Q, range{0, n}, range{0, n}), R);
     // Generate Q
     ung2r(Q, tau);
 

--- a/examples/mdspan/example_mdspan.cpp
+++ b/examples/mdspan/example_mdspan.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
     using std::experimental::submdspan;
 
     using idx_t = std::size_t;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     using my_dextents = dextents<idx_t, 2>;
     using TiledMapping = typename TiledLayout::template mapping<my_dextents>;
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
     mdspan<T, my_dextents, layout_stride> A(
         A_, strideMapping(my_dextents(n, n), std::array<idx_t, 2>{1, lda}));
     // Column Major Matrix Ak with the first k columns of A
-    auto Ak = submdspan(A, pair{0, n}, pair{0, k});
+    auto Ak = submdspan(A, range{0, n}, range{0, k});
     // Tiled Matrix B with the last k*n elements of A_
     mdspan<T, my_dextents, TiledLayout> B(
         &A(n * (lda - k), 0),
@@ -117,8 +117,8 @@ int main(int argc, char** argv)
             A_[i + j * lda] = T(static_cast<float>(0xDEADBEEF));
 
     // Column Major Matrices U and Asym as submatrices of A
-    auto U = submdspan(A, pair{0, k}, pair{0, k});
-    auto Asym = submdspan(A, pair{0, k}, pair{k, 2 * k});
+    auto U = submdspan(A, range{0, k}, range{0, k});
+    auto Asym = submdspan(A, range{0, k}, range{k, 2 * k});
 
     // Fill Asym with random entries
     for (idx_t j = 0; j < k; ++j) {
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
     std::cout << "Cholesky ended with info " << info << std::endl;
 
     // Solve U^H U R = A
-    auto R = submdspan(A, pair{k, 2 * k}, pair{0, k});
+    auto R = submdspan(A, range{k, 2 * k}, range{0, k});
     for (idx_t j = 0; j < k; ++j)
         for (idx_t i = 0; i < k; ++i)
             R(i, j) = Asym(i, j);

--- a/examples/potrf/example_potrf.cpp
+++ b/examples/potrf/example_potrf.cpp
@@ -103,8 +103,11 @@ void run(idx_t n)
 
         // Put garbage on U_
         for (idx_t j = 0; j < n * n; ++j)
-            U_[j] = make_scalar<real_t>(static_cast<float>(0xDEADBEEF),
-                                        static_cast<float>(0xDEADBEEF));
+            if constexpr (is_complex<T>)
+                U_[j] = T(static_cast<float>(0xDEADBEEF),
+                          static_cast<float>(0xDEADBEEF));
+            else
+                U_[j] = T(static_cast<float>(0xDEADBEEF));
 
         // U_ receives the upper part of A
         for (idx_t j = 0; j < n; ++j)
@@ -152,8 +155,11 @@ void run(idx_t n)
 
         // Put garbage on U
         for (idx_t j = 0; j < n * n; ++j)
-            U[j] = make_scalar<real_t>(static_cast<float>(0xDEADBEEF),
-                                       static_cast<float>(0xDEADBEEF));
+            if constexpr (is_complex<T>)
+                U[j] = T(static_cast<float>(0xDEADBEEF),
+                         static_cast<float>(0xDEADBEEF));
+            else
+                U[j] = T(static_cast<float>(0xDEADBEEF));
 
         // U receives the upper part of A
         for (idx_t j = 0; j < n; ++j)

--- a/examples/starpu/example_gemm.cpp
+++ b/examples/starpu/example_gemm.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
     using namespace tlapack;
     using starpu::Matrix;
     using T = float;
-    using pair = std::pair<size_t, size_t>;
+    using range = pair<size_t, size_t>;
 
     srand(3);
     T u = tlapack::uroundoff<T>();
@@ -104,18 +104,18 @@ int main(int argc, char** argv)
             for (size_t i = 0; i < m; i++)
                 A_[(j + d3) * (m + d1) + (i + d1)] = 10 * i + j + 1;
         Matrix<T> Abig(A_, m + d1, k + d3, r, t);
-        auto A = slice(Abig, pair{d1, m + d1}, pair{d3, k + d3});
+        auto A = slice(Abig, range{d1, m + d1}, range{d3, k + d3});
 
         /* create matrix B */
         for (size_t j = 0; j < n; j++)
             for (size_t i = 0; i < k; i++)
                 B_[(j + d2) * (k + d3) + (i + d3)] = 10 * i + j + 1;
         Matrix<T> Bbig(B_, k + d3, n + d2, t, s);
-        auto B = slice(Bbig, pair{d3, k + d3}, pair{d2, n + d2});
+        auto B = slice(Bbig, range{d3, k + d3}, range{d2, n + d2});
 
         /* create matrix C */
         Matrix<T> Cbig(C_, m + d1, n + d2, r, s);
-        auto C = slice(Cbig, pair{d1, m + d1}, pair{d2, n + d2});
+        auto C = slice(Cbig, range{d1, m + d1}, range{d2, n + d2});
 
         std::cout << "Abig = " << Abig << std::endl;
         std::cout << "A = " << A << std::endl;

--- a/examples/starpu/example_multishiftqr.cpp
+++ b/examples/starpu/example_multishiftqr.cpp
@@ -46,7 +46,7 @@ int run(idx_t n, idx_t nx, bool check_error = false)
     // H is upper Hessenberg
     for (idx_t j = 0; j < n; j++) {
         for (idx_t i = 0; i < min(n, j + 2); i++)
-            if constexpr (is_complex<T>::value)
+            if constexpr (is_complex<T>)
                 H_[i + j * n] = T((float)rand() / (float)RAND_MAX,
                                   (float)rand() / (float)RAND_MAX);
             else

--- a/examples/starpu/example_potrf.cpp
+++ b/examples/starpu/example_potrf.cpp
@@ -49,8 +49,11 @@ int run(idx_t n, idx_t nt, idx_t nb, bool check_error = false)
     /* A is symmetric positive definite and B is a copy of A */
     for (idx_t j = 0; j < n; j++)
         for (idx_t i = 0; i < j; i++) {
-            A_[i * n + j] = make_scalar<T>((float)rand() / (float)RAND_MAX,
-                                           (float)rand() / (float)RAND_MAX);
+            if constexpr (is_complex<T>)
+                A_[i * n + j] = T((float)rand() / (float)RAND_MAX,
+                                  (float)rand() / (float)RAND_MAX);
+            else
+                A_[i * n + j] = T((float)rand() / (float)RAND_MAX);
             A_[i + j * n] = conj(A_[i * n + j]);
         }
     for (idx_t i = 0; i < n; i++)

--- a/include/tlapack/base/StrongZero.hpp
+++ b/include/tlapack/base/StrongZero.hpp
@@ -11,6 +11,7 @@
 #ifndef TLAPACK_BASE_STRONGZERO_HH
 #define TLAPACK_BASE_STRONGZERO_HH
 
+#include <cassert>
 #include <cstdint>
 #include <limits>
 
@@ -178,19 +179,7 @@ struct StrongZero {
     friend constexpr StrongZero floor(StrongZero) { return StrongZero(); }
 };
 
-// forward declarations
-template <typename T>
-struct is_complex;
-
-// It is natural to define tlapack::complex_type<StrongZero> is StrongZero.
-// However, for the means of type deduction, StrongZero is considered a real
-// type.
-template <>
-struct is_complex<StrongZero> {
-    static constexpr bool value = false;
-};
-
-namespace internal {
+namespace traits {
 
     // forward declarations
     template <typename... Types>
@@ -210,6 +199,7 @@ namespace internal {
     template <>
     struct real_type_traits<StrongZero, int> {
         using type = StrongZero;
+        constexpr static bool is_real = true;
     };
 
     // for either StrongZero, return the other type
@@ -226,9 +216,54 @@ namespace internal {
     template <>
     struct complex_type_traits<StrongZero, int> {
         using type = StrongZero;
+        constexpr static bool is_complex = false;
     };
-}  // namespace internal
+}  // namespace traits
 
 }  // namespace tlapack
+
+namespace std {
+template <>
+struct numeric_limits<tlapack::StrongZero> : public std::__numeric_limits_base {
+    static constexpr bool is_specialized = true;
+
+    static constexpr tlapack::StrongZero min() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero max() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero lowest() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero epsilon() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero round_error() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero infinity() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero quiet_NaN() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero signaling_NaN() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+    static constexpr tlapack::StrongZero denorm_min() noexcept
+    {
+        return tlapack::StrongZero();
+    }
+};
+}  // namespace std
 
 #endif  // TLAPACK_BASE_STRONGZERO_HH

--- a/include/tlapack/base/constants.hpp
+++ b/include/tlapack/base/constants.hpp
@@ -33,7 +33,7 @@ namespace tlapack {
  *
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t ulp()
 {
     return std::numeric_limits<real_t>::epsilon();
@@ -52,7 +52,7 @@ inline constexpr real_t ulp()
  *
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t uroundoff()
 {
     return ulp<real_t>() * std::numeric_limits<real_t>::round_error();
@@ -70,7 +70,7 @@ inline int digits()
 /** Safe Minimum such that 1/safe_min() is representable
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t safe_min()
 {
     constexpr int fradix = std::numeric_limits<real_t>::radix;
@@ -86,7 +86,7 @@ inline constexpr real_t safe_min()
  *
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t safe_max()
 {
     constexpr int fradix = std::numeric_limits<real_t>::radix;
@@ -99,7 +99,7 @@ inline constexpr real_t safe_max()
 /** Safe Minimum such its square is representable
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t root_min()
 {
     return sqrt(safe_min<real_t>() / ulp<real_t>());
@@ -108,7 +108,7 @@ inline constexpr real_t root_min()
 /** Safe Maximum such its square is representable
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t root_max()
 {
     return sqrt(safe_max<real_t>() * ulp<real_t>());
@@ -118,7 +118,7 @@ inline constexpr real_t root_max()
  * @see https://doi.org/10.1145/355769.355771
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t blue_min()
 {
     const real_t half(0.5);
@@ -132,7 +132,7 @@ inline constexpr real_t blue_min()
  * @see https://doi.org/10.1145/355769.355771
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t blue_max()
 {
     const real_t half(0.5);
@@ -150,7 +150,7 @@ inline constexpr real_t blue_max()
  *
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t blue_scalingMin()
 {
     const real_t half(0.5);
@@ -165,7 +165,7 @@ inline constexpr real_t blue_scalingMin()
  * @see https://doi.org/10.1145/355769.355771
  * @ingroup constants
  */
-template <typename real_t>
+template <TLAPACK_REAL real_t>
 inline constexpr real_t blue_scalingMax()
 {
     const real_t half(0.5);

--- a/include/tlapack/base/scalar_type_traits.hpp
+++ b/include/tlapack/base/scalar_type_traits.hpp
@@ -1,0 +1,189 @@
+/// @file scalar_type_traits.hpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_SCALAR_TRAITS_HH
+#define TLAPACK_SCALAR_TRAITS_HH
+
+#include <complex>
+#include <type_traits>
+
+namespace tlapack {
+
+// -----------------------------------------------------------------------------
+// for any combination of types, determine associated real, scalar,
+// and complex types.
+//
+// real_type< float >                               is float
+// real_type< float, double, complex<float> >       is double
+//
+// scalar_type< float >                             is float
+// scalar_type< float, complex<float> >             is complex<float>
+// scalar_type< float, double, complex<float> >     is complex<double>
+//
+// complex_type< float >                            is complex<float>
+// complex_type< float, double >                    is complex<double>
+// complex_type< float, double, complex<float> >    is complex<double>
+//
+// Adds promotion of complex types based on the common type of the associated
+// real types. This fixes various cases:
+//
+// std::std::common_type_t< double, complex<float> > is complex<float>  (wrong)
+//        scalar_type< double, complex<float> > is complex<double> (right)
+//
+// std::std::common_type_t< int, complex<long> > is not defined (compile error)
+//        scalar_type< int, complex<long> > is complex<long> (right)
+
+// Real type traits
+namespace traits {
+    /// Traits for the list of types @c Types
+    template <typename... Types>
+    struct real_type_traits;
+
+    // Traits for one non-const non-complex std arithmetic type
+    template <typename T>
+    struct real_type_traits<
+        T,
+        std::enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
+        using type = typename std::decay<T>::type;
+        constexpr static bool is_real = true;
+    };
+
+    // Traits for a std complex type (strip complex)
+    template <typename T>
+    struct real_type_traits<std::complex<T>, int> {
+        using type = typename real_type_traits<T, int>::type;
+        constexpr static bool is_real = false;
+    };
+
+    // Traits for a const type (strip const)
+    template <typename T>
+    struct real_type_traits<const T, int> : public real_type_traits<T, int> {};
+
+    // Pointers and references don't have a real type
+    template <typename T>
+    struct real_type_traits<
+        T,
+        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
+        using type = void;
+        constexpr static bool is_real = false;
+    };
+
+    // Deduction for two or more types
+    template <typename T1, typename T2, typename... Types>
+    struct real_type_traits<T1, T2, Types...> {
+        using type =
+            std::common_type_t<typename real_type_traits<T1, int>::type,
+                               typename real_type_traits<T2, Types...>::type>;
+    };
+}  // namespace traits
+
+/// The common real type of the list of types
+template <typename... Types>
+using real_type = typename traits::real_type_traits<Types..., int>::type;
+
+/// True if T is a real scalar type
+template <typename T>
+constexpr bool is_real = traits::real_type_traits<T, int>::is_real;
+
+// Complex type traits
+namespace traits {
+    /// Traits for the list of types @c Types
+    template <typename... Types>
+    struct complex_type_traits;
+
+    // Traits for one non-const non-complex std arithmetic type
+    template <typename T>
+    struct complex_type_traits<
+        T,
+        std::enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
+        using type = std::complex<real_type<T>>;
+        constexpr static bool is_complex = false;
+    };
+
+    // Traits for a std complex type
+    template <typename T>
+    struct complex_type_traits<std::complex<T>, int> {
+        using type = std::complex<real_type<T>>;
+        constexpr static bool is_complex = true;
+    };
+
+    // Traits for a const type (strip const)
+    template <typename T>
+    struct complex_type_traits<const T, int>
+        : public complex_type_traits<T, int> {};
+
+    // Pointers and references don't have a complex type
+    template <typename T>
+    struct complex_type_traits<
+        T,
+        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
+        using type = void;
+        constexpr static bool is_complex = false;
+    };
+
+    // for two or more types
+    template <typename T1, typename T2, typename... Types>
+    struct complex_type_traits<T1, T2, Types...> {
+        using type = typename complex_type_traits<
+            typename real_type_traits<T1, T2, Types...>::type,
+            int>::type;
+    };
+}  // namespace traits
+
+/// The common complex type of the list of types
+template <typename... Types>
+using complex_type = typename traits::complex_type_traits<Types..., int>::type;
+
+/// True if T is a complex scalar type
+template <typename T>
+constexpr bool is_complex = traits::complex_type_traits<T, int>::is_complex;
+
+namespace traits {
+
+    template <typename... Types>
+    struct scalar_type_traits;
+
+    // for one type
+    template <typename T>
+    struct scalar_type_traits<T, int> : scalar_type_traits<T, T, int> {};
+
+    // for two types, one is complex
+    template <typename T1, typename T2>
+    struct scalar_type_traits<
+        T1,
+        T2,
+        std::enable_if_t<is_complex<T1> || is_complex<T2>, int>> {
+        using type = complex_type<T1, T2>;
+    };
+
+    // for two types, neither is complex
+    template <typename T1, typename T2>
+    struct scalar_type_traits<
+        T1,
+        T2,
+        std::enable_if_t<is_real<T1> && is_real<T2>, int>> {
+        using type = real_type<T1, T2>;
+    };
+
+    // for three or more types
+    template <typename T1, typename T2, typename... Types>
+    struct scalar_type_traits<T1, T2, Types...> {
+        using type = typename scalar_type_traits<
+            typename scalar_type_traits<T1, T2, int>::type,
+            Types...>::type;
+    };
+}  // namespace traits
+
+/// The common scalar type of the list of types
+template <typename... Types>
+using scalar_type = typename traits::scalar_type_traits<Types..., int>::type;
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_SCALAR_TRAITS_HH

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -11,12 +11,10 @@
 #ifndef TLAPACK_TYPES_HH
 #define TLAPACK_TYPES_HH
 
-#include <cassert>
-#include <complex>
-#include <type_traits>
 #include <vector>
 
 #include "tlapack/base/StrongZero.hpp"
+#include "tlapack/base/scalar_type_traits.hpp"
 
 // Helpers:
 
@@ -103,247 +101,297 @@ TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_7_VALUES(Uplo,
                                            StrictUpper,
                                            StrictLower)
 
-/**
- * @brief General access.
- *
- * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= n     in a m-by-n matrix.
- *
- *      x x x x x
- *      x x x x x
- *      x x x x x
- *      x x x x x
- */
-struct generalAccess_t {
-    constexpr operator Uplo() const { return Uplo::General; }
-};
+namespace internal {
+    /**
+     * @brief General access.
+     *
+     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= n     in a m-by-n matrix.
+     *
+     *      x x x x x
+     *      x x x x x
+     *      x x x x x
+     *      x x x x x
+     */
+    struct generalAccess_t {
+        constexpr operator Uplo() const { return Uplo::General; }
+    };
 
-/**
- * @brief Upper Triangle access
- *
- * Pairs (i,j) such that 0 <= i <= j,   0 <= j <= n     in a m-by-n matrix.
- *
- *      x x x x x
- *      0 x x x x
- *      0 0 x x x
- *      0 0 0 x x
- */
-struct upperTriangle_t {
-    constexpr operator Uplo() const { return Uplo::Upper; }
-};
+    /**
+     * @brief Upper Triangle access
+     *
+     * Pairs (i,j) such that 0 <= i <= j,   0 <= j <= n     in a m-by-n matrix.
+     *
+     *      x x x x x
+     *      0 x x x x
+     *      0 0 x x x
+     *      0 0 0 x x
+     */
+    struct upperTriangle_t {
+        constexpr operator Uplo() const { return Uplo::Upper; }
+    };
 
-/**
- * @brief Lower Triangle access
- *
- * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i     in a m-by-n matrix.
- *
- *      x 0 0 0 0
- *      x x 0 0 0
- *      x x x 0 0
- *      x x x x 0
- */
-struct lowerTriangle_t {
-    constexpr operator Uplo() const { return Uplo::Lower; }
-};
+    /**
+     * @brief Lower Triangle access
+     *
+     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i     in a m-by-n matrix.
+     *
+     *      x 0 0 0 0
+     *      x x 0 0 0
+     *      x x x 0 0
+     *      x x x x 0
+     */
+    struct lowerTriangle_t {
+        constexpr operator Uplo() const { return Uplo::Lower; }
+    };
 
-/**
- * @brief Upper Hessenberg access
- *
- * Pairs (i,j) such that 0 <= i <= j+1, 0 <= j <= n     in a m-by-n matrix.
- *
- *      x x x x x
- *      x x x x x
- *      0 x x x x
- *      0 0 x x x
- */
-struct upperHessenberg_t {
-    constexpr operator Uplo() const { return Uplo::UpperHessenberg; }
-};
+    /**
+     * @brief Upper Hessenberg access
+     *
+     * Pairs (i,j) such that 0 <= i <= j+1, 0 <= j <= n     in a m-by-n matrix.
+     *
+     *      x x x x x
+     *      x x x x x
+     *      0 x x x x
+     *      0 0 x x x
+     */
+    struct upperHessenberg_t {
+        constexpr operator Uplo() const { return Uplo::UpperHessenberg; }
+    };
 
-/**
- * @brief Lower Hessenberg access
- *
- * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i+1   in a m-by-n matrix.
- *
- *      x x 0 0 0
- *      x x x 0 0
- *      x x x x 0
- *      x x x x x
- */
-struct lowerHessenberg_t {
-    constexpr operator Uplo() const { return Uplo::LowerHessenberg; }
-};
+    /**
+     * @brief Lower Hessenberg access
+     *
+     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i+1   in a m-by-n matrix.
+     *
+     *      x x 0 0 0
+     *      x x x 0 0
+     *      x x x x 0
+     *      x x x x x
+     */
+    struct lowerHessenberg_t {
+        constexpr operator Uplo() const { return Uplo::LowerHessenberg; }
+    };
 
-/**
- * @brief Strict Upper Triangle access
- *
- * Pairs (i,j) such that 0 <= i <= j-1, 0 <= j <= n     in a m-by-n matrix.
- *
- *      0 x x x x
- *      0 0 x x x
- *      0 0 0 x x
- *      0 0 0 0 x
- */
-struct strictUpper_t {
-    constexpr operator Uplo() const { return Uplo::StrictUpper; }
-};
+    /**
+     * @brief Strict Upper Triangle access
+     *
+     * Pairs (i,j) such that 0 <= i <= j-1, 0 <= j <= n     in a m-by-n matrix.
+     *
+     *      0 x x x x
+     *      0 0 x x x
+     *      0 0 0 x x
+     *      0 0 0 0 x
+     */
+    struct strictUpper_t {
+        constexpr operator Uplo() const { return Uplo::StrictUpper; }
+    };
 
-/**
- * @brief Strict Lower Triangle access
- *
- * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i-1   in a m-by-n matrix.
- *
- *      0 0 0 0 0
- *      x 0 0 0 0
- *      x x 0 0 0
- *      x x x 0 0
- */
-struct strictLower_t {
-    constexpr operator Uplo() const { return Uplo::StrictLower; }
-};
+    /**
+     * @brief Strict Lower Triangle access
+     *
+     * Pairs (i,j) such that 0 <= i <= m,   0 <= j <= i-1   in a m-by-n matrix.
+     *
+     *      0 0 0 0 0
+     *      x 0 0 0 0
+     *      x x 0 0 0
+     *      x x x 0 0
+     */
+    struct strictLower_t {
+        constexpr operator Uplo() const { return Uplo::StrictLower; }
+    };
+}  // namespace internal
 
-// constant expressions
-constexpr generalAccess_t dense = {};
-constexpr upperHessenberg_t upperHessenberg = {};
-constexpr lowerHessenberg_t lowerHessenberg = {};
-constexpr upperTriangle_t upperTriangle = {};
-constexpr lowerTriangle_t lowerTriangle = {};
-constexpr strictUpper_t strictUpper = {};
-constexpr strictLower_t strictLower = {};
+// constant expressions for upper/lower access
+
+/// General access
+constexpr internal::generalAccess_t dense = {};
+/// Upper Hessenberg access
+constexpr internal::upperHessenberg_t upperHessenberg = {};
+/// Lower Hessenberg access
+constexpr internal::lowerHessenberg_t lowerHessenberg = {};
+/// Upper Triangle access
+constexpr internal::upperTriangle_t upperTriangle = {};
+/// Lower Triangle access
+constexpr internal::lowerTriangle_t lowerTriangle = {};
+/// Strict Upper Triangle access
+constexpr internal::strictUpper_t strictUpper = {};
+/// Strict Lower Triangle access
+constexpr internal::strictLower_t strictLower = {};
 
 // -----------------------------------------------------------------------------
 // Information about the main diagonal
 
-enum class Diag : char { NonUnit = 'N', Unit = 'U' };
+enum class Diag : char {
+    NonUnit = 'N',  ///< The main diagonal is not assumed to consist of 1's.
+    Unit = 'U'      ///< The main diagonal is assumed to consist of 1's.
+};
 TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Diag, NonUnit, Unit)
 
-struct nonUnit_diagonal_t {
-    constexpr operator Diag() const { return Diag::NonUnit; }
-};
-struct unit_diagonal_t {
-    constexpr operator Diag() const { return Diag::Unit; }
-};
+namespace internal {
+    struct nonUnit_diagonal_t {
+        constexpr operator Diag() const { return Diag::NonUnit; }
+    };
+    struct unit_diagonal_t {
+        constexpr operator Diag() const { return Diag::Unit; }
+    };
+}  // namespace internal
 
-// constants
-constexpr nonUnit_diagonal_t nonUnit_diagonal = {};
-constexpr unit_diagonal_t unit_diagonal = {};
+// constant expressions about the main diagonal
+
+/// The main diagonal is not assumed to consist of 1's.
+constexpr internal::nonUnit_diagonal_t nonUnit_diagonal = {};
+/// The main diagonal is assumed to consist of 1's.
+constexpr internal::unit_diagonal_t unit_diagonal = {};
 
 // -----------------------------------------------------------------------------
 // Operations over data
 
 enum class Op : char {
-    NoTrans = 'N',
-    Trans = 'T',
-    ConjTrans = 'C',
-    Conj = 3  ///< non-transpose conjugate
+    NoTrans = 'N',    ///< no transpose
+    Trans = 'T',      ///< transpose
+    ConjTrans = 'C',  ///< conjugate transpose
+    Conj = 3          ///< non-transpose conjugate
 };
 TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(Op, NoTrans, Trans, ConjTrans, Conj)
 
-struct noTranspose_t {
-    constexpr operator Op() const { return Op::NoTrans; }
-};
-struct transpose_t {
-    constexpr operator Op() const { return Op::Trans; }
-};
-struct conjTranspose_t {
-    constexpr operator Op() const { return Op::ConjTrans; }
-};
+namespace internal {
+    struct noTranspose_t {
+        constexpr operator Op() const { return Op::NoTrans; }
+    };
+    struct transpose_t {
+        constexpr operator Op() const { return Op::Trans; }
+    };
+    struct conjTranspose_t {
+        constexpr operator Op() const { return Op::ConjTrans; }
+    };
+}  // namespace internal
 
-// Constants
-constexpr noTranspose_t noTranspose = {};
-constexpr transpose_t Transpose = {};
-constexpr conjTranspose_t conjTranspose = {};
+// Constant expressions for operations over data
+
+/// no transpose
+constexpr internal::noTranspose_t noTranspose = {};
+/// transpose
+constexpr internal::transpose_t Transpose = {};
+/// conjugate transpose
+constexpr internal::conjTranspose_t conjTranspose = {};
 
 // -----------------------------------------------------------------------------
 // Sides
 
-enum class Side : char { Left = 'L', Right = 'R' };
+enum class Side : char {
+    Left = 'L',  ///< left side
+    Right = 'R'  ///< right side
+};
 TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Side, Left, Right)
 
-struct left_side_t {
-    constexpr operator Side() const { return Side::Left; }
-};
-struct right_side_t {
-    constexpr operator Side() const { return Side::Right; }
-};
+namespace internal {
+    struct left_side_t {
+        constexpr operator Side() const { return Side::Left; }
+    };
+    struct right_side_t {
+        constexpr operator Side() const { return Side::Right; }
+    };
+}  // namespace internal
 
-// Constants
-constexpr left_side_t left_side{};
-constexpr right_side_t right_side{};
+// Constant expressions for sides
+
+/// left side
+constexpr internal::left_side_t left_side{};
+/// right side
+constexpr internal::right_side_t right_side{};
 
 // -----------------------------------------------------------------------------
 // Norm types
 
 enum class Norm : char {
-    One = '1',  // or 'O'
-    Two = '2',
-    Inf = 'I',
-    Fro = 'F',  // or 'E'
-    Max = 'M',
+    One = '1',  ///< one norm
+    Two = '2',  ///< two norm
+    Inf = 'I',  ///< infinity norm of matrices
+    Fro = 'F',  ///< Frobenius norm of matrices
+    Max = 'M',  ///< max norm
 };
 TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES(Norm, One, Two, Inf, Fro, Max)
 
-struct max_norm_t {
-    constexpr operator Norm() const { return Norm::Max; }
-};
-struct one_norm_t {
-    constexpr operator Norm() const { return Norm::One; }
-};
-struct two_norm_t {
-    constexpr operator Norm() const { return Norm::Two; }
-};
-struct inf_norm_t {
-    constexpr operator Norm() const { return Norm::Inf; }
-};
-struct frob_norm_t {
-    constexpr operator Norm() const { return Norm::Fro; }
-};
+namespace internal {
+    struct max_norm_t {
+        constexpr operator Norm() const { return Norm::Max; }
+    };
+    struct one_norm_t {
+        constexpr operator Norm() const { return Norm::One; }
+    };
+    struct two_norm_t {
+        constexpr operator Norm() const { return Norm::Two; }
+    };
+    struct inf_norm_t {
+        constexpr operator Norm() const { return Norm::Inf; }
+    };
+    struct frob_norm_t {
+        constexpr operator Norm() const { return Norm::Fro; }
+    };
+}  // namespace internal
 
-// Constants
-constexpr max_norm_t max_norm = {};
-constexpr one_norm_t one_norm = {};
-constexpr two_norm_t two_norm = {};
-constexpr inf_norm_t inf_norm = {};
-constexpr frob_norm_t frob_norm = {};
+// Constant expressions for norm types
+
+/// max norm
+constexpr internal::max_norm_t max_norm = {};
+/// one norm
+constexpr internal::one_norm_t one_norm = {};
+/// two norm
+constexpr internal::two_norm_t two_norm = {};
+/// infinity norm of matrices
+constexpr internal::inf_norm_t inf_norm = {};
+/// Frobenius norm of matrices
+constexpr internal::frob_norm_t frob_norm = {};
 
 // -----------------------------------------------------------------------------
 // Directions
 
 enum class Direction : char {
-    Forward = 'F',
-    Backward = 'B',
+    Forward = 'F',   ///< Forward direction
+    Backward = 'B',  ///< Backward direction
 };
 TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Direction, Forward, Backward)
 
-struct forward_t {
-    constexpr operator Direction() const { return Direction::Forward; }
-};
-struct backward_t {
-    constexpr operator Direction() const { return Direction::Backward; }
-};
+namespace internal {
+    struct forward_t {
+        constexpr operator Direction() const { return Direction::Forward; }
+    };
+    struct backward_t {
+        constexpr operator Direction() const { return Direction::Backward; }
+    };
+}  // namespace internal
 
-// Constants
-constexpr forward_t forward{};
-constexpr backward_t backward{};
+// Constant expressions for directions
+
+/// Forward direction
+constexpr internal::forward_t forward{};
+/// Backward direction
+constexpr internal::backward_t backward{};
 
 // -----------------------------------------------------------------------------
 // Storage types
 
 enum class StoreV : char {
-    Columnwise = 'C',
-    Rowwise = 'R',
+    Columnwise = 'C',  ///< Columnwise storage
+    Rowwise = 'R',     ///< Rowwise storage
 };
 TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(StoreV, Columnwise, Rowwise)
 
-struct columnwise_storage_t {
-    constexpr operator StoreV() const { return StoreV::Columnwise; }
-};
-struct rowwise_storage_t {
-    constexpr operator StoreV() const { return StoreV::Rowwise; }
-};
+namespace internal {
+    struct columnwise_storage_t {
+        constexpr operator StoreV() const { return StoreV::Columnwise; }
+    };
+    struct rowwise_storage_t {
+        constexpr operator StoreV() const { return StoreV::Rowwise; }
+    };
+}  // namespace internal
 
-// Constants
-constexpr columnwise_storage_t columnwise_storage{};
-constexpr rowwise_storage_t rowwise_storage{};
+// Constant expressions for storage types
+
+/// Columnwise storage
+constexpr internal::columnwise_storage_t columnwise_storage{};
+/// Rowwise storage
+constexpr internal::rowwise_storage_t rowwise_storage{};
 
 // -----------------------------------------------------------------------------
 // Band access
@@ -359,234 +407,33 @@ constexpr rowwise_storage_t rowwise_storage{};
  *      0 x x x x
  *      0 0 x x x
  */
-struct band_t {
+struct BandAccess {
     std::size_t lower_bandwidth;  ///< Number of subdiagonals.
     std::size_t upper_bandwidth;  ///< Number of superdiagonals.
 
-    constexpr band_t(std::size_t kl, std::size_t ku)
+    /**
+     * @brief Construct a new Band Access object
+     *
+     * @param kl Number of subdiagonals.
+     * @param ku Number of superdiagonals.
+     */
+    constexpr BandAccess(std::size_t kl, std::size_t ku)
         : lower_bandwidth(kl), upper_bandwidth(ku)
     {}
 };
 
-}  // namespace tlapack
-
-#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES
-#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES
-#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES
-#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_7_VALUES
-
-namespace tlapack {
-
 // -----------------------------------------------------------------------------
-// for any combination of types, determine associated real, scalar,
-// and complex types.
-//
-// real_type< float >                               is float
-// real_type< float, double, complex<float> >       is double
-//
-// scalar_type< float >                             is float
-// scalar_type< float, complex<float> >             is complex<float>
-// scalar_type< float, double, complex<float> >     is complex<double>
-//
-// complex_type< float >                            is complex<float>
-// complex_type< float, double >                    is complex<double>
-// complex_type< float, double, complex<float> >    is complex<double>
-//
-// Adds promotion of complex types based on the common type of the associated
-// real types. This fixes various cases:
-//
-// std::std::common_type_t< double, complex<float> > is complex<float>  (wrong)
-//        scalar_type< double, complex<float> > is complex<double> (right)
-//
-// std::std::common_type_t< int, complex<long> > is not defined (compile error)
-//        scalar_type< int, complex<long> > is complex<long> (right)
-
-namespace internal {
-    template <typename... Types>
-    struct real_type_traits;
-
-    template <typename... Types>
-    struct complex_type_traits;
-
-    template <typename... Types>
-    struct scalar_type_traits;
-}  // namespace internal
-
-/// define real_type<> type alias
-template <typename... Types>
-using real_type = typename internal::real_type_traits<Types..., int>::type;
-
-/// define complex_type<> type alias
-template <typename... Types>
-using complex_type =
-    typename internal::complex_type_traits<Types..., int>::type;
-
-/// define scalar_type<> type alias
-template <typename... Types>
-using scalar_type = typename internal::scalar_type_traits<Types..., int>::type;
-
-/// True if T is real_type<T>
-template <typename T>
-struct is_real {
-    static constexpr bool value =
-        std::is_same_v<real_type<T>, typename std::decay<T>::type>;
-};
-
-/// True if T is complex_type<T>
-template <typename T>
-struct is_complex {
-    static constexpr bool value =
-        std::is_same_v<complex_type<T>, typename std::decay<T>::type>;
-};
-
-namespace internal {
-
-    // for one std arithmetic type
-    template <typename T>
-    struct real_type_traits<
-        T,
-        std::enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
-        using type = typename std::decay<T>::type;
-    };
-
-    template <typename T>
-    struct real_type_traits<const T, int> {
-        using type = real_type<T>;
-    };
-
-    // for one complex type, strip complex
-    template <typename T>
-    struct real_type_traits<std::complex<T>, int> {
-        using type = real_type<T>;
-    };
-
-    // pointers and references don't have a real type
-    template <typename T>
-    struct real_type_traits<
-        T,
-        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
-        using type = void;
-    };
-
-    // for two or more types
-    template <typename T1, typename T2, typename... Types>
-    struct real_type_traits<T1, T2, Types...> {
-        using type =
-            std::common_type_t<typename real_type_traits<T1, int>::type,
-                               typename real_type_traits<T2, Types...>::type>;
-    };
-
-    // for one std arithmetic type
-    template <typename T>
-    struct complex_type_traits<
-        T,
-        std::enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
-        using type = std::complex<real_type<T>>;
-    };
-
-    template <typename T>
-    struct complex_type_traits<const T, int> {
-        using type = complex_type<T>;
-    };
-
-    // for one complex type, strip complex
-    template <typename T>
-    struct complex_type_traits<std::complex<T>, int> {
-        using type = std::complex<real_type<T>>;
-    };
-
-    // pointers and references don't have a complex type
-    template <typename T>
-    struct complex_type_traits<
-        T,
-        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
-        using type = void;
-    };
-
-    // for two or more types
-    template <typename T1, typename T2, typename... Types>
-    struct complex_type_traits<T1, T2, Types...> {
-        using type =
-            complex_type<typename real_type_traits<T1, T2, Types...>::type>;
-    };
-
-    // for one type
-    template <typename T>
-    struct scalar_type_traits<T, int> : scalar_type_traits<T, T, int> {};
-
-    // for two types, one is complex
-    template <typename T1, typename T2>
-    struct scalar_type_traits<
-        T1,
-        T2,
-        std::enable_if_t<is_complex<T1>::value || is_complex<T2>::value, int>> {
-        using type = complex_type<T1, T2>;
-    };
-
-    // for two types, neither is complex
-    template <typename T1, typename T2>
-    struct scalar_type_traits<
-        T1,
-        T2,
-        std::enable_if_t<is_real<T1>::value && is_real<T2>::value, int>> {
-        using type = real_type<T1, T2>;
-    };
-
-    // for three or more types
-    template <typename T1, typename T2, typename... Types>
-    struct scalar_type_traits<T1, T2, Types...> {
-        using type =
-            typename scalar_type_traits<scalar_type<T1, T2>, Types...>::type;
-    };
-
-    /**
-     * @brief Data type trait.
-     *
-     * The data type is defined on @c type_trait<array_t>::type.
-     *
-     * @tparam T A non-array class.
-     */
-    template <class T, typename = int>
-    struct type_trait {
-        using type = void;
-    };
-
-    /**
-     * @brief Size type trait.
-     *
-     * The size type is defined on @c sizet_trait<array_t>::type.
-     *
-     * @tparam T A non-array class.
-     */
-    template <class T, typename = int>
-    struct sizet_trait {
-        using type = std::size_t;
-    };
-
-}  // namespace internal
-
-/// Alias for @c type_trait<>::type.
-template <class array_t>
-using type_t = typename internal::type_trait<array_t>::type;
-
-/// Alias for @c sizet_trait<>::type.
-template <class array_t>
-using size_type = typename internal::sizet_trait<array_t>::type;
-
 // Workspace
 
 /// Byte type
 using byte = unsigned char;
-/// Byte allocator
-using byteAlloc = std::allocator<byte>;
 /// Vector of bytes. May use a specialized allocator in future
-using vectorOfBytes = std::vector<byte, byteAlloc>;
+using VectorOfBytes = std::vector<byte, std::allocator<byte>>;
 
 // -----------------------------------------------------------------------------
 // Legacy matrix and vector structures
 
 namespace legacy {
-
     /**
      * @brief Describes a row- or column-major matrix
      *
@@ -594,7 +441,7 @@ namespace legacy {
      * @tparam idx_t Integer type of the size attributes.
      */
     template <class T, class idx_t>
-    struct matrix {
+    struct Matrix {
         Layout layout;
         idx_t m;
         idx_t n;
@@ -609,14 +456,17 @@ namespace legacy {
      * @tparam idx_t Integer type of the size attributes.
      */
     template <class T, class idx_t>
-    struct vector {
+    struct Vector {
         idx_t n;
         T* ptr;
         idx_t inc;
     };
-
 }  // namespace legacy
-
 }  // namespace tlapack
+
+#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES
+#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES
+#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES
+#undef TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_7_VALUES
 
 #endif  // TLAPACK_TYPES_HH

--- a/include/tlapack/base/workspace.hpp
+++ b/include/tlapack/base/workspace.hpp
@@ -45,7 +45,7 @@ struct Workspace {
     }
 
     template <class T, class idx_t>
-    inline constexpr Workspace(const legacy::matrix<T, idx_t>& A)
+    inline constexpr Workspace(const legacy::Matrix<T, idx_t>& A)
         : ptr((byte*)A.ptr), ldim(A.ldim * sizeof(T))
     {
         tlapack_check(A.layout == Layout::ColMajor ||

--- a/include/tlapack/blas/asum.hpp
+++ b/include/tlapack/blas/asum.hpp
@@ -42,7 +42,8 @@ auto asum(vector_t const& x)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_VECTOR vector_t, enable_if_allow_optblas_t<vector_t> = 0>
+template <TLAPACK_LEGACY_VECTOR vector_t,
+          enable_if_allow_optblas_t<vector_t> = 0>
 inline auto asum(vector_t const& x)
 {
     // Legacy objects

--- a/include/tlapack/blas/axpy.hpp
+++ b/include/tlapack/blas/axpy.hpp
@@ -47,8 +47,8 @@ void axpy(const alpha_t& alpha, const vectorX_t& x, vectorY_t& y)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<vectorY_t>,
           enable_if_allow_optblas_t<pair<alpha_t, T>,

--- a/include/tlapack/blas/copy.hpp
+++ b/include/tlapack/blas/copy.hpp
@@ -45,8 +45,8 @@ void copy(const vectorX_t& x, vectorY_t& y)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <
-    TLAPACK_VECTOR vectorX_t,
-    TLAPACK_VECTOR vectorY_t,
+    TLAPACK_LEGACY_VECTOR vectorX_t,
+    TLAPACK_LEGACY_VECTOR vectorY_t,
     class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
 inline void copy(const vectorX_t& x, vectorY_t& y)

--- a/include/tlapack/blas/dot.hpp
+++ b/include/tlapack/blas/dot.hpp
@@ -50,8 +50,8 @@ auto dot(const vectorX_t& x, const vectorY_t& y)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <
-    TLAPACK_VECTOR vectorX_t,
-    TLAPACK_VECTOR vectorY_t,
+    TLAPACK_LEGACY_VECTOR vectorX_t,
+    TLAPACK_LEGACY_VECTOR vectorY_t,
     class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
 inline auto dot(const vectorX_t& x, const vectorY_t& y)

--- a/include/tlapack/blas/dotu.hpp
+++ b/include/tlapack/blas/dotu.hpp
@@ -50,8 +50,8 @@ auto dotu(const vectorX_t& x, const vectorY_t& y)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <
-    TLAPACK_VECTOR vectorX_t,
-    TLAPACK_VECTOR vectorY_t,
+    TLAPACK_LEGACY_VECTOR vectorX_t,
+    TLAPACK_LEGACY_VECTOR vectorY_t,
     class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
 inline auto dotu(const vectorX_t& x, const vectorY_t& y)

--- a/include/tlapack/blas/gemm.hpp
+++ b/include/tlapack/blas/gemm.hpp
@@ -212,9 +212,9 @@ void gemm(Op transA,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixB_t,
-          TLAPACK_MATRIX matrixC_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixB_t,
+          TLAPACK_LEGACY_MATRIX matrixC_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<matrixC_t>,

--- a/include/tlapack/blas/gemv.hpp
+++ b/include/tlapack/blas/gemv.hpp
@@ -139,9 +139,9 @@ void gemv(Op trans,
 *
 * @ingroup blas2
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<vectorY_t>,

--- a/include/tlapack/blas/ger.hpp
+++ b/include/tlapack/blas/ger.hpp
@@ -65,9 +65,9 @@ void ger(const alpha_t& alpha,
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<matrixA_t>,
           enable_if_allow_optblas_t<pair<alpha_t, T>,

--- a/include/tlapack/blas/geru.hpp
+++ b/include/tlapack/blas/geru.hpp
@@ -66,9 +66,9 @@ void geru(const alpha_t& alpha,
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<matrixA_t>,
           enable_if_allow_optblas_t<pair<alpha_t, T>,

--- a/include/tlapack/blas/hemm.hpp
+++ b/include/tlapack/blas/hemm.hpp
@@ -188,9 +188,9 @@ void hemm(Side side,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixB_t,
-          TLAPACK_MATRIX matrixC_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixB_t,
+          TLAPACK_LEGACY_MATRIX matrixC_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<matrixC_t>,

--- a/include/tlapack/blas/hemv.hpp
+++ b/include/tlapack/blas/hemv.hpp
@@ -105,9 +105,9 @@ void hemv(Uplo uplo,
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<vectorY_t>,

--- a/include/tlapack/blas/her.hpp
+++ b/include/tlapack/blas/her.hpp
@@ -44,7 +44,7 @@ template <TLAPACK_MATRIX matrixA_t,
           TLAPACK_REAL alpha_t,
           enable_if_t<(
                           /* Requires: */
-                          is_real<alpha_t>::value),
+                          is_real<alpha_t>),
                       int> = 0,
           class T = type_t<matrixA_t>,
           disable_if_allow_optblas_t<pair<alpha_t, real_type<T> >,
@@ -86,8 +86,8 @@ void her(Uplo uplo, const alpha_t& alpha, const vectorX_t& x, matrixA_t& A)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
           TLAPACK_REAL alpha_t,
           class T = type_t<matrixA_t>,
           enable_if_allow_optblas_t<pair<alpha_t, real_type<T> >,

--- a/include/tlapack/blas/her2.hpp
+++ b/include/tlapack/blas/her2.hpp
@@ -93,9 +93,9 @@ void her2(Uplo uplo,
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<matrixA_t>,
           enable_if_allow_optblas_t<pair<alpha_t, T>,

--- a/include/tlapack/blas/her2k.hpp
+++ b/include/tlapack/blas/her2k.hpp
@@ -61,7 +61,7 @@ template <TLAPACK_MATRIX matrixA_t,
           TLAPACK_REAL beta_t,
           enable_if_t<(
                           /* Requires: */
-                          is_real<beta_t>::value),
+                          is_real<beta_t>),
                       int> = 0,
           class T = type_t<matrixC_t>,
           disable_if_allow_optblas_t<pair<matrixA_t, T>,
@@ -207,14 +207,14 @@ void her2k(Uplo uplo,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixB_t,
-          TLAPACK_MATRIX matrixC_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixB_t,
+          TLAPACK_LEGACY_MATRIX matrixC_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_REAL beta_t,
           enable_if_t<(
                           /* Requires: */
-                          is_real<beta_t>::value),
+                          is_real<beta_t>),
                       int> = 0,
           class T = type_t<matrixC_t>,
           enable_if_allow_optblas_t<pair<matrixA_t, T>,

--- a/include/tlapack/blas/herk.hpp
+++ b/include/tlapack/blas/herk.hpp
@@ -58,7 +58,7 @@ template <TLAPACK_MATRIX matrixA_t,
           TLAPACK_REAL beta_t,
           enable_if_t<(
                           /* Requires: */
-                          is_real<alpha_t>::value && is_real<beta_t>::value),
+                          is_real<alpha_t> && is_real<beta_t>),
                       int> = 0,
           class T = type_t<matrixC_t>,
           disable_if_allow_optblas_t<pair<matrixA_t, T>,
@@ -182,8 +182,8 @@ void herk(Uplo uplo,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixC_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixC_t,
           TLAPACK_REAL alpha_t,
           TLAPACK_REAL beta_t,
           class T = type_t<matrixC_t>,

--- a/include/tlapack/blas/iamax.hpp
+++ b/include/tlapack/blas/iamax.hpp
@@ -102,7 +102,7 @@ size_type<vector_t> iamax_ec(const vector_t& x, abs_f absf)
             return i;
         }
         else {  // still no Inf found yet
-            if (is_real<T>::value) {
+            if (is_real<T>) {
                 real_t a = absf(x[i]);
                 if (a > smax) {
                     smax = a;
@@ -180,7 +180,7 @@ size_type<vector_t> iamax_nc(const vector_t& x, abs_f absf)
             return i;
         }
         else {  // still no Inf found yet
-            if (is_real<T>::value) {
+            if (is_real<T>) {
                 real_t a = absf(x[i]);
                 if (a > smax) {
                     smax = a;
@@ -270,7 +270,8 @@ inline size_type<vector_t> iamax(const vector_t& x)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_VECTOR vector_t, enable_if_allow_optblas_t<vector_t> = 0>
+template <TLAPACK_LEGACY_VECTOR vector_t,
+          enable_if_allow_optblas_t<vector_t> = 0>
 inline size_type<vector_t> iamax(vector_t const& x)
 {
     // Legacy objects

--- a/include/tlapack/blas/nrm2.hpp
+++ b/include/tlapack/blas/nrm2.hpp
@@ -44,7 +44,8 @@ inline auto nrm2(const vector_t& x)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_VECTOR vector_t, enable_if_allow_optblas_t<vector_t> = 0>
+template <TLAPACK_LEGACY_VECTOR vector_t,
+          enable_if_allow_optblas_t<vector_t> = 0>
 inline auto nrm2(vector_t const& x)
 {
     // Legacy objects

--- a/include/tlapack/blas/rot.hpp
+++ b/include/tlapack/blas/rot.hpp
@@ -65,8 +65,8 @@ void rot(vectorX_t& x, vectorY_t& y, const c_type& c, const s_type& s)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_REAL c_type,
           TLAPACK_SCALAR s_type,
           class T = type_t<vectorX_t>,

--- a/include/tlapack/blas/rotg.hpp
+++ b/include/tlapack/blas/rotg.hpp
@@ -34,7 +34,7 @@ namespace tlapack {
  * @ingroup blas1
  */
 template <TLAPACK_REAL T,
-          enable_if_t<is_real<T>::value, int> = 0,
+          enable_if_t<is_real<T>, int> = 0,
           disable_if_allow_optblas_t<T> = 0>
 void rotg(T& a, T& b, T& c, T& s)
 {
@@ -101,7 +101,7 @@ void rotg(T& a, T& b, T& c, T& s)
  * @ingroup blas1
  */
 template <TLAPACK_COMPLEX T,
-          enable_if_t<is_complex<T>::value, int> = 0,
+          enable_if_t<is_complex<T>, int> = 0,
           disable_if_allow_optblas_t<T> = 0>
 void rotg(T& a, const T& b, real_type<T>& c, T& s)
 {
@@ -197,7 +197,7 @@ void rotg(T& a, const T& b, real_type<T>& c, T& s)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <TLAPACK_REAL T,
-          enable_if_t<is_real<T>::value, int> = 0,
+          enable_if_t<is_real<T>, int> = 0,
           enable_if_allow_optblas_t<T> = 0>
 inline void rotg(T& a, T& b, T& c, T& s)
 {
@@ -221,7 +221,7 @@ inline void rotg(T& a, T& b, T& c, T& s)
 }
 
 template <TLAPACK_COMPLEX T,
-          enable_if_t<is_complex<T>::value, int> = 0,
+          enable_if_t<is_complex<T>, int> = 0,
           enable_if_allow_optblas_t<T> = 0>
 inline void rotg(T& a, const T& b, real_type<T>& c, T& s)
 {

--- a/include/tlapack/blas/rotm.hpp
+++ b/include/tlapack/blas/rotm.hpp
@@ -110,8 +110,8 @@ void rotm(vectorX_t& x, vectorY_t& y, const T h[4])
 
 template <
     int flag,
-    TLAPACK_VECTOR vectorX_t,
-    TLAPACK_VECTOR vectorY_t,
+    TLAPACK_LEGACY_VECTOR vectorX_t,
+    TLAPACK_LEGACY_VECTOR vectorY_t,
     enable_if_t<((-2 <= flag) && (flag <= 1)), int> = 0,
     class T = type_t<vectorX_t>,
     enable_if_t<is_same_v<T, real_type<T> >, int> = 0,

--- a/include/tlapack/blas/rotmg.hpp
+++ b/include/tlapack/blas/rotmg.hpp
@@ -90,7 +90,7 @@ namespace tlapack {
  * @ingroup blas1
  */
 template <TLAPACK_REAL T,
-          enable_if_t<is_real<T>::value, int> = 0,
+          enable_if_t<is_real<T>, int> = 0,
           disable_if_allow_optblas_t<T> = 0>
 int rotmg(T& d1, T& d2, T& a, const T& b, T h[4])
 {
@@ -215,7 +215,7 @@ int rotmg(T& d1, T& d2, T& a, const T& b, T h[4])
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <TLAPACK_REAL T,
-          enable_if_t<is_real<T>::value, int> = 0,
+          enable_if_t<is_real<T>, int> = 0,
           enable_if_allow_optblas_t<T> = 0>
 inline int rotmg(T& d1, T& d2, T& a, const T b, T h[4])
 {

--- a/include/tlapack/blas/scal.hpp
+++ b/include/tlapack/blas/scal.hpp
@@ -40,7 +40,7 @@ void scal(const alpha_t& alpha, vector_t& x)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_VECTOR vector_t,
+template <TLAPACK_LEGACY_VECTOR vector_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<vector_t>,
           enable_if_allow_optblas_t<pair<alpha_t, T>, pair<vector_t, T> > = 0>

--- a/include/tlapack/blas/swap.hpp
+++ b/include/tlapack/blas/swap.hpp
@@ -49,8 +49,8 @@ void swap(vectorX_t& x, vectorY_t& y)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <
-    TLAPACK_VECTOR vectorX_t,
-    TLAPACK_VECTOR vectorY_t,
+    TLAPACK_LEGACY_VECTOR vectorX_t,
+    TLAPACK_LEGACY_VECTOR vectorY_t,
     class T = type_t<vectorY_t>,
     enable_if_allow_optblas_t<pair<vectorX_t, T>, pair<vectorY_t, T> > = 0>
 inline void swap(vectorX_t& x, vectorY_t& y)

--- a/include/tlapack/blas/symm.hpp
+++ b/include/tlapack/blas/symm.hpp
@@ -186,9 +186,9 @@ void symm(Side side,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixB_t,
-          TLAPACK_MATRIX matrixC_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixB_t,
+          TLAPACK_LEGACY_MATRIX matrixC_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<matrixC_t>,

--- a/include/tlapack/blas/symv.hpp
+++ b/include/tlapack/blas/symv.hpp
@@ -102,9 +102,9 @@ void symv(Uplo uplo,
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<vectorY_t>,

--- a/include/tlapack/blas/syr.hpp
+++ b/include/tlapack/blas/syr.hpp
@@ -74,8 +74,8 @@ void syr(Uplo uplo, const alpha_t& alpha, const vectorX_t& x, matrixA_t& A)
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<matrixA_t>,
           enable_if_allow_optblas_t<pair<alpha_t, T>,

--- a/include/tlapack/blas/syr2.hpp
+++ b/include/tlapack/blas/syr2.hpp
@@ -85,9 +85,9 @@ void syr2(Uplo uplo,
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_VECTOR vectorX_t,
-          TLAPACK_VECTOR vectorY_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_VECTOR vectorX_t,
+          TLAPACK_LEGACY_VECTOR vectorY_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<matrixA_t>,
           enable_if_allow_optblas_t<pair<alpha_t, T>,

--- a/include/tlapack/blas/syr2k.hpp
+++ b/include/tlapack/blas/syr2k.hpp
@@ -170,9 +170,9 @@ void syr2k(Uplo uplo,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixB_t,
-          TLAPACK_MATRIX matrixC_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixB_t,
+          TLAPACK_LEGACY_MATRIX matrixC_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<matrixC_t>,

--- a/include/tlapack/blas/syrk.hpp
+++ b/include/tlapack/blas/syrk.hpp
@@ -152,8 +152,8 @@ void syrk(Uplo uplo,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixC_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixC_t,
           TLAPACK_SCALAR alpha_t,
           TLAPACK_SCALAR beta_t,
           class T = type_t<matrixC_t>,

--- a/include/tlapack/blas/trmm.hpp
+++ b/include/tlapack/blas/trmm.hpp
@@ -297,8 +297,8 @@ void trmm(Side side,
 *
 * @ingroup blas3
 */
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixB_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixB_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<matrixB_t>,
           enable_if_allow_optblas_t<pair<matrixA_t, T>,

--- a/include/tlapack/blas/trmv.hpp
+++ b/include/tlapack/blas/trmv.hpp
@@ -178,8 +178,8 @@ void trmv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <
-    TLAPACK_MATRIX matrixA_t,
-    TLAPACK_VECTOR vectorX_t,
+    TLAPACK_LEGACY_MATRIX matrixA_t,
+    TLAPACK_LEGACY_VECTOR vectorX_t,
     class T = type_t<vectorX_t>,
     enable_if_allow_optblas_t<pair<matrixA_t, T>, pair<vectorX_t, T> > = 0>
 inline void trmv(

--- a/include/tlapack/blas/trsm.hpp
+++ b/include/tlapack/blas/trsm.hpp
@@ -267,8 +267,8 @@ void trsm(Side side,
 
 #ifdef USE_LAPACKPP_WRAPPERS
 
-template <TLAPACK_MATRIX matrixA_t,
-          TLAPACK_MATRIX matrixB_t,
+template <TLAPACK_LEGACY_MATRIX matrixA_t,
+          TLAPACK_LEGACY_MATRIX matrixB_t,
           TLAPACK_SCALAR alpha_t,
           class T = type_t<matrixB_t>,
           enable_if_allow_optblas_t<pair<matrixA_t, T>,

--- a/include/tlapack/blas/trsv.hpp
+++ b/include/tlapack/blas/trsv.hpp
@@ -206,8 +206,8 @@ void trsv(Uplo uplo, Op trans, Diag diag, const matrixA_t& A, vectorX_t& x)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <
-    TLAPACK_MATRIX matrixA_t,
-    TLAPACK_VECTOR vectorX_t,
+    TLAPACK_LEGACY_MATRIX matrixA_t,
+    TLAPACK_LEGACY_VECTOR vectorX_t,
     class T = type_t<vectorX_t>,
     enable_if_allow_optblas_t<pair<matrixA_t, T>, pair<vectorX_t, T> > = 0>
 inline void trsv(

--- a/include/tlapack/lapack/gebd2.hpp
+++ b/include/tlapack/lapack/gebd2.hpp
@@ -46,6 +46,7 @@ inline constexpr workinfo_t gebd2_worksize(const matrix_t& A,
                                            const gebd2_opts_t& opts = {})
 {
     using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -53,13 +54,13 @@ inline constexpr workinfo_t gebd2_worksize(const matrix_t& A,
 
     workinfo_t workinfo;
     if (n > 1) {
-        auto A11 = cols(A, range<idx_t>{1, n});
+        auto A11 = cols(A, range{1, n});
         workinfo = larf_worksize(left_side, forward, columnwise_storage,
                                  col(A, 0), tauv[0], A11, opts);
 
         if (m > 1) {
-            auto B11 = rows(A11, range<idx_t>{1, m});
-            auto row0 = slice(A, 0, range<idx_t>{1, n});
+            auto B11 = rows(A11, range{1, m});
+            auto row0 = slice(A, 0, range{1, n});
 
             workinfo.minMax(larf_worksize(right_side, forward, rowwise_storage,
                                           row0, tauw[0], B11, opts));
@@ -125,7 +126,7 @@ int gebd2(matrix_t& A,
           const gebd2_opts_t& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using T = type_t<matrix_t>;
 
     // constants
@@ -140,7 +141,7 @@ int gebd2(matrix_t& A,
     if (n <= 0) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = gebd2_worksize(A, tauv, tauw, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/gebrd.hpp
+++ b/include/tlapack/lapack/gebrd.hpp
@@ -145,7 +145,7 @@ int gebrd(matrix_t& A,
 {
     using idx_t = size_type<matrix_t>;
     using work_t = matrix_type<matrix_t, vector_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using TA = type_t<matrix_t>;
     using real_t = real_type<TA>;
 
@@ -161,7 +161,7 @@ int gebrd(matrix_t& A,
     const idx_t nb = min(opts.nb, k);
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = gebrd_worksize(A, d, e, tauq, taup, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -182,25 +182,25 @@ int gebrd(matrix_t& A,
         // Reduce rows and columns i:i+ib-1 to bidiagonal form and return
         // the matrices X and Y which are needed to update the unreduced
         // part of the matrix
-        auto A2 = slice(A, pair{i, m}, pair{i, n});
-        auto d2 = slice(d, pair{i, i + ib});
-        auto e2 = slice(e, pair{i, i + ib});
-        auto tauq2 = slice(tauq, pair{i, i + ib});
-        auto taup2 = slice(taup, pair{i, i + ib});
-        auto X2 = slice(X, pair{i, m}, pair{0, ib});
-        auto Y2 = slice(Y, pair{i, n}, pair{0, ib});
+        auto A2 = slice(A, range{i, m}, range{i, n});
+        auto d2 = slice(d, range{i, i + ib});
+        auto e2 = slice(e, range{i, i + ib});
+        auto tauq2 = slice(tauq, range{i, i + ib});
+        auto taup2 = slice(taup, range{i, i + ib});
+        auto X2 = slice(X, range{i, m}, range{0, ib});
+        auto Y2 = slice(Y, range{i, n}, range{0, ib});
         labrd(A2, d2, e2, tauq2, taup2, X2, Y2);
 
         //
         // Update the trailing submatrix A(i+nb:m,i+nb:n), using an update
         // of the form  A := A - V*Y**H - X*U**H
         //
-        auto A3 = slice(A, pair{i + ib, m}, pair{i + ib, n});
-        auto V = slice(A, pair{i + ib, m}, pair{i, i + ib});
-        auto Y3 = slice(Y, pair{i + ib, n}, pair{0, ib});
+        auto A3 = slice(A, range{i + ib, m}, range{i + ib, n});
+        auto V = slice(A, range{i + ib, m}, range{i, i + ib});
+        auto Y3 = slice(Y, range{i + ib, n}, range{0, ib});
         gemm(noTranspose, conjTranspose, -one, V, Y3, one, A3);
-        auto U = slice(A, pair{i, i + ib}, pair{i + ib, n});
-        auto X3 = slice(X, pair{i + ib, m}, pair{0, ib});
+        auto U = slice(A, range{i, i + ib}, range{i + ib, n});
+        auto X3 = slice(X, range{i + ib, m}, range{0, ib});
         gemm(noTranspose, noTranspose, -one, X3, U, one, A3);
 
         //

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -36,12 +36,13 @@ inline constexpr workinfo_t gelq2_worksize(const matrix_t& A,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
 
     if (m > 1) {
-        auto C = rows(A, range<idx_t>{1, m});
+        auto C = rows(A, range{1, m});
         return larf_worksize(right_side, forward, rowwise_storage, row(A, 0),
                              tauw[0], C, opts);
     }
@@ -90,7 +91,7 @@ template <TLAPACK_SMATRIX matrix_t, TLAPACK_VECTOR vector_t>
 int gelq2(matrix_t& A, vector_t& tauw, const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -101,7 +102,7 @@ int gelq2(matrix_t& A, vector_t& tauw, const workspace_opts_t<>& opts = {})
     tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = gelq2_worksize(A, tauw, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/gelqf.hpp
+++ b/include/tlapack/lapack/gelqf.hpp
@@ -49,6 +49,7 @@ inline constexpr workinfo_t gelqf_worksize(
 {
     using idx_t = size_type<A_t>;
     using T = type_t<A_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -57,10 +58,10 @@ inline constexpr workinfo_t gelqf_worksize(
     const idx_t nb = opts.nb;
     const idx_t ib = std::min<idx_t>(nb, k);
 
-    auto A11 = rows(A, range<idx_t>(0, ib));
-    auto TT1 = slice(A, range<idx_t>(0, ib), range<idx_t>(0, ib));
-    auto A12 = slice(A, range<idx_t>(ib, m), range<idx_t>(0, n));
-    auto tauw1 = slice(tau, range<idx_t>(0, ib));
+    auto A11 = rows(A, range(0, ib));
+    auto TT1 = slice(A, range(0, ib), range(0, ib));
+    auto A12 = slice(A, range(ib, m), range(0, n));
+    auto tauw1 = slice(tau, range(0, ib));
 
     workinfo_t workinfo = gelq2_worksize(A11, tauw1);
     workinfo.minMax(larfb_worksize(Side::Right, Op::NoTrans, Direction::Forward,
@@ -112,7 +113,7 @@ int gelqf(A_t& A, tau_t& tau, const gelqf_opts_t<size_type<A_t>>& opts = {})
     Create<A_t> new_matrix;
 
     using idx_t = size_type<A_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -124,7 +125,7 @@ int gelqf(A_t& A, tau_t& tau, const gelqf_opts_t<size_type<A_t>>& opts = {})
     tlapack_check((idx_t)size(tau) >= k);
 
     // Allocate or get workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = gelqf_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/gelqt.hpp
+++ b/include/tlapack/lapack/gelqt.hpp
@@ -44,6 +44,7 @@ inline constexpr workinfo_t gelqt_worksize(const matrix_t& A,
                                            const gelqt_opts_t& opts = {})
 {
     using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -52,8 +53,8 @@ inline constexpr workinfo_t gelqt_worksize(const matrix_t& A,
     const idx_t nb = ncols(TT);
     const idx_t ib = std::min<idx_t>(nb, k);
 
-    auto TT1 = slice(TT, range<idx_t>(0, ib), range<idx_t>(0, ib));
-    auto A11 = rows(A, range<idx_t>(0, ib));
+    auto TT1 = slice(TT, range(0, ib), range(0, ib));
+    auto A11 = rows(A, range(0, ib));
     auto tauw1 = diag(TT1);
 
     return gelq2_worksize(A11, tauw1, opts);
@@ -111,7 +112,7 @@ template <TLAPACK_SMATRIX matrix_t>
 int gelqt(matrix_t& A, matrix_t& TT, const gelqt_opts_t& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -123,7 +124,7 @@ int gelqt(matrix_t& A, matrix_t& TT, const gelqt_opts_t& opts = {})
     tlapack_check_false(nrows(TT) < m || ncols(TT) < nb);
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = gelqt_worksize(A, TT, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/geqlf.hpp
+++ b/include/tlapack/lapack/geqlf.hpp
@@ -49,6 +49,7 @@ inline constexpr workinfo_t geqlf_worksize(
 {
     using idx_t = size_type<A_t>;
     using T = type_t<A_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -57,10 +58,10 @@ inline constexpr workinfo_t geqlf_worksize(
     const idx_t nb = opts.nb;
     const idx_t ib = std::min<idx_t>(nb, k);
 
-    auto A11 = cols(A, range<idx_t>(0, ib));
-    auto TT1 = slice(A, range<idx_t>(0, ib), range<idx_t>(0, ib));
-    auto A12 = slice(A, range<idx_t>(0, m), range<idx_t>(ib, n));
-    auto tauw1 = slice(tau, range<idx_t>(0, ib));
+    auto A11 = cols(A, range(0, ib));
+    auto TT1 = slice(A, range(0, ib), range(0, ib));
+    auto A12 = slice(A, range(0, m), range(ib, n));
+    auto tauw1 = slice(tau, range(0, ib));
 
     workinfo_t workinfo = geql2_worksize(A11, tauw1);
     workinfo.minMax(larfb_worksize(Side::Left, Op::ConjTrans,
@@ -113,7 +114,7 @@ int geqlf(A_t& A, tau_t& tau, const geqlf_opts_t<size_type<A_t>>& opts = {})
     Create<A_t> new_matrix;
 
     using idx_t = size_type<A_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -125,7 +126,7 @@ int geqlf(A_t& A, tau_t& tau, const geqlf_opts_t<size_type<A_t>>& opts = {})
     tlapack_check((idx_t)size(tau) >= k);
 
     // Allocate or get workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = geqlf_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/geqrf.hpp
+++ b/include/tlapack/lapack/geqrf.hpp
@@ -49,6 +49,7 @@ inline constexpr workinfo_t geqrf_worksize(
 {
     using idx_t = size_type<A_t>;
     using T = type_t<A_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -57,10 +58,10 @@ inline constexpr workinfo_t geqrf_worksize(
     const idx_t nb = opts.nb;
     const idx_t ib = std::min<idx_t>(nb, k);
 
-    auto A11 = cols(A, range<idx_t>(0, ib));
-    auto TT1 = slice(A, range<idx_t>(0, ib), range<idx_t>(0, ib));
-    auto A12 = slice(A, range<idx_t>(0, m), range<idx_t>(ib, n));
-    auto tauw1 = slice(tau, range<idx_t>(0, ib));
+    auto A11 = cols(A, range(0, ib));
+    auto TT1 = slice(A, range(0, ib), range(0, ib));
+    auto A12 = slice(A, range(0, m), range(ib, n));
+    auto tauw1 = slice(tau, range(0, ib));
 
     workinfo_t workinfo = geqr2_worksize(A11, tauw1);
     workinfo.minMax(larfb_worksize(Side::Left, Op::ConjTrans,
@@ -114,7 +115,7 @@ int geqrf(A_t& A, tau_t& tau, const geqrf_opts_t<size_type<A_t>>& opts = {})
     Create<A_t> new_matrix;
 
     using idx_t = size_type<A_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -126,7 +127,7 @@ int geqrf(A_t& A, tau_t& tau, const geqrf_opts_t<size_type<A_t>>& opts = {})
     tlapack_check((idx_t)size(tau) >= k);
 
     // Allocate or get workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = geqrf_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/gerqf.hpp
+++ b/include/tlapack/lapack/gerqf.hpp
@@ -49,6 +49,7 @@ inline constexpr workinfo_t gerqf_worksize(
 {
     using idx_t = size_type<A_t>;
     using T = type_t<A_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -57,10 +58,10 @@ inline constexpr workinfo_t gerqf_worksize(
     const idx_t nb = opts.nb;
     const idx_t ib = std::min<idx_t>(nb, k);
 
-    auto A11 = rows(A, range<idx_t>(0, ib));
-    auto TT1 = slice(A, range<idx_t>(0, ib), range<idx_t>(0, ib));
-    auto A12 = slice(A, range<idx_t>(ib, m), range<idx_t>(0, n));
-    auto tauw1 = slice(tau, range<idx_t>(0, ib));
+    auto A11 = rows(A, range(0, ib));
+    auto TT1 = slice(A, range(0, ib), range(0, ib));
+    auto A12 = slice(A, range(ib, m), range(0, n));
+    auto tauw1 = slice(tau, range(0, ib));
 
     workinfo_t workinfo = gerq2_worksize(A11, tauw1);
     workinfo.minMax(larfb_worksize(Side::Right, Op::NoTrans,
@@ -116,7 +117,7 @@ int gerqf(A_t& A, tau_t& tau, const gerqf_opts_t<size_type<A_t>>& opts = {})
     Create<A_t> new_matrix;
 
     using idx_t = size_type<A_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -128,7 +129,7 @@ int gerqf(A_t& A, tau_t& tau, const gerqf_opts_t<size_type<A_t>>& opts = {})
     tlapack_check((idx_t)size(tau) >= k);
 
     // Allocate or get workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = gerqf_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/labrd.hpp
+++ b/include/tlapack/lapack/labrd.hpp
@@ -74,7 +74,7 @@ int labrd(A_t& A,
 {
     using TA = type_t<A_t>;
     using idx_t = size_type<A_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using real_t = real_type<TA>;
 
     // constants
@@ -93,19 +93,19 @@ int labrd(A_t& A,
         //
         for (idx_t i = 0; i < nb; ++i) {
             // Update A(i:m,i)
-            auto y = slice(Y, i, pair{0, i});
-            auto A2 = slice(A, pair{i, m}, pair{0, i});
-            auto a21 = slice(A, pair{i, m}, i);
+            auto y = slice(Y, i, range{0, i});
+            auto A2 = slice(A, range{i, m}, range{0, i});
+            auto a21 = slice(A, range{i, m}, i);
             conjugate(y);
             gemv(noTranspose, -one, A2, y, one, a21);
             conjugate(y);
 
-            auto X2 = slice(X, pair{i, m}, pair{0, i});
-            auto a22 = slice(A, pair{0, i}, i);
-            auto a23 = slice(A, pair{i, m}, i);
+            auto X2 = slice(X, range{i, m}, range{0, i});
+            auto a22 = slice(A, range{0, i}, i);
+            auto a23 = slice(A, range{i, m}, i);
             gemv(noTranspose, -one, X2, a22, one, a23);
             // Generate reflection Q(i) to annihilate A(i+1:m,i)
-            auto v = slice(A, pair{i, m}, i);
+            auto v = slice(A, range{i, m}, i);
             larfg(forward, columnwise_storage, v, tauq[i]);
             d[i] = real(A(i, i));
 
@@ -114,23 +114,23 @@ int labrd(A_t& A,
                 //
                 // Compute Y(i+1:n,i) = y11
                 //
-                auto y11 = slice(Y, pair{i + 1, n}, i);
+                auto y11 = slice(Y, range{i + 1, n}, i);
 
                 // y11 = A(i:m,i+1:n)^H * v
-                auto A0 = slice(A, pair{i, m}, pair{i + 1, n});
+                auto A0 = slice(A, range{i, m}, range{i + 1, n});
                 gemv(conjTranspose, one, A0, v, zero, y11);
                 // t = A(i:m,0:i)^H * v
-                auto A1 = slice(A, pair{i, m}, pair{0, i});
-                auto t = slice(Y, pair{0, i}, i);
+                auto A1 = slice(A, range{i, m}, range{0, i});
+                auto t = slice(Y, range{0, i}, i);
                 gemv(conjTranspose, one, A1, v, zero, t);
                 // y11 = y11 - Y(i+1:n,0:i) * t
-                auto Y2 = slice(Y, pair{i + 1, n}, pair{0, i});
+                auto Y2 = slice(Y, range{i + 1, n}, range{0, i});
                 gemv(noTranspose, -one, Y2, t, one, y11);
                 // t = X(i:m,0:i)^H * v
-                auto X2 = slice(X, pair{i, m}, pair{0, i});
+                auto X2 = slice(X, range{i, m}, range{0, i});
                 gemv(conjTranspose, one, X2, v, zero, t);
                 // y11 = y11 - A(0:i,i+1:n)^H * t
-                auto A2 = slice(A, pair{0, i}, pair{i + 1, n});
+                auto A2 = slice(A, range{0, i}, range{i + 1, n});
                 gemv(conjTranspose, -one, A2, t, one, y11);
                 // y11 = y11 * tauq(i)
                 scal(tauq[i], y11);
@@ -138,21 +138,21 @@ int labrd(A_t& A,
                 //
                 // Update A(i,i+1:n) = a11
                 //
-                auto a11 = slice(A, i, pair{i + 1, n});
+                auto a11 = slice(A, i, range{i + 1, n});
 
                 // a11 = conj(a11) - Y(i+1:n,0:i+1)*conj(s)
                 // for (idx_t l = 0; l < n; ++l)
                 //     A(i, l) = conj(A(i, l));
 
-                auto s = slice(A, i, pair{0, i + 1});
+                auto s = slice(A, i, range{0, i + 1});
                 conjugate(a11);
                 conjugate(s);
-                auto Y3 = slice(Y, pair{i + 1, n}, pair{0, i + 1});
+                auto Y3 = slice(Y, range{i + 1, n}, range{0, i + 1});
                 gemv(noTranspose, -one, Y3, s, one, a11);
                 conjugate(s);
                 // a11 = a11 - A(0:i,i+1:n)^H * conj(X(i,0:i))
-                auto A3 = slice(A, pair{0, i}, pair{i + 1, n});
-                auto x = slice(X, i, pair{0, i});
+                auto A3 = slice(A, range{0, i}, range{i + 1, n});
+                auto x = slice(X, i, range{0, i});
                 conjugate(x);
                 gemv(conjTranspose, -one, A3, x, one, a11);
                 conjugate(x);
@@ -160,7 +160,7 @@ int labrd(A_t& A,
                 //
                 // Generate reflection P(i) to annihilate A(i,i+2:n)
                 //
-                auto w = slice(A, i, pair{i + 1, n});
+                auto w = slice(A, i, range{i + 1, n});
                 larfg(forward, columnwise_storage, w, taup[i]);
                 e[i] = real(A(i, i + 1));
                 A(i, i + 1) = one;
@@ -168,24 +168,24 @@ int labrd(A_t& A,
                 //
                 // Compute X(i+1:m,i) = x11
                 //
-                auto x11 = slice(X, pair{i + 1, m}, i);
+                auto x11 = slice(X, range{i + 1, m}, i);
 
                 // x11 = A(i+1:m,i+1:n) * w
-                auto A4 = slice(A, pair{i + 1, m}, pair{i + 1, n});
+                auto A4 = slice(A, range{i + 1, m}, range{i + 1, n});
                 gemv(noTranspose, one, A4, w, zero, x11);
                 // t = Y(i+1:n,0:i+1)^H * w
-                auto Y4 = slice(Y, pair{i + 1, n}, pair{0, i + 1});
-                auto t2 = slice(X, pair{0, i + 1}, i);
+                auto Y4 = slice(Y, range{i + 1, n}, range{0, i + 1});
+                auto t2 = slice(X, range{0, i + 1}, i);
                 gemv(conjTranspose, one, Y4, w, zero, t2);
                 // x11 = x11 - A(i+1:m,0:i+1) * t
-                auto A5 = slice(A, pair{i + 1, m}, pair{0, i + 1});
+                auto A5 = slice(A, range{i + 1, m}, range{0, i + 1});
                 gemv(noTranspose, -one, A5, t2, one, x11);
                 // t = A(0:i,i+1:n) * w
-                auto A6 = slice(A, pair{0, i}, pair{i + 1, n});
-                auto t3 = slice(X, pair{0, i}, i);
+                auto A6 = slice(A, range{0, i}, range{i + 1, n});
+                auto t3 = slice(X, range{0, i}, i);
                 gemv(noTranspose, one, A6, w, zero, t3);
                 // x11 = x11 - X(i+1:m,0:i) * t
-                auto X4 = slice(X, pair{i + 1, m}, pair{0, i});
+                auto X4 = slice(X, range{i + 1, m}, range{0, i});
                 gemv(noTranspose, -one, X4, t3, one, x11);
                 // x11 = x11 * taup(i)
                 scal(taup[i], x11);
@@ -199,16 +199,16 @@ int labrd(A_t& A,
         //
         for (idx_t i = 0; i < nb; ++i) {
             // Update A(i,i:n)
-            auto Y2 = slice(Y, pair{i, n}, pair{0, i});
-            auto s = slice(A, i, pair{0, i});
-            auto a12 = slice(A, i, pair{i, n});
+            auto Y2 = slice(Y, range{i, n}, range{0, i});
+            auto s = slice(A, i, range{0, i});
+            auto a12 = slice(A, i, range{i, n});
             conjugate(s);
             conjugate(a12);
             gemv(noTranspose, -one, Y2, s, one, a12);
             conjugate(s);
 
-            auto A2 = slice(A, pair{0, i}, pair{i, n});
-            auto x = slice(X, i, pair{0, i});
+            auto A2 = slice(A, range{0, i}, range{i, n});
+            auto x = slice(X, i, range{0, i});
             conjugate(x);
             gemv(conjTranspose, -one, A2, x, one, a12);
             conjugate(x);
@@ -216,7 +216,7 @@ int labrd(A_t& A,
             // Generate reflection P(i) to annihilate A(i,i+1:n)
             //
             //
-            auto w = slice(A, i, pair{i, n});
+            auto w = slice(A, i, range{i, n});
             larfg(forward, columnwise_storage, w, taup[i]);
             d[i] = real(A(i, i));
             A(i, i) = one;
@@ -225,25 +225,25 @@ int labrd(A_t& A,
                 //
                 // Compute X(i+1:m,i) = x11
                 //
-                auto x11 = slice(X, pair{i + 1, m}, i);
+                auto x11 = slice(X, range{i + 1, m}, i);
 
                 // x11 = A(i+1:m,i+1:n) * w
-                auto A4 = slice(A, pair{i + 1, m}, pair{i, n});
+                auto A4 = slice(A, range{i + 1, m}, range{i, n});
                 gemv(noTranspose, one, A4, w, zero, x11);
                 if (i > 0) {
                     // t = Y(i:n,0:i)^H * w
-                    auto Y4 = slice(Y, pair{i, n}, pair{0, i});
-                    auto t2 = slice(X, pair{0, i}, i);
+                    auto Y4 = slice(Y, range{i, n}, range{0, i});
+                    auto t2 = slice(X, range{0, i}, i);
                     gemv(conjTranspose, one, Y4, w, zero, t2);
                     // x11 = x11 - A(i+1:m,0:i) * t
-                    auto A5 = slice(A, pair{i + 1, m}, pair{0, i});
+                    auto A5 = slice(A, range{i + 1, m}, range{0, i});
                     gemv(noTranspose, -one, A5, t2, one, x11);
                     // t = A(0:i,i:n) * w
-                    auto A6 = slice(A, pair{0, i}, pair{i, n});
-                    auto t3 = slice(X, pair{0, i}, i);
+                    auto A6 = slice(A, range{0, i}, range{i, n});
+                    auto t3 = slice(X, range{0, i}, i);
                     gemv(noTranspose, one, A6, w, zero, t3);
                     // x11 = x11 - X(i+1:m,0:i) * t
-                    auto X4 = slice(X, pair{i + 1, m}, pair{0, i});
+                    auto X4 = slice(X, range{i + 1, m}, range{0, i});
                     gemv(noTranspose, -one, X4, t3, one, x11);
                 }
                 // x11 = x11 * taup(i)
@@ -251,21 +251,21 @@ int labrd(A_t& A,
                 conjugate(w);
 
                 // Update A(i+1:m,i)
-                auto y = slice(Y, i, pair{0, i});
-                auto A2 = slice(A, pair{i + 1, m}, pair{0, i});
-                auto a21 = slice(A, pair{i + 1, m}, i);
+                auto y = slice(Y, i, range{0, i});
+                auto A2 = slice(A, range{i + 1, m}, range{0, i});
+                auto a21 = slice(A, range{i + 1, m}, i);
                 conjugate(y);
                 gemv(noTranspose, -one, A2, y, one, a21);
                 conjugate(y);
 
-                auto X2 = slice(X, pair{i + 1, m}, pair{0, i + 1});
-                auto a22 = slice(A, pair{0, i + 1}, i);
+                auto X2 = slice(X, range{i + 1, m}, range{0, i + 1});
+                auto a22 = slice(A, range{0, i + 1}, i);
                 gemv(noTranspose, -one, X2, a22, one, a21);
 
                 //
                 // Generate reflection Q(i) to annihilate A(i+2:m,i)
                 //
-                auto v = slice(A, pair{i + 1, m}, i);
+                auto v = slice(A, range{i + 1, m}, i);
                 larfg(forward, columnwise_storage, v, tauq[i]);
                 e[i] = real(A(i + 1, i));
                 A(i + 1, i) = one;
@@ -273,24 +273,24 @@ int labrd(A_t& A,
                 //
                 // Compute Y(i+1:n,i) = y11
                 //
-                auto y11 = slice(Y, pair{i + 1, n}, i);
+                auto y11 = slice(Y, range{i + 1, n}, i);
 
                 // y11 = A(i+1:m,i+1:n)^H * v
-                auto A0 = slice(A, pair{i + 1, m}, pair{i + 1, n});
+                auto A0 = slice(A, range{i + 1, m}, range{i + 1, n});
                 gemv(conjTranspose, one, A0, v, zero, y11);
                 // t = A(i+1:m,0:i)^H * v
-                auto A1 = slice(A, pair{i + 1, m}, pair{0, i});
-                auto t = slice(Y, pair{0, i}, i);
+                auto A1 = slice(A, range{i + 1, m}, range{0, i});
+                auto t = slice(Y, range{0, i}, i);
                 gemv(conjTranspose, one, A1, v, zero, t);
                 // y11 = y11 - Y(i+1:n,0:i) * t
-                auto Y2 = slice(Y, pair{i + 1, n}, pair{0, i});
+                auto Y2 = slice(Y, range{i + 1, n}, range{0, i});
                 gemv(noTranspose, -one, Y2, t, one, y11);
                 // t = X(i+1:m,0:i+1)^H * v
-                auto t2 = slice(Y, pair{0, i + 1}, i);
-                auto X3 = slice(X, pair{i + 1, m}, pair{0, i + 1});
+                auto t2 = slice(Y, range{0, i + 1}, i);
+                auto X3 = slice(X, range{i + 1, m}, range{0, i + 1});
                 gemv(conjTranspose, one, X3, v, zero, t2);
                 // y11 = y11 - A(0:i+1,i+1:n)^H * t
-                auto A3 = slice(A, pair{0, i + 1}, pair{i + 1, n});
+                auto A3 = slice(A, range{0, i + 1}, range{i + 1, n});
                 gemv(conjTranspose, -one, A3, t2, one, y11);
                 // y11 = y11 * tauq(i)
                 scal(tauq[i], y11);

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -34,7 +34,7 @@ namespace tlapack {
 template <TLAPACK_REAL real_t,
           enable_if_t<(
                           /* Requires: */
-                          is_real<real_t>::value),
+                          is_real<real_t>),
                       int> = 0>
 void ladiv(const real_t& a,
            const real_t& b,
@@ -138,7 +138,7 @@ void ladiv(const real_t& a,
  *
  * @ingroup auxiliary
  */
-template <TLAPACK_COMPLEX T, enable_if_t<is_complex<T>::value, int> = 0>
+template <TLAPACK_COMPLEX T, enable_if_t<is_complex<T>, int> = 0>
 inline T ladiv(const T& x, const T& y)
 {
     real_type<T> zr, zi;

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -69,8 +69,8 @@ namespace tlapack {
  */
 template <TLAPACK_SMATRIX matrix_t,
           TLAPACK_VECTOR vector_t,
-          enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true,
-          enable_if_t<is_real<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_complex<type_t<vector_t>>, bool> = true,
+          enable_if_t<is_real<type_t<matrix_t>>, bool> = true>
 int lahqr(bool want_t,
           bool want_z,
           size_type<matrix_t> ilo,
@@ -82,7 +82,7 @@ int lahqr(bool want_t,
     using TA = type_t<matrix_t>;
     using real_t = real_type<TA>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<vector_type<matrix_t>> new_vector;
@@ -213,7 +213,7 @@ int lahqr(bool want_t,
                 istart = ilo;
                 continue;
             }
-            if (is_real<TA>::value && istart + 2 == istop) {
+            if (is_real<TA> && istart + 2 == istop) {
                 // 2x2 block, normalize the block
                 real_t cs;
                 TA sn;
@@ -236,13 +236,13 @@ int lahqr(bool want_t,
                 // matrix.
                 if (want_t) {
                     if (istart + 2 < istop_m) {
-                        auto x = slice(A, istart, pair{istart + 2, istop_m});
+                        auto x = slice(A, istart, range{istart + 2, istop_m});
                         auto y =
-                            slice(A, istart + 1, pair{istart + 2, istop_m});
+                            slice(A, istart + 1, range{istart + 2, istop_m});
                         rot(x, y, cs, sn);
                     }
-                    auto x2 = slice(A, pair{istart_m, istart}, istart);
-                    auto y2 = slice(A, pair{istart_m, istart}, istart + 1);
+                    auto x2 = slice(A, range{istart_m, istart}, istart);
+                    auto y2 = slice(A, range{istart_m, istart}, istart + 1);
                     rot(x2, y2, cs, sn);
                 }
                 if (want_z) {
@@ -279,7 +279,7 @@ int lahqr(bool want_t,
         complex_type<real_t> s1;
         complex_type<real_t> s2;
         lahqr_eig22(a00, a01, a10, a11, s1, s2);
-        if ((imag(s1) == zero and imag(s2) == zero) or is_complex<TA>::value) {
+        if ((imag(s1) == zero and imag(s2) == zero) or is_complex<TA>) {
             // The eigenvalues are not complex conjugate, keep only the one
             // closest to A(istop-1, istop-1)
             if (abs1(s1 - A(istop - 1, istop - 1)) <=
@@ -299,7 +299,7 @@ int lahqr(bool want_t,
         idx_t istart2 = istart;
         if (istart + 3 < istop) {
             for (idx_t i = istop - 3; i > istart; --i) {
-                auto H = slice(A, pair{i, i + 3}, pair{i, i + 3});
+                auto H = slice(A, range{i, i + 3}, range{i, i + 3});
                 lahqr_shiftcolumn(H, v, s1, s2);
                 larfg(forward, columnwise_storage, v, t1);
                 v[0] = t1;
@@ -318,10 +318,10 @@ int lahqr(bool want_t,
         for (idx_t i = istart2; i < istop - 1; ++i) {
             const idx_t nr = std::min<idx_t>(3, istop - i);
             if (i == istart2) {
-                auto H = slice(A, pair{i, i + nr}, pair{i, i + nr});
-                auto x = slice(v, pair{0, nr});
+                auto H = slice(A, range{i, i + nr}, range{i, i + nr});
+                auto x = slice(v, range{0, nr});
                 lahqr_shiftcolumn(H, x, s1, s2);
-                auto y = slice(v, pair{1, nr});
+                auto y = slice(v, range{1, nr});
                 TA alpha = v[0];
                 larfg(columnwise_storage, alpha, y, t1);
                 v[0] = alpha;
@@ -333,7 +333,7 @@ int lahqr(bool want_t,
                 v[0] = A(i, i - 1);
                 v[1] = A(i + 1, i - 1);
                 if (nr == 3) v[2] = A(i + 2, i - 1);
-                auto x = slice(v, pair{1, nr});
+                auto x = slice(v, range{1, nr});
                 TA alpha = v[0];
                 larfg(columnwise_storage, alpha, x, t1);
                 v[0] = alpha;
@@ -415,8 +415,8 @@ int lahqr(bool want_t,
  */
 template <TLAPACK_SMATRIX matrix_t,
           TLAPACK_VECTOR vector_t,
-          enable_if_t<is_complex<type_t<vector_t>>::value, bool> = true,
-          enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_complex<type_t<vector_t>>, bool> = true,
+          enable_if_t<is_complex<type_t<matrix_t>>, bool> = true>
 int lahqr(bool want_t,
           bool want_z,
           size_type<matrix_t> ilo,

--- a/include/tlapack/lapack/lahqr_schur22.hpp
+++ b/include/tlapack/lapack/lahqr_schur22.hpp
@@ -48,7 +48,7 @@ namespace tlapack {
  *
  * @ingroup auxiliary
  */
-template <TLAPACK_REAL T, enable_if_t<is_real<T>::value, bool> = true>
+template <TLAPACK_REAL T, enable_if_t<is_real<T>, bool> = true>
 int lahqr_schur22(T& a,
                   T& b,
                   T& c,
@@ -192,7 +192,7 @@ int lahqr_schur22(T& a,
     return 0;
 }
 
-template <TLAPACK_COMPLEX T, enable_if_t<is_complex<T>::value, bool> = true>
+template <TLAPACK_COMPLEX T, enable_if_t<is_complex<T>, bool> = true>
 int lahqr_schur22(T& a, T& b, T& c, T& d, T& s1, T& s2, real_type<T>& cs, T& sn)
 {
     return -1;

--- a/include/tlapack/lapack/lahqr_shiftcolumn.hpp
+++ b/include/tlapack/lapack/lahqr_shiftcolumn.hpp
@@ -37,7 +37,7 @@ namespace tlapack {
  */
 template <TLAPACK_MATRIX matrix_t,
           TLAPACK_VECTOR vector_t,
-          enable_if_t<is_real<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_real<type_t<matrix_t>>, bool> = true>
 int lahqr_shiftcolumn(const matrix_t& H,
                       vector_t& v,
                       complex_type<type_t<matrix_t>> s1,
@@ -113,7 +113,7 @@ int lahqr_shiftcolumn(const matrix_t& H,
  */
 template <TLAPACK_MATRIX matrix_t,
           TLAPACK_VECTOR vector_t,
-          enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_complex<type_t<matrix_t>>, bool> = true>
 int lahqr_shiftcolumn(const matrix_t& H,
                       vector_t& v,
                       type_t<matrix_t> s1,

--- a/include/tlapack/lapack/lahr2.hpp
+++ b/include/tlapack/lapack/lahr2.hpp
@@ -66,7 +66,7 @@ int lahr2(size_type<matrix_t> k,
 {
     using TA = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using real_t = real_type<TA>;
 
     // constants
@@ -88,9 +88,9 @@ int lahr2(size_type<matrix_t> k,
             // Update I-th column of A - Y * V**T
             // (Application of the reflectors from the right)
             //
-            auto Y2 = slice(Y, pair{k + 1, n}, pair{0, i});
-            auto Vti = slice(A, k + i, pair{0, i});
-            auto b = slice(A, pair{k + 1, n}, i);
+            auto Y2 = slice(Y, range{k + 1, n}, range{0, i});
+            auto Vti = slice(A, k + i, range{0, i});
+            auto b = slice(A, range{k + 1, n}, i);
             for (idx_t j = 0; j < i; ++j)
                 Vti[j] = conj(Vti[j]);
             gemv(Op::NoTrans, -one, Y2, Vti, one, b);
@@ -105,15 +105,15 @@ int lahr2(size_type<matrix_t> k,
             //
             // where V1 is unit lower triangular
             //
-            auto b1 = slice(b, pair{0, i});
-            auto b2 = slice(b, pair{i, size(b)});
-            auto V = slice(A, pair{k + 1, n}, pair{0, i});
-            auto V1 = slice(V, pair{0, i}, pair{0, i});
-            auto V2 = slice(V, pair{i, nrows(V)}, pair{0, i});
+            auto b1 = slice(b, range{0, i});
+            auto b2 = slice(b, range{i, size(b)});
+            auto V = slice(A, range{k + 1, n}, range{0, i});
+            auto V1 = slice(V, range{0, i}, range{0, i});
+            auto V2 = slice(V, range{i, nrows(V)}, range{0, i});
             //
             // w := V1**T * b1
             //
-            auto w = slice(T, pair{0, i}, nb - 1);
+            auto w = slice(T, range{0, i}, nb - 1);
             copy(b1, w);
             trmv(Uplo::Lower, Op::ConjTrans, Diag::Unit, V1, w);
             //
@@ -123,7 +123,7 @@ int lahr2(size_type<matrix_t> k,
             //
             // w := T**T * w
             //
-            auto T2 = slice(T, pair{0, i}, pair{0, i});
+            auto T2 = slice(T, range{0, i}, range{0, i});
             trmv(Uplo::Upper, Op::ConjTrans, Diag::NonUnit, T2, w);
             //
             // b2 := b2 - V2*w
@@ -137,7 +137,7 @@ int lahr2(size_type<matrix_t> k,
 
             A(k + i, i - 1) = ei;
         }
-        auto v = slice(A, pair{k + i + 1, n}, i);
+        auto v = slice(A, range{k + i + 1, n}, i);
         larfg(forward, columnwise_storage, v, tau[i]);
 
         // larf has been edited to not require A(k+i,i) = one
@@ -148,20 +148,20 @@ int lahr2(size_type<matrix_t> k,
         //
         // Compute  Y(K+1:N,I)
         //
-        auto A2 = slice(A, pair{k + 1, n}, pair{i + 1, n - k});
-        auto y = slice(Y, pair{k + 1, n}, i);
+        auto A2 = slice(A, range{k + 1, n}, range{i + 1, n - k});
+        auto y = slice(Y, range{k + 1, n}, i);
         gemv(Op::NoTrans, one, A2, v, y);
-        auto t = slice(T, pair{0, i}, i);
-        auto A3 = slice(A, pair{k + i + 1, n}, pair{0, i});
+        auto t = slice(T, range{0, i}, i);
+        auto A3 = slice(A, range{k + i + 1, n}, range{0, i});
         gemv(Op::ConjTrans, one, A3, v, t);
-        auto Y2 = slice(Y, pair{k + 1, n}, pair{0, i});
+        auto Y2 = slice(Y, range{k + 1, n}, range{0, i});
         gemv(Op::NoTrans, -one, Y2, t, one, y);
         scal(tau[i], y);
         //
         // Compute T(0:I+1,I)
         //
         scal(-tau[i], t);
-        auto T2 = slice(T, pair{0, i}, pair{0, i});
+        auto T2 = slice(T, range{0, i}, range{0, i});
         trmv(Uplo::Upper, Op::NoTrans, Diag::NonUnit, T2, t);
         T(i, i) = tau[i];
     }
@@ -169,15 +169,15 @@ int lahr2(size_type<matrix_t> k,
     //
     // Compute Y(0:k+1,0:nb)
     //
-    auto A4 = slice(A, pair{0, k + 1}, pair{1, nb + 1});
-    auto Y3 = slice(Y, pair{0, k + 1}, pair{0, nb});
+    auto A4 = slice(A, range{0, k + 1}, range{1, nb + 1});
+    auto Y3 = slice(Y, range{0, k + 1}, range{0, nb});
     lacpy(Uplo::General, A4, Y3);
-    auto V1 = slice(A, pair{k + 1, k + nb + 1}, pair{0, nb});
-    auto Y1 = slice(Y, pair{0, k + 1}, pair{0, nb});
+    auto V1 = slice(A, range{k + 1, k + nb + 1}, range{0, nb});
+    auto Y1 = slice(Y, range{0, k + 1}, range{0, nb});
     trmm(Side::Right, Uplo::Lower, Op::NoTrans, Diag::Unit, one, V1, Y1);
     if (k + nb + 1 < n) {
-        auto A5 = slice(A, pair{0, k + 1}, pair{nb + 1, n - k});
-        auto V2 = slice(A, pair{k + nb + 1, n}, pair{0, nb});
+        auto A5 = slice(A, range{0, k + 1}, range{nb + 1, n - k});
+        auto V2 = slice(A, range{k + nb + 1, n}, range{0, nb});
         gemm(Op::NoTrans, Op::NoTrans, one, A5, V2, one, Y1);
     }
     trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, one, T, Y1);

--- a/include/tlapack/lapack/lange.hpp
+++ b/include/tlapack/lapack/lange.hpp
@@ -217,7 +217,7 @@ auto lange(norm_t normType, const matrix_t& A, const workspace_opts_t<>& opts)
         // the infinite norm.
 
         // Allocates workspace
-        vectorOfBytes localworkdata;
+        VectorOfBytes localworkdata;
         const Workspace work = [&]() {
             workinfo_t workinfo;
             lange_worksize(normType, A, opts);

--- a/include/tlapack/lapack/lanhe.hpp
+++ b/include/tlapack/lapack/lanhe.hpp
@@ -114,7 +114,7 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t n = nrows(A);
@@ -223,11 +223,11 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
         // Sum off-diagonals
         if (uplo == Uplo::Upper) {
             for (idx_t j = 1; j < n; ++j)
-                lassq(slice(A, pair{0, j}, j), scale, ssq);
+                lassq(slice(A, range{0, j}, j), scale, ssq);
         }
         else {
             for (idx_t j = 0; j < n - 1; ++j)
-                lassq(slice(A, pair{j + 1, n}, j), scale, ssq);
+                lassq(slice(A, range{j + 1, n}, j), scale, ssq);
         }
         ssq *= real_t(2);
 
@@ -306,7 +306,7 @@ auto lanhe(norm_t normType,
         if (n <= 0) return real_t(0);
 
         // Allocates workspace
-        vectorOfBytes localworkdata;
+        VectorOfBytes localworkdata;
         const Workspace work = [&]() {
             workinfo_t workinfo;
             lanhe_worksize(normType, uplo, A, opts);

--- a/include/tlapack/lapack/lansy.hpp
+++ b/include/tlapack/lapack/lansy.hpp
@@ -115,7 +115,7 @@ auto lansy(norm_t normType, uplo_t uplo, const matrix_t& A)
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t n = nrows(A);
@@ -202,11 +202,11 @@ auto lansy(norm_t normType, uplo_t uplo, const matrix_t& A)
         // Sum off-diagonals
         if (uplo == Uplo::Upper) {
             for (idx_t j = 1; j < n; ++j)
-                lassq(slice(A, pair{0, j}, j), scale, ssq);
+                lassq(slice(A, range{0, j}, j), scale, ssq);
         }
         else {
             for (idx_t j = 0; j < n - 1; ++j)
-                lassq(slice(A, pair{j + 1, n}, j), scale, ssq);
+                lassq(slice(A, range{j + 1, n}, j), scale, ssq);
         }
         ssq *= 2;
 
@@ -283,7 +283,7 @@ auto lansy(norm_t normType,
         if (n <= 0) return real_t(0);
 
         // Allocates workspace
-        vectorOfBytes localworkdata;
+        VectorOfBytes localworkdata;
         const Workspace work = [&]() {
             workinfo_t workinfo;
             lansy_worksize(normType, uplo, A, opts);

--- a/include/tlapack/lapack/lantr.hpp
+++ b/include/tlapack/lapack/lantr.hpp
@@ -141,6 +141,7 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
@@ -303,25 +304,24 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
         if (uplo == Uplo::Upper) {
             if (diag == Diag::NonUnit) {
                 for (idx_t j = 0; j < n; ++j)
-                    lassq(slice(A, range<idx_t>(0, std::min(j + 1, m)), j),
-                          scale, sum);
+                    lassq(slice(A, range(0, std::min(j + 1, m)), j), scale,
+                          sum);
             }
             else {
                 sum = real_t(std::min(m, n));
                 for (idx_t j = 1; j < n; ++j)
-                    lassq(slice(A, range<idx_t>(0, std::min(j, m)), j), scale,
-                          sum);
+                    lassq(slice(A, range(0, std::min(j, m)), j), scale, sum);
             }
         }
         else {
             if (diag == Diag::NonUnit) {
                 for (idx_t j = 0; j < std::min(m, n); ++j)
-                    lassq(slice(A, range<idx_t>(j, m), j), scale, sum);
+                    lassq(slice(A, range(j, m), j), scale, sum);
             }
             else {
                 sum = real_t(std::min(m, n));
                 for (idx_t j = 0; j < std::min(m - 1, n); ++j)
-                    lassq(slice(A, range<idx_t>(j + 1, m), j), scale, sum);
+                    lassq(slice(A, range(j + 1, m), j), scale, sum);
             }
         }
         norm = scale * sqrt(sum);
@@ -407,7 +407,7 @@ auto lantr(norm_t normType,
         // the infinite norm.
 
         // Allocates workspace
-        vectorOfBytes localworkdata;
+        VectorOfBytes localworkdata;
         const Workspace work = [&]() {
             workinfo_t workinfo;
             lantr_worksize(normType, uplo, diag, A, opts);

--- a/include/tlapack/lapack/lapy2.hpp
+++ b/include/tlapack/lapack/lapy2.hpp
@@ -27,7 +27,7 @@ template <TLAPACK_REAL TX,
           TLAPACK_REAL TY,
           enable_if_t<(
                           /* Requires: */
-                          is_real<TX>::value && is_real<TY>::value),
+                          is_real<TX> && is_real<TY>),
                       int> = 0>
 real_type<TX, TY> lapy2(const TX& x, const TY& y)
 {

--- a/include/tlapack/lapack/lapy3.hpp
+++ b/include/tlapack/lapack/lapy3.hpp
@@ -33,8 +33,7 @@ template <TLAPACK_REAL TX,
           TLAPACK_REAL TZ,
           enable_if_t<(
                           /* Requires: */
-                          is_real<TX>::value && is_real<TY>::value &&
-                          is_real<TZ>::value),
+                          is_real<TX> && is_real<TY> && is_real<TZ>),
                       int> = 0>
 real_type<TX, TY, TZ> lapy3(const TX& x, const TY& y, const TZ& z)
 {

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -54,7 +54,7 @@ template <TLAPACK_SIDE side_t,
           TLAPACK_SCALAR tau_t,
           TLAPACK_VECTOR vectorC0_t,
           TLAPACK_MATRIX matrixC1_t,
-          enable_if_t<is_convertible_v<storage_t, StoreV>, int> = 0>
+          enable_if_t<std::is_convertible_v<storage_t, StoreV>, int> = 0>
 inline constexpr workinfo_t larf_worksize(side_t side,
                                           storage_t storeMode,
                                           vector_t const& x,
@@ -136,7 +136,7 @@ template <TLAPACK_SIDE side_t,
           TLAPACK_SCALAR tau_t,
           TLAPACK_VECTOR vectorC0_t,
           TLAPACK_MATRIX matrixC1_t,
-          enable_if_t<is_convertible_v<storage_t, StoreV>, int> = 0>
+          enable_if_t<std::is_convertible_v<storage_t, StoreV>, int> = 0>
 void larf(side_t side,
           storage_t storeMode,
           vector_t const& x,
@@ -174,7 +174,7 @@ void larf(side_t side,
     }
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     const Workspace work = [&]() {
         workinfo_t workinfo =
             larf_worksize(side, storeMode, x, tau, C0, C1, opts);
@@ -280,7 +280,7 @@ template <TLAPACK_SIDE side_t,
           TLAPACK_SVECTOR vector_t,
           TLAPACK_SCALAR tau_t,
           TLAPACK_SMATRIX matrix_t,
-          enable_if_t<is_convertible_v<direction_t, Direction>, int> = 0>
+          enable_if_t<std::is_convertible_v<direction_t, Direction>, int> = 0>
 inline constexpr workinfo_t larf_worksize(side_t side,
                                           direction_t direction,
                                           storage_t storeMode,
@@ -347,7 +347,7 @@ template <TLAPACK_SIDE side_t,
           TLAPACK_SVECTOR vector_t,
           TLAPACK_SCALAR tau_t,
           TLAPACK_SMATRIX matrix_t,
-          enable_if_t<is_convertible_v<direction_t, Direction>, int> = 0>
+          enable_if_t<std::is_convertible_v<direction_t, Direction>, int> = 0>
 inline void larf(side_t side,
                  direction_t direction,
                  storage_t storeMode,
@@ -357,7 +357,7 @@ inline void larf(side_t side,
                  const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(C);
@@ -390,18 +390,18 @@ inline void larf(side_t side,
 
     if (side == Side::Left) {
         auto C0 = (direction == Direction::Forward) ? row(C, 0) : row(C, m - 1);
-        auto C1 = (direction == Direction::Forward) ? rows(C, pair{1, m})
-                                                    : rows(C, pair{0, m - 1});
-        auto x = (direction == Direction::Forward) ? slice(v, pair{1, m})
-                                                   : slice(v, pair{0, m - 1});
+        auto C1 = (direction == Direction::Forward) ? rows(C, range{1, m})
+                                                    : rows(C, range{0, m - 1});
+        auto x = (direction == Direction::Forward) ? slice(v, range{1, m})
+                                                   : slice(v, range{0, m - 1});
         larf(side, storeMode, x, tau, C0, C1, opts);
     }
     else {  // side == Side::Right
         auto C0 = (direction == Direction::Forward) ? col(C, 0) : col(C, n - 1);
-        auto C1 = (direction == Direction::Forward) ? cols(C, pair{1, n})
-                                                    : cols(C, pair{0, n - 1});
-        auto x = (direction == Direction::Forward) ? slice(v, pair{1, n})
-                                                   : slice(v, pair{0, n - 1});
+        auto C1 = (direction == Direction::Forward) ? cols(C, range{1, n})
+                                                    : cols(C, range{0, n - 1});
+        auto x = (direction == Direction::Forward) ? slice(v, range{1, n})
+                                                   : slice(v, range{0, n - 1});
         larf(side, storeMode, x, tau, C0, C1, opts);
     }
 }

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -213,7 +213,7 @@ int larfb(side_t side,
     using T = type_t<matrixW_t>;
     using real_t = real_type<T>;
 
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<matrixW_t> new_matrix;
@@ -228,7 +228,7 @@ int larfb(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(
         trans != Op::NoTrans && trans != Op::ConjTrans &&
-        ((trans != Op::Trans) || is_complex<type_t<matrixV_t> >::value));
+        ((trans != Op::Trans) || is_complex<type_t<matrixV_t> >));
     tlapack_check_false(direction != Direction::Backward &&
                         direction != Direction::Forward);
     tlapack_check_false(storeMode != StoreV::Columnwise &&
@@ -245,7 +245,7 @@ int larfb(side_t side,
     if (m <= 0 || n <= 0 || k <= 0) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     const Workspace work = [&]() {
         workinfo_t workinfo = larfb_worksize(side, trans, direction, storeMode,
                                              V, Tmatrix, C, opts);
@@ -259,10 +259,10 @@ int larfb(side_t side,
                 // V is an m-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows(V, pair{0, k});
-                const auto V2 = rows(V, pair{k, m});
-                auto C1 = rows(C, pair{0, k});
-                auto C2 = rows(C, pair{k, m});
+                const auto V1 = rows(V, range{0, k});
+                const auto V2 = rows(V, range{k, m});
+                auto C1 = rows(C, range{0, k});
+                auto C2 = rows(C, range{k, m});
                 auto W = new_matrix(work, k, n);
 
                 // W := C1
@@ -290,10 +290,10 @@ int larfb(side_t side,
                 // V is an n-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows(V, pair{0, k});
-                const auto V2 = rows(V, pair{k, n});
-                auto C1 = cols(C, pair{0, k});
-                auto C2 = cols(C, pair{k, n});
+                const auto V1 = rows(V, range{0, k});
+                const auto V2 = rows(V, range{k, n});
+                auto C1 = cols(C, range{0, k});
+                auto C2 = cols(C, range{k, n});
                 auto W = new_matrix(work, m, k);
 
                 // W := C1
@@ -324,10 +324,10 @@ int larfb(side_t side,
                 // V is an m-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows(V, pair{0, m - k});
-                const auto V2 = rows(V, pair{m - k, m});
-                auto C1 = rows(C, pair{0, m - k});
-                auto C2 = rows(C, pair{m - k, m});
+                const auto V1 = rows(V, range{0, m - k});
+                const auto V2 = rows(V, range{m - k, m});
+                auto C1 = rows(C, range{0, m - k});
+                auto C2 = rows(C, range{m - k, m});
                 auto W = new_matrix(work, k, n);
 
                 // W := C2
@@ -355,10 +355,10 @@ int larfb(side_t side,
                 // V is an n-by-k matrix
 
                 // Matrix views
-                const auto V1 = rows(V, pair{0, n - k});
-                const auto V2 = rows(V, pair{n - k, n});
-                auto C1 = cols(C, pair{0, n - k});
-                auto C2 = cols(C, pair{n - k, n});
+                const auto V1 = rows(V, range{0, n - k});
+                const auto V2 = rows(V, range{n - k, n});
+                auto C1 = cols(C, range{0, n - k});
+                auto C2 = cols(C, range{n - k, n});
                 auto W = new_matrix(work, m, k);
 
                 // W := C2
@@ -390,10 +390,10 @@ int larfb(side_t side,
                 // V is an k-by-m matrix
 
                 // Matrix views
-                const auto V1 = cols(V, pair{0, k});
-                const auto V2 = cols(V, pair{k, m});
-                auto C1 = rows(C, pair{0, k});
-                auto C2 = rows(C, pair{k, m});
+                const auto V1 = cols(V, range{0, k});
+                const auto V2 = cols(V, range{k, m});
+                auto C1 = rows(C, range{0, k});
+                auto C2 = rows(C, range{k, m});
                 auto W = new_matrix(work, k, n);
 
                 // W := C1
@@ -421,10 +421,10 @@ int larfb(side_t side,
                 // V is an k-by-n matrix
 
                 // Matrix views
-                const auto V1 = cols(V, pair{0, k});
-                const auto V2 = cols(V, pair{k, n});
-                auto C1 = cols(C, pair{0, k});
-                auto C2 = cols(C, pair{k, n});
+                const auto V1 = cols(V, range{0, k});
+                const auto V2 = cols(V, range{k, n});
+                auto C1 = cols(C, range{0, k});
+                auto C2 = cols(C, range{k, n});
                 auto W = new_matrix(work, m, k);
 
                 // W := C1
@@ -454,10 +454,10 @@ int larfb(side_t side,
                 // V is an k-by-m matrix
 
                 // Matrix views
-                const auto V1 = cols(V, pair{0, m - k});
-                const auto V2 = cols(V, pair{m - k, m});
-                auto C1 = rows(C, pair{0, m - k});
-                auto C2 = rows(C, pair{m - k, m});
+                const auto V1 = cols(V, range{0, m - k});
+                const auto V2 = cols(V, range{m - k, m});
+                auto C1 = rows(C, range{0, m - k});
+                auto C2 = rows(C, range{m - k, m});
                 auto W = new_matrix(work, k, n);
 
                 // W := C2
@@ -485,10 +485,10 @@ int larfb(side_t side,
                 // V is an k-by-n matrix
 
                 // Matrix views
-                const auto V1 = cols(V, pair{0, n - k});
-                const auto V2 = cols(V, pair{n - k, n});
-                auto C1 = cols(C, pair{0, n - k});
-                auto C2 = cols(C, pair{n - k, n});
+                const auto V1 = cols(V, range{0, n - k});
+                const auto V2 = cols(V, range{n - k, n});
+                auto C1 = cols(C, range{0, n - k});
+                auto C2 = cols(C, range{n - k, n});
                 auto W = new_matrix(work, m, k);
 
                 // W := C2

--- a/include/tlapack/lapack/larfg.hpp
+++ b/include/tlapack/lapack/larfg.hpp
@@ -97,9 +97,8 @@ void larfg(storage_t storeMode,
 
     if (xnorm > zero || (imag(alpha) != zero)) {
         // First estimate of beta
-        real_t temp = (is_real<T>::value)
-                          ? lapy2(real(alpha), xnorm)
-                          : lapy3(real(alpha), imag(alpha), xnorm);
+        real_t temp = (is_real<T>) ? lapy2(real(alpha), xnorm)
+                                   : lapy3(real(alpha), imag(alpha), xnorm);
         real_t beta = (real(alpha) < zero) ? temp : -temp;
 
         // Scale if needed
@@ -112,8 +111,8 @@ void larfg(storage_t storeMode,
                 alpha *= rsafemin;
             }
             xnorm = nrm2(x);
-            temp = (is_real<T>::value) ? lapy2(real(alpha), xnorm)
-                                       : lapy3(real(alpha), imag(alpha), xnorm);
+            temp = (is_real<T>) ? lapy2(real(alpha), xnorm)
+                                : lapy3(real(alpha), imag(alpha), xnorm);
             beta = (real(alpha) < zero) ? temp : -temp;
         }
 
@@ -192,14 +191,14 @@ void larfg(storage_t storeMode,
 template <TLAPACK_DIRECTION direction_t,
           TLAPACK_STOREV storage_t,
           TLAPACK_VECTOR vector_t,
-          enable_if_t<is_convertible_v<direction_t, Direction>, int> = 0>
+          enable_if_t<std::is_convertible_v<direction_t, Direction>, int> = 0>
 inline void larfg(direction_t direction,
                   storage_t storeMode,
                   vector_t& v,
                   type_t<vector_t>& tau)
 {
     using idx_t = size_type<vector_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // check arguments
     tlapack_check_false(direction != Direction::Backward &&
@@ -207,8 +206,9 @@ inline void larfg(direction_t direction,
 
     const idx_t alpha_idx = (direction == Direction::Forward) ? 0 : size(v) - 1;
 
-    auto x = slice(v, (direction == Direction::Forward) ? pair(1, size(v))
-                                                        : pair(0, size(v) - 1));
+    auto x =
+        slice(v, (direction == Direction::Forward) ? range(1, size(v))
+                                                   : range(0, size(v) - 1));
     type_t<vector_t> alpha = v[alpha_idx];
     larfg(storeMode, alpha, x, tau);
     v[alpha_idx] = alpha;

--- a/include/tlapack/lapack/larft.hpp
+++ b/include/tlapack/lapack/larft.hpp
@@ -102,7 +102,7 @@ int larft(direction_t direction,
     using idx_t = size_type<matrixV_t>;
 
     // using
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const real_t one(1);
@@ -129,7 +129,7 @@ int larft(direction_t direction,
         // Remaining iterations:
         for (idx_t i = 1; i < k; ++i) {
             // Column vector t := T(0:i,i)
-            auto t = slice(T, pair{0, i}, i);
+            auto t = slice(T, range{0, i}, i);
 
             if (tau[i] == tau_t(0)) {
                 // H(i) =  I
@@ -147,8 +147,8 @@ int larft(direction_t direction,
                     // t := t - tau[i] V(i+1:n,0:i)^H V(i+1:n,i)
                     if (i + 1 < n) {
                         gemv(conjTranspose, -tau[i],
-                             slice(V, pair{i + 1, n}, pair{0, i}),
-                             slice(V, pair{i + 1, n}, i), one, t);
+                             slice(V, range{i + 1, n}, range{0, i}),
+                             slice(V, range{i + 1, n}, i), one, t);
                     }
                 }
                 else {
@@ -158,16 +158,17 @@ int larft(direction_t direction,
 
                     // t := t - tau[i] V(0:i,i:n) V(i,i+1:n)^H
                     if (i + 1 < n) {
-                        auto Ti = slice(T, pair{0, i}, pair{i, i + 1});
+                        auto Ti = slice(T, range{0, i}, range{i, i + 1});
                         gemm(noTranspose, conjTranspose, -tau[i],
-                             slice(V, pair{0, i}, pair{i + 1, n}),
-                             slice(V, pair{i, i + 1}, pair{i + 1, n}), one, Ti);
+                             slice(V, range{0, i}, range{i + 1, n}),
+                             slice(V, range{i, i + 1}, range{i + 1, n}), one,
+                             Ti);
                     }
                 }
 
                 // t := T(0:i,0:i) * t
                 trmv(upperTriangle, noTranspose, nonUnit_diagonal,
-                     slice(T, pair{0, i}, pair{0, i}), t);
+                     slice(T, range{0, i}, range{0, i}), t);
             }
 
             // Update diagonal
@@ -182,7 +183,7 @@ int larft(direction_t direction,
         // Remaining iterations:
         for (idx_t i = k - 2; i != idx_t(-1); --i) {
             // Column vector t := T(0:i,i)
-            auto t = slice(T, pair{i + 1, k}, i);
+            auto t = slice(T, range{i + 1, k}, i);
 
             if (tau[i] == tau_t(0)) {
                 // H(i) =  I
@@ -199,8 +200,8 @@ int larft(direction_t direction,
 
                     // t := t - tau[i] V(0:n-k+i,i+1:k)^H V(0:n-k+i,i)
                     gemv(conjTranspose, -tau[i],
-                         slice(V, pair{0, n - k + i}, pair{i + 1, k}),
-                         slice(V, pair{0, n - k + i}, i), one, t);
+                         slice(V, range{0, n - k + i}, range{i + 1, k}),
+                         slice(V, range{0, n - k + i}, i), one, t);
                 }
                 else {
                     // t := - tau[i] V(i+1:k,n-k+i)
@@ -208,15 +209,16 @@ int larft(direction_t direction,
                         t[j] = -tau[i] * V(j + i + 1, n - k + i);
 
                     // t := t - tau[i] V(i+1:k,0:n-k+i) V(i,0:n-k+i)^H
-                    auto Ti = slice(T, pair{i + 1, k}, pair{i, i + 1});
+                    auto Ti = slice(T, range{i + 1, k}, range{i, i + 1});
                     gemm(noTranspose, conjTranspose, -tau[i],
-                         slice(V, pair{i + 1, k}, pair{0, n - k + i}),
-                         slice(V, pair{i, i + 1}, pair{0, n - k + i}), one, Ti);
+                         slice(V, range{i + 1, k}, range{0, n - k + i}),
+                         slice(V, range{i, i + 1}, range{0, n - k + i}), one,
+                         Ti);
                 }
 
                 // t := T(i+1:k,i+1:k) * t
                 trmv(lowerTriangle, noTranspose, nonUnit_diagonal,
-                     slice(T, pair{i + 1, k}, pair{i + 1, k}), t);
+                     slice(T, range{i + 1, k}, range{i + 1, k}), t);
             }
 
             // Update diagonal

--- a/include/tlapack/lapack/larnv.hpp
+++ b/include/tlapack/lapack/larnv.hpp
@@ -49,56 +49,54 @@ void larnv(Sseq& iseed, vector_t& x)
 
     // Constants
     const idx_t n = size(x);
-    const real_t one(1);
-    const real_t eight(8);
-    const real_t twopi = eight * atan(one);
+    const double twopi(8 * std::atan(1.0));
 
     // Initialize the Mersenne Twister generator
     std::random_device device;
     std::mt19937 generator(device());
     generator.seed(iseed);
 
-    if (idist == 1) {
-        std::uniform_real_distribution<real_t> d1(0, 1);
+    if constexpr (idist == 1) {
+        std::uniform_real_distribution<> d1(0, 1);
         for (idx_t i = 0; i < n; ++i) {
-            if (is_complex<T>::value)
-                x[i] = make_scalar<T>(d1(generator), d1(generator));
+            if constexpr (is_complex<T>)
+                x[i] = T(real_t(d1(generator)), real_t(d1(generator)));
             else
-                x[i] = d1(generator);
+                x[i] = T(d1(generator));
         }
     }
-    else if (idist == 2) {
-        std::uniform_real_distribution<real_t> d2(-1, 1);
+    else if constexpr (idist == 2) {
+        std::uniform_real_distribution<> d2(-1, 1);
         for (idx_t i = 0; i < n; ++i) {
-            if (is_complex<T>::value)
-                x[i] = make_scalar<T>(d2(generator), d2(generator));
+            if constexpr (is_complex<T>)
+                x[i] = T(real_t(d2(generator)), real_t(d2(generator)));
             else
-                x[i] = d2(generator);
+                x[i] = T(d2(generator));
         }
     }
-    else if (idist == 3) {
-        std::normal_distribution<real_t> d3(0, 1);
+    else if constexpr (idist == 3) {
+        std::normal_distribution<> d3(0, 1);
         for (idx_t i = 0; i < n; ++i) {
-            if (is_complex<T>::value)
-                x[i] = make_scalar<T>(d3(generator), d3(generator));
+            if constexpr (is_complex<T>)
+                x[i] = T(real_t(d3(generator)), real_t(d3(generator)));
             else
-                x[i] = d3(generator);
+                x[i] = T(d3(generator));
         }
     }
-    else if (is_complex<T>::value) {
-        if (idist == 4) {
-            std::uniform_real_distribution<real_t> d4(0, 1);
+    else if constexpr (is_complex<T>) {
+        if constexpr (idist == 4) {
+            std::uniform_real_distribution<> d4(0, 1);
             for (idx_t i = 0; i < n; ++i) {
-                real_t r = sqrt(d4(generator));
-                real_t theta = twopi * d4(generator);
-                x[i] = make_scalar<T>(r * cos(theta), r * sin(theta));
+                double r = sqrt(d4(generator));
+                double theta = twopi * d4(generator);
+                x[i] = T(r * cos(theta), r * sin(theta));
             }
         }
-        else if (idist == 5) {
-            std::uniform_real_distribution<real_t> d5(0, 1);
+        else if constexpr (idist == 5) {
+            std::uniform_real_distribution<> d5(0, 1);
             for (idx_t i = 0; i < n; ++i) {
-                real_t theta = twopi * d5(generator);
-                x[i] = make_scalar<T>(cos(theta), sin(theta));
+                double theta = twopi * d5(generator);
+                x[i] = T(real_t(cos(theta)), real_t(sin(theta)));
             }
         }
     }

--- a/include/tlapack/lapack/lascl.hpp
+++ b/include/tlapack/lapack/lascl.hpp
@@ -56,7 +56,7 @@ template <TLAPACK_UPLO uplo_t,
           TLAPACK_REAL b_type,
           enable_if_t<(
                           /* Requires: */
-                          is_real<a_type>::value && is_real<b_type>::value),
+                          is_real<a_type> && is_real<b_type>),
                       int> = 0>
 int lascl(uplo_t uplo, const b_type& b, const a_type& a, matrix_t& A)
 {
@@ -189,9 +189,9 @@ template <TLAPACK_MATRIX matrix_t,
           TLAPACK_REAL b_type,
           enable_if_t<(
                           /* Requires: */
-                          is_real<a_type>::value && is_real<b_type>::value),
+                          is_real<a_type> && is_real<b_type>),
                       int> = 0>
-int lascl(band_t accessType, const b_type& b, const a_type& a, matrix_t& A)
+int lascl(BandAccess accessType, const b_type& b, const a_type& a, matrix_t& A)
 {
     // data traits
     using idx_t = size_type<matrix_t>;

--- a/include/tlapack/lapack/lasy2.hpp
+++ b/include/tlapack/lapack/lasy2.hpp
@@ -29,7 +29,7 @@ namespace tlapack {
  * @ingroup auxiliary
  */
 template <TLAPACK_MATRIX matrix_t,
-          enable_if_t<is_real<type_t<matrix_t> >::value, bool> = true>
+          enable_if_t<is_real<type_t<matrix_t> >, bool> = true>
 int lasy2(Op trans_l,
           Op trans_r,
           int isign,

--- a/include/tlapack/lapack/lauum_recursive.hpp
+++ b/include/tlapack/lapack/lauum_recursive.hpp
@@ -49,7 +49,7 @@ int lauum_recursive(const Uplo& uplo, matrix_t& C)
 
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using real_t = real_type<T>;
 
     const idx_t n = nrows(C);

--- a/include/tlapack/lapack/lu_mult.hpp
+++ b/include/tlapack/lapack/lu_mult.hpp
@@ -43,7 +43,7 @@ void lu_mult(matrix_t& A, const lu_mult_opts_t<size_type<matrix_t>>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using real_t = real_type<T>;
 
     const idx_t m = nrows(A);

--- a/include/tlapack/lapack/move_bulge.hpp
+++ b/include/tlapack/lapack/move_bulge.hpp
@@ -43,7 +43,7 @@ void move_bulge(matrix_t& H,
     using real_t = real_type<T>;
 
     using idx_t = size_type<matrix_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     const real_t zero(0);
     const real_t eps = ulp<real_t>();
 
@@ -77,7 +77,7 @@ void move_bulge(matrix_t& H,
         // 2-small-subdiagonals trick
         std::vector<T> vt_;
         auto vt = new_vector(vt_, 3);
-        auto H2 = slice(H, pair{1, 4}, pair{1, 4});
+        auto H2 = slice(H, range{1, 4}, range{1, 4});
         lahqr_shiftcolumn(H2, vt, s1, s2);
         larfg(forward, columnwise_storage, vt, tau);
         vt[0] = tau;

--- a/include/tlapack/lapack/potf2.hpp
+++ b/include/tlapack/lapack/potf2.hpp
@@ -60,7 +60,7 @@ int potf2(uplo_t uplo, matrix_t& A)
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const real_t one(1);
@@ -77,7 +77,7 @@ int potf2(uplo_t uplo, matrix_t& A)
     if (uplo == Uplo::Upper) {
         // Compute the Cholesky factorization A = U^H * U
         for (idx_t j = 0; j < n; ++j) {
-            auto colj = slice(A, pair{0, j}, j);
+            auto colj = slice(A, range{0, j}, j);
 
             // Compute U(j,j) and test for non-positive-definiteness
             real_t ajj = real(A(j, j)) - real(dot(colj, colj));
@@ -95,8 +95,8 @@ int potf2(uplo_t uplo, matrix_t& A)
 
             // Compute elements j+1:n of row j
             if (j + 1 < n) {
-                auto Ajj = slice(A, pair{0, j}, pair{j + 1, n});
-                auto rowj = slice(A, j, pair{j + 1, n});
+                auto Ajj = slice(A, range{0, j}, range{j + 1, n});
+                auto rowj = slice(A, j, range{j + 1, n});
 
                 // rowj := rowj - conj(colj) * Ajj
                 for (idx_t i = 0; i < j; ++i)
@@ -113,7 +113,7 @@ int potf2(uplo_t uplo, matrix_t& A)
     else {
         // Compute the Cholesky factorization A = L * L^H
         for (idx_t j = 0; j < n; ++j) {
-            auto rowj = slice(A, j, pair{0, j});
+            auto rowj = slice(A, j, range{0, j});
 
             // Compute L(j,j) and test for non-positive-definiteness
             real_t ajj = real(A(j, j)) - real(dot(rowj, rowj));
@@ -131,8 +131,8 @@ int potf2(uplo_t uplo, matrix_t& A)
 
             // Compute elements j+1:n of column j
             if (j + 1 < n) {
-                auto Ajj = slice(A, pair{j + 1, n}, pair{0, j});
-                auto colj = slice(A, pair{j + 1, n}, j);
+                auto Ajj = slice(A, range{j + 1, n}, range{0, j});
+                auto colj = slice(A, range{j + 1, n}, j);
 
                 // colj := colj - Ajj * conj(rowj)
                 for (idx_t i = 0; i < j; ++i)
@@ -153,7 +153,7 @@ int potf2(uplo_t uplo, matrix_t& A)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <TLAPACK_UPLO uplo_t,
-          TLAPACK_SMATRIX matrix_t,
+          TLAPACK_LEGACY_MATRIX matrix_t,
           enable_if_allow_optblas_t<matrix_t> = 0>
 int potf2(uplo_t uplo, matrix_t& A)
 {

--- a/include/tlapack/lapack/potrf2.hpp
+++ b/include/tlapack/lapack/potrf2.hpp
@@ -75,7 +75,7 @@ int potrf2(uplo_t uplo, matrix_t& A, const ec_opts_t& opts = {})
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const real_t one(1);
@@ -110,8 +110,8 @@ int potrf2(uplo_t uplo, matrix_t& A, const ec_opts_t& opts = {})
         const idx_t n1 = n / 2;
 
         // Define A11 and A22
-        auto A11 = slice(A, pair{0, n1}, pair{0, n1});
-        auto A22 = slice(A, pair{n1, n}, pair{n1, n});
+        auto A11 = slice(A, range{0, n1}, range{0, n1});
+        auto A22 = slice(A, range{n1, n}, range{n1, n});
 
         // Factor A11
         int info = potrf2(uplo, A11, noErrorCheck);
@@ -126,7 +126,7 @@ int potrf2(uplo_t uplo, matrix_t& A, const ec_opts_t& opts = {})
 
         if (uplo == Uplo::Upper) {
             // Update and scale A12
-            auto A12 = slice(A, pair{0, n1}, pair{n1, n});
+            auto A12 = slice(A, range{0, n1}, range{n1, n});
             trsm(Side::Left, Uplo::Upper, Op::ConjTrans, Diag::NonUnit, one,
                  A11, A12);
 
@@ -135,7 +135,7 @@ int potrf2(uplo_t uplo, matrix_t& A, const ec_opts_t& opts = {})
         }
         else {
             // Update and scale A21
-            auto A21 = slice(A, pair{n1, n}, pair{0, n1});
+            auto A21 = slice(A, range{n1, n}, range{0, n1});
             trsm(Side::Right, Uplo::Lower, Op::ConjTrans, Diag::NonUnit, one,
                  A11, A21);
 

--- a/include/tlapack/lapack/potrf_blocked.hpp
+++ b/include/tlapack/lapack/potrf_blocked.hpp
@@ -72,7 +72,7 @@ int potrf_blocked(uplo_t uplo,
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const real_t one(1);
@@ -97,8 +97,8 @@ int potrf_blocked(uplo_t uplo,
                 idx_t jb = min(nb, n - j);
 
                 // Define AJJ and A1J
-                auto AJJ = slice(A, pair{j, j + jb}, pair{j, j + jb});
-                auto A1J = slice(A, pair{0, j}, pair{j, j + jb});
+                auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
+                auto A1J = slice(A, range{0, j}, range{j, j + jb});
 
                 herk(uplo, conjTranspose, -one, A1J, one, AJJ);
 
@@ -114,8 +114,8 @@ int potrf_blocked(uplo_t uplo,
 
                 if (j + jb < n) {
                     // Define B and C
-                    auto B = slice(A, pair{0, j}, pair{j + jb, n});
-                    auto C = slice(A, pair{j, j + jb}, pair{j + jb, n});
+                    auto B = slice(A, range{0, j}, range{j + jb, n});
+                    auto C = slice(A, range{j, j + jb}, range{j + jb, n});
 
                     // Compute the current block row
                     gemm(conjTranspose, noTranspose, -one, A1J, B, one, C);
@@ -129,8 +129,8 @@ int potrf_blocked(uplo_t uplo,
                 idx_t jb = min(nb, n - j);
 
                 // Define AJJ and AJ1
-                auto AJJ = slice(A, pair{j, j + jb}, pair{j, j + jb});
-                auto AJ1 = slice(A, pair{j, j + jb}, pair{0, j});
+                auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
+                auto AJ1 = slice(A, range{j, j + jb}, range{0, j});
 
                 herk(uplo, noTranspose, -one, AJ1, one, AJJ);
 
@@ -146,8 +146,8 @@ int potrf_blocked(uplo_t uplo,
 
                 if (j + jb < n) {
                     // Define B and C
-                    auto B = slice(A, pair{j + jb, n}, pair{0, j});
-                    auto C = slice(A, pair{j + jb, n}, pair{j, j + jb});
+                    auto B = slice(A, range{j + jb, n}, range{0, j});
+                    auto C = slice(A, range{j + jb, n}, range{j, j + jb});
 
                     // Compute the current block row
                     gemm(noTranspose, conjTranspose, -one, B, AJ1, one, C);
@@ -178,7 +178,7 @@ inline int potrf_blocked(uplo_t uplo, matrix_t& A)
 #ifdef USE_LAPACKPP_WRAPPERS
 
 template <TLAPACK_UPLO uplo_t,
-          TLAPACK_SMATRIX matrix_t,
+          TLAPACK_LEGACY_MATRIX matrix_t,
           enable_if_allow_optblas_t<matrix_t> = 0>
 inline int potrf_blocked(uplo_t uplo, matrix_t& A)
 {

--- a/include/tlapack/lapack/potrf_blocked_right_looking.hpp
+++ b/include/tlapack/lapack/potrf_blocked_right_looking.hpp
@@ -66,7 +66,7 @@ int potrf_rl(uplo_t uplo,
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const real_t one(1);
@@ -91,7 +91,7 @@ int potrf_rl(uplo_t uplo,
                 idx_t jb = min(nb, n - j);
 
                 // Define AJJ
-                auto AJJ = slice(A, pair{j, j + jb}, pair{j, j + jb});
+                auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
 
                 int info = potf2(uplo, AJJ);
                 if (info != 0) {
@@ -104,8 +104,8 @@ int potrf_rl(uplo_t uplo,
                 }
 
                 if (j + jb < n) {
-                    auto B = slice(A, pair{j, j + jb}, pair{j + jb, n});
-                    auto C = slice(A, pair{j + jb, n}, pair{j + jb, n});
+                    auto B = slice(A, range{j, j + jb}, range{j + jb, n});
+                    auto C = slice(A, range{j + jb, n}, range{j + jb, n});
 
                     trsm(left_side, uplo, conjTranspose, nonUnit_diagonal, one,
                          AJJ, B);
@@ -118,7 +118,7 @@ int potrf_rl(uplo_t uplo,
                 idx_t jb = min(nb, n - j);
 
                 // Define AJJ
-                auto AJJ = slice(A, pair{j, j + jb}, pair{j, j + jb});
+                auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
 
                 int info = potf2(uplo, AJJ);
                 if (info != 0) {
@@ -131,8 +131,8 @@ int potrf_rl(uplo_t uplo,
                 }
 
                 if (j + jb < n) {
-                    auto B = slice(A, pair{j + jb, n}, pair{j, j + jb});
-                    auto C = slice(A, pair{j + jb, n}, pair{j + jb, n});
+                    auto B = slice(A, range{j + jb, n}, range{j, j + jb});
+                    auto C = slice(A, range{j + jb, n}, range{j + jb, n});
 
                     trsm(right_side, uplo, conjTranspose, nonUnit_diagonal, one,
                          AJJ, B);

--- a/include/tlapack/lapack/rscl.hpp
+++ b/include/tlapack/lapack/rscl.hpp
@@ -18,7 +18,7 @@ namespace tlapack {
 
 template <TLAPACK_VECTOR vector_t,
           TLAPACK_REAL alpha_t,
-          enable_if_t<is_real<alpha_t>::value, int> = 0>
+          enable_if_t<is_real<alpha_t>, int> = 0>
 void rscl(const alpha_t& alpha, vector_t& x)
 {
     using real_t = real_type<alpha_t>;
@@ -71,7 +71,7 @@ void rscl(const alpha_t& alpha, vector_t& x)
  */
 template <TLAPACK_VECTOR vector_t,
           TLAPACK_COMPLEX alpha_t,
-          enable_if_t<is_complex<alpha_t>::value, int> = 0>
+          enable_if_t<is_complex<alpha_t>, int> = 0>
 void rscl(const alpha_t& alpha, vector_t& x)
 {
     using real_t = real_type<alpha_t>;

--- a/include/tlapack/lapack/schur_move.hpp
+++ b/include/tlapack/lapack/schur_move.hpp
@@ -61,24 +61,24 @@ int schur_move(bool want_q,
     if (n == 0) return 0;
 
     // Check if ifst points to the middle of a 2x2 block
-    if (is_real<T>::value)
+    if (is_real<T>)
         if (ifst > 0)
             if (A(ifst, ifst - 1) != zero) ifst = ifst - 1;
 
     // Size of the current block, can be either 1, 2
     idx_t nbf = 1;
-    if (is_real<T>::value)
+    if (is_real<T>)
         if (ifst < n - 1)
             if (A(ifst + 1, ifst) != zero) nbf = 2;
 
     // Check if ilst points to the middle of a 2x2 block
-    if (is_real<T>::value)
+    if (is_real<T>)
         if (ilst > 0)
             if (A(ilst, ilst - 1) != zero) ilst = ilst - 1;
 
     // Size of the final block, can be either 1, 2
     idx_t nbl = 1;
-    if (is_real<T>::value)
+    if (is_real<T>)
         if (ilst < n - 1)
             if (A(ilst + 1, ilst) != zero) nbl = 2;
 
@@ -90,7 +90,7 @@ int schur_move(bool want_q,
         while (here != ilst) {
             // Size of the next eigenvalue block
             idx_t nbnext = 1;
-            if (is_real<T>::value)
+            if (is_real<T>)
                 if (here + nbf + 1 < n)
                     if (A(here + nbf + 1, here + nbf) != zero) nbnext = 2;
 
@@ -107,7 +107,7 @@ int schur_move(bool want_q,
         while (here != ilst) {
             // Size of the next eigenvalue block
             idx_t nbnext = 1;
-            if (is_real<T>::value)
+            if (is_real<T>)
                 if (here > 1)
                     if (A(here - 1, here - 2) != zero) nbnext = 2;
 

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -45,7 +45,7 @@ namespace tlapack {
  * @ingroup auxiliary
  */
 template <TLAPACK_SMATRIX matrix_t,
-          enable_if_t<is_real<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_real<type_t<matrix_t>>, bool> = true>
 int schur_swap(bool want_q,
                matrix_t& A,
                matrix_t& Q,
@@ -55,7 +55,7 @@ int schur_swap(bool want_q,
 {
     using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor for creating new matrices
     Create<matrix_t> new_matrix;
@@ -112,14 +112,14 @@ int schur_swap(bool want_q,
 
         // Apply transformation from the left
         if (j2 < n) {
-            auto row1 = slice(A, j0, pair{j2, n});
-            auto row2 = slice(A, j1, pair{j2, n});
+            auto row1 = slice(A, j0, range{j2, n});
+            auto row2 = slice(A, j1, range{j2, n});
             rot(row1, row2, cs, sn);
         }
         // Apply transformation from the right
         if (j0 > 0) {
-            auto col1 = slice(A, pair{0, j0}, j0);
-            auto col2 = slice(A, pair{0, j0}, j1);
+            auto col1 = slice(A, range{0, j0}, j0);
+            auto col2 = slice(A, range{0, j0}, j1);
             rot(col1, col2, cs, sn);
         }
         if (want_q) {
@@ -144,8 +144,8 @@ int schur_swap(bool want_q,
 
         // Make B upper triangular
         T tau1, tau2;
-        auto v1 = slice(B, pair{0, 3}, 0);
-        auto v2 = slice(B, pair{1, 3}, 1);
+        auto v1 = slice(B, range{0, 3}, 0);
+        auto v2 = slice(B, range{1, 3}, 1);
         larfg(forward, columnwise_storage, v1, tau1);
         const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
         B(0, 1) = B(0, 1) - sum * tau1;
@@ -212,8 +212,8 @@ int schur_swap(bool want_q,
 
         // Make B upper triangular
         T tau1, tau2;
-        auto v1 = slice(B, pair{0, 3}, 0);
-        auto v2 = slice(B, pair{1, 3}, 1);
+        auto v1 = slice(B, range{0, 3}, 0);
+        auto v2 = slice(B, range{1, 3}, 1);
         larfg(forward, columnwise_storage, v1, tau1);
         const T sum = B(0, 1) + v1[1] * B(1, 1) + v1[2] * B(2, 1);
         B(0, 1) = B(0, 1) - sum * tau1;
@@ -268,7 +268,7 @@ int schur_swap(bool want_q,
         std::vector<T> D_;
         auto D = new_matrix(D_, 4, 4);
 
-        auto AD_slice = slice(A, pair{j0, j0 + 4}, pair{j0, j0 + 4});
+        auto AD_slice = slice(A, range{j0, j0 + 4}, range{j0, j0 + 4});
         lacpy(Uplo::General, AD_slice, D);
         auto dnorm = lange(Norm::Max, D);
 
@@ -278,10 +278,10 @@ int schur_swap(bool want_q,
 
         std::vector<T> V_;
         auto V = new_matrix(V_, 4, 2);
-        auto X = slice(V, pair{0, 2}, pair{0, 2});
-        auto TL = slice(D, pair{0, 2}, pair{0, 2});
-        auto TR = slice(D, pair{2, 4}, pair{2, 4});
-        auto B = slice(D, pair{0, 2}, pair{2, 4});
+        auto X = slice(V, range{0, 2}, range{0, 2});
+        auto TL = slice(D, range{0, 2}, range{0, 2});
+        auto TR = slice(D, range{2, 4}, range{2, 4});
+        auto B = slice(D, range{0, 2}, range{2, 4});
         T scale, xnorm;
         lasy2(Op::NoTrans, Op::NoTrans, -1, TL, TR, B, scale, X, xnorm);
 
@@ -292,8 +292,8 @@ int schur_swap(bool want_q,
 
         // Make V upper triangular
         T tau1, tau2;
-        auto v1 = slice(V, pair{0, 4}, 0);
-        auto v2 = slice(V, pair{1, 4}, 1);
+        auto v1 = slice(V, range{0, 4}, 0);
+        auto v2 = slice(V, range{1, 4}, 1);
         larfg(forward, columnwise_storage, v1, tau1);
         const T sum =
             V(0, 1) + v1[1] * V(1, 1) + v1[2] * V(2, 1) + v1[3] * V(3, 1);
@@ -393,14 +393,14 @@ int schur_swap(bool want_q,
         lahqr_schur22(A(j0, j0), A(j0, j1), A(j1, j0), A(j1, j1), s1, s2, cs,
                       sn);  // Apply transformation from the left
         if (j2 < n) {
-            auto row1 = slice(A, j0, pair{j2, n});
-            auto row2 = slice(A, j1, pair{j2, n});
+            auto row1 = slice(A, j0, range{j2, n});
+            auto row2 = slice(A, j1, range{j2, n});
             rot(row1, row2, cs, sn);
         }
         // Apply transformation from the right
         if (j0 > 0) {
-            auto col1 = slice(A, pair{0, j0}, j0);
-            auto col2 = slice(A, pair{0, j0}, j1);
+            auto col1 = slice(A, range{0, j0}, j0);
+            auto col2 = slice(A, range{0, j0}, j1);
             rot(col1, col2, cs, sn);
         }
         if (want_q) {
@@ -419,14 +419,14 @@ int schur_swap(bool want_q,
                       A(j1_2, j1_2), s1, s2, cs,
                       sn);  // Apply transformation from the left
         if (j0_2 + 2 < n) {
-            auto row1 = slice(A, j0_2, pair{j0_2 + 2, n});
-            auto row2 = slice(A, j1_2, pair{j0_2 + 2, n});
+            auto row1 = slice(A, j0_2, range{j0_2 + 2, n});
+            auto row2 = slice(A, j1_2, range{j0_2 + 2, n});
             rot(row1, row2, cs, sn);
         }
         // Apply transformation from the right
         if (j0_2 > 0) {
-            auto col1 = slice(A, pair{0, j0_2}, j0_2);
-            auto col2 = slice(A, pair{0, j0_2}, j1_2);
+            auto col1 = slice(A, range{0, j0_2}, j0_2);
+            auto col2 = slice(A, range{0, j0_2}, j1_2);
             rot(col1, col2, cs, sn);
         }
         if (want_q) {
@@ -446,7 +446,7 @@ int schur_swap(bool want_q,
  * @ingroup auxiliary
  */
 template <TLAPACK_SMATRIX matrix_t,
-          enable_if_t<is_complex<type_t<matrix_t>>::value, bool> = true>
+          enable_if_t<is_complex<type_t<matrix_t>>, bool> = true>
 int schur_swap(bool want_q,
                matrix_t& A,
                matrix_t& Q,
@@ -457,7 +457,7 @@ int schur_swap(bool want_q,
     using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     const idx_t n = ncols(A);
 
@@ -490,14 +490,14 @@ int schur_swap(bool want_q,
 
     // Apply transformation from the left
     if (j2 < n) {
-        auto row1 = slice(A, j0, pair{j2, n});
-        auto row2 = slice(A, j1, pair{j2, n});
+        auto row1 = slice(A, j0, range{j2, n});
+        auto row2 = slice(A, j1, range{j2, n});
         rot(row1, row2, cs, sn);
     }
     // Apply transformation from the right
     if (j0 > 0) {
-        auto col1 = slice(A, pair{0, j0}, j0);
-        auto col2 = slice(A, pair{0, j0}, j1);
+        auto col1 = slice(A, range{0, j0}, j0);
+        auto col2 = slice(A, range{0, j0}, j1);
         rot(col1, col2, cs, conj(sn));
     }
     if (want_q) {

--- a/include/tlapack/lapack/transpose.hpp
+++ b/include/tlapack/lapack/transpose.hpp
@@ -40,7 +40,7 @@ void conjtranspose(matrixA_t& A,
                    const transpose_opts_t<size_type<matrixA_t>>& opts = {})
 {
     using idx_t = size_type<matrixA_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
@@ -60,15 +60,15 @@ void conjtranspose(matrixA_t& A,
         const idx_t m1 = m / 2;
         const idx_t n1 = n / 2;
 
-        auto A00 = slice(A, pair(0, m1), pair(0, n1));
-        auto A01 = slice(A, pair(0, m1), pair(n1, n));
-        auto A10 = slice(A, pair(m1, m), pair(0, n1));
-        auto A11 = slice(A, pair(m1, m), pair(n1, n));
+        auto A00 = slice(A, range(0, m1), range(0, n1));
+        auto A01 = slice(A, range(0, m1), range(n1, n));
+        auto A10 = slice(A, range(m1, m), range(0, n1));
+        auto A11 = slice(A, range(m1, m), range(n1, n));
 
-        auto B00 = slice(B, pair(0, n1), pair(0, m1));
-        auto B01 = slice(B, pair(0, n1), pair(m1, m));
-        auto B10 = slice(B, pair(n1, n), pair(0, m1));
-        auto B11 = slice(B, pair(n1, n), pair(m1, m));
+        auto B00 = slice(B, range(0, n1), range(0, m1));
+        auto B01 = slice(B, range(0, n1), range(m1, m));
+        auto B10 = slice(B, range(n1, n), range(0, m1));
+        auto B11 = slice(B, range(n1, n), range(m1, m));
 
         conjtranspose(A00, B00, opts);
         conjtranspose(A01, B10, opts);
@@ -97,7 +97,7 @@ void transpose(matrixA_t& A,
                const transpose_opts_t<size_type<matrixA_t>>& opts = {})
 {
     using idx_t = size_type<matrixA_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
@@ -117,15 +117,15 @@ void transpose(matrixA_t& A,
         const idx_t m1 = m / 2;
         const idx_t n1 = n / 2;
 
-        auto A00 = slice(A, pair(0, m1), pair(0, n1));
-        auto A01 = slice(A, pair(0, m1), pair(n1, n));
-        auto A10 = slice(A, pair(m1, m), pair(0, n1));
-        auto A11 = slice(A, pair(m1, m), pair(n1, n));
+        auto A00 = slice(A, range(0, m1), range(0, n1));
+        auto A01 = slice(A, range(0, m1), range(n1, n));
+        auto A10 = slice(A, range(m1, m), range(0, n1));
+        auto A11 = slice(A, range(m1, m), range(n1, n));
 
-        auto B00 = slice(B, pair(0, n1), pair(0, m1));
-        auto B01 = slice(B, pair(0, n1), pair(m1, m));
-        auto B10 = slice(B, pair(n1, n), pair(0, m1));
-        auto B11 = slice(B, pair(n1, n), pair(m1, m));
+        auto B00 = slice(B, range(0, n1), range(0, m1));
+        auto B01 = slice(B, range(0, n1), range(m1, m));
+        auto B10 = slice(B, range(n1, n), range(0, m1));
+        auto B11 = slice(B, range(n1, n), range(m1, m));
 
         transpose(A00, B00, opts);
         transpose(A01, B10, opts);

--- a/include/tlapack/lapack/trtri_recursive.hpp
+++ b/include/tlapack/lapack/trtri_recursive.hpp
@@ -52,7 +52,7 @@ int trtri_recursive(uplo_t uplo,
 {
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using real_t = real_type<T>;
 
     const idx_t n = nrows(C);

--- a/include/tlapack/lapack/ul_mult.hpp
+++ b/include/tlapack/lapack/ul_mult.hpp
@@ -35,6 +35,7 @@ int ul_mult(matrix_t& A)
 {
     using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // check arguments
     tlapack_check(nrows(A) == ncols(A));
@@ -49,14 +50,10 @@ int ul_mult(matrix_t& A)
     idx_t n0 = n / 2;
 
     // break A into four parts
-    auto A00 = tlapack::slice(A, tlapack::range<idx_t>(0, n0),
-                              tlapack::range<idx_t>(0, n0));
-    auto A10 = tlapack::slice(A, tlapack::range<idx_t>(n0, n),
-                              tlapack::range<idx_t>(0, n0));
-    auto A01 = tlapack::slice(A, tlapack::range<idx_t>(0, n0),
-                              tlapack::range<idx_t>(n0, n));
-    auto A11 = tlapack::slice(A, tlapack::range<idx_t>(n0, n),
-                              tlapack::range<idx_t>(n0, n));
+    auto A00 = tlapack::slice(A, range(0, n0), range(0, n0));
+    auto A10 = tlapack::slice(A, range(n0, n), range(0, n0));
+    auto A01 = tlapack::slice(A, range(0, n0), range(n0, n));
+    auto A11 = tlapack::slice(A, range(n0, n), range(n0, n));
 
     // calculate top left corner
     ul_mult(A00);

--- a/include/tlapack/lapack/ung2l.hpp
+++ b/include/tlapack/lapack/ung2l.hpp
@@ -37,12 +37,13 @@ inline constexpr workinfo_t ung2l_worksize(const matrix_t& A,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t n = ncols(A);
 
     if (n > 1) {
-        auto C = cols(A, range<idx_t>{1, n});
+        auto C = cols(A, range{1, n});
         return larf_worksize(Side::Left, Direction::Backward,
                              StoreV::Columnwise, col(A, 0), tau[0], C, opts);
     }
@@ -81,7 +82,7 @@ int ung2l(matrix_t& A, const vector_t& tau, const workspace_opts_t<>& opts = {})
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const real_t zero(0);
@@ -97,7 +98,7 @@ int ung2l(matrix_t& A, const vector_t& tau, const workspace_opts_t<>& opts = {})
     if (n <= 0) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = ung2l_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -115,11 +116,11 @@ int ung2l(matrix_t& A, const vector_t& tau, const workspace_opts_t<>& opts = {})
 
     for (idx_t i = 0; i < k; ++i) {
         idx_t ii = n - k + i;
-        auto v = slice(A, pair{0, m - k + i + 1}, ii);
-        auto C = slice(A, pair{0, m - k + i + 1}, pair{0, ii});
+        auto v = slice(A, range{0, m - k + i + 1}, ii);
+        auto C = slice(A, range{0, m - k + i + 1}, range{0, ii});
         larf(Side::Left, Direction::Backward, StoreV::Columnwise, v, tau[i], C,
              larfOpts);
-        auto x = slice(A, pair{0, m - k + i}, ii);
+        auto x = slice(A, range{0, m - k + i}, ii);
         scal(-tau[i], x);
         A(m - k + i, ii) = one - tau[i];
 

--- a/include/tlapack/lapack/ung2r.hpp
+++ b/include/tlapack/lapack/ung2r.hpp
@@ -37,13 +37,14 @@ inline constexpr workinfo_t ung2r_worksize(const matrix_t& A,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     if (n > 1 && m > 1) {
-        auto C = cols(A, range<idx_t>{1, n});
+        auto C = cols(A, range{1, n});
         return larf_worksize(left_side, forward, columnwise_storage, col(A, 0),
                              tau[0], C, opts);
     }
@@ -78,7 +79,7 @@ int ung2r(matrix_t& A, const vector_t& tau, const workspace_opts_t<>& opts = {})
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const real_t zero(0);
@@ -94,7 +95,7 @@ int ung2r(matrix_t& A, const vector_t& tau, const workspace_opts_t<>& opts = {})
     if (n <= 0) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = ung2r_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -113,10 +114,10 @@ int ung2r(matrix_t& A, const vector_t& tau, const workspace_opts_t<>& opts = {})
     for (idx_t i = k - 1; i != idx_t(-1); --i) {
         // Apply $H_{i+1}$ to $A( i:m-1, i:n-1 )$ from the left
         // Define v and C
-        auto v = slice(A, pair{i, m}, i);
-        auto C = slice(A, pair{i, m}, pair{i + 1, n});
+        auto v = slice(A, range{i, m}, i);
+        auto C = slice(A, range{i, m}, range{i + 1, n});
         larf(left_side, forward, columnwise_storage, v, tau[i], C, larfOpts);
-        auto x = slice(A, pair{i + 1, m}, i);
+        auto x = slice(A, range{i + 1, m}, i);
         scal(-tau[i], x);
         A(i, i) = one - tau[i];
 

--- a/include/tlapack/lapack/ungbr.hpp
+++ b/include/tlapack/lapack/ungbr.hpp
@@ -59,7 +59,7 @@ inline constexpr workinfo_t ungbr_q_worksize(
     const ungbr_opts_t<workT_t>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
@@ -68,8 +68,8 @@ inline constexpr workinfo_t ungbr_q_worksize(
         return ungqr_worksize(A, tau, opts);
     }
     else {
-        auto A2 = slice(A, pair{0, m - 1}, pair{0, m - 1});
-        auto tau2 = slice(tau, pair{0, m - 1});
+        auto A2 = slice(A, range{0, m - 1}, range{0, m - 1});
+        auto tau2 = slice(tau, range{0, m - 1});
         return ungqr_worksize(A2, tau2, opts);
     }
 }
@@ -104,14 +104,14 @@ inline constexpr workinfo_t ungbr_p_worksize(
     const ungbr_opts_t<workT_t>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
     if (m >= k) {
-        auto A2 = slice(A, pair{0, n - 1}, pair{0, n - 1});
-        auto tau2 = slice(tau, pair{0, n - 1});
+        auto A2 = slice(A, range{0, n - 1}, range{0, n - 1});
+        auto tau2 = slice(tau, range{0, n - 1});
         return unglq_worksize(A2, tau2, opts);
     }
     else {
@@ -162,7 +162,7 @@ int ungbr_q(const size_type<matrix_t> k,
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const real_t zero(0);
@@ -190,8 +190,8 @@ int ungbr_q(const size_type<matrix_t> k,
             A(i, 0) = zero;
         if (m > 1) {
             // Form Q(1:m,1:m)
-            auto A2 = slice(A, pair{1, m}, pair{1, m});
-            auto tau2 = slice(tau, pair{0, m - 1});
+            auto A2 = slice(A, range{1, m}, range{1, m});
+            auto tau2 = slice(tau, range{0, m - 1});
             ungqr(A2, tau2, ungqrOpts);
         }
     }
@@ -242,7 +242,7 @@ int ungbr_p(const size_type<matrix_t> k,
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const real_t zero(0);
@@ -275,8 +275,8 @@ int ungbr_p(const size_type<matrix_t> k,
             A(0, j) = zero;
         }
         if (n > 1) {
-            auto A2 = slice(A, pair{1, n}, pair{1, n});
-            auto tau2 = slice(tau, pair{0, n - 1});
+            auto A2 = slice(A, range{1, n}, range{1, n});
+            auto tau2 = slice(tau, range{0, n - 1});
             unglq(A2, tau2, unglqOpts);
         }
     }

--- a/include/tlapack/lapack/unghr.hpp
+++ b/include/tlapack/lapack/unghr.hpp
@@ -49,7 +49,7 @@ int unghr(size_type<matrix_t> ilo,
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const real_t zero(0);
@@ -94,8 +94,8 @@ int unghr(size_type<matrix_t> ilo,
     // Now that the vectors are shifted, we can call orgqr to generate the
     // matrix orgqr is not yet implemented, so we call org2r instead
     if (nh > 0) {
-        auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo + 1, ihi});
-        auto tau_s = slice(tau, pair{ilo, ihi - 1});
+        auto A_s = slice(A, range{ilo + 1, ihi}, range{ilo + 1, ihi});
+        auto tau_s = slice(tau, range{ilo, ihi - 1});
         ung2r(A_s, tau_s, opts);
     }
 
@@ -130,14 +130,14 @@ inline constexpr workinfo_t unghr_worksize(size_type<matrix_t> ilo,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t nh = (ihi > ilo + 1) ? ihi - 1 - ilo : 0;
 
     if (nh > 0 && ilo + 1 < ihi) {
-        auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo + 1, ihi});
-        auto tau_s = slice(tau, pair{ilo, ihi - 1});
+        auto A_s = slice(A, range{ilo + 1, ihi}, range{ilo + 1, ihi});
+        auto tau_s = slice(tau, range{ilo, ihi - 1});
         return ung2r_worksize(A_s, tau_s, opts);
     }
     return workinfo_t{};

--- a/include/tlapack/lapack/ungl2.hpp
+++ b/include/tlapack/lapack/ungl2.hpp
@@ -37,12 +37,13 @@ inline constexpr workinfo_t ungl2_worksize(const matrix_t& Q,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t k = nrows(Q);
 
     if (k > 1) {
-        auto C = rows(Q, range<idx_t>{1, k});
+        auto C = rows(Q, range{1, k});
         return larf_worksize(right_side, forward, rowwise_storage, row(Q, 0),
                              tauw[0], C, opts);
     }
@@ -85,7 +86,7 @@ int ungl2(matrix_t& Q,
 {
     using idx_t = size_type<matrix_t>;
     using T = type_t<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using real_t = real_type<T>;
 
     // constants
@@ -100,7 +101,7 @@ int ungl2(matrix_t& Q,
     tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = ungl2_worksize(Q, tauw, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);

--- a/include/tlapack/lapack/unglq.hpp
+++ b/include/tlapack/lapack/unglq.hpp
@@ -56,7 +56,7 @@ inline constexpr workinfo_t unglq_worksize(
     using idx_t = size_type<matrix_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrix_t, vector_t> >;
     using T = type_t<matrixT_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const idx_t k = size(tau);
@@ -71,8 +71,8 @@ inline constexpr workinfo_t unglq_worksize(
         const idx_t m = nrows(A);
 
         // Empty matrices
-        const auto V = slice(A, pair{0, nb}, pair{0, m});
-        const auto matrixT = slice(A, pair{0, nb}, pair{0, nb});
+        const auto V = slice(A, range{0, nb}, range{0, m});
+        const auto matrixT = slice(A, range{0, nb}, range{0, nb});
 
         // Internal workspace queries
         workinfo += larfb_worksize(right_side, conjTranspose, forward,
@@ -121,7 +121,7 @@ int unglq(matrix_t& A,
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrix_t, vector_t> >;
 
     // Functor
@@ -142,7 +142,7 @@ int unglq(matrix_t& A,
     if (n <= 0) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = unglq_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -167,23 +167,23 @@ int unglq(matrix_t& A,
 
     for (idx_t i = ((k - 1) / nb) * nb; i != idx_t(-nb); i = i - nb) {
         idx_t ib = min<idx_t>(nb, k - i);
-        const auto taui = slice(tau, pair{i, i + ib});
+        const auto taui = slice(tau, range{i, i + ib});
         // Use block reflector to update most of the matrix
         // We do this first because the reflectors will be destroyed by the
         // unblocked code later.
         if (i + ib < m) {
             // Form the triangular factor of the block reflector
             // H = H(i) H(i+1) . . . H(i+ib-1)
-            const auto V = slice(A, pair{i, i + ib}, pair{i, n});
-            auto matrixTi = slice(matrixT, pair{0, ib}, pair{0, ib});
-            auto C = slice(A, pair{i + ib, m}, pair{i, n});
+            const auto V = slice(A, range{i, i + ib}, range{i, n});
+            auto matrixTi = slice(matrixT, range{0, ib}, range{0, ib});
+            auto C = slice(A, range{i + ib, m}, range{i, n});
 
             larft(forward, rowwise_storage, V, taui, matrixTi);
             larfb(right_side, conjTranspose, forward, rowwise_storage, V,
                   matrixTi, C, larfbOpts);
         }
         // Use unblocked code to apply H to columns i:n of current block
-        auto Ai = slice(A, pair{i, i + ib}, pair{i, n});
+        auto Ai = slice(A, range{i, i + ib}, range{i, n});
         ungl2(Ai, taui, larfOpts);
         // Set rows 0:i-1 of current block to zero
         for (idx_t j = 0; j < i; ++j)

--- a/include/tlapack/lapack/ungql.hpp
+++ b/include/tlapack/lapack/ungql.hpp
@@ -56,7 +56,7 @@ inline constexpr workinfo_t ungql_worksize(
     using idx_t = size_type<matrix_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrix_t, vector_t> >;
     using T = type_t<matrixT_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const idx_t k = size(tau);
@@ -71,8 +71,8 @@ inline constexpr workinfo_t ungql_worksize(
         const idx_t m = nrows(A);
 
         // Empty matrices
-        const auto V = slice(A, pair{0, m}, pair{0, nb});
-        const auto matrixT = slice(A, pair{0, nb}, pair{0, nb});
+        const auto V = slice(A, range{0, m}, range{0, nb});
+        const auto matrixT = slice(A, range{0, nb}, range{0, nb});
 
         // Internal workspace queries
         workinfo += larfb_worksize(left_side, noTranspose, backward,
@@ -117,7 +117,7 @@ int ungql(matrix_t& A,
     using T = type_t<matrix_t>;
     using real_t = real_type<T>;
     using idx_t = size_type<matrix_t>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrix_t, vector_t> >;
 
     // Functor
@@ -138,7 +138,7 @@ int ungql(matrix_t& A,
     if (n <= 0) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = ungql_worksize(A, tau, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -162,23 +162,24 @@ int ungql(matrix_t& A,
     for (idx_t i = 0; i < k; i += nb) {
         idx_t ib = min<idx_t>(nb, k - i);
         idx_t ii = n - k + i;
-        const auto taui = slice(tau, pair{i, i + ib});
+        const auto taui = slice(tau, range{i, i + ib});
         // Use block reflector to update most of the matrix
         // We do this first because the reflectors will be destroyed by the
         // unblocked code later.
         if (ii > 0) {
             // Form the triangular factor of the block reflector
             // H = H(i) H(i+1) . . . H(i+ib-1)
-            const auto V = slice(A, pair{0, m - k + i + ib}, pair{ii, ii + ib});
-            auto matrixTi = slice(matrixT, pair{0, ib}, pair{0, ib});
-            auto C = slice(A, pair{0, m - k + i + ib}, pair{0, ii});
+            const auto V =
+                slice(A, range{0, m - k + i + ib}, range{ii, ii + ib});
+            auto matrixTi = slice(matrixT, range{0, ib}, range{0, ib});
+            auto C = slice(A, range{0, m - k + i + ib}, range{0, ii});
 
             larft(backward, columnwise_storage, V, taui, matrixTi);
             larfb(left_side, noTranspose, backward, columnwise_storage, V,
                   matrixTi, C, larfbOpts);
         }
         // Use unblocked code to apply H to rows 0:m-k+i+ib of current block
-        auto Ai = slice(A, pair{0, m - k + i + ib}, pair{ii, ii + ib});
+        auto Ai = slice(A, range{0, m - k + i + ib}, range{ii, ii + ib});
         ung2l(Ai, taui, larfOpts);
         // Set rows m-k+i+ib:m of current block to zero
         for (idx_t j = ii; j < ii + ib; ++j)

--- a/include/tlapack/lapack/unm2r.hpp
+++ b/include/tlapack/lapack/unm2r.hpp
@@ -57,14 +57,14 @@ inline constexpr workinfo_t unm2r_worksize(side_t side,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrixA_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(C);
     const idx_t n = ncols(C);
     const idx_t nA = (side == Side::Left) ? m : n;
 
-    auto v = slice(A, pair{0, nA}, 0);
+    auto v = slice(A, range{0, nA}, 0);
     return larf_worksize(side, forward, columnwise_storage, v, tau[0], C, opts);
 }
 
@@ -137,7 +137,7 @@ int unm2r(side_t side,
 {
     using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixA_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(C);
@@ -149,13 +149,13 @@ int unm2r(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = unm2r_worksize(side, trans, A, tau, C, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -174,16 +174,16 @@ int unm2r(side_t side,
 
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
-        auto v = slice(A, pair{i, nA}, i);
+        auto v = slice(A, range{i, nA}, i);
 
         if (side == Side::Left) {
-            auto Ci = rows(C, pair{i, m});
+            auto Ci = rows(C, range{i, m});
             larf(left_side, forward, columnwise_storage, v,
                  (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
                  larfOpts);
         }
         else {
-            auto Ci = cols(C, pair{i, n});
+            auto Ci = cols(C, range{i, n});
             larf(right_side, forward, columnwise_storage, v,
                  (trans == Op::ConjTrans) ? conj(tau[i]) : tau[i], Ci,
                  larfOpts);

--- a/include/tlapack/lapack/unmhr.hpp
+++ b/include/tlapack/lapack/unmhr.hpp
@@ -65,13 +65,13 @@ int unmhr(Side side,
           const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
-    auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo, ihi - 1});
-    auto tau_s = slice(tau, pair{ilo, ihi - 1});
+    auto A_s = slice(A, range{ilo + 1, ihi}, range{ilo, ihi - 1});
+    auto tau_s = slice(tau, range{ilo, ihi - 1});
     auto C_s = (side == Side::Left)
-                   ? slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)})
-                   : slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
+                   ? slice(C, range{ilo + 1, ihi}, range{0, ncols(C)})
+                   : slice(C, range{0, nrows(C)}, range{ilo + 1, ihi});
 
     unm2r(side, trans, A_s, tau_s, C_s, opts);
 
@@ -120,13 +120,13 @@ inline constexpr workinfo_t unmhr_worksize(Side side,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrix_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
-    auto A_s = slice(A, pair{ilo + 1, ihi}, pair{ilo, ihi - 1});
-    auto tau_s = slice(tau, pair{ilo, ihi - 1});
+    auto A_s = slice(A, range{ilo + 1, ihi}, range{ilo, ihi - 1});
+    auto tau_s = slice(tau, range{ilo, ihi - 1});
     auto C_s = (side == Side::Left)
-                   ? slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)})
-                   : slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
+                   ? slice(C, range{ilo + 1, ihi}, range{0, ncols(C)})
+                   : slice(C, range{0, nrows(C)}, range{ilo + 1, ihi});
 
     return unm2r_worksize(side, trans, A_s, tau_s, C_s, opts);
 }

--- a/include/tlapack/lapack/unml2.hpp
+++ b/include/tlapack/lapack/unml2.hpp
@@ -57,14 +57,14 @@ inline constexpr workinfo_t unml2_worksize(side_t side,
                                            const workspace_opts_t<>& opts = {})
 {
     using idx_t = size_type<matrixA_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(C);
     const idx_t n = ncols(C);
     const idx_t nA = (side == Side::Left) ? m : n;
 
-    auto v = slice(A, 0, pair{0, nA});
+    auto v = slice(A, 0, range{0, nA});
     return larf_worksize(side, forward, rowwise_storage, v, tau[0], C, opts);
 }
 
@@ -125,7 +125,7 @@ int unml2(side_t side,
 {
     using TA = type_t<matrixA_t>;
     using idx_t = size_type<matrixA_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // constants
     const idx_t m = nrows(C);
@@ -137,13 +137,13 @@ int unml2(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = unml2_worksize(side, trans, A, tau, C, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -162,15 +162,15 @@ int unml2(side_t side,
 
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
-        auto v = slice(A, i, pair{i, nA});
+        auto v = slice(A, i, range{i, nA});
 
         if (side == Side::Left) {
-            auto Ci = rows(C, pair{i, m});
+            auto Ci = rows(C, range{i, m});
             larf(left_side, forward, rowwise_storage, v,
                  (trans == Op::NoTrans) ? conj(tau[i]) : tau[i], Ci, larfOpts);
         }
         else {
-            auto Ci = cols(C, pair{i, n});
+            auto Ci = cols(C, range{i, n});
             larf(right_side, forward, rowwise_storage, v,
                  (trans == Op::NoTrans) ? conj(tau[i]) : tau[i], Ci, larfOpts);
         }

--- a/include/tlapack/lapack/unmlq.hpp
+++ b/include/tlapack/lapack/unmlq.hpp
@@ -77,7 +77,7 @@ inline constexpr workinfo_t unmlq_worksize(
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
     using T = type_t<matrixT_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const idx_t k = size(tau);
@@ -94,8 +94,8 @@ inline constexpr workinfo_t unmlq_worksize(
         const idx_t nA = (side == Side::Left) ? m : n;
 
         // Empty matrices
-        const auto V = slice(A, pair{0, nb}, pair{0, nA});
-        const auto matrixT = slice(A, pair{0, nb}, pair{0, nb});
+        const auto V = slice(A, range{0, nb}, range{0, nA});
+        const auto matrixT = slice(A, range{0, nb}, range{0, nb});
 
         // Internal workspace queries
         workinfo += larfb_worksize(
@@ -178,7 +178,7 @@ int unmlq(side_t side,
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
 
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<matrixT_t> new_matrix;
@@ -194,13 +194,13 @@ int unmlq(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = unmlq_worksize(side, trans, A, tau, C, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -224,17 +224,17 @@ int unmlq(side_t side,
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
         idx_t ib = min<idx_t>(nb, k - i);
-        const auto V = slice(A, pair{i, i + ib}, pair{i, nA});
-        const auto taui = slice(tau, pair{i, i + ib});
-        auto matrixTi = slice(matrixT, pair{0, ib}, pair{0, ib});
+        const auto V = slice(A, range{i, i + ib}, range{i, nA});
+        const auto taui = slice(tau, range{i, i + ib});
+        auto matrixTi = slice(matrixT, range{0, ib}, range{0, ib});
 
         // Form the triangular factor of the block reflector
         // $H = H(i) H(i+1) ... H(i+ib-1)$
         larft(forward, rowwise_storage, V, taui, matrixTi);
 
         // H or H**H is applied to either C[0:m-k+i+1,0:n] or C[0:m,0:n-k+i+1]
-        auto Ci = (side == Side::Left) ? slice(C, pair{i, m}, pair{0, n})
-                                       : slice(C, pair{0, m}, pair{i, n});
+        auto Ci = (side == Side::Left) ? slice(C, range{i, m}, range{0, n})
+                                       : slice(C, range{0, m}, range{i, n});
 
         // Apply H or H**H
         larfb(side, (trans == Op::NoTrans) ? Op::ConjTrans : Op::NoTrans,

--- a/include/tlapack/lapack/unmql.hpp
+++ b/include/tlapack/lapack/unmql.hpp
@@ -90,7 +90,7 @@ inline constexpr workinfo_t unmql_worksize(
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
     using T = type_t<matrixT_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const idx_t k = size(tau);
@@ -107,8 +107,8 @@ inline constexpr workinfo_t unmql_worksize(
         const idx_t nA = (side == Side::Left) ? m : n;
 
         // Empty matrices
-        const auto V = slice(A, pair{0, nA}, pair{0, nb});
-        const auto matrixT = slice(A, pair{0, nb}, pair{0, nb});
+        const auto V = slice(A, range{0, nA}, range{0, nb});
+        const auto matrixT = slice(A, range{0, nb}, range{0, nb});
 
         // Internal workspace queries
         workinfo += larfb_worksize(side, trans, backward, columnwise_storage, V,
@@ -190,7 +190,7 @@ int unmql(side_t side,
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
 
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<matrixT_t> new_matrix;
@@ -206,13 +206,13 @@ int unmql(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = unmql_worksize(side, trans, A, tau, C, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -236,9 +236,9 @@ int unmql(side_t side,
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
         idx_t ib = min<idx_t>(nb, k - i);
-        const auto V = slice(A, pair{0, nA - k + i + ib}, pair{i, i + ib});
-        const auto taui = slice(tau, pair{i, i + ib});
-        auto matrixTi = slice(matrixT, pair{0, ib}, pair{0, ib});
+        const auto V = slice(A, range{0, nA - k + i + ib}, range{i, i + ib});
+        const auto taui = slice(tau, range{i, i + ib});
+        auto matrixTi = slice(matrixT, range{0, ib}, range{0, ib});
 
         // Form the triangular factor of the block reflector
         // $H = H(i) H(i+1) ... H(i+ib-1)$
@@ -246,8 +246,8 @@ int unmql(side_t side,
 
         // H or H**H is applied to either C[i:m,0:n] or C[0:m,i:n]
         auto Ci = (side == Side::Left)
-                      ? slice(C, pair{0, m - k + i + ib}, pair{0, n})
-                      : slice(C, pair{0, m}, pair{0, n - k + i + ib});
+                      ? slice(C, range{0, m - k + i + ib}, range{0, n})
+                      : slice(C, range{0, m}, range{0, n - k + i + ib});
 
         // Apply H or H**H
         larfb(side, trans, backward, columnwise_storage, V, matrixTi, Ci,

--- a/include/tlapack/lapack/unmqr.hpp
+++ b/include/tlapack/lapack/unmqr.hpp
@@ -77,7 +77,7 @@ inline constexpr workinfo_t unmqr_worksize(
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
     using T = type_t<matrixT_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Constants
     const idx_t k = size(tau);
@@ -94,8 +94,8 @@ inline constexpr workinfo_t unmqr_worksize(
         const idx_t nA = (side == Side::Left) ? m : n;
 
         // Empty matrices
-        const auto V = slice(A, pair{0, nA}, pair{0, nb});
-        const auto matrixT = slice(A, pair{0, nb}, pair{0, nb});
+        const auto V = slice(A, range{0, nA}, range{0, nb});
+        const auto matrixT = slice(A, range{0, nb}, range{0, nb});
 
         // Internal workspace queries
         workinfo += larfb_worksize(side, trans, forward, columnwise_storage, V,
@@ -177,7 +177,7 @@ int unmqr(side_t side,
     using idx_t = size_type<matrixC_t>;
     using matrixT_t = deduce_work_t<workT_t, matrix_type<matrixA_t, tau_t> >;
 
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<matrixT_t> new_matrix;
@@ -193,13 +193,13 @@ int unmqr(side_t side,
     tlapack_check_false(side != Side::Left && side != Side::Right);
     tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                         trans != Op::ConjTrans);
-    tlapack_check_false(trans == Op::Trans && is_complex<TA>::value);
+    tlapack_check_false(trans == Op::Trans && is_complex<TA>);
 
     // quick return
     if ((m == 0) || (n == 0) || (k == 0)) return 0;
 
     // Allocates workspace
-    vectorOfBytes localworkdata;
+    VectorOfBytes localworkdata;
     Workspace work = [&]() {
         workinfo_t workinfo = unmqr_worksize(side, trans, A, tau, C, opts);
         return alloc_workspace(localworkdata, workinfo, opts.work);
@@ -223,17 +223,17 @@ int unmqr(side_t side,
     // Main loop
     for (idx_t i = i0; i != iN; i += inc) {
         idx_t ib = min<idx_t>(nb, k - i);
-        const auto V = slice(A, pair{i, nA}, pair{i, i + ib});
-        const auto taui = slice(tau, pair{i, i + ib});
-        auto matrixTi = slice(matrixT, pair{0, ib}, pair{0, ib});
+        const auto V = slice(A, range{i, nA}, range{i, i + ib});
+        const auto taui = slice(tau, range{i, i + ib});
+        auto matrixTi = slice(matrixT, range{0, ib}, range{0, ib});
 
         // Form the triangular factor of the block reflector
         // $H = H(i) H(i+1) ... H(i+ib-1)$
         larft(forward, columnwise_storage, V, taui, matrixTi);
 
         // H or H**H is applied to either C[i:m,0:n] or C[0:m,i:n]
-        auto Ci = (side == Side::Left) ? slice(C, pair{i, m}, pair{0, n})
-                                       : slice(C, pair{0, m}, pair{i, n});
+        auto Ci = (side == Side::Left) ? slice(C, range{i, m}, range{0, n})
+                                       : slice(C, range{0, m}, range{i, n});
 
         // Apply H or H**H
         larfb(side, trans, forward, columnwise_storage, V, matrixTi, Ci,

--- a/include/tlapack/legacy_api/blas/her2k.hpp
+++ b/include/tlapack/legacy_api/blas/her2k.hpp
@@ -122,7 +122,7 @@ namespace legacy {
                             uplo != Uplo::General);
         tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                             trans != Op::ConjTrans);
-        tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
+        tlapack_check_false(is_complex<TA> && trans == Op::Trans);
         tlapack_check_false(n < 0);
         tlapack_check_false(k < 0);
         tlapack_check_false(lda < ((layout == Layout::RowMajor)

--- a/include/tlapack/legacy_api/blas/herk.hpp
+++ b/include/tlapack/legacy_api/blas/herk.hpp
@@ -106,7 +106,7 @@ namespace legacy {
                             uplo != Uplo::General);
         tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                             trans != Op::ConjTrans);
-        tlapack_check_false(is_complex<TA>::value && trans == Op::Trans);
+        tlapack_check_false(is_complex<TA> && trans == Op::Trans);
         tlapack_check_false(n < 0);
         tlapack_check_false(k < 0);
         tlapack_check_false(lda < ((layout == Layout::RowMajor)

--- a/include/tlapack/legacy_api/blas/syr2k.hpp
+++ b/include/tlapack/legacy_api/blas/syr2k.hpp
@@ -122,7 +122,7 @@ namespace legacy {
                             uplo != Uplo::General);
         tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                             trans != Op::ConjTrans);
-        tlapack_check_false(is_complex<TA>::value && trans == Op::ConjTrans);
+        tlapack_check_false(is_complex<TA> && trans == Op::ConjTrans);
         tlapack_check_false(n < 0);
         tlapack_check_false(k < 0);
         tlapack_check_false(lda < ((layout == Layout::RowMajor)

--- a/include/tlapack/legacy_api/blas/syrk.hpp
+++ b/include/tlapack/legacy_api/blas/syrk.hpp
@@ -108,7 +108,7 @@ namespace legacy {
                             uplo != Uplo::General);
         tlapack_check_false(trans != Op::NoTrans && trans != Op::Trans &&
                             trans != Op::ConjTrans);
-        tlapack_check_false(is_complex<TA>::value && trans == Op::ConjTrans);
+        tlapack_check_false(is_complex<TA> && trans == Op::ConjTrans);
         tlapack_check_false(n < 0);
         tlapack_check_false(k < 0);
         tlapack_check_false(lda < ((layout == Layout::RowMajor)

--- a/include/tlapack/legacy_api/lapack/larfb.hpp
+++ b/include/tlapack/legacy_api/lapack/larfb.hpp
@@ -144,7 +144,7 @@ namespace legacy {
         // check arguments
         tlapack_check_false(side != Side::Left && side != Side::Right);
         tlapack_check_false(trans != Op::NoTrans && trans != Op::ConjTrans &&
-                            ((trans != Op::Trans) || is_complex<TV>::value));
+                            ((trans != Op::Trans) || is_complex<TV>));
         tlapack_check_false(direction != Direction::Backward &&
                             direction != Direction::Forward);
         tlapack_check_false(storev != StoreV::Columnwise &&

--- a/include/tlapack/legacy_api/lapack/lascl.hpp
+++ b/include/tlapack/legacy_api/lapack/lascl.hpp
@@ -105,15 +105,15 @@ namespace legacy {
 
         if (matrixtype == MatrixType::LowerBand) {
             auto A_ = create_banded_matrix<T>(A, m, n, kl, 0);
-            return lascl(band_t(kl, 0), b, a, A_);
+            return lascl(BandAccess(kl, 0), b, a, A_);
         }
         else if (matrixtype == MatrixType::UpperBand) {
             auto A_ = create_banded_matrix<T>(A, m, n, 0, ku);
-            return lascl(band_t(0, ku), b, a, A_);
+            return lascl(BandAccess(0, ku), b, a, A_);
         }
         else if (matrixtype == MatrixType::Band) {
             auto A_ = create_banded_matrix<T>(A, m, n, kl, ku);
-            return lascl(band_t(kl, ku), b, a, A_);
+            return lascl(BandAccess(kl, ku), b, a, A_);
         }
         else {
             auto A_ = create_matrix<T>(A, m, n, lda);

--- a/include/tlapack/plugins/debugutils.hpp
+++ b/include/tlapack/plugins/debugutils.hpp
@@ -54,7 +54,7 @@ std::string visualize_matrix_text(const matrix_t& A)
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
-    const int width = is_complex<type_t<matrix_t>>::value ? 25 : 10;
+    const int width = is_complex<type_t<matrix_t>> ? 25 : 10;
 
     std::stringstream stream;
     stream << "{ \"kind\":{ \"text\": true },\"text\": \"";

--- a/include/tlapack/plugins/eigen_half.hpp
+++ b/include/tlapack/plugins/eigen_half.hpp
@@ -16,18 +16,20 @@
 
 namespace tlapack {
 
-namespace internal {
+namespace traits {
     // Eigen::half is a real type that satisfies tlapack::concepts::Real
     template <>
     struct real_type_traits<Eigen::half, int> {
         using type = Eigen::half;
+        constexpr static bool is_real = true;
     };
     // The complex type of Eigen::half is std::complex<Eigen::half>
     template <>
     struct complex_type_traits<Eigen::half, int> {
         using type = std::complex<Eigen::half>;
+        constexpr static bool is_complex = false;
     };
-}  // namespace internal
+}  // namespace traits
 
 // Forward declarations
 template <typename T>

--- a/include/tlapack/plugins/mpreal.hpp
+++ b/include/tlapack/plugins/mpreal.hpp
@@ -16,18 +16,20 @@
 
 namespace tlapack {
 
-namespace internal {
+namespace traits {
     // mpfr::mpreal is a real type that satisfies tlapack::concepts::Real
     template <>
     struct real_type_traits<mpfr::mpreal, int> {
         using type = mpfr::mpreal;
+        constexpr static bool is_real = true;
     };
     // The complex type of mpfr::mpreal is std::complex<mpfr::mpreal>
     template <>
     struct complex_type_traits<mpfr::mpreal, int> {
         using type = std::complex<mpfr::mpreal>;
+        constexpr static bool is_complex = false;
     };
-}  // namespace internal
+}  // namespace traits
 
 // Forward declarations
 template <typename T>

--- a/include/tlapack/plugins/starpu.hpp
+++ b/include/tlapack/plugins/starpu.hpp
@@ -17,16 +17,12 @@
 namespace tlapack {
 
 // Forward declarations
-template <class T, std::enable_if_t<is_real<T>::value, int> = 0>
+template <class T, std::enable_if_t<is_real<T>, int> = 0>
 inline constexpr real_type<T> real(const T& x);
-template <class T, std::enable_if_t<is_real<T>::value, int> = 0>
+template <class T, std::enable_if_t<is_real<T>, int> = 0>
 inline constexpr real_type<T> imag(const T& x);
-template <class T, std::enable_if_t<is_real<T>::value, int> = 0>
+template <class T, std::enable_if_t<is_real<T>, int> = 0>
 inline constexpr T conj(const T& x);
-template <class T>
-struct is_real;
-template <class T>
-struct is_complex;
 
 template <class T>
 inline constexpr real_type<T> real(const starpu::MatrixEntry<T>& x)
@@ -52,26 +48,14 @@ inline constexpr real_type<T> abs(const starpu::MatrixEntry<T>& x)
     return abs(x);
 }
 
-namespace internal {
+namespace traits {
     template <class T>
-    struct real_type_traits<starpu::MatrixEntry<T>, int> {
-        using type = real_type<T>;
-    };
+    struct real_type_traits<starpu::MatrixEntry<T>, int>
+        : public real_type_traits<T, int> {};
     template <class T>
-    struct complex_type_traits<starpu::MatrixEntry<T>, int> {
-        using type = complex_type<T>;
-    };
-}  // namespace internal
-
-template <class T>
-struct is_real<starpu::MatrixEntry<T>> {
-    static constexpr bool value = is_real<T>::value;
-};
-
-template <class T>
-struct is_complex<starpu::MatrixEntry<T>> {
-    static constexpr bool value = is_complex<T>::value;
-};
+    struct complex_type_traits<starpu::MatrixEntry<T>, int>
+        : public complex_type_traits<T, int> {};
+}  // namespace traits
 
 }  // namespace tlapack
 
@@ -267,7 +251,7 @@ constexpr auto diag(starpu::Matrix<T>& A, int diagIdx = 0)
     return row(A, 0);
 }
 
-namespace internal {
+namespace traits {
 
     template <class TA, class TB>
     struct matrix_type_traits<starpu::Matrix<TA>, starpu::Matrix<TB>, int> {
@@ -283,7 +267,7 @@ namespace internal {
 
     /// Create legacyMatrix @see Create
     template <class T>
-    struct CreateImpl<starpu::Matrix<T>, int> {
+    struct CreateFunctor<starpu::Matrix<T>, int> {
         using matrix_t = starpu::Matrix<T>;
 
         inline constexpr auto operator()(std::vector<T>& v,
@@ -341,7 +325,7 @@ namespace internal {
                                                  W.getLdim() / sizeof(T), 1, m);
         }
     };
-}  // namespace internal
+}  // namespace traits
 
 }  // namespace tlapack
 

--- a/include/tlapack/starpu/MatrixEntry.hpp
+++ b/include/tlapack/starpu/MatrixEntry.hpp
@@ -14,20 +14,10 @@
 
 #include <tuple>
 
+#include "tlapack/base/scalar_type_traits.hpp"
 #include "tlapack/starpu/types.hpp"
 
 namespace tlapack {
-
-namespace internal {
-    // for zero types
-    template <typename... Types>
-    struct real_type_traits;
-}  // namespace internal
-
-/// define real_type<> type alias
-template <typename... Types>
-using real_type = typename internal::real_type_traits<Types..., int>::type;
-
 namespace starpu {
 
     namespace internal {

--- a/test/blaspp/blas/util.hh
+++ b/test/blaspp/blas/util.hh
@@ -20,7 +20,32 @@
 
 namespace blas {
 
-    using namespace tlapack;
+    using tlapack::real_type;
+    using tlapack::complex_type;
+    using tlapack::scalar_type;
+
+    using tlapack::Layout;
+    using tlapack::Op;
+    using tlapack::Uplo;
+    using tlapack::Diag;
+    using tlapack::Side;
+
+    using tlapack::real;
+    using tlapack::imag;
+    using tlapack::conj;
+
+    //------------------------------------------------------------------------------
+    /// True if T is std::complex<T2> for some type T2.
+    template <typename T>
+    struct is_complex:
+        std::integral_constant<bool, false>
+    {};
+
+    // specialize for std::complex
+    template <typename T>
+    struct is_complex< std::complex<T> >:
+        std::integral_constant<bool, true>
+    {};
 
     // Empty structure since <T>LAPACK is not defining device BLAS
     struct Queue

--- a/test/include/NaNPropagComplex.hpp
+++ b/test/include/NaNPropagComplex.hpp
@@ -193,17 +193,15 @@ struct NaNPropagComplex : public std::complex<T> {
     }
 };
 
-namespace internal {
+namespace traits {
     template <typename T>
-    struct real_type_traits<NaNPropagComplex<T>, int> {
-        using type = real_type<T>;
-    };
+    struct real_type_traits<NaNPropagComplex<T>, int>
+        : public real_type_traits<std::complex<T>, int> {};
 
     template <typename T>
-    struct complex_type_traits<NaNPropagComplex<T>, int> {
-        using type = NaNPropagComplex<real_type<T>>;
-    };
-}  // namespace internal
+    struct complex_type_traits<NaNPropagComplex<T>, int>
+        : public complex_type_traits<std::complex<T>, int> {};
+}  // namespace traits
 
 template <typename T>
 inline T abs(const NaNPropagComplex<T>& x)

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -23,6 +23,7 @@
 #include <tlapack/base/utils.hpp>
 #include <tlapack/blas/gemm.hpp>
 #include <tlapack/blas/herk.hpp>
+#include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/lanhe.hpp>
 #include <tlapack/lapack/laset.hpp>
 
@@ -48,13 +49,13 @@ class rand_generator {
     }
 };
 
-template <typename T, enable_if_t<is_real<T>::value, bool> = true>
+template <typename T, enable_if_t<is_real<T>, bool> = true>
 T rand_helper(rand_generator& gen)
 {
     return T(static_cast<float>(gen()) / static_cast<float>(gen.max()));
 }
 
-template <typename T, enable_if_t<is_complex<T>::value, bool> = true>
+template <typename T, enable_if_t<is_complex<T>, bool> = true>
 T rand_helper(rand_generator& gen)
 {
     using real_t = real_type<T>;
@@ -63,13 +64,13 @@ T rand_helper(rand_generator& gen)
     return complex_type<real_t>(r1, r2);
 }
 
-template <typename T, enable_if_t<is_real<T>::value, bool> = true>
+template <typename T, enable_if_t<is_real<T>, bool> = true>
 T rand_helper()
 {
     return T(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));
 }
 
-template <typename T, enable_if_t<is_complex<T>::value, bool> = true>
+template <typename T, enable_if_t<is_complex<T>, bool> = true>
 T rand_helper()
 {
     using real_t = real_type<T>;

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -165,7 +165,7 @@ TEMPLATE_TEST_CASE("Multishift QR",
         idx_t i = ilo;
         while (i < ihi) {
             int nb = 1;
-            if (is_real<T>::value)
+            if (is_real<T>)
                 if (i + 1 < ihi)
                     if (H(i + 1, i) != zero) nb = 2;
 

--- a/test/src/test_eigenplugin.cpp
+++ b/test/src/test_eigenplugin.cpp
@@ -16,25 +16,25 @@
 template <class block_t>
 void test_block()
 {
-    CHECK(tlapack::internal::is_eigen_dense<block_t> == true);
-    CHECK(tlapack::internal::is_eigen_matrix<block_t> == true);
-    CHECK(tlapack::internal::is_eigen_block<block_t> == true);
+    CHECK(tlapack::eigen::internal::is_eigen_dense<block_t> == true);
+    CHECK(tlapack::eigen::internal::is_eigen_matrix<block_t> == true);
+    CHECK(tlapack::eigen::internal::is_eigen_block<block_t> == true);
 }
 
 template <class matrix_t>
 void test_matrix()
 {
-    CHECK(tlapack::internal::is_eigen_dense<matrix_t> == true);
-    CHECK(tlapack::internal::is_eigen_matrix<matrix_t> == true);
-    CHECK(tlapack::internal::is_eigen_block<matrix_t> == false);
+    CHECK(tlapack::eigen::internal::is_eigen_dense<matrix_t> == true);
+    CHECK(tlapack::eigen::internal::is_eigen_matrix<matrix_t> == true);
+    CHECK(tlapack::eigen::internal::is_eigen_block<matrix_t> == false);
 }
 
 template <class map_t>
 void test_map()
 {
-    CHECK(tlapack::internal::is_eigen_dense<map_t> == true);
-    CHECK(tlapack::internal::is_eigen_matrix<map_t> == true);
-    CHECK(tlapack::internal::is_eigen_block<map_t> == false);
+    CHECK(tlapack::eigen::internal::is_eigen_dense<map_t> == true);
+    CHECK(tlapack::eigen::internal::is_eigen_matrix<map_t> == true);
+    CHECK(tlapack::eigen::internal::is_eigen_block<map_t> == false);
 }
 
 template <class matrix_t>
@@ -67,10 +67,11 @@ void test_maps()
 
 TEST_CASE("is_eigen_dense, is_eigen_block and is_eigen_map work", "[plugins]")
 {
-    CHECK(tlapack::internal::is_eigen_dense<int> == false);
-    CHECK(tlapack::internal::is_eigen_dense<float> == false);
-    CHECK(tlapack::internal::is_eigen_dense<std::complex<float>> == false);
-    CHECK(tlapack::internal::is_eigen_dense<std::string> == false);
+    CHECK(tlapack::eigen::internal::is_eigen_dense<int> == false);
+    CHECK(tlapack::eigen::internal::is_eigen_dense<float> == false);
+    CHECK(tlapack::eigen::internal::is_eigen_dense<std::complex<float>> ==
+          false);
+    CHECK(tlapack::eigen::internal::is_eigen_dense<std::string> == false);
 
     using M0 = Eigen::MatrixXd;
     using M1 = Eigen::VectorXd;
@@ -112,7 +113,7 @@ TEST_CASE("legacy_matrix works", "[plugins]")
         Eigen::MatrixXd A2 = A.block<1, 2>(1, 0);
 
         auto B = tlapack::legacy_matrix(A);
-        auto C = tlapack::legacy::matrix<double, Eigen::Index>{
+        auto C = tlapack::legacy::Matrix<double, Eigen::Index>{
             tlapack::layout<Eigen::Matrix2d>, A.rows(), A.cols(), A.data(),
             A.rows()};
         CHECK(B.layout == C.layout);
@@ -122,7 +123,7 @@ TEST_CASE("legacy_matrix works", "[plugins]")
         CHECK(B.ldim == C.ldim);
 
         auto B2 = tlapack::legacy_matrix(A2);
-        auto C2 = tlapack::legacy::matrix<double, Eigen::Index>{
+        auto C2 = tlapack::legacy::Matrix<double, Eigen::Index>{
             tlapack::layout<Eigen::MatrixXd>, A2.rows(), A2.cols(), A2.data(),
             A2.outerStride()};
         CHECK(B2.layout == C2.layout);
@@ -132,7 +133,7 @@ TEST_CASE("legacy_matrix works", "[plugins]")
         CHECK(B2.ldim == C2.ldim);
 
         auto B3 = tlapack::legacy_vector(A2);
-        auto C3 = tlapack::legacy::vector<double, Eigen::Index>{
+        auto C3 = tlapack::legacy::Vector<double, Eigen::Index>{
             A2.size(), A2.data(), A2.innerStride()};
         CHECK(B3.n == C3.n);
         CHECK(B3.ptr == C3.ptr);
@@ -143,7 +144,7 @@ TEST_CASE("legacy_matrix works", "[plugins]")
         A << 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, -1, -2, -3, -4, -5;
 
         auto B = tlapack::legacy_matrix(A);
-        auto C = tlapack::legacy::matrix<float, Eigen::Index>{
+        auto C = tlapack::legacy::Matrix<float, Eigen::Index>{
             tlapack::layout<Eigen::Matrix<float, -1, -1, Eigen::RowMajor>>,
             A.rows(), A.cols(), A.data(), A.outerStride()};
         CHECK(B.layout == C.layout);
@@ -154,7 +155,7 @@ TEST_CASE("legacy_matrix works", "[plugins]")
 
         Eigen::Matrix<float, -1, 1> A2 = A.col(3);
         auto B2 = tlapack::legacy_vector(A2);
-        auto C2 = tlapack::legacy::vector<float, Eigen::Index>{
+        auto C2 = tlapack::legacy::Vector<float, Eigen::Index>{
             A2.size(), A2.data(), A2.innerStride()};
         CHECK(B2.n == C2.n);
         CHECK(B2.ptr == C2.ptr);
@@ -164,20 +165,20 @@ TEST_CASE("legacy_matrix works", "[plugins]")
 
 TEST_CASE("slice works", "[plugins]")
 {
-    using pair = tlapack::range<Eigen::Index>;
+    using range = std::pair<Eigen::Index, Eigen::Index>;
 
     {
         Eigen::Matrix2d A;
         A << 1, 3, 2, 4;
 
-        auto B = tlapack::slice(A, pair{1, 2}, pair{1, 2});
+        auto B = tlapack::slice(A, range{1, 2}, range{1, 2});
         CHECK(B(0, 0) == A(1, 1));
     }
     {
         Eigen::MatrixXd A(2, 2);
         A << 1, 3, 2, 4;
 
-        auto B = tlapack::slice(A, pair{1, 2}, pair{1, 2});
+        auto B = tlapack::slice(A, range{1, 2}, range{1, 2});
         CHECK(B(0, 0) == A(1, 1));
     }
 }

--- a/test/src/test_gebd2.cpp
+++ b/test/src/test_gebd2.cpp
@@ -39,7 +39,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor
@@ -105,7 +105,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Generate m-by-k unitary matrix Q
         ungbr_opts_t<matrix_t> ungbrOpts;
         ungbrOpts.nb = 2;
-        lacpy(Uplo::Lower, slice(A, pair{0, m}, pair{0, k}), Q);
+        lacpy(Uplo::Lower, slice(A, range{0, m}, range{0, k}), Q);
         ungbr_q(n, Q, tauv, ungbrOpts);
 
         // Test for Q's orthogonality
@@ -114,7 +114,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         auto orth_Q = check_orthogonality(Q, Wq);
         CHECK(orth_Q <= tol);
 
-        lacpy(Uplo::Upper, slice(A, pair{0, k}, pair{0, n}), Z);
+        lacpy(Uplo::Upper, slice(A, range{0, k}, range{0, n}), Z);
         ungbr_p(m, Z, tauw, ungbrOpts);
 
         // Test for Z's orthogonality

--- a/test/src/test_gebrd.cpp
+++ b/test/src/test_gebrd.cpp
@@ -38,7 +38,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor
@@ -109,7 +109,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Generate m-by-k unitary matrix Q
         ungbr_opts_t<matrix_t> ungbrOpts;
         ungbrOpts.nb = nb;
-        lacpy(Uplo::Lower, slice(A, pair{0, m}, pair{0, k}), Q);
+        lacpy(Uplo::Lower, slice(A, range{0, m}, range{0, k}), Q);
         ungbr_q(n, Q, tauv, ungbrOpts);
 
         // Test for Q's orthogonality
@@ -118,7 +118,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         auto orth_Q = check_orthogonality(Q, Wq);
         CHECK(orth_Q <= tol);
 
-        lacpy(Uplo::Upper, slice(A, pair{0, k}, pair{0, n}), Z);
+        lacpy(Uplo::Upper, slice(A, range{0, k}, range{0, n}), Z);
         ungbr_p(m, Z, tauw, ungbrOpts);
 
         // Test for Z's orthogonality

--- a/test/src/test_gelq2.cpp
+++ b/test/src/test_gelq2.cpp
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_gelqf.cpp
+++ b/test/src/test_gelqf.cpp
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_gelqt.cpp
+++ b/test/src/test_gelqt.cpp
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_geql2.cpp
+++ b/test/src/test_geql2.cpp
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_geqlf.cpp
+++ b/test/src/test_geqlf.cpp
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_geqr2.cpp
+++ b/test/src/test_geqr2.cpp
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("QR factorization of a general m-by-n matrix",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_geqrf.cpp
+++ b/test/src/test_geqrf.cpp
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("QR factorization of a general m-by-n matrix",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_gerq2.cpp
+++ b/test/src/test_gerq2.cpp
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_gerqf.cpp
+++ b/test/src/test_gerqf.cpp
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_getrf.cpp
+++ b/test/src/test_getrf.cpp
@@ -34,6 +34,7 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
     typedef real_type<T> real_t;  // equivalent to using real_t = real_type<T>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<matrix_t> new_matrix;
@@ -82,19 +83,15 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
 
         // A contains L and U now, then form A <--- LU
         if (m > n) {
-            auto A0 = tlapack::slice(A, tlapack::range<idx_t>(0, n),
-                                     tlapack::range<idx_t>(0, n));
-            auto A1 = tlapack::slice(A, tlapack::range<idx_t>(n, m),
-                                     tlapack::range<idx_t>(0, n));
+            auto A0 = tlapack::slice(A, range(0, n), range(0, n));
+            auto A1 = tlapack::slice(A, range(n, m), range(0, n));
             trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit,
                  real_t(1), A0, A1);
             lu_mult(A0);
         }
         else if (m < n) {
-            auto A0 = tlapack::slice(A, tlapack::range<idx_t>(0, m),
-                                     tlapack::range<idx_t>(0, m));
-            auto A1 = tlapack::slice(A, tlapack::range<idx_t>(0, m),
-                                     tlapack::range<idx_t>(m, n));
+            auto A0 = tlapack::slice(A, range(0, m), range(0, m));
+            auto A1 = tlapack::slice(A, range(0, m), range(m, n));
             trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, real_t(1),
                  A0, A1);
             lu_mult(A0);

--- a/test/src/test_larf.cpp
+++ b/test/src/test_larf.cpp
@@ -33,7 +33,7 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
     using T = type_t<vector_t>;
     using idx_t = size_type<vector_t>;
     using real_t = real_type<T>;
-    using pair = pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<vector_t> new_vector;
@@ -50,7 +50,7 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
         GENERATE(as<std::string>{}, "direction,v", "alpha,x");
 
     // Skip tests with invalid parameters
-    if (typeAlpha == "Complex" && is_real<T>::value) return;
+    if (typeAlpha == "Complex" && is_real<T>) return;
 
     // Vectors
     std::vector<T> v_;
@@ -104,8 +104,8 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
 
         if (whichLARFG == "alpha,x") {
             auto x =
-                slice(v, (direction == Direction::Forward) ? pair(1, n)
-                                                           : pair(0, n - 1));
+                slice(v, (direction == Direction::Forward) ? range(1, n)
+                                                           : range(0, n - 1));
             larfg(storeMode, v[alphaIdx], x, tau);
         }
         else  // whichLARFG == "direction,v"

--- a/test/src/test_mdspanplugin.cpp
+++ b/test/src/test_mdspanplugin.cpp
@@ -36,7 +36,7 @@ TEST_CASE("STD layouts work as expected", "[plugins]")
     using tlapack::slice;
 
     using idx_t = std::size_t;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = std::pair<idx_t, idx_t>;
 
     using my_dextents = dextents<idx_t, 2>;
 
@@ -55,27 +55,28 @@ TEST_CASE("STD layouts work as expected", "[plugins]")
 
     SECTION("Slicing a mdspan sometimes turns the layout into Unspecified")
     {
-        CHECK(layout<decltype(slice(A, pair{0, 1}, pair{0, 1}))> ==
+        CHECK(layout<decltype(slice(A, range{0, 1}, range{0, 1}))> ==
               Layout::Unspecified);
-        CHECK(layout<decltype(slice(B, pair{0, 1}, pair{0, 1}))> ==
+        CHECK(layout<decltype(slice(B, range{0, 1}, range{0, 1}))> ==
               Layout::Unspecified);
-        CHECK(layout<decltype(slice(C, pair{0, 1}, pair{0, 1}))> ==
+        CHECK(layout<decltype(slice(C, range{0, 1}, range{0, 1}))> ==
               Layout::Unspecified);
 
         SECTION("layout_left (Column-major contiguous data)")
         {
-            CHECK(layout<decltype(slice(A, pair{0, nrows(A)}, pair{0, 1}))> ==
+            CHECK(layout<decltype(slice(A, range{0, nrows(A)}, range{0, 1}))> ==
                   Layout::Unspecified);
-            CHECK(layout<decltype(slice(A, pair{0, nrows(A)}, 1))> ==
+            CHECK(layout<decltype(slice(A, range{0, nrows(A)}, 1))> ==
                   Layout::Strided);
-            CHECK(layout<decltype(slice(A, pair{0, 1}, pair{0, ncols(A)}))> ==
+            CHECK(layout<decltype(slice(A, range{0, 1}, range{0, ncols(A)}))> ==
                   Layout::Unspecified);
-            CHECK(layout<decltype(slice(A, 1, pair{0, ncols(A)}))> ==
+            CHECK(layout<decltype(slice(A, 1, range{0, ncols(A)}))> ==
                   Layout::Strided);
 
-            CHECK(layout<decltype(cols(A, pair{0, 1}))> == Layout::ColMajor);
+            CHECK(layout<decltype(cols(A, range{0, 1}))> == Layout::ColMajor);
             CHECK(layout<decltype(col(A, 1))> == Layout::Strided);
-            CHECK(layout<decltype(rows(A, pair{0, 1}))> == Layout::Unspecified);
+            CHECK(layout<decltype(rows(A, range{0, 1}))> ==
+                  Layout::Unspecified);
             CHECK(layout<decltype(row(A, 1))> == Layout::Strided);
         }
     }

--- a/test/src/test_potrf.cpp
+++ b/test/src/test_potrf.cpp
@@ -40,7 +40,7 @@ TEMPLATE_TEST_CASE(
     // Functor
     Create<matrix_t> new_matrix;
 
-    using variant_t = std::pair<PotrfVariant, idx_t>;
+    using variant_t = pair<PotrfVariant, idx_t>;
     const variant_t variant =
         GENERATE((variant_t(PotrfVariant::Blocked, 1)),
                  (variant_t(PotrfVariant::Blocked, 2)),
@@ -144,7 +144,7 @@ TEMPLATE_TEST_CASE("Cholesky factorization access valid positions only",
     // Functor
     Create<matrix_t> new_matrix;
 
-    using variant_t = std::pair<PotrfVariant, idx_t>;
+    using variant_t = pair<PotrfVariant, idx_t>;
     const variant_t variant =
         GENERATE((variant_t(PotrfVariant::Blocked, 2)),
                  (variant_t(PotrfVariant::RightLooking, 2)),

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results",
     idx_t n1 = GENERATE(1, 2);
     idx_t n2 = GENERATE(1, 2);
 
-    if (is_real<T>::value || (n1 == 1 && n2 == 1)) {
+    if (is_real<T> || (n1 == 1 && n2 == 1)) {
         // ifst and ilst point to the same block, n1 must be equal to n2 for
         // the test to make sense.
         if (ifst == ilst and n1 != n2) n2 = n1;
@@ -83,7 +83,7 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results",
                 A(ilst, ilst - 1) = rand_helper<T>();
         }
 
-        if (is_real<T>::value) {
+        if (is_real<T>) {
             // Put a 2x2 block in the middle
             A(5, 4) = rand_helper<T>();
         }

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -45,7 +45,7 @@ TEMPLATE_TEST_CASE("schur swap gives correct result",
     const idx_t n1 = GENERATE(1, 2);
     const idx_t n2 = GENERATE(1, 2);
 
-    if (is_real<T>::value || (n1 == 1 && n2 == 1)) {
+    if (is_real<T> || (n1 == 1 && n2 == 1)) {
         const real_t eps = uroundoff<real_t>();
         const real_t tol = real_t(1.0e2 * n) * eps;
 

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -122,7 +122,7 @@ TEMPLATE_TEST_CASE("Double shift QR",
         idx_t i = ilo;
         while (i < ihi) {
             int nb = 1;
-            if (is_real<T>::value)
+            if (is_real<T>)
                 if (i + 1 < ihi)
                     if (H(i + 1, i) != zero) nb = 2;
 

--- a/test/src/test_unm2l.cpp
+++ b/test/src/test_unm2l.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QL factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_unm2r.cpp
+++ b/test/src/test_unm2r.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QR factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_unmhr.cpp
+++ b/test/src/test_unmhr.cpp
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr",
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
     using real_t = real_type<T>;
-    using pair = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
 
     // Functor
     Create<matrix_t> new_matrix;
@@ -100,11 +100,11 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr",
         unghr(ilo, ihi, H, tau);
 
         // Multiply C_copy with the orthogonal factor
-        auto Q = slice(H, pair{ilo + 1, ihi}, pair{ilo + 1, ihi});
+        auto Q = slice(H, range{ilo + 1, ihi}, range{ilo + 1, ihi});
         if (side == Side::Left) {
             auto C_copy_s =
-                slice(C_copy, pair{ilo + 1, ihi}, pair{0, ncols(C)});
-            auto C_s = slice(C, pair{ilo + 1, ihi}, pair{0, ncols(C)});
+                slice(C_copy, range{ilo + 1, ihi}, range{0, ncols(C)});
+            auto C_s = slice(C, range{ilo + 1, ihi}, range{0, ncols(C)});
             gemm(op, Op::NoTrans, one, Q, C_copy_s, -one, C_s);
             for (idx_t i = 0; i < ilo + 1; ++i)
                 for (idx_t j = 0; j < ncols(C); ++j)
@@ -115,8 +115,8 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr",
         }
         else {
             auto C_copy_s =
-                slice(C_copy, pair{0, nrows(C)}, pair{ilo + 1, ihi});
-            auto C_s = slice(C, pair{0, nrows(C)}, pair{ilo + 1, ihi});
+                slice(C_copy, range{0, nrows(C)}, range{ilo + 1, ihi});
+            auto C_s = slice(C, range{0, nrows(C)}, range{ilo + 1, ihi});
             gemm(Op::NoTrans, op, one, C_copy_s, Q, -one, C_s);
             for (idx_t j = 0; j < ilo + 1; ++j)
                 for (idx_t i = 0; i < nrows(C); ++i)

--- a/test/src/test_unml2.cpp
+++ b/test/src/test_unml2.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal LQ factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_unmlq.cpp
+++ b/test/src/test_unmlq.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal LQ factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_unmql.cpp
+++ b/test/src/test_unmql.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QL factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_unmqr.cpp
+++ b/test/src/test_unmqr.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QR factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_unmr2.cpp
+++ b/test/src/test_unmr2.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal RQ factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_unmrq.cpp
+++ b/test/src/test_unmrq.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal RQ factor",
     using matrix_t = TestType;
     using T = type_t<matrix_t>;
     using idx_t = size_type<matrix_t>;
-    using range = std::pair<idx_t, idx_t>;
+    using range = pair<idx_t, idx_t>;
     typedef real_type<T> real_t;
 
     // Functor

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -33,20 +33,20 @@ TEMPLATE_TEST_CASE("is_matrix works", "[utils]", TLAPACK_TYPES_TO_TEST)
 {
     using matrix_t = TestType;
 
-    CHECK(is_matrix<matrix_t>);
+    CHECK(internal::is_matrix<matrix_t>);
 }
 
 TEST_CASE("is_matrix and is_vector work", "[utils]")
 {
-    CHECK(!is_matrix<std::vector<float> >);
-    CHECK(!is_matrix<legacyVector<float> >);
+    CHECK(!internal::is_matrix<std::vector<float> >);
+    CHECK(!internal::is_matrix<legacyVector<float> >);
 
-    CHECK(is_vector<std::vector<float> >);
-    CHECK(is_vector<legacyVector<float> >);
+    CHECK(internal::is_vector<std::vector<float> >);
+    CHECK(internal::is_vector<legacyVector<float> >);
 
-    CHECK(!is_matrix<float>);
-    CHECK(!is_matrix<std::complex<double> >);
+    CHECK(!internal::is_matrix<float>);
+    CHECK(!internal::is_matrix<std::complex<double> >);
 
-    CHECK(!is_vector<float>);
-    CHECK(!is_vector<std::complex<double> >);
+    CHECK(!internal::is_vector<float>);
+    CHECK(!internal::is_vector<std::complex<double> >);
 }


### PR DESCRIPTION
Concepts:
- New concepts: `LegacyArray`, `LegacyMatrix`, `LegacyVector`
- Real concept now requires specialization of `std::numeric_limits<real_t>` and functions `min()` and `max()`

Renaming and repositioning:
- band_t -> BandAccess
- is_real<T>::value -> is_real<T>
- is_complex<T>::value -> is_complex<T>
- `internal::type_trait` -> `trait::entry_type_trait`. Also, moved other traits to namespace `traits`.
- `LayoutImpl` -> `layout_trait`
- `TransposeTypeImpl` -> `matrix_type_traits<>::transpose_type`
- `internal::CreateImpl` -> `trait::CreateFunctor`. This is not a trait but it is closely related, so I kept it there.
- `vectorOfBytes` -> `VectorOfBytes`
- `legacy::matrix` -> `legacy::Matrix`
- `legacy::vector` -> `legacy::Vector`
- Move traits in `types.hpp` to `scalar_type_traits.hpp`
- Change alias name `pair` to `range`. This is just to be uniform among the implementations and ease reading the codes in the library.
- Move a couple of structures to `tlapack::internal`. Reduce pollution in namespace `tlapack`.

Deletion:
- Remove `make_scalar` and use `if constexpr`.
- Remove `std::atan`, `std::sin`, `std::cos` and a couple of other `std::` from namespace `tlapack`.