### PR TITLE
Remove dependency legacy arrays

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -218,7 +218,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      CXXFLAGS: "-Wall -pedantic -Wno-unused-variable -Wno-unused-function -D TLAPACK_TYPES_TO_TEST=\"(legacyMatrix<mpfr::mpreal>), (legacyMatrix<mpfr::mpreal,std::size_t,Layout::RowMajor>)\""
+      CXXFLAGS: "-Wall -pedantic -Wno-unused-variable -Wno-unused-function -D TLAPACK_TYPES_TO_TEST=\"(LegacyMatrix<mpfr::mpreal>), (LegacyMatrix<mpfr::mpreal,std::size_t,Layout::RowMajor>)\""
       
     steps:     
     

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Please read [CONTRIBUTING.md](https://github.com/tlapack/tlapack/blob/master/CON
   
     1. various precision types: `float`, `double`, `std::complex<float>`, `std::complex<double>` and `Eigen::half`.
   
-    2. various matrix and vector data structures: `tlapack::legacyMatrix`, `Eigen::Matrix` and `std::experimental::mdspan` (the latter from `https://github.com/kokkos/mdspan`). 
+    2. various matrix and vector data structures: `tlapack::LegacyMatrix`, `Eigen::Matrix` and `std::experimental::mdspan` (the latter from `https://github.com/kokkos/mdspan`). 
 
 + Tests from [testBLAS](https://github.com/tlapack/testBLAS) for good conformance with BLAS standards.
 

--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -33,11 +33,6 @@
                 library.
 
     ----------------------------------------------------------------------------
-    @defgroup abstract_matrix   Abstract matrix interface
-    @brief      These routines should be implemented for each data structure
-                representing matrices and vectors.
-
-    ----------------------------------------------------------------------------
     @defgroup constants         Scaling constants
 
     ------------------------------------------------------------

--- a/examples/access_types/example_accessTypes.cpp
+++ b/examples/access_types/example_accessTypes.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv)
         data1[i] = i + 1;
 
     std::cout << std::endl << "Matrix1:";
-    legacyMatrix<int, size_t, Layout::RowMajor> A1(m, n, &data1[0], n);
+    LegacyMatrix<int, size_t, Layout::RowMajor> A1(m, n, &data1[0], n);
     printMatrix(A1);
     std::cout << std::endl;
 
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
               << std::endl;
 
     std::cout << std::endl << "Matrix2:";
-    legacyBandedMatrix<int> A2(m, m, n / 2, n - n / 2 - 1, &data1[0]);
+    LegacyBandedMatrix<int> A2(m, m, n / 2, n - n / 2 - 1, &data1[0]);
     printBandedMatrix(A2);
     std::cout << std::endl;
 

--- a/examples/cpp_visualizer/cpp_visualizer_example.cpp
+++ b/examples/cpp_visualizer/cpp_visualizer_example.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
     const T zero(0);
 
     std::unique_ptr<T[]> A_(new T[n * n]);
-    tlapack::legacyMatrix<T> A(n, n, &A_[0], n);
+    tlapack::LegacyMatrix<T> A(n, n, &A_[0], n);
 
     tlapack::laset(tlapack::Uplo::General, zero, one, A);
 

--- a/examples/eigenvalues/example_eigenvalues.cpp
+++ b/examples/eigenvalues/example_eigenvalues.cpp
@@ -110,7 +110,7 @@ void run(size_t n,
          bool verbose = false)
 {
     using real_t = tlapack::real_type<T>;
-    using matrix_t = tlapack::legacyMatrix<T>;
+    using matrix_t = tlapack::LegacyMatrix<T>;
     using std::size_t;
 
     constexpr bool use_lapack

--- a/examples/eigenvalues/profile_aed.cpp
+++ b/examples/eigenvalues/profile_aed.cpp
@@ -92,7 +92,7 @@ void run(size_t n, size_t nw, bool use_fortran)
 {
     using real_t = tlapack::real_type<T>;
     using std::size_t;
-    using matrix_t = tlapack::legacyMatrix<real_t>;
+    using matrix_t = tlapack::LegacyMatrix<real_t>;
 
     constexpr bool use_lapack
 #ifdef USE_LAPACK

--- a/examples/gemm/example_gemm.cpp
+++ b/examples/gemm/example_gemm.cpp
@@ -28,9 +28,9 @@ void run(size_t m, size_t n, size_t k)
     using idx_t = size_t;
     using tlapack::min;
     using colmajor_matrix_t =
-        tlapack::legacyMatrix<T, idx_t, tlapack::Layout::ColMajor>;
+        tlapack::LegacyMatrix<T, idx_t, tlapack::Layout::ColMajor>;
     using rowmajor_matrix_t =
-        tlapack::legacyMatrix<T, idx_t, tlapack::Layout::RowMajor>;
+        tlapack::LegacyMatrix<T, idx_t, tlapack::Layout::RowMajor>;
 
     // Functors for creating new matrices
     tlapack::Create<colmajor_matrix_t> new_colmajor_matrix;

--- a/examples/gemm/example_gemm.cpp
+++ b/examples/gemm/example_gemm.cpp
@@ -110,7 +110,7 @@ void run(size_t m, size_t n, size_t k)
               << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 
-    // Using abstract interface:
+    // Using main interface:
 
     bestTime = std::chrono::nanoseconds::max();
     for (int run = 0; run < Nruns; ++run) {
@@ -138,12 +138,12 @@ void run(size_t m, size_t n, size_t k)
     }
 
     // Output
-    std::cout << "Using abstract interface:" << std::endl
+    std::cout << "Using main interface:" << std::endl
               << "||C-AB||_F = " << tlapack::legacy::nrm2(n, &C_[0], 1)
               << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;
 
-    // Using abstract interface with row major layout:
+    // Using main interface with row major layout:
 
     bestTime = std::chrono::nanoseconds::max();
     for (int run = 0; run < Nruns; ++run) {
@@ -171,7 +171,7 @@ void run(size_t m, size_t n, size_t k)
     }
 
     // Output
-    std::cout << "Using abstract interface with row major layout:" << std::endl
+    std::cout << "Using main interface with row major layout:" << std::endl
               << "||C-AB||_F = " << tlapack::legacy::nrm2(n, &C_[0], 1)
               << std::endl
               << "time = " << bestTime.count() * 1.0e-6 << " ms" << std::endl;

--- a/examples/geqr2/example_geqr2.cpp
+++ b/examples/geqr2/example_geqr2.cpp
@@ -49,7 +49,7 @@ template <typename real_t>
 void run(size_t m, size_t n)
 {
     using std::size_t;
-    using matrix_t = tlapack::legacyMatrix<real_t>;
+    using matrix_t = tlapack::LegacyMatrix<real_t>;
 
     // Functors for creating new matrices
     tlapack::Create<matrix_t> new_matrix;

--- a/examples/lu/example_lu.cpp
+++ b/examples/lu/example_lu.cpp
@@ -35,7 +35,7 @@ void run(size_t n)
 
     // Create the n-by-n matrix A
     std::vector<T> A_(n * n);
-    tlapack::legacyMatrix<T, idx_t, L> A(n, n, A_.data(), n);
+    tlapack::LegacyMatrix<T, idx_t, L> A(n, n, A_.data(), n);
 
     // forming A, a random matrix
     for (idx_t j = 0; j < n; ++j)
@@ -47,7 +47,7 @@ void run(size_t n)
     // Allocate space for the LU decomposition
     std::vector<size_t> piv(n);
     std::vector<T> LU_(n * n);
-    tlapack::legacyMatrix<T, idx_t, L> LU(n, n, LU_.data(), n);
+    tlapack::LegacyMatrix<T, idx_t, L> LU(n, n, LU_.data(), n);
 
     // Matrix A is kept unchanged
     tlapack::lacpy(tlapack::dense, A, LU);
@@ -61,7 +61,7 @@ void run(size_t n)
 
     // create X to store invese of A later
     std::vector<T> X_(n * n, T(0));
-    tlapack::legacyMatrix<T, idx_t, L> X(n, n, X_.data(), n);
+    tlapack::LegacyMatrix<T, idx_t, L> X(n, n, X_.data(), n);
 
     // step 0: store Identity on X
     for (size_t i = 0; i < n; i++)
@@ -87,7 +87,7 @@ void run(size_t n)
 
     // create E to store A * X
     std::vector<T> E_(n * n);
-    tlapack::legacyMatrix<T, idx_t, L> E(n, n, E_.data(), n);
+    tlapack::LegacyMatrix<T, idx_t, L> E(n, n, E_.data(), n);
 
     // E <----- A * X - I
     tlapack::gemm(tlapack::Op::NoTrans, tlapack::Op::NoTrans, real_t(1), A, X,

--- a/examples/potrf/example_potrf.cpp
+++ b/examples/potrf/example_potrf.cpp
@@ -78,7 +78,7 @@ void run(idx_t n)
 
     // Matrix A
     std::vector<T> A_(n * n);
-    legacyMatrix<T> A(n, n, &A_[0], n);
+    LegacyMatrix<T> A(n, n, &A_[0], n);
 
     // // Flops
     // const real_t nFlops = real_t(n*n*n) / 3;
@@ -99,7 +99,7 @@ void run(idx_t n)
     // 1) Using <T>LAPACK API:
     {
         std::vector<T> U_(n * n);
-        legacyMatrix<T> U(n, n, &U_[0], n);
+        LegacyMatrix<T> U(n, n, &U_[0], n);
 
         // Put garbage on U_
         for (idx_t j = 0; j < n * n; ++j)
@@ -132,7 +132,7 @@ void run(idx_t n)
 
         // Solve U^H U R = A
         std::vector<T> R_(n * n);
-        legacyMatrix<T> R(n, n, &R_[0], n);
+        LegacyMatrix<T> R(n, n, &R_[0], n);
         lacpy(dense, A, R);
         potrs(upperTriangle, U, R);
 
@@ -185,9 +185,9 @@ void run(idx_t n)
 
         // Solve U^H U R = A
         std::vector<T> R_(n * n);
-        legacyMatrix<T> R(n, n, &R_[0], n);
+        LegacyMatrix<T> R(n, n, &R_[0], n);
         lacpy(dense, A, R);
-        potrs(upperTriangle, legacyMatrix<T>(n, n, &U[0], n), R);
+        potrs(upperTriangle, LegacyMatrix<T>(n, n, &U[0], n), R);
 
         // error = ||R-Id||_F / ||Id||_F
         for (idx_t i = 0; i < n; ++i)

--- a/include/tlapack/LegacyBandedMatrix.hpp
+++ b/include/tlapack/LegacyBandedMatrix.hpp
@@ -1,4 +1,4 @@
-/// @file legacyBandedMatrix.hpp
+/// @file LegacyBandedMatrix.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 //
 // Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
@@ -13,7 +13,6 @@
 #include <cassert>
 
 #include "tlapack/base/exceptionHandling.hpp"
-#include "tlapack/base/types.hpp"
 
 namespace tlapack {
 
@@ -28,7 +27,7 @@ namespace tlapack {
  * @tparam idx_t Index type
  */
 template <typename T, class idx_t = std::size_t>
-struct legacyBandedMatrix {
+struct LegacyBandedMatrix {
     idx_t m, n, kl, ku;  ///< Sizes
     T* ptr;              ///< Pointer to array in memory
 
@@ -62,7 +61,7 @@ struct legacyBandedMatrix {
         return ptr[(ku + i) + j * (ku + kl)];
     }
 
-    inline constexpr legacyBandedMatrix(
+    inline constexpr LegacyBandedMatrix(
         idx_t m, idx_t n, idx_t kl, idx_t ku, T* ptr)
         : m(m), n(n), kl(kl), ku(ku), ptr(ptr)
     {

--- a/include/tlapack/LegacyMatrix.hpp
+++ b/include/tlapack/LegacyMatrix.hpp
@@ -1,4 +1,4 @@
-/// @file legacyArray.hpp
+/// @file LegacyMatrix.hpp
 /// @author Weslley S Pereira, University of Colorado Denver, USA
 /// @author Thijs Steel, KU Leuven, Belgium
 //
@@ -8,20 +8,19 @@
 // <T>LAPACK is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef TLAPACK_LEGACY_ARRAY_HH
-#define TLAPACK_LEGACY_ARRAY_HH
+#ifndef TLAPACK_LEGACY_MATRIX_HH
+#define TLAPACK_LEGACY_MATRIX_HH
 
 #include <cassert>
 
 #include "tlapack/base/exceptionHandling.hpp"
-#include "tlapack/base/legacyBandedMatrix.hpp"
 #include "tlapack/base/types.hpp"
 
 namespace tlapack {
 
 /** Legacy matrix.
  *
- * legacyMatrix::ldim is assumed to be positive.
+ * LegacyMatrix::ldim is assumed to be positive.
  *
  * @tparam T Floating-point type
  * @tparam idx_t Index type
@@ -32,7 +31,7 @@ template <class T,
           Layout L = Layout::ColMajor,
           std::enable_if_t<(L == Layout::RowMajor) || (L == Layout::ColMajor),
                            int> = 0>
-struct legacyMatrix {
+struct LegacyMatrix {
     idx_t m, n;  ///< Sizes
     T* ptr;      ///< Pointer to array in memory
     idx_t ldim;  ///< Leading dimension
@@ -59,7 +58,7 @@ struct legacyMatrix {
                                             : ptr[i * ldim + j];
     }
 
-    inline constexpr legacyMatrix(idx_t m, idx_t n, T* ptr, idx_t ldim)
+    inline constexpr LegacyMatrix(idx_t m, idx_t n, T* ptr, idx_t ldim)
         : m(m), n(n), ptr(ptr), ldim(ldim)
     {
         tlapack_check(m >= 0);
@@ -67,7 +66,7 @@ struct legacyMatrix {
         tlapack_check(ldim >= ((layout == Layout::ColMajor) ? m : n));
     }
 
-    inline constexpr legacyMatrix(idx_t m, idx_t n, T* ptr)
+    inline constexpr LegacyMatrix(idx_t m, idx_t n, T* ptr)
         : m(m), n(n), ptr(ptr), ldim((layout == Layout::ColMajor) ? m : n)
     {
         tlapack_check(m >= 0);
@@ -75,55 +74,6 @@ struct legacyMatrix {
     }
 };
 
-namespace internal {
-
-    /// Auxiliary data type to vector increments.
-    struct StrongOne {
-        inline constexpr operator int() const { return 1; }
-        inline constexpr StrongOne(int i = 1) { assert(i == 1); }
-    };
-}  // namespace internal
-
-/** Legacy vector.
- *
- * @tparam T Floating-point type
- * @tparam idx_t Index type
- * @tparam D Either Direction::Forward or Direction::Backward
- */
-template <typename T,
-          class idx_t = std::size_t,
-          typename int_t = internal::StrongOne,
-          Direction D = Direction::Forward>
-struct legacyVector {
-    idx_t n;    ///< Size
-    T* ptr;     ///< Pointer to array in memory
-    int_t inc;  ///< Memory increment
-
-    static constexpr Direction direction = D;
-
-    inline constexpr const T& operator[](idx_t i) const noexcept
-    {
-        assert(i >= 0);
-        assert(i < n);
-        return (direction == Direction::Forward) ? *(ptr + (i * inc))
-                                                 : *(ptr + ((n - 1) - i) * inc);
-    }
-
-    inline constexpr T& operator[](idx_t i) noexcept
-    {
-        assert(i >= 0);
-        assert(i < n);
-        return (direction == Direction::Forward) ? *(ptr + (i * inc))
-                                                 : *(ptr + ((n - 1) - i) * inc);
-    }
-
-    inline constexpr legacyVector(idx_t n, T* ptr, int_t inc = 1)
-        : n(n), ptr(ptr), inc(inc)
-    {
-        tlapack_check_false(n < 0);
-    }
-};
-
 }  // namespace tlapack
 
-#endif  // TLAPACK_LEGACY_ARRAY_HH
+#endif  // TLAPACK_LEGACY_MATRIX_HH

--- a/include/tlapack/LegacyVector.hpp
+++ b/include/tlapack/LegacyVector.hpp
@@ -1,0 +1,74 @@
+/// @file LegacyVector.hpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+/// @author Thijs Steel, KU Leuven, Belgium
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_LEGACY_VECTOR_HH
+#define TLAPACK_LEGACY_VECTOR_HH
+
+#include <cassert>
+
+#include "tlapack/base/exceptionHandling.hpp"
+#include "tlapack/base/types.hpp"
+
+namespace tlapack {
+
+namespace internal {
+    /// Auxiliary data type to vector increments.
+    struct StrongOne {
+        inline constexpr operator int() const { return 1; }
+        inline constexpr StrongOne(int i = 1) { assert(i == 1); }
+    };
+}  // namespace internal
+
+/** Legacy vector.
+ *
+ * @tparam T Floating-point type
+ * @tparam idx_t Index type
+ * @tparam D Either Direction::Forward or Direction::Backward
+ */
+template <
+    typename T,
+    class idx_t = std::size_t,
+    typename int_t = internal::StrongOne,
+    Direction D = Direction::Forward,
+    std::enable_if_t<(D == Direction::Forward) || (D == Direction::Backward),
+                     int> = 0>
+struct LegacyVector {
+    idx_t n;    ///< Size
+    T* ptr;     ///< Pointer to array in memory
+    int_t inc;  ///< Memory increment
+
+    static constexpr Direction direction = D;
+
+    inline constexpr const T& operator[](idx_t i) const noexcept
+    {
+        assert(i >= 0);
+        assert(i < n);
+        return (direction == Direction::Forward) ? *(ptr + (i * inc))
+                                                 : *(ptr + ((n - 1) - i) * inc);
+    }
+
+    inline constexpr T& operator[](idx_t i) noexcept
+    {
+        assert(i >= 0);
+        assert(i < n);
+        return (direction == Direction::Forward) ? *(ptr + (i * inc))
+                                                 : *(ptr + ((n - 1) - i) * inc);
+    }
+
+    inline constexpr LegacyVector(idx_t n, T* ptr, int_t inc = 1)
+        : n(n), ptr(ptr), inc(inc)
+    {
+        tlapack_check_false(n < 0);
+    }
+};
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_LEGACY_MATRIX_HH

--- a/include/tlapack/base/constants.hpp
+++ b/include/tlapack/base/constants.hpp
@@ -19,11 +19,6 @@ namespace tlapack {
 
 // -----------------------------------------------------------------------------
 // Macros to compute scaling constants
-//
-// @details
-//
-// Anderson E (2017) Algorithm 978: Safe scaling in the level 1 BLAS.
-// ACM Trans Math Softw 44:. https://doi.org/10.1145/3061665
 
 /** Unit in the Last Place
  * \[
@@ -59,6 +54,10 @@ inline constexpr real_t uroundoff()
 }
 
 /** Digits
+ *
+ * Number of digits p in the mantissa.
+ * @see std::numeric_limits<real_t>::digits.
+ *
  * @ingroup constants
  */
 template <typename real_t>
@@ -67,7 +66,11 @@ inline int digits()
     return std::numeric_limits<real_t>::digits;
 }
 
-/** Safe Minimum such that 1/safe_min() is representable
+/** Safe Minimum
+ *
+ * Smallest normal positive power of two such that its inverse (1/safe_min()) is
+ * finite.
+ *
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
@@ -80,9 +83,9 @@ inline constexpr real_t safe_min()
     return max(pow(fradix, real_t(expm - 1)), pow(fradix, real_t(1 - expM)));
 }
 
-/** Safe Maximum such that 1/safe_max() is representable
+/** Safe Maximum
  *
- * safe_max() := 1/SAFMIN
+ * safe_max() := 1/safe_min()
  *
  * @ingroup constants
  */
@@ -94,24 +97,6 @@ inline constexpr real_t safe_max()
     constexpr int expM = std::numeric_limits<real_t>::max_exponent;
 
     return min(pow(fradix, real_t(1 - expm)), pow(fradix, real_t(expM - 1)));
-}
-
-/** Safe Minimum such its square is representable
- * @ingroup constants
- */
-template <TLAPACK_REAL real_t>
-inline constexpr real_t root_min()
-{
-    return sqrt(safe_min<real_t>() / ulp<real_t>());
-}
-
-/** Safe Maximum such its square is representable
- * @ingroup constants
- */
-template <TLAPACK_REAL real_t>
-inline constexpr real_t root_max()
-{
-    return sqrt(safe_max<real_t>() * ulp<real_t>());
 }
 
 /** Blue's min constant b for the sum of squares

--- a/include/tlapack/base/exceptionHandling.hpp
+++ b/include/tlapack/base/exceptionHandling.hpp
@@ -20,6 +20,8 @@
  *
  * @note Only used if TLAPACK_ENABLE_INFCHECK is defined and TLAPACK_NDEBUG
  * is not defined.
+ * 
+ * @ingroup exception
  */
 #ifndef TLAPACK_DEFAULT_INFCHECK
     #define TLAPACK_DEFAULT_INFCHECK true
@@ -31,6 +33,8 @@
  *
  * @note Only used if TLAPACK_ENABLE_NANCHECK is defined and TLAPACK_NDEBUG
  * is not defined.
+ * 
+ * @ingroup exception
  *
  */
 #ifndef TLAPACK_DEFAULT_NANCHECK
@@ -38,10 +42,6 @@
 #endif
 
 namespace tlapack {
-
-using check_error = std::domain_error;
-using internal_error = std::runtime_error;
-
 namespace internal {
 
     /**
@@ -101,9 +101,9 @@ struct ec_opts_t {
      *
      * @ingroup exception
      */
-    #define tlapack_check(cond)                                              \
-        do {                                                                 \
-            if (!static_cast<bool>(cond)) throw tlapack::check_error(#cond); \
+    #define tlapack_check(cond)                                           \
+        do {                                                              \
+            if (!static_cast<bool>(cond)) throw std::domain_error(#cond); \
         } while (false)
 
     /**
@@ -116,9 +116,9 @@ struct ec_opts_t {
      *
      * @ingroup exception
      */
-    #define tlapack_check_false(cond)                                       \
-        do {                                                                \
-            if (static_cast<bool>(cond)) throw tlapack::check_error(#cond); \
+    #define tlapack_check_false(cond)                                    \
+        do {                                                             \
+            if (static_cast<bool>(cond)) throw std::domain_error(#cond); \
         } while (false)
 
 #else  // !defined(TLAPACK_CHECK_INPUT) || defined(TLAPACK_NDEBUG)
@@ -146,7 +146,7 @@ struct ec_opts_t {
      * @ingroup exception
      */
     #define tlapack_error(info, detailedInfo) \
-        throw tlapack::internal_error(        \
+        throw std::runtime_error(             \
             tlapack::internal::error_msg(info, detailedInfo))
 
     /**

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -481,7 +481,6 @@ namespace internal {
 }  // namespace internal
 
 /// Alias for @c internal::AllowOptBLASImpl<,int>::value.
-/// @ingroup abstract_matrix
 template <class... Ts>
 constexpr bool allow_optblas = internal::AllowOptBLASImpl<Ts..., int>::value;
 

--- a/include/tlapack/blas/rotg.hpp
+++ b/include/tlapack/blas/rotg.hpp
@@ -114,8 +114,8 @@ void rotg(T& a, const T& b, real_type<T>& c, T& s)
     // Scaling constants
     const real_t safmin = safe_min<real_t>();
     const real_t safmax = safe_max<real_t>();
-    const real_t rtmin = root_min<real_t>();
-    const real_t rtmax = root_max<real_t>();
+    const real_t rtmin = sqrt(safmin / ulp<real_t>());
+    const real_t rtmax = sqrt(safmax * ulp<real_t>());
 
     // quick return
     if (b == zero) {

--- a/include/tlapack/lapack/lange.hpp
+++ b/include/tlapack/lapack/lange.hpp
@@ -12,7 +12,6 @@
 #ifndef TLAPACK_LANGE_HH
 #define TLAPACK_LANGE_HH
 
-#include "tlapack/base/legacyArray.hpp"
 #include "tlapack/lapack/lassq.hpp"
 
 namespace tlapack {
@@ -223,7 +222,7 @@ auto lange(norm_t normType, const matrix_t& A, const workspace_opts_t<>& opts)
             lange_worksize(normType, A, opts);
             return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T, idx_t> w(m, work);
+        auto w = Create<vector_type<matrix_t>>(work, m);
 
         // Norm value
         real_t norm(0);

--- a/include/tlapack/lapack/lanhe.hpp
+++ b/include/tlapack/lapack/lanhe.hpp
@@ -12,7 +12,6 @@
 #ifndef TLAPACK_LANHE_HH
 #define TLAPACK_LANHE_HH
 
-#include "tlapack/base/legacyArray.hpp"
 #include "tlapack/lapack/lassq.hpp"
 
 namespace tlapack {
@@ -312,7 +311,7 @@ auto lanhe(norm_t normType,
             lanhe_worksize(normType, uplo, A, opts);
             return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T, idx_t> w(n, work);
+        auto w = Create<vector_type<matrix_t>>(work, n);
 
         // Norm value
         real_t norm(0);

--- a/include/tlapack/lapack/lansy.hpp
+++ b/include/tlapack/lapack/lansy.hpp
@@ -12,7 +12,6 @@
 #ifndef TLAPACK_LANSY_HH
 #define TLAPACK_LANSY_HH
 
-#include "tlapack/base/legacyArray.hpp"
 #include "tlapack/lapack/lassq.hpp"
 
 namespace tlapack {
@@ -289,7 +288,7 @@ auto lansy(norm_t normType,
             lansy_worksize(normType, uplo, A, opts);
             return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T, idx_t> w(n, work);
+        auto w = Create<vector_type<matrix_t>>(work, n);
 
         // Norm value
         real_t norm(0);

--- a/include/tlapack/lapack/lantr.hpp
+++ b/include/tlapack/lapack/lantr.hpp
@@ -12,7 +12,6 @@
 #ifndef TLAPACK_LANTR_HH
 #define TLAPACK_LANTR_HH
 
-#include "tlapack/base/legacyArray.hpp"
 #include "tlapack/lapack/lassq.hpp"
 
 namespace tlapack {
@@ -413,7 +412,7 @@ auto lantr(norm_t normType,
             lantr_worksize(normType, uplo, diag, A, opts);
             return alloc_workspace(localworkdata, workinfo, opts.work);
         }();
-        legacyVector<T, idx_t> w(n, work);
+        auto w = Create<vector_type<matrix_t>>(work, n);
 
         // Norm value
         real_t norm(0);

--- a/include/tlapack/legacy_api/base/legacyArray.hpp
+++ b/include/tlapack/legacy_api/base/legacyArray.hpp
@@ -73,7 +73,7 @@ namespace legacy {
         template <typename T>
         inline constexpr auto create_backward_vector(T* x, idx_t n)
         {
-            return legacyVector<T, idx_t, ::tlapack::internal::StrongOne,
+            return legacyVector<T, idx_t, tlapack::internal::StrongOne,
                                 Direction::Backward>{n, x};
         }
 

--- a/include/tlapack/legacy_api/base/legacyArray.hpp
+++ b/include/tlapack/legacy_api/base/legacyArray.hpp
@@ -20,13 +20,13 @@ namespace legacy {
         template <typename T>
         inline constexpr auto create_matrix(T* A, idx_t m, idx_t n, idx_t lda)
         {
-            return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, lda};
+            return LegacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, lda};
         }
 
         template <typename T>
         inline constexpr auto create_matrix(T* A, idx_t m, idx_t n)
         {
-            return legacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, m};
+            return LegacyMatrix<T, idx_t, Layout::ColMajor>{m, n, A, m};
         }
 
         template <typename T>
@@ -35,45 +35,45 @@ namespace legacy {
                                                      idx_t n,
                                                      idx_t lda)
         {
-            return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, lda};
+            return LegacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, lda};
         }
 
         template <typename T>
         inline constexpr auto create_rowmajor_matrix(T* A, idx_t m, idx_t n)
         {
-            return legacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, n};
+            return LegacyMatrix<T, idx_t, Layout::RowMajor>{m, n, A, n};
         }
 
         template <typename T>
         inline constexpr auto create_banded_matrix(
             T* A, idx_t m, idx_t n, idx_t kl, idx_t ku)
         {
-            return legacyBandedMatrix<T, idx_t>{m, n, kl, ku, A};
+            return LegacyBandedMatrix<T, idx_t>{m, n, kl, ku, A};
         }
 
         template <typename T, typename int_t>
         inline constexpr auto create_vector(T* x, idx_t n, int_t inc)
         {
-            return legacyVector<T, idx_t, int_t>{n, x, inc};
+            return LegacyVector<T, idx_t, int_t>{n, x, inc};
         }
 
         template <typename T>
         inline constexpr auto create_vector(T* x, idx_t n)
         {
-            return legacyVector<T, idx_t>{n, x};
+            return LegacyVector<T, idx_t>{n, x};
         }
 
         template <typename T, typename int_t>
         inline constexpr auto create_backward_vector(T* x, idx_t n, int_t inc)
         {
-            return legacyVector<T, idx_t, int_t, Direction::Backward>{n, x,
+            return LegacyVector<T, idx_t, int_t, Direction::Backward>{n, x,
                                                                       inc};
         }
 
         template <typename T>
         inline constexpr auto create_backward_vector(T* x, idx_t n)
         {
-            return legacyVector<T, idx_t, tlapack::internal::StrongOne,
+            return LegacyVector<T, idx_t, tlapack::internal::StrongOne,
                                 Direction::Backward>{n, x};
         }
 

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -12,8 +12,10 @@
 
 #include <cassert>
 
+#include "tlapack/LegacyBandedMatrix.hpp"
+#include "tlapack/LegacyMatrix.hpp"
+#include "tlapack/LegacyVector.hpp"
 #include "tlapack/base/arrayTraits.hpp"
-#include "tlapack/base/legacyArray.hpp"
 #include "tlapack/base/workspace.hpp"
 
 namespace tlapack {
@@ -24,11 +26,11 @@ namespace tlapack {
 namespace legacy {
     namespace internal {
         template <typename T, class idx_t, Layout L>
-        std::true_type is_legacy_type_f(const legacyMatrix<T, idx_t, L>*);
+        std::true_type is_legacy_type_f(const LegacyMatrix<T, idx_t, L>*);
 
         template <typename T, class idx_t, class int_t, Direction D>
         std::true_type is_legacy_type_f(
-            const legacyVector<T, idx_t, int_t, D>*);
+            const LegacyVector<T, idx_t, int_t, D>*);
 
         std::false_type is_legacy_type_f(const void*);
     }  // namespace internal
@@ -44,58 +46,58 @@ namespace legacy {
 // Data traits
 
 namespace traits {
-    /// Layout for legacyMatrix
+    /// Layout for LegacyMatrix
     template <typename T, class idx_t, Layout L>
-    struct layout_trait<legacyMatrix<T, idx_t, L>, int> {
+    struct layout_trait<LegacyMatrix<T, idx_t, L>, int> {
         static constexpr Layout value = L;
     };
 
-    /// Layout for legacyVector
+    /// Layout for LegacyVector
     template <typename T, class idx_t, typename int_t, Direction D>
-    struct layout_trait<legacyVector<T, idx_t, int_t, D>, int> {
+    struct layout_trait<LegacyVector<T, idx_t, int_t, D>, int> {
         static constexpr Layout value = Layout::Strided;
     };
 
     // Matrix type traits
     template <class T, class idx_t>
-    struct matrix_type_traits<legacyMatrix<T, idx_t, Layout::ColMajor>, int> {
-        using type = legacyMatrix<T, idx_t, Layout::ColMajor>;
-        using transpose_type = legacyMatrix<T, idx_t, Layout::RowMajor>;
+    struct matrix_type_traits<LegacyMatrix<T, idx_t, Layout::ColMajor>, int> {
+        using type = LegacyMatrix<T, idx_t, Layout::ColMajor>;
+        using transpose_type = LegacyMatrix<T, idx_t, Layout::RowMajor>;
     };
     template <class T, class idx_t>
-    struct matrix_type_traits<legacyMatrix<T, idx_t, Layout::RowMajor>, int> {
-        using type = legacyMatrix<T, idx_t, Layout::RowMajor>;
-        using transpose_type = legacyMatrix<T, idx_t, Layout::ColMajor>;
+    struct matrix_type_traits<LegacyMatrix<T, idx_t, Layout::RowMajor>, int> {
+        using type = LegacyMatrix<T, idx_t, Layout::RowMajor>;
+        using transpose_type = LegacyMatrix<T, idx_t, Layout::ColMajor>;
     };
     template <typename T, class idx_t, typename int_t, Direction D>
-    struct matrix_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
-        using type = legacyMatrix<T, idx_t, Layout::ColMajor>;
+    struct matrix_type_traits<LegacyVector<T, idx_t, int_t, D>, int> {
+        using type = LegacyMatrix<T, idx_t, Layout::ColMajor>;
     };
 
     template <class T, class idx_t, typename int_t, Direction D>
-    struct real_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
-        using type = legacyVector<real_type<T>, idx_t, int_t, D>;
+    struct real_type_traits<LegacyVector<T, idx_t, int_t, D>, int> {
+        using type = LegacyVector<real_type<T>, idx_t, int_t, D>;
     };
 
     template <typename T, class idx_t, Layout layout>
-    struct real_type_traits<legacyMatrix<T, idx_t, layout>, int> {
-        using type = legacyMatrix<real_type<T>, idx_t, layout>;
+    struct real_type_traits<LegacyMatrix<T, idx_t, layout>, int> {
+        using type = LegacyMatrix<real_type<T>, idx_t, layout>;
     };
 
     template <class T, class idx_t, typename int_t, Direction D>
-    struct complex_type_traits<legacyVector<T, idx_t, int_t, D>, int> {
-        using type = legacyVector<complex_type<T>, idx_t, int_t, D>;
+    struct complex_type_traits<LegacyVector<T, idx_t, int_t, D>, int> {
+        using type = LegacyVector<complex_type<T>, idx_t, int_t, D>;
     };
 
     template <typename T, class idx_t, Layout layout>
-    struct complex_type_traits<legacyMatrix<T, idx_t, layout>, int> {
-        using type = legacyMatrix<complex_type<T>, idx_t, layout>;
+    struct complex_type_traits<LegacyMatrix<T, idx_t, layout>, int> {
+        using type = LegacyMatrix<complex_type<T>, idx_t, layout>;
     };
 
-    /// Create legacyMatrix @see Create
+    /// Create LegacyMatrix @see Create
     template <class T, class idx_t, Layout layout>
-    struct CreateFunctor<legacyMatrix<T, idx_t, layout>, int> {
-        using matrix_t = legacyMatrix<T, idx_t, layout>;
+    struct CreateFunctor<LegacyMatrix<T, idx_t, layout>, int> {
+        using matrix_t = LegacyMatrix<T, idx_t, layout>;
 
         inline constexpr auto operator()(std::vector<T>& v,
                                          idx_t m,
@@ -135,10 +137,10 @@ namespace traits {
         }
     };
 
-    /// Create legacyVector @see Create
+    /// Create LegacyVector @see Create
     template <class T, class idx_t, typename int_t, Direction D>
-    struct CreateFunctor<legacyVector<T, idx_t, int_t, D>, int> {
-        using vector_t = legacyVector<T, idx_t, int_t, D>;
+    struct CreateFunctor<LegacyVector<T, idx_t, int_t, D>, int> {
+        using vector_t = LegacyVector<T, idx_t, int_t, D>;
 
         inline constexpr auto operator()(std::vector<T>& v, idx_t m) const
         {
@@ -174,61 +176,61 @@ namespace traits {
 // -----------------------------------------------------------------------------
 // Data descriptors
 
-// Number of rows of legacyMatrix
+// Number of rows of LegacyMatrix
 template <typename T, class idx_t, Layout layout>
-inline constexpr auto nrows(const legacyMatrix<T, idx_t, layout>& A)
+inline constexpr auto nrows(const LegacyMatrix<T, idx_t, layout>& A)
 {
     return A.m;
 }
 
-// Number of columns of legacyMatrix
+// Number of columns of LegacyMatrix
 template <typename T, class idx_t, Layout layout>
-inline constexpr auto ncols(const legacyMatrix<T, idx_t, layout>& A)
+inline constexpr auto ncols(const LegacyMatrix<T, idx_t, layout>& A)
 {
     return A.n;
 }
 
-// Size of legacyVector
+// Size of LegacyVector
 template <typename T, class idx_t, typename int_t, Direction direction>
-inline constexpr auto size(const legacyVector<T, idx_t, int_t, direction>& x)
+inline constexpr auto size(const LegacyVector<T, idx_t, int_t, direction>& x)
 {
     return x.n;
 }
 
-// Number of rows of legacyBandedMatrix
+// Number of rows of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto nrows(const legacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto nrows(const LegacyBandedMatrix<T, idx_t>& A)
 {
     return A.m;
 }
 
-// Number of columns of legacyBandedMatrix
+// Number of columns of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto ncols(const legacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto ncols(const LegacyBandedMatrix<T, idx_t>& A)
 {
     return A.n;
 }
 
-// Lowerband of legacyBandedMatrix
+// Lowerband of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto lowerband(const legacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto lowerband(const LegacyBandedMatrix<T, idx_t>& A)
 {
     return A.kl;
 }
 
-// Upperband of legacyBandedMatrix
+// Upperband of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto upperband(const legacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto upperband(const LegacyBandedMatrix<T, idx_t>& A)
 {
     return A.ku;
 }
 
 // -----------------------------------------------------------------------------
-// Block operations for const legacyMatrix
+// Block operations for const LegacyMatrix
 
 #define isSlice(SliceSpec) !std::is_convertible<SliceSpec, idx_t>::value
 
-// Slice legacyMatrix
+// Slice LegacyMatrix
 template <
     typename T,
     class idx_t,
@@ -237,7 +239,7 @@ template <
     class SliceSpecCol,
     typename std::enable_if<isSlice(SliceSpecRow) && isSlice(SliceSpecCol),
                             int>::type = 0>
-inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto slice(const LegacyMatrix<T, idx_t, layout>& A,
                             SliceSpecRow&& rows,
                             SliceSpecCol&& cols) noexcept
 {
@@ -249,7 +251,7 @@ inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
            cols.first == cols.second);
     assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
-    return legacyMatrix<const T, idx_t, layout>(
+    return LegacyMatrix<const T, idx_t, layout>(
         rows.second - rows.first, cols.second - cols.first,
         (layout == Layout::ColMajor) ? &A.ptr[rows.first + cols.first * A.ldim]
                                      : &A.ptr[rows.first * A.ldim + cols.first],
@@ -258,10 +260,10 @@ inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
 
 #undef isSlice
 
-// Slice legacyMatrix over a single row
+// Slice LegacyMatrix over a single row
 template <typename T, class idx_t, Layout layout, class SliceSpecCol>
-inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
-                            size_type<legacyMatrix<T, idx_t, layout>> rowIdx,
+inline constexpr auto slice(const LegacyMatrix<T, idx_t, layout>& A,
+                            size_type<LegacyMatrix<T, idx_t, layout>> rowIdx,
                             SliceSpecCol&& cols) noexcept
 {
     assert((cols.first >= 0 and (idx_t) cols.first < ncols(A)) ||
@@ -269,105 +271,105 @@ inline constexpr auto slice(const legacyMatrix<T, idx_t, layout>& A,
     assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
     assert(rowIdx >= 0 and rowIdx < nrows(A));
-    return legacyVector<const T, idx_t, idx_t>(
+    return LegacyVector<const T, idx_t, idx_t>(
         cols.second - cols.first,
         (layout == Layout::ColMajor) ? &A.ptr[rowIdx + cols.first * A.ldim]
                                      : &A.ptr[rowIdx * A.ldim + cols.first],
         layout == Layout::ColMajor ? A.ldim : 1);
 }
 
-// Slice legacyMatrix over a single column
+// Slice LegacyMatrix over a single column
 template <typename T, class idx_t, Layout layout, class SliceSpecRow>
 inline constexpr auto slice(
-    const legacyMatrix<T, idx_t, layout>& A,
+    const LegacyMatrix<T, idx_t, layout>& A,
     SliceSpecRow&& rows,
-    size_type<legacyMatrix<T, idx_t, layout>> colIdx) noexcept
+    size_type<LegacyMatrix<T, idx_t, layout>> colIdx) noexcept
 {
     assert((rows.first >= 0 and (idx_t) rows.first < nrows(A)) ||
            rows.first == rows.second);
     assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
     assert(rows.first <= rows.second);
     assert(colIdx >= 0 and colIdx < ncols(A));
-    return legacyVector<const T, idx_t, idx_t>(
+    return LegacyVector<const T, idx_t, idx_t>(
         rows.second - rows.first,
         (layout == Layout::ColMajor) ? &A.ptr[rows.first + colIdx * A.ldim]
                                      : &A.ptr[rows.first * A.ldim + colIdx],
         layout == Layout::RowMajor ? A.ldim : 1);
 }
 
-// Get rows of legacyMatrix
+// Get rows of LegacyMatrix
 template <typename T, class idx_t, Layout layout, class SliceSpec>
-inline constexpr auto rows(const legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto rows(const LegacyMatrix<T, idx_t, layout>& A,
                            SliceSpec&& rows) noexcept
 {
     assert((rows.first >= 0 and (idx_t) rows.first < nrows(A)) ||
            rows.first == rows.second);
     assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
     assert(rows.first <= rows.second);
-    return legacyMatrix<const T, idx_t, layout>(
+    return LegacyMatrix<const T, idx_t, layout>(
         rows.second - rows.first, A.n,
         (layout == Layout::ColMajor) ? &A.ptr[rows.first]
                                      : &A.ptr[rows.first * A.ldim],
         A.ldim);
 }
 
-// Get a row of a column-major legacyMatrix
+// Get a row of a column-major LegacyMatrix
 template <typename T, class idx_t>
-inline constexpr auto row(const legacyMatrix<T, idx_t>& A,
-                          size_type<legacyMatrix<T, idx_t>> rowIdx) noexcept
+inline constexpr auto row(const LegacyMatrix<T, idx_t>& A,
+                          size_type<LegacyMatrix<T, idx_t>> rowIdx) noexcept
 {
     assert(rowIdx >= 0 and rowIdx < nrows(A));
-    return legacyVector<const T, idx_t, idx_t>(A.n, &A.ptr[rowIdx], A.ldim);
+    return LegacyVector<const T, idx_t, idx_t>(A.n, &A.ptr[rowIdx], A.ldim);
 }
 
-// Get a row of a row-major legacyMatrix
+// Get a row of a row-major LegacyMatrix
 template <typename T, class idx_t>
 inline constexpr auto row(
-    const legacyMatrix<T, idx_t, Layout::RowMajor>& A,
-    size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> rowIdx) noexcept
+    const LegacyMatrix<T, idx_t, Layout::RowMajor>& A,
+    size_type<LegacyMatrix<T, idx_t, Layout::RowMajor>> rowIdx) noexcept
 {
     assert(rowIdx >= 0 and rowIdx < nrows(A));
-    return legacyVector<const T, idx_t>(A.n, &A.ptr[rowIdx * A.ldim]);
+    return LegacyVector<const T, idx_t>(A.n, &A.ptr[rowIdx * A.ldim]);
 }
 
-// Get columns of legacyMatrix
+// Get columns of LegacyMatrix
 template <typename T, class idx_t, Layout layout, class SliceSpec>
-inline constexpr auto cols(const legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto cols(const LegacyMatrix<T, idx_t, layout>& A,
                            SliceSpec&& cols) noexcept
 {
     assert((cols.first >= 0 and (idx_t) cols.first < ncols(A)) ||
            cols.first == cols.second);
     assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
-    return legacyMatrix<const T, idx_t, layout>(
+    return LegacyMatrix<const T, idx_t, layout>(
         A.m, cols.second - cols.first,
         (layout == Layout::ColMajor) ? &A.ptr[cols.first * A.ldim]
                                      : &A.ptr[cols.first],
         A.ldim);
 }
 
-// Get a column of a column-major legacyMatrix
+// Get a column of a column-major LegacyMatrix
 template <typename T, class idx_t>
-inline constexpr auto col(const legacyMatrix<T, idx_t>& A,
-                          size_type<legacyMatrix<T, idx_t>> colIdx) noexcept
+inline constexpr auto col(const LegacyMatrix<T, idx_t>& A,
+                          size_type<LegacyMatrix<T, idx_t>> colIdx) noexcept
 {
     assert(colIdx >= 0 and colIdx < ncols(A));
-    return legacyVector<const T, idx_t>(A.m, &A.ptr[colIdx * A.ldim]);
+    return LegacyVector<const T, idx_t>(A.m, &A.ptr[colIdx * A.ldim]);
 }
 
-// Get a column of a row-major legacyMatrix
+// Get a column of a row-major LegacyMatrix
 template <typename T, class idx_t>
 inline constexpr auto col(
-    const legacyMatrix<T, idx_t, Layout::RowMajor>& A,
-    size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> colIdx) noexcept
+    const LegacyMatrix<T, idx_t, Layout::RowMajor>& A,
+    size_type<LegacyMatrix<T, idx_t, Layout::RowMajor>> colIdx) noexcept
 {
     assert(colIdx >= 0 and colIdx < ncols(A));
-    return legacyVector<const T, idx_t, idx_t>(A.m, &A.ptr[colIdx], A.ldim);
+    return LegacyVector<const T, idx_t, idx_t>(A.m, &A.ptr[colIdx], A.ldim);
 }
 
-// Diagonal of a legacyMatrix
+// Diagonal of a LegacyMatrix
 template <typename T, class idx_t, Layout layout>
-inline constexpr auto diag(const legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto diag(const LegacyMatrix<T, idx_t, layout>& A,
                            int diagIdx = 0) noexcept
 {
     assert(diagIdx >= 0 || (idx_t)(-diagIdx) < nrows(A));
@@ -379,32 +381,32 @@ inline constexpr auto diag(const legacyMatrix<T, idx_t, layout>& A,
     idx_t n = (diagIdx >= 0) ? std::min(A.m + diagIdx, A.n) - (idx_t)diagIdx
                              : std::min(A.m, A.n - diagIdx) + (idx_t)diagIdx;
 
-    return legacyVector<const T, idx_t, idx_t>(n, ptr, A.ldim + 1);
+    return LegacyVector<const T, idx_t, idx_t>(n, ptr, A.ldim + 1);
 }
 
-// slice legacyVector
+// slice LegacyVector
 template <typename T,
           class idx_t,
           typename int_t,
           Direction direction,
           class SliceSpec>
-inline constexpr auto slice(const legacyVector<T, idx_t, int_t, direction>& v,
+inline constexpr auto slice(const LegacyVector<T, idx_t, int_t, direction>& v,
                             SliceSpec&& rows) noexcept
 {
     assert((rows.first >= 0 and (idx_t) rows.first < size(v)) ||
            rows.first == rows.second);
     assert(rows.second >= 0 and (idx_t) rows.second <= size(v));
     assert(rows.first <= rows.second);
-    return legacyVector<const T, idx_t, int_t, direction>(
+    return LegacyVector<const T, idx_t, int_t, direction>(
         rows.second - rows.first, &v.ptr[rows.first * v.inc], v.inc);
 }
 
 // -----------------------------------------------------------------------------
-// Block operations for non-const legacyMatrix
+// Block operations for non-const LegacyMatrix
 
 #define isSlice(SliceSpec) !std::is_convertible<SliceSpec, idx_t>::value
 
-// Slice legacyMatrix
+// Slice LegacyMatrix
 template <
     typename T,
     class idx_t,
@@ -413,7 +415,7 @@ template <
     class SliceSpecCol,
     typename std::enable_if<isSlice(SliceSpecRow) && isSlice(SliceSpecCol),
                             int>::type = 0>
-inline constexpr auto slice(legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto slice(LegacyMatrix<T, idx_t, layout>& A,
                             SliceSpecRow&& rows,
                             SliceSpecCol&& cols) noexcept
 {
@@ -425,7 +427,7 @@ inline constexpr auto slice(legacyMatrix<T, idx_t, layout>& A,
            cols.first == cols.second);
     assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
-    return legacyMatrix<T, idx_t, layout>(
+    return LegacyMatrix<T, idx_t, layout>(
         rows.second - rows.first, cols.second - cols.first,
         (layout == Layout::ColMajor) ? &A.ptr[rows.first + cols.first * A.ldim]
                                      : &A.ptr[rows.first * A.ldim + cols.first],
@@ -434,10 +436,10 @@ inline constexpr auto slice(legacyMatrix<T, idx_t, layout>& A,
 
 #undef isSlice
 
-// Slice legacyMatrix over a single row
+// Slice LegacyMatrix over a single row
 template <typename T, class idx_t, Layout layout, class SliceSpecCol>
-inline constexpr auto slice(legacyMatrix<T, idx_t, layout>& A,
-                            size_type<legacyMatrix<T, idx_t, layout>> rowIdx,
+inline constexpr auto slice(LegacyMatrix<T, idx_t, layout>& A,
+                            size_type<LegacyMatrix<T, idx_t, layout>> rowIdx,
                             SliceSpecCol&& cols) noexcept
 {
     assert((cols.first >= 0 and (idx_t) cols.first < ncols(A)) ||
@@ -445,105 +447,105 @@ inline constexpr auto slice(legacyMatrix<T, idx_t, layout>& A,
     assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
     assert(rowIdx >= 0 and rowIdx < nrows(A));
-    return legacyVector<T, idx_t, idx_t>(
+    return LegacyVector<T, idx_t, idx_t>(
         cols.second - cols.first,
         (layout == Layout::ColMajor) ? &A.ptr[rowIdx + cols.first * A.ldim]
                                      : &A.ptr[rowIdx * A.ldim + cols.first],
         layout == Layout::ColMajor ? A.ldim : 1);
 }
 
-// Slice legacyMatrix over a single column
+// Slice LegacyMatrix over a single column
 template <typename T, class idx_t, Layout layout, class SliceSpecRow>
 inline constexpr auto slice(
-    legacyMatrix<T, idx_t, layout>& A,
+    LegacyMatrix<T, idx_t, layout>& A,
     SliceSpecRow&& rows,
-    size_type<legacyMatrix<T, idx_t, layout>> colIdx) noexcept
+    size_type<LegacyMatrix<T, idx_t, layout>> colIdx) noexcept
 {
     assert((rows.first >= 0 and (idx_t) rows.first < nrows(A)) ||
            rows.first == rows.second);
     assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
     assert(rows.first <= rows.second);
     assert(colIdx >= 0 and colIdx < ncols(A));
-    return legacyVector<T, idx_t, idx_t>(
+    return LegacyVector<T, idx_t, idx_t>(
         rows.second - rows.first,
         (layout == Layout::ColMajor) ? &A.ptr[rows.first + colIdx * A.ldim]
                                      : &A.ptr[rows.first * A.ldim + colIdx],
         layout == Layout::RowMajor ? A.ldim : 1);
 }
 
-// Get rows of legacyMatrix
+// Get rows of LegacyMatrix
 template <typename T, class idx_t, Layout layout, class SliceSpec>
-inline constexpr auto rows(legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto rows(LegacyMatrix<T, idx_t, layout>& A,
                            SliceSpec&& rows) noexcept
 {
     assert((rows.first >= 0 and (idx_t) rows.first < nrows(A)) ||
            rows.first == rows.second);
     assert(rows.second >= 0 and (idx_t) rows.second <= nrows(A));
     assert(rows.first <= rows.second);
-    return legacyMatrix<T, idx_t, layout>(rows.second - rows.first, A.n,
+    return LegacyMatrix<T, idx_t, layout>(rows.second - rows.first, A.n,
                                           (layout == Layout::ColMajor)
                                               ? &A.ptr[rows.first]
                                               : &A.ptr[rows.first * A.ldim],
                                           A.ldim);
 }
 
-// Get a row of a column-major legacyMatrix
+// Get a row of a column-major LegacyMatrix
 template <typename T, class idx_t>
-inline constexpr auto row(legacyMatrix<T, idx_t>& A,
-                          size_type<legacyMatrix<T, idx_t>> rowIdx) noexcept
+inline constexpr auto row(LegacyMatrix<T, idx_t>& A,
+                          size_type<LegacyMatrix<T, idx_t>> rowIdx) noexcept
 {
     assert(rowIdx >= 0 and rowIdx < nrows(A));
-    return legacyVector<T, idx_t, idx_t>(A.n, &A.ptr[rowIdx], A.ldim);
+    return LegacyVector<T, idx_t, idx_t>(A.n, &A.ptr[rowIdx], A.ldim);
 }
 
-// Get a row of a row-major legacyMatrix
+// Get a row of a row-major LegacyMatrix
 template <typename T, class idx_t>
 inline constexpr auto row(
-    legacyMatrix<T, idx_t, Layout::RowMajor>& A,
-    size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> rowIdx) noexcept
+    LegacyMatrix<T, idx_t, Layout::RowMajor>& A,
+    size_type<LegacyMatrix<T, idx_t, Layout::RowMajor>> rowIdx) noexcept
 {
     assert(rowIdx >= 0 and rowIdx < nrows(A));
-    return legacyVector<T, idx_t>(A.n, &A.ptr[rowIdx * A.ldim]);
+    return LegacyVector<T, idx_t>(A.n, &A.ptr[rowIdx * A.ldim]);
 }
 
-// Get columns of legacyMatrix
+// Get columns of LegacyMatrix
 template <typename T, class idx_t, Layout layout, class SliceSpec>
-inline constexpr auto cols(legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto cols(LegacyMatrix<T, idx_t, layout>& A,
                            SliceSpec&& cols) noexcept
 {
     assert((cols.first >= 0 and (idx_t) cols.first < ncols(A)) ||
            cols.first == cols.second);
     assert(cols.second >= 0 and (idx_t) cols.second <= ncols(A));
     assert(cols.first <= cols.second);
-    return legacyMatrix<T, idx_t, layout>(A.m, cols.second - cols.first,
+    return LegacyMatrix<T, idx_t, layout>(A.m, cols.second - cols.first,
                                           (layout == Layout::ColMajor)
                                               ? &A.ptr[cols.first * A.ldim]
                                               : &A.ptr[cols.first],
                                           A.ldim);
 }
 
-// Get a column of a column-major legacyMatrix
+// Get a column of a column-major LegacyMatrix
 template <typename T, class idx_t>
-inline constexpr auto col(legacyMatrix<T, idx_t>& A,
-                          size_type<legacyMatrix<T, idx_t>> colIdx) noexcept
+inline constexpr auto col(LegacyMatrix<T, idx_t>& A,
+                          size_type<LegacyMatrix<T, idx_t>> colIdx) noexcept
 {
     assert(colIdx >= 0 and colIdx < ncols(A));
-    return legacyVector<T, idx_t>(A.m, &A.ptr[colIdx * A.ldim]);
+    return LegacyVector<T, idx_t>(A.m, &A.ptr[colIdx * A.ldim]);
 }
 
-// Get a column of a row-major legacyMatrix
+// Get a column of a row-major LegacyMatrix
 template <typename T, class idx_t>
 inline constexpr auto col(
-    legacyMatrix<T, idx_t, Layout::RowMajor>& A,
-    size_type<legacyMatrix<T, idx_t, Layout::RowMajor>> colIdx) noexcept
+    LegacyMatrix<T, idx_t, Layout::RowMajor>& A,
+    size_type<LegacyMatrix<T, idx_t, Layout::RowMajor>> colIdx) noexcept
 {
     assert(colIdx >= 0 and colIdx < ncols(A));
-    return legacyVector<T, idx_t, idx_t>(A.m, &A.ptr[colIdx], A.ldim);
+    return LegacyVector<T, idx_t, idx_t>(A.m, &A.ptr[colIdx], A.ldim);
 }
 
-// Diagonal of a legacyMatrix
+// Diagonal of a LegacyMatrix
 template <typename T, class idx_t, Layout layout>
-inline constexpr auto diag(legacyMatrix<T, idx_t, layout>& A,
+inline constexpr auto diag(LegacyMatrix<T, idx_t, layout>& A,
                            int diagIdx = 0) noexcept
 {
     assert(diagIdx >= 0 || (idx_t)(-diagIdx) < nrows(A));
@@ -555,23 +557,23 @@ inline constexpr auto diag(legacyMatrix<T, idx_t, layout>& A,
     idx_t n = (diagIdx >= 0) ? std::min(A.m + diagIdx, A.n) - (idx_t)diagIdx
                              : std::min(A.m, A.n - diagIdx) + (idx_t)diagIdx;
 
-    return legacyVector<T, idx_t, idx_t>(n, ptr, A.ldim + 1);
+    return LegacyVector<T, idx_t, idx_t>(n, ptr, A.ldim + 1);
 }
 
-// slice legacyVector
+// slice LegacyVector
 template <typename T,
           class idx_t,
           typename int_t,
           Direction direction,
           class SliceSpec>
-inline constexpr auto slice(legacyVector<T, idx_t, int_t, direction>& v,
+inline constexpr auto slice(LegacyVector<T, idx_t, int_t, direction>& v,
                             SliceSpec&& rows) noexcept
 {
     assert((rows.first >= 0 and (idx_t) rows.first < size(v)) ||
            rows.first == rows.second);
     assert(rows.second >= 0 and (idx_t) rows.second <= size(v));
     assert(rows.first <= rows.second);
-    return legacyVector<T, idx_t, int_t, direction>(
+    return LegacyVector<T, idx_t, int_t, direction>(
         rows.second - rows.first, &v.ptr[rows.first * v.inc], v.inc);
 }
 
@@ -619,7 +621,7 @@ namespace traits {
                 ? Layout::RowMajor
                 : Layout::ColMajor;
 
-        using type = legacyMatrix<T, idx_t, L>;
+        using type = LegacyMatrix<T, idx_t, L>;
     };
 
     // for two types
@@ -634,7 +636,7 @@ namespace traits {
         using T = scalar_type<type_t<vecA_t>, type_t<vecB_t>>;
         using idx_t = size_type<vecA_t>;
 
-        using type = legacyVector<T, idx_t, idx_t>;
+        using type = LegacyVector<T, idx_t, idx_t>;
     };
 
     #undef TLAPACK_USE_PREFERRED_MATRIX_TYPE
@@ -660,7 +662,7 @@ namespace traits {
                 ? Layout::RowMajor
                 : Layout::ColMajor;
 
-        using type = legacyMatrix<T, idx_t, L>;
+        using type = LegacyMatrix<T, idx_t, L>;
     };
 
     // for two types
@@ -675,7 +677,7 @@ namespace traits {
         using T = scalar_type<type_t<matrixA_t>, type_t<matrixB_t>>;
         using idx_t = size_type<matrixA_t>;
 
-        using type = legacyVector<T, idx_t, idx_t>;
+        using type = LegacyVector<T, idx_t, idx_t>;
     };
 
 #endif  // TLAPACK_PREFERRED_MATRIX
@@ -686,14 +688,14 @@ namespace traits {
 
 template <typename T, class idx_t, Layout layout>
 inline constexpr auto legacy_matrix(
-    const legacyMatrix<T, idx_t, layout>& A) noexcept
+    const LegacyMatrix<T, idx_t, layout>& A) noexcept
 {
     return legacy::Matrix<T, idx_t>{layout, A.m, A.n, A.ptr, A.ldim};
 }
 
 template <class T, class idx_t, class int_t, Direction direction>
 inline constexpr auto legacy_matrix(
-    const legacyVector<T, idx_t, int_t, direction>& v) noexcept
+    const LegacyVector<T, idx_t, int_t, direction>& v) noexcept
 {
     return legacy::Matrix<T, idx_t>{Layout::ColMajor, 1, v.n, v.ptr,
                                     (idx_t)v.inc};
@@ -701,7 +703,7 @@ inline constexpr auto legacy_matrix(
 
 template <typename T, class idx_t, typename int_t, Direction direction>
 inline constexpr auto legacy_vector(
-    const legacyVector<T, idx_t, int_t, direction>& v) noexcept
+    const LegacyVector<T, idx_t, int_t, direction>& v) noexcept
 {
     assert(direction == Direction::Forward || std::is_signed<idx_t>::value ||
            v.inc == 0);

--- a/include/tlapack/plugins/starpu.hpp
+++ b/include/tlapack/plugins/starpu.hpp
@@ -271,7 +271,7 @@ namespace traits {
         using type = starpu::Matrix<T>;
     };
 
-    /// Create legacyMatrix @see Create
+    /// Create starpu::Matrix<T> @see Create
     template <class T>
     struct CreateFunctor<starpu::Matrix<T>, int> {
         using matrix_t = starpu::Matrix<T>;

--- a/include/tlapack/plugins/stdvector.hpp
+++ b/include/tlapack/plugins/stdvector.hpp
@@ -12,11 +12,8 @@
 
 #include <vector>
 
-#include "tlapack/base/arrayTraits.hpp"
-#include "tlapack/base/workspace.hpp"
-
 #ifndef TLAPACK_USE_MDSPAN
-    #include "tlapack/base/legacyArray.hpp"
+    #include "tlapack/LegacyVector.hpp"
 #else
     #include <experimental/mdspan>
 #endif
@@ -46,7 +43,7 @@ inline constexpr auto slice(const std::vector<T, Allocator>& v,
     assert(rows.second >= 0 && (std::size_t)rows.second <= size(v));
     assert(rows.first <= rows.second);
 #ifndef TLAPACK_USE_MDSPAN
-    return legacyVector<T, std::size_t>(rows.second - rows.first,
+    return LegacyVector<T, std::size_t>(rows.second - rows.first,
                                         (T*)v.data() + rows.first);
 #else
     return std::experimental::mdspan<T, std::experimental::dextents<1> >(

--- a/include/tlapack/starpu/Matrix.hpp
+++ b/include/tlapack/starpu/Matrix.hpp
@@ -26,7 +26,7 @@ namespace starpu {
     namespace internal {
 
         /**
-         * @brief Abstract class for accessing the elements of a matrix
+         * @brief Class for accessing the elements of a tlapack::starpu::Matrix
          *
          * @details This class is used to implement the operator() and
          * operator[] for the Matrix class. It is not intended to be used

--- a/test/include/TestUploMatrix.hpp
+++ b/test/include/TestUploMatrix.hpp
@@ -33,12 +33,12 @@ template <class T,
           class idx_t = std::size_t,
           Uplo uplo = Uplo::Upper,
           Layout L = Layout::ColMajor>
-struct TestUploMatrix : public legacyMatrix<T, idx_t, L> {
+struct TestUploMatrix : public LegacyMatrix<T, idx_t, L> {
     int modifier =
         0;  ///< Modifier to the access region. Enables slicing of the matrix.
 
-    TestUploMatrix(const legacyMatrix<T, idx_t, L>& A)
-        : legacyMatrix<T, idx_t, L>(A)
+    TestUploMatrix(const LegacyMatrix<T, idx_t, L>& A)
+        : LegacyMatrix<T, idx_t, L>(A)
     {}
 
     // Overload of the access operator
@@ -49,7 +49,7 @@ struct TestUploMatrix : public legacyMatrix<T, idx_t, L> {
         else if (uplo == Uplo::Lower)
             assert((int)i >= (int)j + modifier);
 
-        return legacyMatrix<T, idx_t, L>::operator()(i, j);
+        return LegacyMatrix<T, idx_t, L>::operator()(i, j);
     };
 
     // Overload of the access operator
@@ -60,7 +60,7 @@ struct TestUploMatrix : public legacyMatrix<T, idx_t, L> {
         else if (uplo == Uplo::Lower)
             assert((int)i >= (int)j + modifier);
 
-        return legacyMatrix<T, idx_t, L>::operator()(i, j);
+        return LegacyMatrix<T, idx_t, L>::operator()(i, j);
     };
 };
 
@@ -82,7 +82,7 @@ inline constexpr auto slice(const TestUploMatrix<T, idx_t, uplo, layout>& A,
                             SliceSpecCol&& cols) noexcept
 {
     TestUploMatrix<const T, idx_t, uplo, layout> B(
-        slice((const legacyMatrix<T, idx_t, layout>&)A, rows, cols));
+        slice((const LegacyMatrix<T, idx_t, layout>&)A, rows, cols));
     B.modifier = A.modifier + cols.first - rows.first;
     return B;
 }
@@ -94,7 +94,7 @@ inline constexpr auto rows(const TestUploMatrix<T, idx_t, uplo, layout>& A,
                            SliceSpec&& slice) noexcept
 {
     TestUploMatrix<const T, idx_t, uplo, layout> B(
-        rows((const legacyMatrix<T, idx_t, layout>&)A, slice));
+        rows((const LegacyMatrix<T, idx_t, layout>&)A, slice));
     B.modifier = A.modifier - slice.first;
     return B;
 }
@@ -104,7 +104,7 @@ inline constexpr auto cols(const TestUploMatrix<T, idx_t, uplo, layout>& A,
                            SliceSpec&& slice) noexcept
 {
     TestUploMatrix<const T, idx_t, uplo, layout> B(
-        cols((const legacyMatrix<T, idx_t, layout>&)A, slice));
+        cols((const LegacyMatrix<T, idx_t, layout>&)A, slice));
     B.modifier = A.modifier + slice.first;
     return B;
 }
@@ -125,7 +125,7 @@ inline constexpr auto slice(TestUploMatrix<T, idx_t, uplo, layout>& A,
                             SliceSpecCol&& cols) noexcept
 {
     TestUploMatrix<T, idx_t, uplo, layout> B(
-        slice((legacyMatrix<T, idx_t, layout>&)A, rows, cols));
+        slice((LegacyMatrix<T, idx_t, layout>&)A, rows, cols));
     B.modifier = A.modifier + cols.first - rows.first;
     return B;
 }
@@ -137,7 +137,7 @@ inline constexpr auto rows(TestUploMatrix<T, idx_t, uplo, layout>& A,
                            SliceSpec&& slice) noexcept
 {
     TestUploMatrix<T, idx_t, uplo, layout> B(
-        rows((legacyMatrix<T, idx_t, layout>&)A, slice));
+        rows((LegacyMatrix<T, idx_t, layout>&)A, slice));
     B.modifier = A.modifier - slice.first;
     return B;
 }
@@ -147,7 +147,7 @@ inline constexpr auto cols(TestUploMatrix<T, idx_t, uplo, layout>& A,
                            SliceSpec&& slice) noexcept
 {
     TestUploMatrix<T, idx_t, uplo, layout> B(
-        cols((legacyMatrix<T, idx_t, layout>&)A, slice));
+        cols((LegacyMatrix<T, idx_t, layout>&)A, slice));
     B.modifier = A.modifier + slice.first;
     return B;
 }

--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -37,14 +37,14 @@
 #ifndef TLAPACK_REAL_TYPES_TO_TEST
 
     #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST                      \
-        (legacyMatrix<float, std::size_t, Layout::ColMajor>),      \
-            (legacyMatrix<double, std::size_t, Layout::ColMajor>), \
-            (legacyMatrix<float, std::size_t, Layout::RowMajor>),  \
-            (legacyMatrix<double, std::size_t, Layout::RowMajor>)
+        (LegacyMatrix<float, std::size_t, Layout::ColMajor>),      \
+            (LegacyMatrix<double, std::size_t, Layout::ColMajor>), \
+            (LegacyMatrix<float, std::size_t, Layout::RowMajor>),  \
+            (LegacyMatrix<double, std::size_t, Layout::RowMajor>)
 
     #ifdef TLAPACK_TEST_MPFR
         #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_MPREAL \
-            , legacyMatrix<mpfr::mpreal>
+            , LegacyMatrix<mpfr::mpreal>
     #else
         #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_MPREAL
     #endif
@@ -87,13 +87,13 @@
 
     #ifndef TLAPACK_LEGACY_COMPLEX_TYPES_TO_TEST
         #define TLAPACK_LEGACY_COMPLEX_TYPES_TO_TEST             \
-            (legacyMatrix<std::complex<float>, std::size_t,      \
+            (LegacyMatrix<std::complex<float>, std::size_t,      \
                           Layout::ColMajor>),                    \
-                (legacyMatrix<std::complex<double>, std::size_t, \
+                (LegacyMatrix<std::complex<double>, std::size_t, \
                               Layout::ColMajor>),                \
-                (legacyMatrix<std::complex<float>, std::size_t,  \
+                (LegacyMatrix<std::complex<float>, std::size_t,  \
                               Layout::RowMajor>),                \
-                (legacyMatrix<std::complex<double>, std::size_t, \
+                (LegacyMatrix<std::complex<double>, std::size_t, \
                               Layout::RowMajor>)
     #endif
 

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -214,41 +214,41 @@ real_type<type_t<matrix_t>> check_similarity_transform(matrix_t& A,
 // GDB doesn't handle templates well, so we explicitly define some versions of
 // the functions for common template arguments
 //
-void print_matrix_r(const legacyMatrix<float, size_t, Layout::ColMajor>& A);
-void print_matrix_d(const legacyMatrix<double, size_t, Layout::ColMajor>& A);
+void print_matrix_r(const LegacyMatrix<float, size_t, Layout::ColMajor>& A);
+void print_matrix_d(const LegacyMatrix<double, size_t, Layout::ColMajor>& A);
 void print_matrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A);
+    const LegacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A);
 void print_matrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A);
+    const LegacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A);
 void print_rowmajormatrix_r(
-    const legacyMatrix<float, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<float, size_t, Layout::RowMajor>& A);
 void print_rowmajormatrix_d(
-    const legacyMatrix<double, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<double, size_t, Layout::RowMajor>& A);
 void print_rowmajormatrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A);
 void print_rowmajormatrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A);
 
 //
 // GDB doesn't handle templates well, so we explicitly define some versions of
 // the functions for common template arguments
 //
 std::string visualize_matrix_r(
-    const legacyMatrix<float, size_t, Layout::ColMajor>& A);
+    const LegacyMatrix<float, size_t, Layout::ColMajor>& A);
 std::string visualize_matrix_d(
-    const legacyMatrix<double, size_t, Layout::ColMajor>& A);
+    const LegacyMatrix<double, size_t, Layout::ColMajor>& A);
 std::string visualize_matrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A);
+    const LegacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A);
 std::string visualize_matrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A);
+    const LegacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A);
 std::string visualize_rowmajormatrix_r(
-    const legacyMatrix<float, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<float, size_t, Layout::RowMajor>& A);
 std::string visualize_rowmajormatrix_d(
-    const legacyMatrix<double, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<double, size_t, Layout::RowMajor>& A);
 std::string visualize_rowmajormatrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A);
 std::string visualize_rowmajormatrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A);
+    const LegacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A);
 
 }  // namespace tlapack
 

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -39,10 +39,10 @@ TEMPLATE_TEST_CASE("is_matrix works", "[utils]", TLAPACK_TYPES_TO_TEST)
 TEST_CASE("is_matrix and is_vector work", "[utils]")
 {
     CHECK(!internal::is_matrix<std::vector<float> >);
-    CHECK(!internal::is_matrix<legacyVector<float> >);
+    CHECK(!internal::is_matrix<LegacyVector<float> >);
 
     CHECK(internal::is_vector<std::vector<float> >);
-    CHECK(internal::is_vector<legacyVector<float> >);
+    CHECK(internal::is_vector<LegacyVector<float> >);
 
     CHECK(!internal::is_matrix<float>);
     CHECK(!internal::is_matrix<std::complex<double> >);

--- a/test/src/testutils.cpp
+++ b/test/src/testutils.cpp
@@ -6,41 +6,41 @@ namespace tlapack {
 // GDB doesn't handle templates well, so we explicitly define some versions of
 // the functions for common template arguments
 //
-void print_matrix_r(const legacyMatrix<float, size_t, Layout::ColMajor>& A)
+void print_matrix_r(const LegacyMatrix<float, size_t, Layout::ColMajor>& A)
 {
     print_matrix(A);
 }
-void print_matrix_d(const legacyMatrix<double, size_t, Layout::ColMajor>& A)
+void print_matrix_d(const LegacyMatrix<double, size_t, Layout::ColMajor>& A)
 {
     print_matrix(A);
 }
 void print_matrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A)
+    const LegacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A)
 {
     print_matrix(A);
 }
 void print_matrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A)
+    const LegacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A)
 {
     print_matrix(A);
 }
 void print_rowmajormatrix_r(
-    const legacyMatrix<float, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<float, size_t, Layout::RowMajor>& A)
 {
     print_matrix(A);
 }
 void print_rowmajormatrix_d(
-    const legacyMatrix<double, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<double, size_t, Layout::RowMajor>& A)
 {
     print_matrix(A);
 }
 void print_rowmajormatrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A)
 {
     print_matrix(A);
 }
 void print_rowmajormatrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A)
 {
     print_matrix(A);
 }
@@ -50,42 +50,42 @@ void print_rowmajormatrix_z(
 // the functions for common template arguments
 //
 std::string visualize_matrix_r(
-    const legacyMatrix<float, size_t, Layout::ColMajor>& A)
+    const LegacyMatrix<float, size_t, Layout::ColMajor>& A)
 {
     return visualize_matrix(A);
 }
 std::string visualize_matrix_d(
-    const legacyMatrix<double, size_t, Layout::ColMajor>& A)
+    const LegacyMatrix<double, size_t, Layout::ColMajor>& A)
 {
     return visualize_matrix(A);
 }
 std::string visualize_matrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A)
+    const LegacyMatrix<std::complex<float>, size_t, Layout::ColMajor>& A)
 {
     return visualize_matrix(A);
 }
 std::string visualize_matrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A)
+    const LegacyMatrix<std::complex<double>, size_t, Layout::ColMajor>& A)
 {
     return visualize_matrix(A);
 }
 std::string visualize_rowmajormatrix_r(
-    const legacyMatrix<float, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<float, size_t, Layout::RowMajor>& A)
 {
     return visualize_matrix(A);
 }
 std::string visualize_rowmajormatrix_d(
-    const legacyMatrix<double, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<double, size_t, Layout::RowMajor>& A)
 {
     return visualize_matrix(A);
 }
 std::string visualize_rowmajormatrix_c(
-    const legacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<std::complex<float>, size_t, Layout::RowMajor>& A)
 {
     return visualize_matrix(A);
 }
 std::string visualize_rowmajormatrix_z(
-    const legacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A)
+    const LegacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A)
 {
     return visualize_matrix(A);
 }


### PR DESCRIPTION
- There was still some dependency on LegacyMatrix, LegacyVector and LegacyBandedMatrix. I moved them out of `tlapack/base`. Their names now are following the CamelCase style, as is usual for class names in C++. I will update the naming conventions on the Contributing guidelines