### PR TITLE
Moves specialization of std::abs to NaNPropagComplex

### DIFF
--- a/include/tlapack/base/StrongZero.hpp
+++ b/include/tlapack/base/StrongZero.hpp
@@ -15,6 +15,8 @@
 #include <cstdint>
 #include <limits>
 
+#include "tlapack/base/scalar_type_traits.hpp"
+
 namespace tlapack {
 
 /**
@@ -173,19 +175,18 @@ struct StrongZero {
 
     // Math functions
 
+    friend constexpr StrongZero abs(StrongZero) { return StrongZero(); }
     friend constexpr StrongZero sqrt(StrongZero) { return StrongZero(); }
     friend constexpr int pow(int, StrongZero) { return 1; }
+    friend constexpr float log2(StrongZero)
+    {
+        return -std::numeric_limits<float>::infinity();
+    }
     friend constexpr StrongZero ceil(StrongZero) { return StrongZero(); }
     friend constexpr StrongZero floor(StrongZero) { return StrongZero(); }
 };
 
 namespace traits {
-
-    // forward declarations
-    template <typename... Types>
-    struct real_type_traits;
-    template <typename... Types>
-    struct complex_type_traits;
 
     // for either StrongZero, return the other type
     template <typename T>

--- a/include/tlapack/base/arrayTraits.hpp
+++ b/include/tlapack/base/arrayTraits.hpp
@@ -15,6 +15,7 @@
 
 namespace tlapack {
 
+// C++ standard utils:
 using std::enable_if_t;
 using std::is_same_v;
 

--- a/include/tlapack/base/concepts.hpp
+++ b/include/tlapack/base/concepts.hpp
@@ -23,23 +23,22 @@
 
 namespace tlapack {
 
-// Forward declarations
-template <typename T>
-inline T abs(const T& x);
+// C++ standard math functions:
+using std::abs;
+using std::ceil;
+using std::floor;
+using std::isinf;
+using std::isnan;
+using std::log2;
+using std::max;
+using std::min;
+using std::pow;  // We only use pow(int, T), see below in the concept Real.
+using std::sqrt;
+
+// C++ standard types:
+using std::pair;
 
 namespace concepts {
-
-    using std::abs;
-    using std::ceil;
-    using std::floor;
-    using std::isinf;
-    using std::isnan;
-    using std::max;
-    using std::min;
-    using std::pair;
-    using std::pow;
-    using std::sqrt;
-
     /** @interface tlapack::concepts::Arithmetic
      * @brief Concept for a type that supports arithmetic operations.
      *
@@ -79,8 +78,8 @@ namespace concepts {
      * - it must implement the copy assignment operator @c =.
      *
      * - it must support the math operators @c abs(), @c sqrt(), @c pow(int,),
-     * @c ceil(), and @c floor(). Those functions must be callable from the
-     * namespace @c tlapack.
+     * @c log2(), @c ceil(), and @c floor(). Those functions must be callable
+     * from the namespace @c tlapack.
      *
      * - it must support the boolean functions @c isinf() and @c isnan(), which
      * must be callable from the namespace @c tlapack.
@@ -127,6 +126,7 @@ namespace concepts {
         abs(a);
         sqrt(a);
         pow(2, a);
+        log2(a);
         ceil(a);
         floor(a);
         min(a, b);
@@ -257,10 +257,10 @@ namespace concepts {
      * use the following operations to slice a vector:
      *
      * - View of entries i to j, excluding j, a vector v of length n, where 0 <=
-     * i <= j <= n, using the function @c slice(vector_t&, std::pair<idx_t,
-     * idx_t>). The call <tt>slice(v, std::pair{i,j})</tt> returns a vector of
-     * length (j-i) whose type satisfy tlapack::concepts::Vector. This function
-     * must be callable from the namespace @c tlapack.
+     * i <= j <= n, using the function @c slice(vector_t&, pair<idx_t, idx_t>).
+     * The call <tt>slice(v, pair{i,j})</tt> returns a vector of length (j-i)
+     * whose type satisfy tlapack::concepts::Vector. This function must be
+     * callable from the namespace @c tlapack.
      *
      * @tparam vector_t Vector type.
      *
@@ -271,7 +271,7 @@ namespace concepts {
     {
         // Subvector view
         {
-            slice(v, std::pair<int, int>{0, 0})
+            slice(v, pair<int, int>{0, 0})
         }
         ->Vector<>;
     };
@@ -327,18 +327,18 @@ namespace concepts {
      *
      * - Submatrix view A(i:j,k:l) of a m-by-n matrix A(0:m,0:n), where
      * 0 <= i <= j <= m and 0 <= k <= l <= n, using the function
-     * @c slice(matrix_t&, std::pair<idx_t,idx_t>, std::pair<idx_t,idx_t>). The
-     * call <tt>slice(A, std::pair{i,j}, std::pair{k,l})</tt> returns a
+     * @c slice(matrix_t&, pair<idx_t,idx_t>, pair<idx_t,idx_t>). The
+     * call <tt>slice(A, pair{i,j}, pair{k,l})</tt> returns a
      * (j-i)-by-(l-k) matrix whose type satisfy tlapack::concepts::Matrix.
      *
      * - View of rows i to j, excluding j, of a m-by-n matrix A(0:m,0:n), where
      * 0 <= i <= j <= m, using the function @c rows(matrix_t&,
-     * std::pair<idx_t,idx_t>). The call <tt>rows(A, std::pair{i,j})</tt>
-     * returns a (j-i)-by-n matrix whose type satisfy tlapack::concepts::Matrix.
+     * pair<idx_t,idx_t>). The call <tt>rows(A, pair{i,j})</tt> returns a
+     * (j-i)-by-n matrix whose type satisfy tlapack::concepts::Matrix.
      *
      * - View of columns i to j, excluding j, of a m-by-n matrix A(0:m,0:n),
      * where 0 <= i <= j <= n, using the function @c cols(matrix_t&,
-     * std::pair<idx_t,idx_t>). The call <tt>cols(A, std::pair{i,j})</tt>
+     * pair<idx_t,idx_t>). The call <tt>cols(A, pair{i,j})</tt>
      * returns a m-by-(j-i) matrix whose type satisfy tlapack::concepts::Matrix.
      *
      * - View of row i of a m-by-n matrix A(0:m,0:n), where 0 <= i < m, using
@@ -353,14 +353,14 @@ namespace concepts {
      *
      * - View of entries i to j, excluding j, of row k of a m-by-n matrix, where
      * 0 <= i <= j <= n and 0 <= k < m, using the function @c slice(matrix_t&,
-     * idx_t, std::pair<idx_t,idx_t>). The call <tt>slice(A, k, std::pair{i,j})
+     * idx_t, pair<idx_t,idx_t>). The call <tt>slice(A, k, pair{i,j})
      * </tt> returns a vector of length (j-i) whose type satisfy
      * tlapack::concepts::Vector.
      *
      * - View of entries i to j, excluding j, of column k of a m-by-n matrix,
      * where 0 <= i <= j <= m and 0 <= k < n, using the function
-     * @c slice(matrix_t&, std::pair<idx_t,idx_t>, idx_t). The call
-     * <tt>slice(A, std::pair{i,j}, k)</tt> returns a vector of length (j-i)
+     * @c slice(matrix_t&, pair<idx_t,idx_t>, idx_t). The call
+     * <tt>slice(A, pair{i,j}, k)</tt> returns a vector of length (j-i)
      * whose type satisfy tlapack::concepts::Vector.
      *
      * - View of the i-th diagonal of a m-by-n matrix A(0:m,0:n), where -m < i <
@@ -380,19 +380,19 @@ namespace concepts {
     {
         // Submatrix view (matrix)
         {
-            slice(A, std::pair<int, int>{0, 1}, std::pair<int, int>{0, 1})
+            slice(A, pair<int, int>{0, 1}, pair<int, int>{0, 1})
         }
         ->Matrix<>;
 
         // View of multiple rows (matrix)
         {
-            rows(A, std::pair<int, int>{0, 1})
+            rows(A, pair<int, int>{0, 1})
         }
         ->Matrix<>;
 
         // View of multiple columns (matrix)
         {
-            cols(A, std::pair<int, int>{0, 1})
+            cols(A, pair<int, int>{0, 1})
         }
         ->Matrix<>;
 
@@ -410,13 +410,13 @@ namespace concepts {
 
         // View of a slice of a row (vector)
         {
-            slice(A, 0, std::pair<int, int>{0, 1})
+            slice(A, 0, pair<int, int>{0, 1})
         }
         ->Vector<>;
 
         // View of a slice of a column (vector)
         {
-            slice(A, std::pair<int, int>{0, 1}, 0)
+            slice(A, pair<int, int>{0, 1}, 0)
         }
         ->Vector<>;
 

--- a/include/tlapack/base/concepts.hpp
+++ b/include/tlapack/base/concepts.hpp
@@ -29,6 +29,7 @@ inline T abs(const T& x);
 
 namespace concepts {
 
+    using std::abs;
     using std::ceil;
     using std::floor;
     using std::isinf;
@@ -90,6 +91,13 @@ namespace concepts {
      * - it must have a specialization of @c std::numeric_limits<>.
      *
      * @tparam T Type.
+     *
+     * @note Note that the functions @c min() and @c max() may not propagate
+     * NaNs. The implementation in the C++ standard library says nothing about
+     * NaN propagation in @c std::min() and @c std::max() and we follow the same
+     * rule. The C++ documentation shows possible implementations that do not
+     * propagate NaNs. See: https://en.cppreference.com/w/cpp/algorithm/max and
+     * https://en.cppreference.com/w/cpp/algorithm/min.
      *
      * @ingroup concepts
      */
@@ -205,7 +213,7 @@ namespace concepts {
         a = std::forward<T>(a);
 
         // Math functions
-        tlapack::abs(a);
+        abs(a);
     };
 
     /** @interface tlapack::concepts::Vector

--- a/include/tlapack/base/constants.hpp
+++ b/include/tlapack/base/constants.hpp
@@ -92,11 +92,7 @@ inline constexpr real_t safe_min()
 template <TLAPACK_REAL real_t>
 inline constexpr real_t safe_max()
 {
-    constexpr int fradix = std::numeric_limits<real_t>::radix;
-    constexpr int expm = std::numeric_limits<real_t>::min_exponent;
-    constexpr int expM = std::numeric_limits<real_t>::max_exponent;
-
-    return min(pow(fradix, real_t(1 - expm)), pow(fradix, real_t(expM - 1)));
+    return real_t(1) / safe_min<real_t>();
 }
 
 /** Blue's min constant b for the sum of squares

--- a/include/tlapack/base/scalar_type_traits.hpp
+++ b/include/tlapack/base/scalar_type_traits.hpp
@@ -15,6 +15,9 @@
 
 namespace tlapack {
 
+// C++ standard utils:
+using std::enable_if_t;
+
 // -----------------------------------------------------------------------------
 // for any combination of types, determine associated real, scalar,
 // and complex types.
@@ -49,7 +52,7 @@ namespace traits {
     template <typename T>
     struct real_type_traits<
         T,
-        std::enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
+        enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
         using type = typename std::decay<T>::type;
         constexpr static bool is_real = true;
     };
@@ -69,7 +72,7 @@ namespace traits {
     template <typename T>
     struct real_type_traits<
         T,
-        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
+        enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
         using type = void;
         constexpr static bool is_real = false;
     };
@@ -101,7 +104,7 @@ namespace traits {
     template <typename T>
     struct complex_type_traits<
         T,
-        std::enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
+        enable_if_t<std::is_arithmetic_v<T> && !std::is_const_v<T>, int>> {
         using type = std::complex<real_type<T>>;
         constexpr static bool is_complex = false;
     };
@@ -122,7 +125,7 @@ namespace traits {
     template <typename T>
     struct complex_type_traits<
         T,
-        std::enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
+        enable_if_t<std::is_pointer_v<T> || std::is_reference_v<T>, int>> {
         using type = void;
         constexpr static bool is_complex = false;
     };
@@ -158,16 +161,15 @@ namespace traits {
     struct scalar_type_traits<
         T1,
         T2,
-        std::enable_if_t<is_complex<T1> || is_complex<T2>, int>> {
+        enable_if_t<is_complex<T1> || is_complex<T2>, int>> {
         using type = complex_type<T1, T2>;
     };
 
     // for two types, neither is complex
     template <typename T1, typename T2>
-    struct scalar_type_traits<
-        T1,
-        T2,
-        std::enable_if_t<is_real<T1> && is_real<T2>, int>> {
+    struct scalar_type_traits<T1,
+                              T2,
+                              enable_if_t<is_real<T1> && is_real<T2>, int>> {
         using type = real_type<T1, T2>;
     };
 

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -30,17 +30,19 @@ namespace tlapack {
 
 // -----------------------------------------------------------------------------
 // From std C++
+using std::abs;
 using std::ceil;
-using std::enable_if_t;
 using std::floor;
-using std::is_same_v;
 using std::isinf;
 using std::isnan;
 using std::max;
 using std::min;
-using std::pair;
 using std::pow;
 using std::sqrt;
+
+using std::enable_if_t;
+using std::is_same_v;
+using std::pair;
 
 //------------------------------------------------------------------------------
 
@@ -399,38 +401,6 @@ bool hasnan(const vector_t& x)
     for (idx_t i = 0; i < n; ++i)
         if (isnan(x[i])) return true;
     return false;
-}
-
-// -----------------------------------------------------------------------------
-// Absolute value
-
-/** 2-norm absolute value, sqrt( |Re(x)|^2 + |Im(x)|^2 )
- *
- * Note that std::abs< std::complex > does not overflow or underflow at
- * intermediate stages of the computation.
- * @see https://en.cppreference.com/w/cpp/numeric/complex/abs
- * but it may not propagate NaNs.
- *
- * Also, std::abs< mpfr::mpreal > may not propagate Infs.
- */
-template <typename T>
-inline T abs(const T& x);
-
-inline float abs(float x) { return std::fabs(x); }
-inline double abs(double x) { return std::fabs(x); }
-inline long double abs(long double x) { return std::fabs(x); }
-
-template <typename T>
-inline T abs(const std::complex<T>& x)
-{
-    // If the default value of ErrorCheck::nan is true then check for NaNs
-    if (ErrorCheck().nan && isnan(x))
-        return std::numeric_limits<T>::quiet_NaN();
-    // If the default value of ErrorCheck::inf is true then check for Infs
-    else if (ErrorCheck().inf && isinf(x))
-        return std::numeric_limits<T>::infinity();
-    else
-        return std::abs(x);
 }
 
 // -----------------------------------------------------------------------------

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -28,20 +28,23 @@
 
 namespace tlapack {
 
-// -----------------------------------------------------------------------------
-// From std C++
+// C++ standard utils:
+using std::enable_if_t;
+using std::is_same_v;
+
+// C++ standard math functions:
 using std::abs;
 using std::ceil;
 using std::floor;
 using std::isinf;
 using std::isnan;
+using std::log2;
 using std::max;
 using std::min;
-using std::pow;
+using std::pow;  // We only use pow(int, T), see below in the concept Real.
 using std::sqrt;
 
-using std::enable_if_t;
-using std::is_same_v;
+// C++ standard types:
 using std::pair;
 
 //------------------------------------------------------------------------------
@@ -90,8 +93,8 @@ inline int sgn(const real_t& val)
 
 // -----------------------------------------------------------------------------
 /// isinf for complex numbers
-template <typename real_t>
-inline bool isinf(const std::complex<real_t>& x)
+template <typename T, enable_if_t<is_complex<T>, int> = 0>
+inline bool isinf(const T& x)
 {
     return isinf(real(x)) || isinf(imag(x));
 }
@@ -277,8 +280,8 @@ bool hasinf(const vector_t& x)
 
 // -----------------------------------------------------------------------------
 /// isnan for complex numbers
-template <typename real_t>
-inline bool isnan(const std::complex<real_t>& x)
+template <typename T, enable_if_t<is_complex<T>, int> = 0>
+inline bool isnan(const T& x)
 {
     return isnan(real(x)) || isnan(imag(x));
 }

--- a/include/tlapack/blas/iamax.hpp
+++ b/include/tlapack/blas/iamax.hpp
@@ -11,7 +11,6 @@
 #ifndef TLAPACK_BLAS_IAMAX_HH
 #define TLAPACK_BLAS_IAMAX_HH
 
-#include "tlapack/base/constants.hpp"
 #include "tlapack/base/utils.hpp"
 
 namespace tlapack {

--- a/include/tlapack/blas/rotg.hpp
+++ b/include/tlapack/blas/rotg.hpp
@@ -47,8 +47,8 @@ void rotg(T& a, T& b, T& c, T& s)
     const T safmax = safe_max<T>();
 
     // Norms
-    const T anorm = tlapack::abs(a);
-    const T bnorm = tlapack::abs(b);
+    const T anorm = abs(a);
+    const T bnorm = abs(b);
 
     // quick return
     if (bnorm == zero) {
@@ -126,7 +126,7 @@ void rotg(T& a, const T& b, real_type<T>& c, T& s)
 
     if (a == zero) {
         c = zero;
-        real_t g1 = max(tlapack::abs(real(b)), tlapack::abs(imag(b)));
+        real_t g1 = max(abs(real(b)), abs(imag(b)));
         if (g1 > rtmin && g1 < rtmax) {
             // Use unscaled algorithm
             real_t g2 = real(b) * real(b) + imag(b) * imag(b);
@@ -146,8 +146,8 @@ void rotg(T& a, const T& b, real_type<T>& c, T& s)
         }
     }
     else {
-        real_t f1 = max(tlapack::abs(real(a)), tlapack::abs(imag(a)));
-        real_t g1 = max(tlapack::abs(real(b)), tlapack::abs(imag(b)));
+        real_t f1 = max(abs(real(a)), abs(imag(a)));
+        real_t g1 = max(abs(real(b)), abs(imag(b)));
         if (f1 > rtmin && f1 < rtmax && g1 > rtmin && g1 < rtmax) {
             // Use unscaled algorithm
             real_t f2 = real(a) * real(a) + imag(a) * imag(a);
@@ -204,8 +204,8 @@ inline void rotg(T& a, T& b, T& c, T& s)
     // Constants
     const T zero = 0;
     const T one = 1;
-    const T anorm = tlapack::abs(a);
-    const T bnorm = tlapack::abs(b);
+    const T anorm = abs(a);
+    const T bnorm = abs(b);
 
     T r;
     ::lapack::lartg(a, b, &c, &s, &r);

--- a/include/tlapack/blas/rotmg.hpp
+++ b/include/tlapack/blas/rotmg.hpp
@@ -126,7 +126,7 @@ int rotmg(T& d1, T& d2, T& a, const T& b, T h[4])
             const T q2 = p2 * b;
             const T q1 = p1 * a;
 
-            if (tlapack::abs(q1) > tlapack::abs(q2)) {
+            if (abs(q1) > abs(q2)) {
                 flag = zero;
                 h[1] = -b / a;
                 h[2] = p2 / p1;
@@ -182,8 +182,7 @@ int rotmg(T& d1, T& d2, T& a, const T& b, T h[4])
             }
 
             if (d2 != zero) {
-                while ((tlapack::abs(d2) <= rgamsq) ||
-                       (tlapack::abs(d2) >= gamsq)) {
+                while ((abs(d2) <= rgamsq) || (abs(d2) >= gamsq)) {
                     if (flag == 0) {
                         h[0] = one;
                         h[3] = one;
@@ -194,7 +193,7 @@ int rotmg(T& d1, T& d2, T& a, const T& b, T h[4])
                         h[2] = one;
                         flag = -1;
                     }
-                    if (tlapack::abs(d2) <= rgamsq) {
+                    if (abs(d2) <= rgamsq) {
                         d2 *= gam * gam;
                         h[1] /= gam;
                         h[3] /= gam;

--- a/include/tlapack/lapack/gebd2.hpp
+++ b/include/tlapack/lapack/gebd2.hpp
@@ -134,8 +134,8 @@ int gebd2(matrix_t& A,
     const idx_t n = ncols(A);
 
     // check arguments
-    tlapack_check_false((idx_t)size(tauv) < std::min<idx_t>(m, n));
-    tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tauv) < min(m, n));
+    tlapack_check_false((idx_t)size(tauw) < min(m, n));
 
     // quick return
     if (n <= 0) return 0;

--- a/include/tlapack/lapack/gehrd.hpp
+++ b/include/tlapack/lapack/gehrd.hpp
@@ -64,7 +64,7 @@ WorkInfo gehrd_worksize(size_type<matrix_t> ilo,
     using T = type_t<work_t>;
 
     const idx_t n = ncols(A);
-    const idx_t nb = std::min(opts.nb, ihi - ilo - 1);
+    const idx_t nb = min(opts.nb, ihi - ilo - 1);
 
     return WorkInfo(sizeof(T) * (n + nb), nb);
 }
@@ -132,10 +132,10 @@ int gehrd(size_type<matrix_t> ilo,
     const idx_t n = ncols(A);
 
     // Blocksize
-    idx_t nb = std::min(opts.nb, ihi - ilo - 1);
+    idx_t nb = min(opts.nb, ihi - ilo - 1);
     // Size of the last block which be handled with unblocked code
     idx_t nx_switch = opts.nx_switch;
-    idx_t nx = std::max(nb, nx_switch);
+    idx_t nx = max(nb, nx_switch);
 
     // check arguments
     tlapack_check_false((ilo < 0) or (ilo >= n));
@@ -167,7 +167,7 @@ int gehrd(size_type<matrix_t> ilo,
 
     idx_t i = ilo;
     for (; i + nx < ihi - 1; i = i + nb) {
-        const idx_t nb2 = std::min(nb, ihi - i - 1);
+        const idx_t nb2 = min(nb, ihi - i - 1);
 
         auto V = slice(A, range{i + 1, ihi}, range{i, i + nb2});
         auto A2 = slice(A, range{0, ihi}, range{i, ihi});

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -99,7 +99,7 @@ int gelq2(matrix_t& A, vector_t& tauw, const WorkspaceOpts<>& opts = {})
     const idx_t k = min(m, n);
 
     // check arguments
-    tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tauw) < min(m, n));
 
     // Allocates workspace
     VectorOfBytes localworkdata;

--- a/include/tlapack/lapack/gelqf.hpp
+++ b/include/tlapack/lapack/gelqf.hpp
@@ -54,7 +54,7 @@ inline constexpr WorkInfo gelqf_worksize(
     const idx_t n = ncols(A);
     const idx_t k = min(m, n);
     const idx_t nb = opts.nb;
-    const idx_t ib = std::min<idx_t>(nb, k);
+    const idx_t ib = min(nb, k);
 
     auto A11 = rows(A, range(0, ib));
     auto TT1 = slice(A, range(0, ib), range(0, ib));
@@ -138,7 +138,7 @@ int gelqf(A_t& A, tau_t& tau, const GelqfOpts<size_type<A_t>>& opts = {})
 
     // Main computational loop
     for (idx_t j = 0; j < k; j += nb) {
-        idx_t ib = std::min<idx_t>(nb, k - j);
+        idx_t ib = min(nb, k - j);
 
         // Compute the LQ factorization of the current block A(j:j+ib-1,j:n)
         auto A11 = slice(A, range(j, j + ib), range(j, n));

--- a/include/tlapack/lapack/gelqt.hpp
+++ b/include/tlapack/lapack/gelqt.hpp
@@ -51,7 +51,7 @@ inline constexpr WorkInfo gelqt_worksize(const matrix_t& A,
     const idx_t n = ncols(A);
     const idx_t k = min(m, n);
     const idx_t nb = ncols(TT);
-    const idx_t ib = std::min<idx_t>(nb, k);
+    const idx_t ib = min(nb, k);
 
     auto TT1 = slice(TT, range(0, ib), range(0, ib));
     auto A11 = rows(A, range(0, ib));
@@ -135,7 +135,7 @@ int gelqt(matrix_t& A, matrix_t& TT, const GelqtOpts& opts = {})
 
     for (idx_t j = 0; j < k; j += nb) {
         // Use blocked code initially
-        idx_t ib = std::min<idx_t>(nb, k - j);
+        idx_t ib = min(nb, k - j);
 
         // Compute the LQ factorization of the current block A(j:j+ib-1,j:n)
         auto TT1 = slice(TT, range(j, j + ib), range(0, ib));

--- a/include/tlapack/lapack/geql2.hpp
+++ b/include/tlapack/lapack/geql2.hpp
@@ -96,10 +96,10 @@ int geql2(matrix_t& A, vector_t& tau, const WorkspaceOpts<>& opts = {})
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
-    const idx_t k = std::min<idx_t>(m, n);
+    const idx_t k = min(m, n);
 
     // check arguments
-    tlapack_check_false((idx_t)size(tau) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tau) < min(m, n));
 
     // quick return
     if (n <= 0) return 0;

--- a/include/tlapack/lapack/geqlf.hpp
+++ b/include/tlapack/lapack/geqlf.hpp
@@ -54,7 +54,7 @@ inline constexpr WorkInfo geqlf_worksize(
     const idx_t n = ncols(A);
     const idx_t k = min(m, n);
     const idx_t nb = opts.nb;
-    const idx_t ib = std::min<idx_t>(nb, k);
+    const idx_t ib = min(nb, k);
 
     auto A11 = cols(A, range(0, ib));
     auto TT1 = slice(A, range(0, ib), range(0, ib));
@@ -140,7 +140,7 @@ int geqlf(A_t& A, tau_t& tau, const GeqlfOpts<size_type<A_t>>& opts = {})
     // Main computational loop
     for (idx_t j2 = 0; j2 < k; j2 += nb) {
         idx_t j = n - j2;
-        idx_t ib = std::min<idx_t>(nb, k - j2);
+        idx_t ib = min(nb, k - j2);
 
         // Compute the QR factorization of the current block A(0:m-n+j,j-ib:j)
         auto A11 = slice(A, range(0, m - (n - j)), range(j - ib, j));

--- a/include/tlapack/lapack/geqr2.hpp
+++ b/include/tlapack/lapack/geqr2.hpp
@@ -98,7 +98,7 @@ int geqr2(matrix_t& A, vector_t& tau, const WorkspaceOpts<>& opts = {})
     const idx_t k = std::min<idx_t>(m, n - 1);
 
     // check arguments
-    tlapack_check_false((idx_t)size(tau) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tau) < min(m, n));
 
     // quick return
     if (n <= 0 || m <= 0) return 0;

--- a/include/tlapack/lapack/geqrf.hpp
+++ b/include/tlapack/lapack/geqrf.hpp
@@ -54,7 +54,7 @@ inline constexpr WorkInfo geqrf_worksize(
     const idx_t n = ncols(A);
     const idx_t k = min(m, n);
     const idx_t nb = opts.nb;
-    const idx_t ib = std::min<idx_t>(nb, k);
+    const idx_t ib = min(nb, k);
 
     auto A11 = cols(A, range(0, ib));
     auto TT1 = slice(A, range(0, ib), range(0, ib));
@@ -140,7 +140,7 @@ int geqrf(A_t& A, tau_t& tau, const GeqrfOpts<size_type<A_t>>& opts = {})
 
     // Main computational loop
     for (idx_t j = 0; j < k; j += nb) {
-        idx_t ib = std::min<idx_t>(nb, k - j);
+        idx_t ib = min(nb, k - j);
 
         // Compute the QR factorization of the current block A(j:m,j:j+ib)
         auto A11 = slice(A, range(j, m), range(j, j + ib));

--- a/include/tlapack/lapack/gerq2.hpp
+++ b/include/tlapack/lapack/gerq2.hpp
@@ -96,10 +96,10 @@ int gerq2(matrix_t& A, vector_t& tau, const WorkspaceOpts<>& opts = {})
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
-    const idx_t k = std::min<idx_t>(m, n);
+    const idx_t k = min(m, n);
 
     // check arguments
-    tlapack_check_false((idx_t)size(tau) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tau) < min(m, n));
 
     // quick return
     if (n <= 0) return 0;

--- a/include/tlapack/lapack/gerqf.hpp
+++ b/include/tlapack/lapack/gerqf.hpp
@@ -54,7 +54,7 @@ inline constexpr WorkInfo gerqf_worksize(
     const idx_t n = ncols(A);
     const idx_t k = min(m, n);
     const idx_t nb = opts.nb;
-    const idx_t ib = std::min<idx_t>(nb, k);
+    const idx_t ib = min(nb, k);
 
     auto A11 = rows(A, range(0, ib));
     auto TT1 = slice(A, range(0, ib), range(0, ib));
@@ -142,7 +142,7 @@ int gerqf(A_t& A, tau_t& tau, const GerqfOpts<size_type<A_t>>& opts = {})
 
     // Main computational loop
     for (idx_t j2 = 0; j2 < k; j2 += nb) {
-        idx_t ib = std::min<idx_t>(nb, k - j2);
+        idx_t ib = min(nb, k - j2);
         idx_t j = m - j2 - ib;
 
         // Compute the RQ factorization of the current block A(j:j+ib,0:n-j2)

--- a/include/tlapack/lapack/getrf_level0.hpp
+++ b/include/tlapack/lapack/getrf_level0.hpp
@@ -56,7 +56,7 @@ int getrf_level0(matrix_t& A, piv_t& piv)
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
-    const idx_t end = std::min<idx_t>(m, n);
+    const idx_t end = min(m, n);
 
     // check arguments
     tlapack_check((idx_t)size(piv) >= end);

--- a/include/tlapack/lapack/getrf_recursive.hpp
+++ b/include/tlapack/lapack/getrf_recursive.hpp
@@ -63,10 +63,7 @@ int getrf_recursive(matrix_t& A, piv_t& piv)
     // Using the following lines to pass the abs function to iamax
     // TODO: Replace the following lines by a lambda function if we adopt C++17
     struct abs_f {
-        inline constexpr real_t operator()(const T& x) const
-        {
-            return tlapack::abs(x);
-        }
+        inline constexpr real_t operator()(const T& x) const { return abs(x); }
     };
     abs_f absf;
     IamaxOpts<abs_f> optsIamax(absf);
@@ -74,7 +71,7 @@ int getrf_recursive(matrix_t& A, piv_t& piv)
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
-    const idx_t k = std::min<idx_t>(m, n);
+    const idx_t k = min(m, n);
 
     // check arguments
     tlapack_check((idx_t)size(piv) >= k);

--- a/include/tlapack/lapack/lacpy.hpp
+++ b/include/tlapack/lapack/lacpy.hpp
@@ -51,14 +51,14 @@ void lacpy(uplo_t uplo, const matrixA_t& A, matrixB_t& B)
     if (uplo == Uplo::Upper) {
         // Set the strictly upper triangular or trapezoidal part of B
         for (idx_t j = 0; j < n; ++j) {
-            const idx_t M = std::min(m, j + 1);
+            const idx_t M = min(m, j + 1);
             for (idx_t i = 0; i < M; ++i)
                 B(i, j) = A(i, j);
         }
     }
     else if (uplo == Uplo::Lower) {
         // Set the strictly lower triangular or trapezoidal part of B
-        const idx_t N = std::min(m, n);
+        const idx_t N = min(m, n);
         for (idx_t j = 0; j < N; ++j)
             for (idx_t i = j; i < m; ++i)
                 B(i, j) = A(i, j);

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -113,7 +113,7 @@ void ladiv(const real_t& a,
     }
 
     // compute the quotient
-    if (tlapack::abs(d) <= tlapack::abs(c)) {
+    if (abs(d) <= abs(c)) {
         sladiv1(aa, bb, cc, dd, p, q);
     }
     else {

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -187,15 +187,14 @@ int lahqr(bool want_t,
                 // eps*|A(i,i)|*|A(i-1,i-1)| The multiplications might overflow
                 // so we do some scaling first.
                 //
-                real_t ab = std::max(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                real_t ba = std::min(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                real_t aa =
-                    std::max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
-                real_t bb =
-                    std::min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                const real_t aij = abs1(A(i, i - 1));
+                const real_t aji = abs1(A(i - 1, i));
+                real_t ab = (aij > aji) ? aij : aji;  // Propagates NaNs in aji
+                real_t ba = (aij < aji) ? aij : aji;  // Propagates NaNs in aji
+                real_t aa = max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                real_t bb = min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
                 real_t s = aa + ab;
-                if (ba * (ab / s) <=
-                    std::max(small_num, eps * (bb * (aa / s)))) {
+                if (ba * (ab / s) <= max(small_num, eps * (bb * (aa / s)))) {
                     // A(i,i-1) is negligible, take i as new istart.
                     A(i, i - 1) = zero;
                     istart = i;
@@ -363,7 +362,7 @@ int lahqr(bool want_t,
                     A(i + 2, j) = A(i + 2, j) - sum * t3;
                 }
                 // Apply G from the right to A
-                for (idx_t j = istart_m; j < std::min(i + 4, istop); ++j) {
+                for (idx_t j = istart_m; j < min(i + 4, istop); ++j) {
                     sum = A(j, i) + v2 * A(j, i + 1) + v3 * A(j, i + 2);
                     A(j, i) = A(j, i) - sum * conj(t1);
                     A(j, i + 1) = A(j, i + 1) - sum * conj(t2);
@@ -387,7 +386,7 @@ int lahqr(bool want_t,
                     A(i + 1, j) = A(i + 1, j) - sum * t2;
                 }
                 // Apply G from the right to A
-                for (idx_t j = istart_m; j < std::min(i + 3, istop); ++j) {
+                for (idx_t j = istart_m; j < min(i + 3, istop); ++j) {
                     sum = A(j, i) + v2 * A(j, i + 1);
                     A(j, i) = A(j, i) - sum * conj(t1);
                     A(j, i + 1) = A(j, i + 1) - sum * conj(t2);
@@ -504,10 +503,10 @@ int lahqr(bool want_t,
             real_t tst = abs1(A(i - 1, i - 1)) + abs1(A(i, i));
             if (tst == zero) {
                 if (i >= ilo + 2) {
-                    tst = tst + tlapack::abs(A(i - 1, i - 2));
+                    tst = tst + abs(A(i - 1, i - 2));
                 }
                 if (i < ihi) {
-                    tst = tst + tlapack::abs(A(i + 1, i));
+                    tst = tst + abs(A(i + 1, i));
                 }
             }
             if (abs1(A(i, i - 1)) <= eps * tst) {
@@ -522,15 +521,14 @@ int lahqr(bool want_t,
                 // eps*|A(i,i)|*|A(i-1,i-1)| The multiplications might overflow
                 // so we do some scaling first.
                 //
-                real_t ab = std::max(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                real_t ba = std::min(abs1(A(i, i - 1)), abs1(A(i - 1, i)));
-                real_t aa =
-                    std::max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
-                real_t bb =
-                    std::min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                const real_t aij = abs1(A(i, i - 1));
+                const real_t aji = abs1(A(i - 1, i));
+                real_t ab = (aij > aji) ? aij : aji;  // Propagates NaNs in aji
+                real_t ba = (aij < aji) ? aij : aji;  // Propagates NaNs in aji
+                real_t aa = max(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
+                real_t bb = min(abs1(A(i, i)), abs1(A(i, i) - A(i - 1, i - 1)));
                 real_t s = aa + ab;
-                if (ba * (ab / s) <=
-                    std::max(small_num, eps * (bb * (aa / s)))) {
+                if (ba * (ab / s) <= max(small_num, eps * (bb * (aa / s)))) {
                     // A(i,i-1) is negligible, take i as new istart.
                     A(i, i - 1) = zero;
                     istart = i;
@@ -552,8 +550,8 @@ int lahqr(bool want_t,
         k_defl = k_defl + 1;
         if (k_defl % non_convergence_limit == 0) {
             // Exceptional shift
-            real_t s = tlapack::abs(A(istop - 1, istop - 2));
-            if (istop > ilo + 2) s = s + tlapack::abs(A(istop - 2, istop - 3));
+            real_t s = abs(A(istop - 1, istop - 2));
+            if (istop > ilo + 2) s = s + abs(A(istop - 2, istop - 3));
             a00 = dat1 * s + A(istop - 1, istop - 1);
             a01 = dat2 * s;
             a10 = s;
@@ -616,7 +614,7 @@ int lahqr(bool want_t,
                 A(i, j) = tmp;
             }
             // Apply G**H from the right to A
-            for (idx_t j = istart_m; j < std::min(i + 3, istop); ++j) {
+            for (idx_t j = istart_m; j < min(i + 3, istop); ++j) {
                 TA tmp = cs * A(j, i) + conj(sn) * A(j, i + 1);
                 A(j, i + 1) = -sn * A(j, i) + cs * A(j, i + 1);
                 A(j, i) = tmp;

--- a/include/tlapack/lapack/lahqr_schur22.hpp
+++ b/include/tlapack/lapack/lahqr_schur22.hpp
@@ -58,17 +58,14 @@ int lahqr_schur22(T& a,
                   T& cs,
                   T& sn)
 {
-    using std::log;
-
     const T zero(0);
     const T half(0.5);
     const T one(1);
-    const T two(2);
     const T multpl(4);
 
     const T eps = ulp<T>();
     const T safmin = safe_min<T>();
-    const T safmn2 = pow(2, T((int)(log(safmin / eps) / log(two)) / 2));
+    const T safmn2 = pow(2, T((int)(log2(safmin / eps)) / 2));
     const T safmx2 = one / safmn2;
 
     if (c == zero) {

--- a/include/tlapack/lapack/lange.hpp
+++ b/include/tlapack/lapack/lange.hpp
@@ -116,7 +116,7 @@ auto lange(norm_t normType, const matrix_t& A)
     if (normType == Norm::Max) {
         for (idx_t j = 0; j < n; ++j) {
             for (idx_t i = 0; i < m; ++i) {
-                real_t temp = tlapack::abs(A(i, j));
+                real_t temp = abs(A(i, j));
 
                 if (temp > norm)
                     norm = temp;
@@ -130,7 +130,7 @@ auto lange(norm_t normType, const matrix_t& A)
         for (idx_t i = 0; i < m; ++i) {
             real_t sum(0);
             for (idx_t j = 0; j < n; ++j)
-                sum += tlapack::abs(A(i, j));
+                sum += abs(A(i, j));
 
             if (sum > norm)
                 norm = sum;
@@ -143,7 +143,7 @@ auto lange(norm_t normType, const matrix_t& A)
         for (idx_t j = 0; j < n; ++j) {
             real_t sum(0);
             for (idx_t i = 0; i < m; ++i)
-                sum += tlapack::abs(A(i, j));
+                sum += abs(A(i, j));
 
             if (sum > norm)
                 norm = sum;
@@ -228,11 +228,11 @@ auto lange(norm_t normType, const matrix_t& A, const WorkspaceOpts<>& opts)
         real_t norm(0);
 
         for (idx_t i = 0; i < m; ++i)
-            w[i] = tlapack::abs(A(i, 0));
+            w[i] = abs(A(i, 0));
 
         for (idx_t j = 1; j < n; ++j)
             for (idx_t i = 0; i < m; ++i)
-                w[i] += tlapack::abs(A(i, j));
+                w[i] += abs(A(i, j));
 
         for (idx_t i = 0; i < m; ++i) {
             real_t temp = w[i];

--- a/include/tlapack/lapack/lanhe.hpp
+++ b/include/tlapack/lapack/lanhe.hpp
@@ -133,7 +133,7 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
         if (uplo == Uplo::Upper) {
             for (idx_t j = 0; j < n; ++j) {
                 for (idx_t i = 0; i < j; ++i) {
-                    real_t temp = tlapack::abs(A(i, j));
+                    real_t temp = abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
@@ -142,7 +142,7 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
                     }
                 }
                 {
-                    real_t temp = tlapack::abs(real(A(j, j)));
+                    real_t temp = abs(real(A(j, j)));
 
                     if (temp > norm)
                         norm = temp;
@@ -155,7 +155,7 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
         else {
             for (idx_t j = 0; j < n; ++j) {
                 {
-                    real_t temp = tlapack::abs(real(A(j, j)));
+                    real_t temp = abs(real(A(j, j)));
 
                     if (temp > norm)
                         norm = temp;
@@ -164,7 +164,7 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
                     }
                 }
                 for (idx_t i = j + 1; i < n; ++i) {
-                    real_t temp = tlapack::abs(A(i, j));
+                    real_t temp = abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
@@ -181,12 +181,12 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
                 real_t temp(0);
 
                 for (idx_t i = 0; i < j; ++i)
-                    temp += tlapack::abs(A(i, j));
+                    temp += abs(A(i, j));
 
-                temp += tlapack::abs(real(A(j, j)));
+                temp += abs(real(A(j, j)));
 
                 for (idx_t i = j + 1; i < n; ++i)
-                    temp += tlapack::abs(A(j, i));
+                    temp += abs(A(j, i));
 
                 if (temp > norm)
                     norm = temp;
@@ -200,12 +200,12 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
                 real_t temp(0);
 
                 for (idx_t i = 0; i < j; ++i)
-                    temp += tlapack::abs(A(j, i));
+                    temp += abs(A(j, i));
 
-                temp += tlapack::abs(real(A(j, j)));
+                temp += abs(real(A(j, j)));
 
                 for (idx_t i = j + 1; i < n; ++i)
-                    temp += tlapack::abs(A(i, j));
+                    temp += abs(A(i, j));
 
                 if (temp > norm)
                     norm = temp;
@@ -233,7 +233,7 @@ auto lanhe(norm_t normType, uplo_t uplo, const matrix_t& A)
         // Sum the real part in the diagonal
         lassq(diag(A, 0), scale, ssq,
               // Lambda function to get the absolute value of the real part :
-              [](const T& x) { return tlapack::abs(real(x)); });
+              [](const T& x) { return abs(real(x)); });
 
         // Compute the scaled square root
         norm = scale * sqrt(ssq);
@@ -323,11 +323,11 @@ auto lanhe(norm_t normType,
             for (idx_t j = 0; j < n; ++j) {
                 real_t sum(0);
                 for (idx_t i = 0; i < j; ++i) {
-                    const real_t absa = tlapack::abs(A(i, j));
+                    const real_t absa = abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }
-                w[j] = sum + tlapack::abs(real(A(j, j)));
+                w[j] = sum + abs(real(A(j, j)));
             }
             for (idx_t i = 0; i < n; ++i) {
                 real_t sum = w[i];
@@ -340,9 +340,9 @@ auto lanhe(norm_t normType,
         }
         else {
             for (idx_t j = 0; j < n; ++j) {
-                real_t sum = w[j] + tlapack::abs(real(A(j, j)));
+                real_t sum = w[j] + abs(real(A(j, j)));
                 for (idx_t i = j + 1; i < n; ++i) {
-                    const real_t absa = tlapack::abs(A(i, j));
+                    const real_t absa = abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }

--- a/include/tlapack/lapack/lansy.hpp
+++ b/include/tlapack/lapack/lansy.hpp
@@ -134,7 +134,7 @@ auto lansy(norm_t normType, uplo_t uplo, const matrix_t& A)
         if (uplo == Uplo::Upper) {
             for (idx_t j = 0; j < n; ++j) {
                 for (idx_t i = 0; i <= j; ++i) {
-                    real_t temp = tlapack::abs(A(i, j));
+                    real_t temp = abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
@@ -147,7 +147,7 @@ auto lansy(norm_t normType, uplo_t uplo, const matrix_t& A)
         else {
             for (idx_t j = 0; j < n; ++j) {
                 for (idx_t i = j; i < n; ++i) {
-                    real_t temp = tlapack::abs(A(i, j));
+                    real_t temp = abs(A(i, j));
 
                     if (temp > norm)
                         norm = temp;
@@ -164,10 +164,10 @@ auto lansy(norm_t normType, uplo_t uplo, const matrix_t& A)
                 real_t temp = 0;
 
                 for (idx_t i = 0; i <= j; ++i)
-                    temp += tlapack::abs(A(i, j));
+                    temp += abs(A(i, j));
 
                 for (idx_t i = j + 1; i < n; ++i)
-                    temp += tlapack::abs(A(j, i));
+                    temp += abs(A(j, i));
 
                 if (temp > norm)
                     norm = temp;
@@ -181,10 +181,10 @@ auto lansy(norm_t normType, uplo_t uplo, const matrix_t& A)
                 real_t temp = 0;
 
                 for (idx_t i = 0; i <= j; ++i)
-                    temp += tlapack::abs(A(j, i));
+                    temp += abs(A(j, i));
 
                 for (idx_t i = j + 1; i < n; ++i)
-                    temp += tlapack::abs(A(i, j));
+                    temp += abs(A(i, j));
 
                 if (temp > norm)
                     norm = temp;
@@ -300,11 +300,11 @@ auto lansy(norm_t normType,
             for (idx_t j = 0; j < n; ++j) {
                 real_t sum(0);
                 for (idx_t i = 0; i < j; ++i) {
-                    const real_t absa = tlapack::abs(A(i, j));
+                    const real_t absa = abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }
-                w[j] = sum + tlapack::abs(A(j, j));
+                w[j] = sum + abs(A(j, j));
             }
             for (idx_t i = 0; i < n; ++i) {
                 real_t sum = w[i];
@@ -317,9 +317,9 @@ auto lansy(norm_t normType,
         }
         else {
             for (idx_t j = 0; j < n; ++j) {
-                real_t sum = w[j] + tlapack::abs(A(j, j));
+                real_t sum = w[j] + abs(A(j, j));
                 for (idx_t i = j + 1; i < n; ++i) {
-                    const real_t absa = tlapack::abs(A(i, j));
+                    const real_t absa = abs(A(i, j));
                     sum += absa;
                     w[i] += absa;
                 }

--- a/include/tlapack/lapack/lantr.hpp
+++ b/include/tlapack/lapack/lantr.hpp
@@ -162,8 +162,8 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
         if (diag == Diag::NonUnit) {
             if (uplo == Uplo::Upper) {
                 for (idx_t j = 0; j < n; ++j) {
-                    for (idx_t i = 0; i <= std::min(j, m - 1); ++i) {
-                        real_t temp = tlapack::abs(A(i, j));
+                    for (idx_t i = 0; i <= min(j, m - 1); ++i) {
+                        real_t temp = abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
@@ -176,7 +176,7 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
             else {
                 for (idx_t j = 0; j < n; ++j) {
                     for (idx_t i = j; i < m; ++i) {
-                        real_t temp = tlapack::abs(A(i, j));
+                        real_t temp = abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
@@ -191,8 +191,8 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
             norm = real_t(1);
             if (uplo == Uplo::Upper) {
                 for (idx_t j = 0; j < n; ++j) {
-                    for (idx_t i = 0; i < std::min(j, m); ++i) {
-                        real_t temp = tlapack::abs(A(i, j));
+                    for (idx_t i = 0; i < min(j, m); ++i) {
+                        real_t temp = abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
@@ -205,7 +205,7 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
             else {
                 for (idx_t j = 0; j < n; ++j) {
                     for (idx_t i = j + 1; i < m; ++i) {
-                        real_t temp = tlapack::abs(A(i, j));
+                        real_t temp = abs(A(i, j));
 
                         if (temp > norm)
                             norm = temp;
@@ -223,11 +223,11 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
                 real_t sum(0);
                 if (diag == Diag::NonUnit)
                     for (idx_t j = i; j < n; ++j)
-                        sum += tlapack::abs(A(i, j));
+                        sum += abs(A(i, j));
                 else {
                     sum = real_t(1);
                     for (idx_t j = i + 1; j < n; ++j)
-                        sum += tlapack::abs(A(i, j));
+                        sum += abs(A(i, j));
                 }
 
                 if (sum > norm)
@@ -241,12 +241,12 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
             for (idx_t i = 0; i < m; ++i) {
                 real_t sum(0);
                 if (diag == Diag::NonUnit || i >= n)
-                    for (idx_t j = 0; j <= std::min(i, n - 1); ++j)
-                        sum += tlapack::abs(A(i, j));
+                    for (idx_t j = 0; j <= min(i, n - 1); ++j)
+                        sum += abs(A(i, j));
                 else {
                     sum = real_t(1);
                     for (idx_t j = 0; j < i; ++j)
-                        sum += tlapack::abs(A(i, j));
+                        sum += abs(A(i, j));
                 }
 
                 if (sum > norm)
@@ -262,12 +262,12 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
             for (idx_t j = 0; j < n; ++j) {
                 real_t sum(0);
                 if (diag == Diag::NonUnit || j >= m)
-                    for (idx_t i = 0; i <= std::min(j, m - 1); ++i)
-                        sum += tlapack::abs(A(i, j));
+                    for (idx_t i = 0; i <= min(j, m - 1); ++i)
+                        sum += abs(A(i, j));
                 else {
                     sum = real_t(1);
                     for (idx_t i = 0; i < j; ++i)
-                        sum += tlapack::abs(A(i, j));
+                        sum += abs(A(i, j));
                 }
 
                 if (sum > norm)
@@ -282,11 +282,11 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
                 real_t sum(0);
                 if (diag == Diag::NonUnit)
                     for (idx_t i = j; i < m; ++i)
-                        sum += tlapack::abs(A(i, j));
+                        sum += abs(A(i, j));
                 else {
                     sum = real_t(1);
                     for (idx_t i = j + 1; i < m; ++i)
-                        sum += tlapack::abs(A(i, j));
+                        sum += abs(A(i, j));
                 }
 
                 if (sum > norm)
@@ -303,23 +303,22 @@ auto lantr(norm_t normType, uplo_t uplo, diag_t diag, const matrix_t& A)
         if (uplo == Uplo::Upper) {
             if (diag == Diag::NonUnit) {
                 for (idx_t j = 0; j < n; ++j)
-                    lassq(slice(A, range(0, std::min(j + 1, m)), j), scale,
-                          sum);
+                    lassq(slice(A, range(0, min(j + 1, m)), j), scale, sum);
             }
             else {
-                sum = real_t(std::min(m, n));
+                sum = real_t(min(m, n));
                 for (idx_t j = 1; j < n; ++j)
-                    lassq(slice(A, range(0, std::min(j, m)), j), scale, sum);
+                    lassq(slice(A, range(0, min(j, m)), j), scale, sum);
             }
         }
         else {
             if (diag == Diag::NonUnit) {
-                for (idx_t j = 0; j < std::min(m, n); ++j)
+                for (idx_t j = 0; j < min(m, n); ++j)
                     lassq(slice(A, range(j, m), j), scale, sum);
             }
             else {
-                sum = real_t(std::min(m, n));
-                for (idx_t j = 0; j < std::min(m - 1, n); ++j)
+                sum = real_t(min(m, n));
+                for (idx_t j = 0; j < min(m - 1, n); ++j)
                     lassq(slice(A, range(j + 1, m), j), scale, sum);
             }
         }
@@ -423,16 +422,16 @@ auto lantr(norm_t normType,
                     w[i] = real_t(0);
 
                 for (idx_t j = 0; j < n; ++j)
-                    for (idx_t i = 0; i <= std::min(j, m - 1); ++i)
-                        w[i] += tlapack::abs(A(i, j));
+                    for (idx_t i = 0; i <= min(j, m - 1); ++i)
+                        w[i] += abs(A(i, j));
             }
             else {
                 for (idx_t i = 0; i < m; ++i)
                     w[i] = real_t(1);
 
                 for (idx_t j = 1; j < n; ++j) {
-                    for (idx_t i = 0; i < std::min(j, m); ++i)
-                        w[i] += tlapack::abs(A(i, j));
+                    for (idx_t i = 0; i < min(j, m); ++i)
+                        w[i] += abs(A(i, j));
                 }
             }
         }
@@ -443,17 +442,17 @@ auto lantr(norm_t normType,
 
                 for (idx_t j = 0; j < n; ++j)
                     for (idx_t i = j; i < m; ++i)
-                        w[i] += tlapack::abs(A(i, j));
+                        w[i] += abs(A(i, j));
             }
             else {
-                for (idx_t i = 0; i < std::min(m, n); ++i)
+                for (idx_t i = 0; i < min(m, n); ++i)
                     w[i] = real_t(1);
                 for (idx_t i = n; i < m; ++i)
                     w[i] = real_t(0);
 
                 for (idx_t j = 1; j < n; ++j) {
                     for (idx_t i = j + 1; i < m; ++i)
-                        w[i] += tlapack::abs(A(i, j));
+                        w[i] += abs(A(i, j));
                 }
             }
         }

--- a/include/tlapack/lapack/lassq.hpp
+++ b/include/tlapack/lapack/lassq.hpp
@@ -176,7 +176,7 @@ void lassq(const vector_t& x,
  *
  * Specific implementation using
  * \code{.cpp}
- *      absF = []( const T& x ) { return tlapack::abs( x ); }
+ *      absF = []( const T& x ) { return abs( x ); }
  * \endcode
  * where T is the type_t< vector_t >.
  *
@@ -188,10 +188,9 @@ inline void lassq(const vector_t& x,
                   real_type<type_t<vector_t>>& sumsq)
 {
     using T = type_t<vector_t>;
-    return lassq(
-        x, scale, sumsq,
-        // Lambda function that returns the absolute value using tlapack::abs :
-        [](const T& x) { return tlapack::abs(x); });
+    return lassq(x, scale, sumsq,
+                 // Lambda function that returns the absolute value using abs :
+                 [](const T& x) { return abs(x); });
 }
 
 }  // namespace tlapack

--- a/include/tlapack/lapack/lassq.hpp
+++ b/include/tlapack/lapack/lassq.hpp
@@ -32,9 +32,9 @@ namespace tlapack {
  *    we require:   scale <= sqrt( HUGE ) / ssml       on entry,
  * where
  *    tbig -- upper threshold for values whose square is representable;
- *    sbig -- scaling constant for big numbers; @see base/constants.hpp
+ *    sbig -- scaling constant for big numbers; @see constants.hpp
  *    tsml -- lower threshold for values whose square is representable;
- *    ssml -- scaling constant for small numbers; @see base/constants.hpp
+ *    ssml -- scaling constant for small numbers; @see constants.hpp
  * and
  *    TINY*EPS -- tiniest representable number;
  *    HUGE     -- biggest representable number.

--- a/include/tlapack/lapack/multishift_qr.hpp
+++ b/include/tlapack/lapack/multishift_qr.hpp
@@ -301,14 +301,14 @@ int multishift_qr(bool want_t,
         // Agressive early deflation
         //
         idx_t nh = istop - istart;
-        idx_t nwupbd = std::min(nh, nw_max);
+        idx_t nwupbd = min(nh, nw_max);
         if (k_defl < non_convergence_limit_window) {
-            nw = std::min(nwupbd, nwr);
+            nw = min(nwupbd, nwr);
         }
         else {
             // There have been no deflations in many iterations
             // Try to vary the deflation window size.
-            nw = std::min(nwupbd, 2 * nw);
+            nw = min(nwupbd, 2 * nw);
         }
         if (nh <= 4) {
             // n >= nmin, so there is always enough space for a 4x4 window
@@ -336,12 +336,12 @@ int multishift_qr(bool want_t,
         // Here, the QR sweep is skipped if many eigenvalues have just been
         // deflated or if the remaining active block is small.
         if (ld > 0 and (100 * ld > nwr * nibble or
-                        (istop - istart) <= std::min(nmin, nw_max))) {
+                        (istop - istart) <= min(nmin, nw_max))) {
             continue;
         }
 
         k_defl = k_defl + 1;
-        idx_t ns = std::min(nh - 1, std::min(ls, nsr));
+        idx_t ns = min(nh - 1, min(ls, nsr));
 
         idx_t i_shifts = istop - ls;
 
@@ -423,10 +423,8 @@ int multishift_qr(bool want_t,
         if (is_real<TA>) {
             if (ns == 2) {
                 if (imag(w[i_shifts]) == zero) {
-                    if (tlapack::abs(real(w[i_shifts]) -
-                                     A(istop - 1, istop - 1)) <
-                        tlapack::abs(real(w[i_shifts + 1]) -
-                                     A(istop - 1, istop - 1)))
+                    if (abs(real(w[i_shifts]) - A(istop - 1, istop - 1)) <
+                        abs(real(w[i_shifts + 1]) - A(istop - 1, istop - 1)))
                         w[i_shifts + 1] = w[i_shifts];
                     else
                         w[i_shifts] = w[i_shifts + 1];

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -140,7 +140,7 @@ void multishift_QR_sweep(bool want_t,
 
     const idx_t n_block_max = (n - 3) / 3;
     const idx_t n_shifts_max =
-        std::min(ihi - ilo - 1, std::max<idx_t>(2, 3 * (n_block_max / 4)));
+        min(ihi - ilo - 1, std::max<idx_t>(2, 3 * (n_block_max / 4)));
 
     idx_t n_shifts = std::min<idx_t>(size(s), n_shifts_max);
     if (n_shifts % 2 == 1) n_shifts = n_shifts - 1;
@@ -173,7 +173,7 @@ void multishift_QR_sweep(bool want_t,
         // The calculations are initially limited to the window:
         // A(ilo:ilo+n_block,ilo:ilo+n_block) The rest is updated later via
         // level 3 BLAS
-        idx_t n_block = std::min(n_block_desired, ihi - ilo);
+        idx_t n_block = min(n_block_desired, ihi - ilo);
         idx_t istart_m = ilo;
         idx_t istop_m = ilo + n_block;
         auto U2 = slice(U, range{0, n_block}, range{0, n_block});
@@ -182,8 +182,7 @@ void multishift_QR_sweep(bool want_t,
         for (idx_t i_pos_last = ilo; i_pos_last < ilo + n_block - 2;
              ++i_pos_last) {
             // The number of bulges that are in the pencil
-            idx_t n_active_bulges =
-                std::min(n_bulges, ((i_pos_last - ilo) / 2) + 1);
+            idx_t n_active_bulges = min(n_bulges, ((i_pos_last - ilo) / 2) + 1);
             for (idx_t i_bulge = 0; i_bulge < n_active_bulges; ++i_bulge) {
                 idx_t i_pos = i_pos_last - 2 * i_bulge;
                 auto v = col(V, i_bulge);
@@ -246,24 +245,26 @@ void multishift_QR_sweep(bool want_t,
                                 tst1 += abs1(A(i_pos + 3, i_pos));
                         }
                         if (abs1(A(i_pos, i_pos - 1)) <
-                            std::max(small_num, eps * tst1)) {
+                            max(small_num, eps * tst1)) {
+                            const real_t aij = abs1(A(i_pos, i_pos - 1));
+                            const real_t aji = abs1(A(i_pos - 1, i_pos));
                             const real_t ab =
-                                std::max(abs1(A(i_pos, i_pos - 1)),
-                                         abs1(A(i_pos - 1, i_pos)));
+                                (aij > aji) ? aij
+                                            : aji;  // Propagates NaNs in aji
                             const real_t ba =
-                                std::min(abs1(A(i_pos, i_pos - 1)),
-                                         abs1(A(i_pos - 1, i_pos)));
+                                (aij < aji) ? aij
+                                            : aji;  // Propagates NaNs in aji
                             const real_t aa =
-                                std::max(abs1(A(i_pos, i_pos)),
-                                         abs1(A(i_pos, i_pos) -
-                                              A(i_pos - 1, i_pos - 1)));
+                                max(abs1(A(i_pos, i_pos)),
+                                    abs1(A(i_pos, i_pos) -
+                                         A(i_pos - 1, i_pos - 1)));
                             const real_t bb =
-                                std::min(abs1(A(i_pos, i_pos)),
-                                         abs1(A(i_pos, i_pos) -
-                                              A(i_pos - 1, i_pos - 1)));
+                                min(abs1(A(i_pos, i_pos)),
+                                    abs1(A(i_pos, i_pos) -
+                                         A(i_pos - 1, i_pos - 1)));
                             const real_t s = aa + ab;
                             if (ba * (ab / s) <=
-                                std::max(small_num, eps * (bb * (aa / s)))) {
+                                max(small_num, eps * (bb * (aa / s)))) {
                                 A(i_pos, i_pos - 1) = zero;
                             }
                         }
@@ -308,8 +309,8 @@ void multishift_QR_sweep(bool want_t,
                 idx_t i_pos = i_pos_last - 2 * i_bulge;
                 auto v = col(V, i_bulge);
                 idx_t i1 = 0;
-                idx_t i2 = std::min(
-                    nrows(U2), (i_pos_last - ilo) + (i_pos_last - ilo) + 3);
+                idx_t i2 =
+                    min(nrows(U2), (i_pos_last - ilo) + (i_pos_last - ilo) + 3);
                 for (idx_t j = i1; j < i2; ++j) {
                     const TA sum = U2(j, i_pos - ilo) +
                                    v[1] * U2(j, i_pos - ilo + 1) +
@@ -450,24 +451,26 @@ void multishift_QR_sweep(bool want_t,
                                 tst1 += abs1(A(i_pos + 3, i_pos));
                         }
                         if (abs1(A(i_pos, i_pos - 1)) <
-                            std::max(small_num, eps * tst1)) {
+                            max(small_num, eps * tst1)) {
+                            const real_t aij = abs1(A(i_pos, i_pos - 1));
+                            const real_t aji = abs1(A(i_pos - 1, i_pos));
                             const real_t ab =
-                                std::max(abs1(A(i_pos, i_pos - 1)),
-                                         abs1(A(i_pos - 1, i_pos)));
+                                (aij > aji) ? aij
+                                            : aji;  // Propagates NaNs in aji
                             const real_t ba =
-                                std::min(abs1(A(i_pos, i_pos - 1)),
-                                         abs1(A(i_pos - 1, i_pos)));
+                                (aij < aji) ? aij
+                                            : aji;  // Propagates NaNs in aji
                             const real_t aa =
-                                std::max(abs1(A(i_pos, i_pos)),
-                                         abs1(A(i_pos, i_pos) -
-                                              A(i_pos - 1, i_pos - 1)));
+                                max(abs1(A(i_pos, i_pos)),
+                                    abs1(A(i_pos, i_pos) -
+                                         A(i_pos - 1, i_pos - 1)));
                             const real_t bb =
-                                std::min(abs1(A(i_pos, i_pos)),
-                                         abs1(A(i_pos, i_pos) -
-                                              A(i_pos - 1, i_pos - 1)));
+                                min(abs1(A(i_pos, i_pos)),
+                                    abs1(A(i_pos, i_pos) -
+                                         A(i_pos - 1, i_pos - 1)));
                             const real_t s = aa + ab;
                             if (ba * (ab / s) <=
-                                std::max(small_num, eps * (bb * (aa / s)))) {
+                                max(small_num, eps * (bb * (aa / s)))) {
                                 A(i_pos, i_pos - 1) = zero;
                             }
                         }
@@ -514,9 +517,9 @@ void multishift_QR_sweep(bool want_t,
                 idx_t i1 = (i_pos - i_pos_block) -
                            (i_pos_last - i_pos_block - n_shifts + 2);
                 idx_t i2 =
-                    std::min(nrows(U2),
-                             (i_pos_last - i_pos_block) +
-                                 (i_pos_last - i_pos_block - n_shifts + 2) + 3);
+                    min(nrows(U2),
+                        (i_pos_last - i_pos_block) +
+                            (i_pos_last - i_pos_block - n_shifts + 2) + 3);
                 for (idx_t j = i1; j < i2; ++j) {
                     const TA sum = U2(j, i_pos - i_pos_block) +
                                    v[1] * U2(j, i_pos - i_pos_block + 1) +
@@ -700,25 +703,28 @@ void multishift_QR_sweep(bool want_t,
                                     tst1 += abs1(A(i_pos + 3, i_pos));
                             }
                             if (abs1(A(i_pos, i_pos - 1)) <
-                                std::max(small_num, eps * tst1)) {
+                                max(small_num, eps * tst1)) {
+                                const real_t aij = abs1(A(i_pos, i_pos - 1));
+                                const real_t aji = abs1(A(i_pos - 1, i_pos));
                                 const real_t ab =
-                                    std::max(abs1(A(i_pos, i_pos - 1)),
-                                             abs1(A(i_pos - 1, i_pos)));
+                                    (aij > aji)
+                                        ? aij
+                                        : aji;  // Propagates NaNs in aji
                                 const real_t ba =
-                                    std::min(abs1(A(i_pos, i_pos - 1)),
-                                             abs1(A(i_pos - 1, i_pos)));
+                                    (aij < aji)
+                                        ? aij
+                                        : aji;  // Propagates NaNs in aji
                                 const real_t aa =
-                                    std::max(abs1(A(i_pos, i_pos)),
-                                             abs1(A(i_pos, i_pos) -
-                                                  A(i_pos - 1, i_pos - 1)));
+                                    max(abs1(A(i_pos, i_pos)),
+                                        abs1(A(i_pos, i_pos) -
+                                             A(i_pos - 1, i_pos - 1)));
                                 const real_t bb =
-                                    std::min(abs1(A(i_pos, i_pos)),
-                                             abs1(A(i_pos, i_pos) -
-                                                  A(i_pos - 1, i_pos - 1)));
+                                    min(abs1(A(i_pos, i_pos)),
+                                        abs1(A(i_pos, i_pos) -
+                                             A(i_pos - 1, i_pos - 1)));
                                 const real_t s = aa + ab;
                                 if (ba * (ab / s) <=
-                                    std::max(small_num,
-                                             eps * (bb * (aa / s)))) {
+                                    max(small_num, eps * (bb * (aa / s)))) {
                                     A(i_pos, i_pos - 1) = zero;
                                 }
                             }
@@ -737,7 +743,7 @@ void multishift_QR_sweep(bool want_t,
             // {
             //     idx_t i_bulge_start2 = (i_pos_last + 2 > j) ? (i_pos_last + 2
             //     - j) / 2 : 0; i_bulge_start2 =
-            //     std::max(i_bulge_start,i_bulge_start2); for (idx_t i_bulge =
+            //     max(i_bulge_start,i_bulge_start2); for (idx_t i_bulge =
             //     i_bulge_start2; i_bulge < n_bulges; ++i_bulge)
             //     {
             //         idx_t i_pos = i_pos_last - 2 * i_bulge;
@@ -770,9 +776,9 @@ void multishift_QR_sweep(bool want_t,
                 idx_t i1 = (i_pos - i_pos_block) -
                            (i_pos_last - i_pos_block - n_shifts + 2);
                 idx_t i2 =
-                    std::min(nrows(U2),
-                             (i_pos_last - i_pos_block) +
-                                 (i_pos_last - i_pos_block - n_shifts + 2) + 3);
+                    min(nrows(U2),
+                        (i_pos_last - i_pos_block) +
+                            (i_pos_last - i_pos_block - n_shifts + 2) + 3);
                 for (idx_t j = i1; j < i2; ++j) {
                     const TA sum = U2(j, i_pos - i_pos_block) +
                                    v[1] * U2(j, i_pos - i_pos_block + 1) +

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -275,6 +275,7 @@ int schur_swap(bool want_q,
         const T eps = ulp<T>();
         const T small_num = safe_min<T>() / eps;
         T thresh = max(ten * eps * dnorm, small_num);
+        // Note: max() may not propagate NaNs.
 
         std::vector<T> V_;
         auto V = new_matrix(V_, 4, 2);

--- a/include/tlapack/lapack/unghr.hpp
+++ b/include/tlapack/lapack/unghr.hpp
@@ -59,7 +59,7 @@ int unghr(size_type<matrix_t> ilo,
     const idx_t nh = ihi > ilo + 1 ? ihi - 1 - ilo : 0;
 
     // check arguments
-    tlapack_check_false((idx_t)size(tau) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tau) < min(m, n));
 
     // Shift the vectors which define the elementary reflectors one
     // column to the right, and set the first ilo and the last n-ihi

--- a/include/tlapack/lapack/ungl2.hpp
+++ b/include/tlapack/lapack/ungl2.hpp
@@ -96,7 +96,7 @@ int ungl2(matrix_t& Q, const vector_t& tauw, const WorkspaceOpts<>& opts = {})
         min(k, m);  // desired number of Householder reflectors to use
 
     // check arguments
-    tlapack_check_false((idx_t)size(tauw) < std::min<idx_t>(m, n));
+    tlapack_check_false((idx_t)size(tauw) < min(m, n));
 
     // Allocates workspace
     VectorOfBytes localworkdata;

--- a/include/tlapack/legacy_api/blas/gemv.hpp
+++ b/include/tlapack/legacy_api/blas/gemv.hpp
@@ -98,7 +98,6 @@ namespace legacy {
               int_t incy)
     {
         using internal::create_matrix;
-        using std::abs;
         using scalar_t = scalar_type<TA, TX, TY>;
 
         // check arguments

--- a/include/tlapack/legacy_api/blas/trmv.hpp
+++ b/include/tlapack/legacy_api/blas/trmv.hpp
@@ -84,7 +84,6 @@ namespace legacy {
               int_t incx)
     {
         using internal::create_matrix;
-        using std::abs;
 
         // check arguments
         tlapack_check_false(layout != Layout::ColMajor &&

--- a/include/tlapack/legacy_api/blas/trsv.hpp
+++ b/include/tlapack/legacy_api/blas/trsv.hpp
@@ -88,7 +88,6 @@ namespace legacy {
               int_t incx)
     {
         using internal::create_matrix;
-        using std::abs;
 
         // check arguments
         tlapack_check_false(layout != Layout::ColMajor &&

--- a/include/tlapack/legacy_api/lapack/geqr2.hpp
+++ b/include/tlapack/legacy_api/lapack/geqr2.hpp
@@ -52,7 +52,7 @@ namespace legacy {
 
         // Matrix views
         auto A_ = create_matrix(A, m, n, lda);
-        auto tau_ = create_vector(tau, std::min(m, n));
+        auto tau_ = create_vector(tau, min(m, n));
 
         return geqr2(A_, tau_);
     }

--- a/include/tlapack/legacy_api/lapack/lassq.hpp
+++ b/include/tlapack/legacy_api/lapack/lassq.hpp
@@ -33,9 +33,9 @@ namespace legacy {
      *    we require:   scale <= sqrt( HUGE ) / ssml       on entry,
      * where
      *    tbig -- upper threshold for values whose square is representable;
-     *    sbig -- scaling constant for big numbers; @see base/constants.hpp
+     *    sbig -- scaling constant for big numbers; @see constants.hpp
      *    tsml -- lower threshold for values whose square is representable;
-     *    ssml -- scaling constant for small numbers; @see base/constants.hpp
+     *    ssml -- scaling constant for small numbers; @see constants.hpp
      * and
      *    TINY*EPS -- tiniest representable number;
      *    HUGE     -- biggest representable number.

--- a/include/tlapack/legacy_api/lapack/ung2r.hpp
+++ b/include/tlapack/legacy_api/lapack/ung2r.hpp
@@ -57,7 +57,7 @@ namespace legacy {
 
         // Matrix views
         auto A_ = create_matrix<TA>(A, m, n, lda);
-        auto tau_ = create_vector((TT*)tau, std::min<idx_t>(m, n));
+        auto tau_ = create_vector((TT*)tau, min(m, n));
 
         return ung2r(A_, tau_);
     }

--- a/include/tlapack/plugins/eigen_half.hpp
+++ b/include/tlapack/plugins/eigen_half.hpp
@@ -31,20 +31,6 @@ namespace traits {
     };
 }  // namespace traits
 
-// Forward declarations
-template <typename T>
-T abs(const T& x);
-template <typename T>
-bool isnan(const std::complex<T>& x);
-template <typename T>
-bool isinf(const std::complex<T>& x);
-
-template <>
-inline Eigen::half abs(const Eigen::half& x)
-{
-    return Eigen::half_impl::abs(x);
-}
-
 inline Eigen::half pow(int base, const Eigen::half& exp)
 {
     return Eigen::half_impl::pow(Eigen::half(base), exp);
@@ -60,9 +46,9 @@ std::complex<Eigen::half> sqrt(const std::complex<Eigen::half>& z)
     const Eigen::half two(2);
     const Eigen::half half(0.5);
 
-    if (isnan(z))
+    if (isnan(x) || isnan(y))
         return std::numeric_limits<Eigen::half>::quiet_NaN();
-    else if (isinf(z))
+    else if (isinf(x) || isinf(y))
         return std::numeric_limits<Eigen::half>::infinity();
     else if (x == zero) {
         Eigen::half t = sqrt(half * abs(y));

--- a/include/tlapack/plugins/mpreal.hpp
+++ b/include/tlapack/plugins/mpreal.hpp
@@ -31,16 +31,6 @@ namespace traits {
     };
 }  // namespace traits
 
-// Forward declarations
-template <typename T>
-inline T abs(const T& x);
-
-template <>
-inline mpfr::mpreal abs(const mpfr::mpreal& x)
-{
-    return mpfr::abs(x);
-}
-
 // Argument-dependent lookup (ADL) will include the remaining functions,
 // e.g., mpfr::sin, mpfr::cos.
 // Including them here may cause ambiguous call of overloaded function.

--- a/include/tlapack/plugins/starpu.hpp
+++ b/include/tlapack/plugins/starpu.hpp
@@ -42,12 +42,6 @@ inline constexpr T conj(const starpu::MatrixEntry<T>& x)
     return conj(T(x));
 }
 
-template <class T>
-inline constexpr real_type<T> abs(const starpu::MatrixEntry<T>& x)
-{
-    return abs(x);
-}
-
 namespace traits {
     template <class T>
     struct real_type_traits<starpu::MatrixEntry<T>, int>

--- a/include/tlapack/starpu/MatrixEntry.hpp
+++ b/include/tlapack/starpu/MatrixEntry.hpp
@@ -240,15 +240,11 @@ namespace starpu {
             return operate_and_assign<internal::Operation::Divide, T>(x);
         }
 
-        // Other math functions
+        // Math functions to satisfy the concept Scalar
 
         constexpr friend real_type<T> abs(const MatrixEntry& x) noexcept
         {
             return abs(T(x));
-        }
-        constexpr friend T sqrt(const MatrixEntry& x) noexcept
-        {
-            return sqrt(T(x));
         }
 
         // Display value in ostream

--- a/include/tlapack/starpu/functions.hpp
+++ b/include/tlapack/starpu/functions.hpp
@@ -74,24 +74,24 @@ namespace starpu {
                 const T beta_ = (T)beta;
                 cublasStatus_t status;
 
-                if constexpr (std::is_same_v<T, float>)
+                if constexpr (is_same_v<T, float>)
                     status = cublasSgemm(starpu_cublas_get_local_handle(), opA,
                                          opB, m, n, k, &alpha_, (const float*)A,
                                          lda, (const float*)B, ldb, &beta_,
                                          (float*)C, ldc);
-                else if constexpr (std::is_same_v<T, double>)
+                else if constexpr (is_same_v<T, double>)
                     status = cublasDgemm(
                         starpu_cublas_get_local_handle(), opA, opB, m, n, k,
                         &alpha_, (const double*)A, lda, (const double*)B, ldb,
                         &beta_, (double*)C, ldc);
-                else if constexpr (std::is_same_v<real_type<T>, float>)
+                else if constexpr (is_same_v<real_type<T>, float>)
                     status = cublasCgemm(
                         starpu_cublas_get_local_handle(), opA, opB, m, n, k,
                         (const cuFloatComplex*)&alpha_,
                         (const cuFloatComplex*)A, lda, (const cuFloatComplex*)B,
                         ldb, (const cuFloatComplex*)&beta_, (cuFloatComplex*)C,
                         ldc);
-                else if constexpr (std::is_same_v<real_type<T>, double>)
+                else if constexpr (is_same_v<real_type<T>, double>)
                     status =
                         cublasZgemm(starpu_cublas_get_local_handle(), opA, opB,
                                     m, n, k, (const cuDoubleComplex*)&alpha_,
@@ -254,21 +254,21 @@ namespace starpu {
                 const real_t beta_ = (real_t)beta;
                 cublasStatus_t status;
 
-                if constexpr (std::is_same_v<T, float>)
+                if constexpr (is_same_v<T, float>)
                     status = cublasSsyrk(
                         starpu_cublas_get_local_handle(), uplo_, op_, n, k,
                         &alpha_, (const float*)A, lda, &beta_, (float*)C, ldc);
-                else if constexpr (std::is_same_v<T, double>)
+                else if constexpr (is_same_v<T, double>)
                     status =
                         cublasDsyrk(starpu_cublas_get_local_handle(), uplo_,
                                     op_, n, k, &alpha_, (const double*)A, lda,
                                     &beta_, (double*)C, ldc);
-                else if constexpr (std::is_same_v<real_type<T>, float>)
+                else if constexpr (is_same_v<real_type<T>, float>)
                     status = cublasCherk(starpu_cublas_get_local_handle(),
                                          uplo_, op_, n, k, &alpha_,
                                          (const cuFloatComplex*)A, lda, &beta_,
                                          (cuFloatComplex*)C, ldc);
-                else if constexpr (std::is_same_v<real_type<T>, double>)
+                else if constexpr (is_same_v<real_type<T>, double>)
                     status = cublasZherk(starpu_cublas_get_local_handle(),
                                          uplo_, op_, n, k, &alpha_,
                                          (const cuDoubleComplex*)A, lda, &beta_,
@@ -425,22 +425,22 @@ namespace starpu {
                 const T alpha_ = (T)alpha;
                 cublasStatus_t status;
 
-                if constexpr (std::is_same_v<T, float>)
+                if constexpr (is_same_v<T, float>)
                     status =
                         cublasStrsm(starpu_cublas_get_local_handle(), side_,
                                     uplo_, op_, diag_, m, n, &alpha_,
                                     (const float*)A, lda, (float*)B, ldb);
-                else if constexpr (std::is_same_v<T, double>)
+                else if constexpr (is_same_v<T, double>)
                     status =
                         cublasDtrsm(starpu_cublas_get_local_handle(), side_,
                                     uplo_, op_, diag_, m, n, &alpha_,
                                     (const double*)A, lda, (double*)B, ldb);
-                else if constexpr (std::is_same_v<real_type<T>, float>)
+                else if constexpr (is_same_v<real_type<T>, float>)
                     status = cublasCtrsm(
                         starpu_cublas_get_local_handle(), side_, uplo_, op_,
                         diag_, m, n, (const cuFloatComplex*)&alpha_,
                         (const cuFloatComplex*)A, lda, (cuFloatComplex*)B, ldb);
-                else if constexpr (std::is_same_v<real_type<T>, double>)
+                else if constexpr (is_same_v<real_type<T>, double>)
                     status = cublasZtrsm(starpu_cublas_get_local_handle(),
                                          side_, uplo_, op_, diag_, m, n,
                                          (const cuDoubleComplex*)&alpha_,
@@ -498,21 +498,21 @@ namespace starpu {
                 const cublasFillMode_t uplo_ = cuda::uplo2cublas(uplo);
                 cusolverStatus_t status = CUSOLVER_STATUS_SUCCESS;
 
-                if constexpr (std::is_same_v<T, float>)
+                if constexpr (is_same_v<T, float>)
                     status = cusolverDnSpotrf(
                         starpu_cusolverDn_get_local_handle(), uplo_, n,
                         (float*)A, lda, (float*)w, lwork / sizeof(float), info);
-                else if constexpr (std::is_same_v<T, double>)
+                else if constexpr (is_same_v<T, double>)
                     status =
                         cusolverDnDpotrf(starpu_cusolverDn_get_local_handle(),
                                          uplo_, n, (double*)A, lda, (double*)w,
                                          lwork / sizeof(double), info);
-                else if constexpr (std::is_same_v<real_type<T>, float>)
+                else if constexpr (is_same_v<real_type<T>, float>)
                     status = cusolverDnCpotrf(
                         starpu_cusolverDn_get_local_handle(), uplo_, n,
                         (cuFloatComplex*)A, lda, (cuFloatComplex*)w,
                         lwork / sizeof(cuFloatComplex), info);
-                else if constexpr (std::is_same_v<real_type<T>, double>)
+                else if constexpr (is_same_v<real_type<T>, double>)
                     status = cusolverDnZpotrf(
                         starpu_cusolverDn_get_local_handle(), uplo_, n,
                         (cuDoubleComplex*)A, lda, (cuDoubleComplex*)w,

--- a/include/tlapack/starpu/potf2.hpp
+++ b/include/tlapack/starpu/potf2.hpp
@@ -34,8 +34,7 @@ int potf2(uplo_t uplo, starpu::Matrix<T>& A)
     // Use blocked algorithm if matrix contains more than one tile
     if (nx > 1 || ny > 1) {
         BlockedCholeskyOpts<idx_t> potrf_opts;
-        potrf_opts.nb =
-            std::min(std::min(A.nblockrows(), A.nblockcols()), n - 1);
+        potrf_opts.nb = min(min(A.nblockrows(), A.nblockcols()), n - 1);
         return potrf_blocked(uplo, A, potrf_opts);
     }
 

--- a/include/tlapack/starpu/tasks.hpp
+++ b/include/tlapack/starpu/tasks.hpp
@@ -219,25 +219,25 @@ namespace starpu {
                 const cublasFillMode_t uplo_ = cuda::uplo2cublas(uplo);
                 const int n = starpu_matrix_get_nx(A.handle);
 
-                if constexpr (std::is_same_v<T, float>) {
+                if constexpr (is_same_v<T, float>) {
                     cusolverDnSpotrf_bufferSize(
                         starpu_cusolverDn_get_local_handle(), uplo_, n, nullptr,
                         n, &lwork);
                     lwork *= sizeof(float);
                 }
-                else if constexpr (std::is_same_v<T, double>) {
+                else if constexpr (is_same_v<T, double>) {
                     cusolverDnDpotrf_bufferSize(
                         starpu_cusolverDn_get_local_handle(), uplo_, n, nullptr,
                         n, &lwork);
                     lwork *= sizeof(double);
                 }
-                else if constexpr (std::is_same_v<real_type<T>, float>) {
+                else if constexpr (is_same_v<real_type<T>, float>) {
                     cusolverDnCpotrf_bufferSize(
                         starpu_cusolverDn_get_local_handle(), uplo_, n, nullptr,
                         n, &lwork);
                     lwork *= sizeof(cuFloatComplex);
                 }
-                else if constexpr (std::is_same_v<real_type<T>, double>) {
+                else if constexpr (is_same_v<real_type<T>, double>) {
                     cusolverDnZpotrf_bufferSize(
                         starpu_cusolverDn_get_local_handle(), uplo_, n, nullptr,
                         n, &lwork);

--- a/include/tlapack/starpu/utils.hpp
+++ b/include/tlapack/starpu/utils.hpp
@@ -15,6 +15,11 @@
 #include "tlapack/base/types.hpp"
 
 namespace tlapack {
+
+// C++ standard utils:
+using std::enable_if_t;
+using std::is_same_v;
+
 namespace starpu {
     namespace cuda {
 
@@ -39,11 +44,10 @@ namespace starpu {
 
 #ifdef STARPU_USE_CUDA
         template <class T>
-        struct is_cublas<
-            T,
-            std::enable_if_t<(std::is_same_v<real_type<T>, float> ||
-                              std::is_same_v<real_type<T>, double>),
-                             int>> {
+        struct is_cublas<T,
+                         enable_if_t<(is_same_v<real_type<T>, float> ||
+                                      is_same_v<real_type<T>, double>),
+                                     int>> {
             static constexpr bool value = true;
         };
 

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -74,7 +74,7 @@ TEMPLATE_TEST_CASE("Multishift QR",
 
     if (matrix_type == "Random") {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < std::min(n, j + 2); ++i)
+            for (idx_t i = 0; i < min(n, j + 2); ++i)
                 A(i, j) = rand_helper<T>(gen);
 
         for (idx_t j = 0; j < n; ++j)
@@ -85,7 +85,7 @@ TEMPLATE_TEST_CASE("Multishift QR",
         const real_t large_num = safe_max<real_t>() * ulp<real_t>();
 
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < std::min(n, j + 2); ++i)
+            for (idx_t i = 0; i < min(n, j + 2); ++i)
                 A(i, j) = large_num;
 
         for (idx_t j = 0; j < n; ++j)
@@ -171,7 +171,7 @@ TEMPLATE_TEST_CASE("Multishift QR",
 
             if (nb == 1) {
                 CHECK(abs1(s[i] - H(i, i)) <=
-                      tol * std::max(real_t(1), abs1(H(i, i))));
+                      tol * max(real_t(1), abs1(H(i, i))));
                 i = i + 1;
             }
             else {
@@ -188,9 +188,8 @@ TEMPLATE_TEST_CASE("Multishift QR",
                     s1 = s2;
                     s2 = swp;
                 }
-                CHECK(abs1(s[i] - s1) <= tol * std::max(real_t(1), abs1(s1)));
-                CHECK(abs1(s[i + 1] - s2) <=
-                      tol * std::max(real_t(1), abs1(s2)));
+                CHECK(abs1(s[i] - s1) <= tol * max(real_t(1), abs1(s1)));
+                CHECK(abs1(s[i + 1] - s2) <= tol * max(real_t(1), abs1(s2)));
                 i = i + 2;
             }
         }

--- a/test/src/test_concepts.cpp
+++ b/test/src/test_concepts.cpp
@@ -11,9 +11,17 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <tlapack/base/concepts.hpp>
 
+#include "NaNPropagComplex.hpp"
+
 #if __cplusplus >= 202002L
 
 using namespace tlapack::concepts;
+
+template <TLAPACK_COMPLEX T>
+void f(T x)
+{
+    return;
+}
 
 TEST_CASE("Concept Arithmetic works as expected", "[concept]")
 {
@@ -27,6 +35,12 @@ TEST_CASE("Concept Arithmetic works as expected", "[concept]")
 TEST_CASE("Concept Vector works as expected", "[concept]")
 {
     REQUIRE(Vector<std::vector<float>>);
+}
+
+TEST_CASE("Concept Complex works as expected", "[concept]")
+{
+    REQUIRE(Complex<std::complex<float>>);
+    REQUIRE(Complex<tlapack::NaNPropagComplex<float>>);
 }
 
 #endif

--- a/test/src/test_gelqt.cpp
+++ b/test/src/test_gelqt.cpp
@@ -81,7 +81,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
 
             // Build tauw vector from matrix TT
             for (idx_t j = 0; j < min(m, n); j += nb) {
-                idx_t ib = std::min<idx_t>(nb, min(m, n) - j);
+                idx_t ib = min(nb, min(m, n) - j);
 
                 for (idx_t i = 0; i < ib; i++)
                     tauw[i + j] = TT(i + j, i);

--- a/test/src/test_larf.cpp
+++ b/test/src/test_larf.cpp
@@ -128,7 +128,7 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
         else {
             CHECK(one <= real(tau));
             CHECK(real(tau) <= two);
-            CHECK(tlapack::abs(tau - one) <= one);
+            CHECK(abs(tau - one) <= one);
         }
 
         const T vHw = dot(v, w);
@@ -144,9 +144,8 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
         }
 
         // Check that larfg returns the expected reflection
-        CHECK(tlapack::abs(real(w[alphaIdx]) - beta) / tol <
-              tlapack::abs(beta));
-        CHECK(tlapack::abs(imag(w[alphaIdx])) / tol < one);
+        CHECK(abs(real(w[alphaIdx]) - beta) / tol < abs(beta));
+        CHECK(abs(imag(w[alphaIdx])) / tol < one);
         w[alphaIdx] = zero;
         CHECK(tlapack::nrm2(w) / tol < one);
     }
@@ -181,7 +180,7 @@ TEMPLATE_TEST_CASE("Application of Householder reflectors",
     {
         // Constants
         const idx_t k = (side == Side::Left) ? m : n;
-        const real_t tol = real_t(4 * std::max(m, n)) * ulp<real_t>();
+        const real_t tol = real_t(4 * max(m, n)) * ulp<real_t>();
         const real_t one(1);
         const idx_t oneIdx = (direction == Direction::Forward) ? 0 : k - 1;
 

--- a/test/src/test_rscl.cpp
+++ b/test/src/test_rscl.cpp
@@ -211,10 +211,9 @@ TEMPLATE_TEST_CASE("reciprocal scaling works on limit cases",
                         if (!isinf(v_scal[i]) && !isnan(v_scal[i])) break;
                     }
                     else {
-                        const real_t rel_bnd = tol * tlapack::abs(v_ref[i]);
-                        const real_t err = tlapack::abs(v_scal[i] - v_ref[i]);
-                        const real_t err_naive =
-                            tlapack::abs(v_naive[i] - v_ref[i]);
+                        const real_t rel_bnd = tol * abs(v_ref[i]);
+                        const real_t err = abs(v_scal[i] - v_ref[i]);
+                        const real_t err_naive = abs(v_naive[i] - v_ref[i]);
 
                         if (rel_bnd > zero || err_naive > zero) {
                             // If either the relative bound or err_naive is
@@ -240,10 +239,9 @@ TEMPLATE_TEST_CASE("reciprocal scaling works on limit cases",
                 }
 
                 if (i != v.size()) {
-                    const real_t rel_bnd = tol * tlapack::abs(v_ref[i]);
-                    const real_t err = tlapack::abs(v_scal[i] - v_ref[i]);
-                    const real_t err_naive =
-                        tlapack::abs(v_naive[i] - v_ref[i]);
+                    const real_t rel_bnd = tol * abs(v_ref[i]);
+                    const real_t err = abs(v_scal[i] - v_ref[i]);
+                    const real_t err_naive = abs(v_naive[i] - v_ref[i]);
                     UNSCOPED_INFO("v[" << i << "] = " << std::scientific
                                        << v[i]);
                     UNSCOPED_INFO("v[" << i << "]/alpha = " << std::scientific

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE("Double shift QR",
 
     if (matrix_type == "Random") {
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < std::min(n, j + 2); ++i)
+            for (idx_t i = 0; i < min(n, j + 2); ++i)
                 A(i, j) = rand_helper<T>();
 
         for (idx_t j = 0; j < n; ++j)
@@ -75,7 +75,7 @@ TEMPLATE_TEST_CASE("Double shift QR",
         const real_t large_num = safe_max<real_t>() * uroundoff<real_t>();
 
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < std::min(n, j + 2); ++i)
+            for (idx_t i = 0; i < min(n, j + 2); ++i)
                 A(i, j) = large_num;
 
         for (idx_t j = 0; j < n; ++j)
@@ -128,7 +128,7 @@ TEMPLATE_TEST_CASE("Double shift QR",
 
             if (nb == 1) {
                 CHECK(abs1(s[i] - H(i, i)) <=
-                      tol * std::max(real_t(1), abs1(H(i, i))));
+                      tol * max(real_t(1), abs1(H(i, i))));
                 i = i + 1;
             }
             else {
@@ -145,9 +145,8 @@ TEMPLATE_TEST_CASE("Double shift QR",
                     s1 = s2;
                     s2 = swp;
                 }
-                CHECK(abs1(s[i] - s1) <= tol * std::max(real_t(1), abs1(s1)));
-                CHECK(abs1(s[i + 1] - s2) <=
-                      tol * std::max(real_t(1), abs1(s2)));
+                CHECK(abs1(s[i] - s1) <= tol * max(real_t(1), abs1(s1)));
+                CHECK(abs1(s[i + 1] - s2) <= tol * max(real_t(1), abs1(s2)));
                 i = i + 2;
             }
         }


### PR DESCRIPTION
This PR tries to improve the usage of intrinsic `std` functions. The major change is to move the specialization of `std::abs` from `utils.hpp` to the class `tlapack::NaNPropagComplex<T>`. The current design in the master branch treats `std::abs` of `std::complex<T>` differently from other math operations, in terms of NaN propagation. In fact, we already know that even a multiplication of two `std::complex` can fail to propagate NaNs. Thus, I believe we should either (1) use `std::complex<T>` as is, or (2) use another complex type, such as `tlapack::NaNPropagComplex<T>`.  

Moreover:
- Adds comments about min and max not propagating NaNs.
- Improves a piece of code in terms of NaN propagation.
- remove unnecessary std:: from std::max and std::min.