### PR TITLE
Use constant expressions instead of enum values

### DIFF
--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -264,6 +264,9 @@ namespace internal {
     struct ConjTranspose {
         constexpr operator Op() const { return Op::ConjTrans; }
     };
+    struct Conjugate {
+        constexpr operator Op() const { return Op::Conj; }
+    };
 }  // namespace internal
 
 // Constant expressions for operations over data
@@ -274,6 +277,8 @@ constexpr internal::NoTranspose NO_TRANS = {};
 constexpr internal::Transpose TRANSPOSE = {};
 /// conjugate transpose
 constexpr internal::ConjTranspose CONJ_TRANS = {};
+/// non-transpose conjugate
+constexpr internal::Conjugate CONJUGATE = {};
 
 // -----------------------------------------------------------------------------
 // Sides

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -189,6 +189,11 @@ bool hasinf(uplo_t uplo, const matrix_t& A)
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
 
+    tlapack_check(uplo == Uplo::General || uplo == Uplo::UpperHessenberg ||
+                  uplo == Uplo::LowerHessenberg || uplo == Uplo::Upper ||
+                  uplo == Uplo::Lower || uplo == Uplo::StrictUpper ||
+                  uplo == Uplo::StrictLower);
+
     if (uplo == Uplo::UpperHessenberg) {
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < ((j < m) ? j + 2 : m); ++i)
@@ -316,6 +321,11 @@ bool hasnan(uplo_t uplo, const matrix_t& A)
     // constants
     const idx_t m = nrows(A);
     const idx_t n = ncols(A);
+
+    tlapack_check(uplo == Uplo::General || uplo == Uplo::UpperHessenberg ||
+                  uplo == Uplo::LowerHessenberg || uplo == Uplo::Upper ||
+                  uplo == Uplo::Lower || uplo == Uplo::StrictUpper ||
+                  uplo == Uplo::StrictLower);
 
     if (uplo == Uplo::UpperHessenberg) {
         for (idx_t j = 0; j < n; ++j)

--- a/include/tlapack/lapack/agressive_early_deflation.hpp
+++ b/include/tlapack/lapack/agressive_early_deflation.hpp
@@ -264,11 +264,11 @@ void agressive_early_deflation(bool want_t,
     // window (note the use of infqr later in the code).
     auto A_window = slice(A, range{kwtop, ihi}, range{kwtop, ihi});
     auto s_window = slice(s, range{kwtop, ihi});
-    laset(Uplo::Lower, zero, zero, TW);
+    laset(LOWER_TRIANGLE, zero, zero, TW);
     for (idx_t j = 0; j < jw; ++j)
         for (idx_t i = 0; i < min(j + 2, jw); ++i)
             TW(i, j) = A_window(i, j);
-    laset(Uplo::General, zero, one, V);
+    laset(GENERAL, zero, one, V);
     int infqr;
     if (jw < opts.nmin)
         infqr = lahqr(true, true, 0, jw, TW, s_window, V);
@@ -434,15 +434,15 @@ void agressive_early_deflation(bool want_t,
             WorkspaceOpts<> work2(Wv_aux);
 
             auto TW_slice = slice(TW, range{0, ns}, range{0, jw});
-            larf(Side::Left, FORWARD, COLUMNWISE_STORAGE, v, conj(tau),
-                 TW_slice, work2);
+            larf(LEFT_SIDE, FORWARD, COLUMNWISE_STORAGE, v, conj(tau), TW_slice,
+                 work2);
 
             auto TW_slice2 = slice(TW, range{0, jw}, range{0, ns});
-            larf(Side::Right, FORWARD, COLUMNWISE_STORAGE, v, tau, TW_slice2,
+            larf(RIGHT_SIDE, FORWARD, COLUMNWISE_STORAGE, v, tau, TW_slice2,
                  work2);
 
             auto V_slice = slice(V, range{0, jw}, range{0, ns});
-            larf(Side::Right, FORWARD, COLUMNWISE_STORAGE, v, tau, V_slice,
+            larf(RIGHT_SIDE, FORWARD, COLUMNWISE_STORAGE, v, tau, V_slice,
                  work2);
         }
 
@@ -452,7 +452,7 @@ void agressive_early_deflation(bool want_t,
             gehrd(0, ns, TW, tau, gehrdOpts);
 
             WorkspaceOpts<> work2(slice(WV, range{0, jw}, 1));
-            unmhr(Side::Right, Op::NoTrans, 0, ns, TW, tau, V, work2);
+            unmhr(RIGHT_SIDE, NO_TRANS, 0, ns, TW, tau, V, work2);
         }
     }
 
@@ -486,8 +486,8 @@ void agressive_early_deflation(bool want_t,
             auto A_slice = slice(A, range{kwtop, ihi}, range{i, i + iblock});
             auto WH_slice =
                 slice(WH, range{0, nrows(A_slice)}, range{0, ncols(A_slice)});
-            gemm(Op::ConjTrans, Op::NoTrans, one, V, A_slice, WH_slice);
-            lacpy(Uplo::General, WH_slice, A_slice);
+            gemm(CONJ_TRANS, NO_TRANS, one, V, A_slice, WH_slice);
+            lacpy(GENERAL, WH_slice, A_slice);
             i = i + iblock;
         }
     }
@@ -499,8 +499,8 @@ void agressive_early_deflation(bool want_t,
             auto A_slice = slice(A, range{i, i + iblock}, range{kwtop, ihi});
             auto WV_slice =
                 slice(WV, range{0, nrows(A_slice)}, range{0, ncols(A_slice)});
-            gemm(Op::NoTrans, Op::NoTrans, one, A_slice, V, WV_slice);
-            lacpy(Uplo::General, WV_slice, A_slice);
+            gemm(NO_TRANS, NO_TRANS, one, A_slice, V, WV_slice);
+            lacpy(GENERAL, WV_slice, A_slice);
             i = i + iblock;
         }
     }
@@ -512,8 +512,8 @@ void agressive_early_deflation(bool want_t,
             auto Z_slice = slice(Z, range{i, i + iblock}, range{kwtop, ihi});
             auto WV_slice =
                 slice(WV, range{0, nrows(Z_slice)}, range{0, ncols(Z_slice)});
-            gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, V, WV_slice);
-            lacpy(Uplo::General, WV_slice, Z_slice);
+            gemm(NO_TRANS, NO_TRANS, one, Z_slice, V, WV_slice);
+            lacpy(GENERAL, WV_slice, Z_slice);
             i = i + iblock;
         }
     }

--- a/include/tlapack/lapack/gehrd.hpp
+++ b/include/tlapack/lapack/gehrd.hpp
@@ -186,12 +186,12 @@ int gehrd(size_type<matrix_t> ilo,
             V(nb2 - 1, nb2 - 1) = one;
             auto A3 = slice(A, range{0, ihi}, range{i + nb2, ihi});
             auto Y_2 = slice(Y, range{0, ihi}, range{0, nb2});
-            gemm(Op::NoTrans, Op::ConjTrans, -one, Y_2, V2, one, A3);
+            gemm(NO_TRANS, CONJ_TRANS, -one, Y_2, V2, one, A3);
             V(nb2 - 1, nb2 - 1) = ei;
         }
         // Apply the block reflector H to A(0:i+1,i+1:i+ib) from the right
         auto V1 = slice(A, range{i + 1, i + nb2 + 1}, range{i, i + nb2});
-        trmm(Side::Right, Uplo::Lower, Op::ConjTrans, Diag::Unit, one, V1, Y_s);
+        trmm(RIGHT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, one, V1, Y_s);
         for (idx_t j = 0; j < nb2 - 1; ++j) {
             auto A4 = slice(A, range{0, i + 1}, i + j + 1);
             axpy(-one, slice(Y, range{0, i + 1}, j), A4);
@@ -199,8 +199,8 @@ int gehrd(size_type<matrix_t> ilo,
 
         // Apply the block reflector H to A(i+1:ihi,i+nb:n) from the left
         auto A5 = slice(A, range{i + 1, ihi}, range{i + nb2, n});
-        larfb(Side::Left, Op::ConjTrans, Direction::Forward, StoreV::Columnwise,
-              V, T_s, A5, larfbOpts);
+        larfb(LEFT_SIDE, CONJ_TRANS, FORWARD, COLUMNWISE_STORAGE, V, T_s, A5,
+              larfbOpts);
     }
 
     gehd2(i, ihi, A, tau, gehd2Opts);

--- a/include/tlapack/lapack/gelq2.hpp
+++ b/include/tlapack/lapack/gelq2.hpp
@@ -122,7 +122,7 @@ int gelq2(matrix_t& A, vector_t& tauw, const WorkspaceOpts<>& opts = {})
         if (j < k - 1 || k < m) {
             // Apply H(j) to A(j+1:m,j:n) from the right
             auto Q11 = slice(A, range(j + 1, m), range(j, n));
-            larf(Side::Right, FORWARD, ROWWISE_STORAGE, w, tauw[j], Q11,
+            larf(RIGHT_SIDE, FORWARD, ROWWISE_STORAGE, w, tauw[j], Q11,
                  larfOpts);
         }
     }

--- a/include/tlapack/lapack/gelqf.hpp
+++ b/include/tlapack/lapack/gelqf.hpp
@@ -62,8 +62,8 @@ inline constexpr WorkInfo gelqf_worksize(
     auto tauw1 = slice(tau, range(0, ib));
 
     WorkInfo workinfo = gelq2_worksize(A11, tauw1);
-    workinfo.minMax(larfb_worksize(Side::Right, Op::NoTrans, Direction::Forward,
-                                   StoreV::Rowwise, A11, TT1, A12));
+    workinfo.minMax(larfb_worksize(RIGHT_SIDE, NO_TRANS, FORWARD,
+                                   ROWWISE_STORAGE, A11, TT1, A12));
 
     workinfo += WorkInfo(sizeof(T) * nb, nb);
 
@@ -150,12 +150,12 @@ int gelqf(A_t& A, tau_t& tau, const GelqfOpts<size_type<A_t>>& opts = {})
             // Form the triangular factor of the block reflector H = H(j)
             // H(j+1) . . . H(j+ib-1)
             auto TT1 = slice(TT, range(0, ib), range(0, ib));
-            larft(Direction::Forward, StoreV::Rowwise, A11, tauw1, TT1);
+            larft(FORWARD, ROWWISE_STORAGE, A11, tauw1, TT1);
 
             // Apply H to A(j+ib:m,j:n) from the right
             auto A12 = slice(A, range(j + ib, m), range(j, n));
-            larfb(Side::Right, Op::NoTrans, Direction::Forward, StoreV::Rowwise,
-                  A11, TT1, A12, larfbOpts);
+            larfb(RIGHT_SIDE, NO_TRANS, FORWARD, ROWWISE_STORAGE, A11, TT1, A12,
+                  larfbOpts);
         }
     }
 

--- a/include/tlapack/lapack/gelqt.hpp
+++ b/include/tlapack/lapack/gelqt.hpp
@@ -146,7 +146,7 @@ int gelqt(matrix_t& A, matrix_t& TT, const GelqtOpts& opts = {})
 
         // Form the triangular factor of the block reflector H = H(j) H(j+1)
         // . . . H(j+ib-1)
-        larft(Direction::Forward, StoreV::Rowwise, A11, tauw1, TT1);
+        larft(FORWARD, ROWWISE_STORAGE, A11, tauw1, TT1);
 
         if (j + ib < k) {
             // Apply H to A(j+ib:m,j:n) from the right
@@ -154,8 +154,8 @@ int gelqt(matrix_t& A, matrix_t& TT, const GelqtOpts& opts = {})
 
             WorkspaceOpts<void> work1(
                 slice(TT, range(j + ib, m), range(0, ib)));
-            larfb(Side::Right, Op::NoTrans, Direction::Forward, StoreV::Rowwise,
-                  A11, TT1, A12, work1);
+            larfb(RIGHT_SIDE, NO_TRANS, FORWARD, ROWWISE_STORAGE, A11, TT1, A12,
+                  work1);
         }
     }
 

--- a/include/tlapack/lapack/geql2.hpp
+++ b/include/tlapack/lapack/geql2.hpp
@@ -43,8 +43,8 @@ inline constexpr WorkInfo geql2_worksize(const matrix_t& A,
 
     if (n > 1) {
         auto C = cols(A, range{1, n});
-        return larf_worksize(Side::Left, Direction::Backward,
-                             StoreV::Columnwise, col(A, 0), tau[0], C, opts);
+        return larf_worksize(LEFT_SIDE, BACKWARD, COLUMNWISE_STORAGE, col(A, 0),
+                             tau[0], C, opts);
     }
 
     return WorkInfo{};
@@ -121,13 +121,13 @@ int geql2(matrix_t& A, vector_t& tau, const WorkspaceOpts<>& opts = {})
         auto v = slice(A, range{0, m - k + i + 1}, n - k + i);
 
         // Generate the (i+1)-th elementary Householder reflection on v
-        larfg(Direction::Backward, StoreV::Columnwise, v, tau[i]);
+        larfg(BACKWARD, COLUMNWISE_STORAGE, v, tau[i]);
 
         // Apply the reflector to the rest of the matrix
         if (n + i > k) {
             auto C = slice(A, range{0, m - k + i + 1}, range{0, n - k + i});
-            larf(Side::Left, Direction::Backward, StoreV::Columnwise, v,
-                 conj(tau[i]), C, larfOpts);
+            larf(LEFT_SIDE, BACKWARD, COLUMNWISE_STORAGE, v, conj(tau[i]), C,
+                 larfOpts);
         }
     }
 

--- a/include/tlapack/lapack/geqlf.hpp
+++ b/include/tlapack/lapack/geqlf.hpp
@@ -62,9 +62,8 @@ inline constexpr WorkInfo geqlf_worksize(
     auto tauw1 = slice(tau, range(0, ib));
 
     WorkInfo workinfo = geql2_worksize(A11, tauw1);
-    workinfo.minMax(larfb_worksize(Side::Left, Op::ConjTrans,
-                                   Direction::Backward, StoreV::Columnwise, A11,
-                                   TT1, A12));
+    workinfo.minMax(larfb_worksize(LEFT_SIDE, CONJ_TRANS, BACKWARD,
+                                   COLUMNWISE_STORAGE, A11, TT1, A12));
 
     workinfo += WorkInfo(sizeof(T) * nb, nb);
 
@@ -151,12 +150,12 @@ int geqlf(A_t& A, tau_t& tau, const GeqlfOpts<size_type<A_t>>& opts = {})
         if (j > ib) {
             // Form the triangular factor of the block reflector
             auto TT1 = slice(TT, range(0, ib), range(0, ib));
-            larft(Direction::Backward, StoreV::Columnwise, A11, tauw1, TT1);
+            larft(BACKWARD, COLUMNWISE_STORAGE, A11, tauw1, TT1);
 
             // Apply H to A(0:m-n+j,0:j-ib) from the left
             auto A12 = slice(A, range(0, m - (n - j)), range(0, j - ib));
-            larfb(Side::Left, Op::ConjTrans, Direction::Backward,
-                  StoreV::Columnwise, A11, TT1, A12, larfbOpts);
+            larfb(LEFT_SIDE, CONJ_TRANS, BACKWARD, COLUMNWISE_STORAGE, A11, TT1,
+                  A12, larfbOpts);
         }
     }
 

--- a/include/tlapack/lapack/geqrf.hpp
+++ b/include/tlapack/lapack/geqrf.hpp
@@ -62,9 +62,8 @@ inline constexpr WorkInfo geqrf_worksize(
     auto tauw1 = slice(tau, range(0, ib));
 
     WorkInfo workinfo = geqr2_worksize(A11, tauw1);
-    workinfo.minMax(larfb_worksize(Side::Left, Op::ConjTrans,
-                                   Direction::Forward, StoreV::Columnwise, A11,
-                                   TT1, A12));
+    workinfo.minMax(larfb_worksize(LEFT_SIDE, CONJ_TRANS, FORWARD,
+                                   COLUMNWISE_STORAGE, A11, TT1, A12));
 
     workinfo += WorkInfo(sizeof(T) * nb, nb);
 
@@ -152,12 +151,12 @@ int geqrf(A_t& A, tau_t& tau, const GeqrfOpts<size_type<A_t>>& opts = {})
             // Form the triangular factor of the block reflector H = H(j)
             // H(j+1) . . . H(j+ib-1)
             auto TT1 = slice(TT, range(0, ib), range(0, ib));
-            larft(Direction::Forward, StoreV::Columnwise, A11, tauw1, TT1);
+            larft(FORWARD, COLUMNWISE_STORAGE, A11, tauw1, TT1);
 
             // Apply H to A(j:m,j+ib:n) from the left
             auto A12 = slice(A, range(j, m), range(j + ib, n));
-            larfb(Side::Left, Op::ConjTrans, Direction::Forward,
-                  StoreV::Columnwise, A11, TT1, A12, larfbOpts);
+            larfb(LEFT_SIDE, CONJ_TRANS, FORWARD, COLUMNWISE_STORAGE, A11, TT1,
+                  A12, larfbOpts);
         }
     }
 

--- a/include/tlapack/lapack/gerq2.hpp
+++ b/include/tlapack/lapack/gerq2.hpp
@@ -43,8 +43,8 @@ inline constexpr WorkInfo gerq2_worksize(const matrix_t& A,
 
     if (n > 1) {
         auto C = cols(A, range{1, n});
-        return larf_worksize(Side::Right, Direction::Backward, StoreV::Rowwise,
-                             col(A, 0), tau[0], C, opts);
+        return larf_worksize(RIGHT_SIDE, BACKWARD, ROWWISE_STORAGE, col(A, 0),
+                             tau[0], C, opts);
     }
 
     return WorkInfo{};
@@ -121,13 +121,12 @@ int gerq2(matrix_t& A, vector_t& tau, const WorkspaceOpts<>& opts = {})
         auto v = slice(A, m - 1 - i2, range{0, n - i2});
 
         // Generate the (i+1)-th elementary Householder reflection on v
-        larfg(Direction::Backward, StoreV::Rowwise, v, tau[i]);
+        larfg(BACKWARD, ROWWISE_STORAGE, v, tau[i]);
 
         // Apply the reflector to the rest of the matrix
         if (m > i2 + 1) {
             auto C = slice(A, range{0, m - 1 - i2}, range{0, n - i2});
-            larf(Side::Right, Direction::Backward, StoreV::Rowwise, v, tau[i],
-                 C, larfOpts);
+            larf(RIGHT_SIDE, BACKWARD, ROWWISE_STORAGE, v, tau[i], C, larfOpts);
         }
     }
 

--- a/include/tlapack/lapack/gerqf.hpp
+++ b/include/tlapack/lapack/gerqf.hpp
@@ -62,9 +62,8 @@ inline constexpr WorkInfo gerqf_worksize(
     auto tauw1 = slice(tau, range(0, ib));
 
     WorkInfo workinfo = gerq2_worksize(A11, tauw1);
-    workinfo.minMax(larfb_worksize(Side::Right, Op::NoTrans,
-                                   Direction::Backward, StoreV::Rowwise, A11,
-                                   TT1, A12));
+    workinfo.minMax(larfb_worksize(RIGHT_SIDE, NO_TRANS, BACKWARD,
+                                   ROWWISE_STORAGE, A11, TT1, A12));
 
     workinfo += WorkInfo(sizeof(T) * nb, nb);
 
@@ -154,12 +153,12 @@ int gerqf(A_t& A, tau_t& tau, const GerqfOpts<size_type<A_t>>& opts = {})
         if (j > 0) {
             // Form the triangular factor of the block reflector
             auto TT1 = slice(TT, range(0, ib), range(0, ib));
-            larft(Direction::Backward, StoreV::Rowwise, A11, tauw1, TT1);
+            larft(BACKWARD, ROWWISE_STORAGE, A11, tauw1, TT1);
 
             // Apply H to A(0:j,0:n-j2) from the right
             auto A12 = slice(A, range(0, j), range(0, n - j2));
-            larfb(Side::Right, Op::NoTrans, Direction::Backward,
-                  StoreV::Rowwise, A11, TT1, A12, larfbOpts);
+            larfb(RIGHT_SIDE, NO_TRANS, BACKWARD, ROWWISE_STORAGE, A11, TT1,
+                  A12, larfbOpts);
         }
     }
 

--- a/include/tlapack/lapack/getrf_recursive.hpp
+++ b/include/tlapack/lapack/getrf_recursive.hpp
@@ -136,7 +136,7 @@ int getrf_recursive(matrix_t& A, piv_t& piv)
         }
 
         // Solve triangular system A0 X = A1 and update A1
-        trsm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, T(1), A0, A1);
+        trsm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, T(1), A0, A1);
 
         return 0;
     }
@@ -174,10 +174,10 @@ int getrf_recursive(matrix_t& A, piv_t& piv)
         auto piv1 = tlapack::slice(piv, range(k0, k));
 
         // Solve the triangular system of equations given by A00 X = A01
-        trsm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, T(1), A00, A01);
+        trsm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, T(1), A00, A01);
 
         // A11 <---- A11 - (A10 * A01)
-        gemm(Op::NoTrans, Op::NoTrans, real_t(-1), A10, A01, real_t(1), A11);
+        gemm(NO_TRANS, NO_TRANS, real_t(-1), A10, A01, real_t(1), A11);
 
         // Finding LU factorization of A11 in place
         info = getrf_recursive(A11, piv1);

--- a/include/tlapack/lapack/getri_uili.hpp
+++ b/include/tlapack/lapack/getri_uili.hpp
@@ -42,11 +42,11 @@ int getri_uili(matrix_t& A)
     tlapack_check(nrows(A) == ncols(A));
 
     // Invert the upper part of A; U
-    int info = trtri_recursive(Uplo::Upper, Diag::NonUnit, A);
+    int info = trtri_recursive(UPPER_TRIANGLE, NON_UNIT_DIAG, A);
     if (info != 0) return info;
 
     // Invert the lower part of A; L which has 1 on the diagonal
-    trtri_recursive(Uplo::Lower, Diag::Unit, A);
+    trtri_recursive(LOWER_TRIANGLE, UNIT_DIAG, A);
 
     // multiply U^{-1} and L^{-1} in place using ul_mult
     ul_mult(A);

--- a/include/tlapack/lapack/getri_uxli.hpp
+++ b/include/tlapack/lapack/getri_uxli.hpp
@@ -99,7 +99,7 @@ int getri_uxli(matrix_t& A, const WorkspaceOpts<>& opts = {})
             auto slicework = tlapack::slice(w, range(0, n - j - 1));
 
             // first step of the algorithm, work1 holds x12
-            tlapack::gemv(Op::Trans, T(-1) / A(j, j), X22, u12, slicework);
+            tlapack::gemv(TRANSPOSE, T(-1) / A(j, j), X22, u12, slicework);
 
             // second line of the algorithm, work2 holds x21
             A(j, j) = (T(1) / A(j, j)) - tlapack::dotu(l21, slicework);
@@ -108,7 +108,7 @@ int getri_uxli(matrix_t& A, const WorkspaceOpts<>& opts = {})
             tlapack::copy(slicework, u12);
 
             // third line of the algorithm
-            tlapack::gemv(Op::NoTrans, T(-1), X22, l21, slicework);
+            tlapack::gemv(NO_TRANS, T(-1), X22, l21, slicework);
 
             // update l21
             tlapack::copy(slicework, l21);

--- a/include/tlapack/lapack/larf.hpp
+++ b/include/tlapack/lapack/larf.hpp
@@ -187,7 +187,7 @@ void larf(side_t side,
             // w := C0^H + C1^H*x
             for (idx_t i = 0; i < k; ++i)
                 w[i] = conj(C0[i]);
-            gemv(Op::ConjTrans, one, C1, x, one, w);
+            gemv(CONJ_TRANS, one, C1, x, one, w);
 
             // C1 := C1 - tau*x*w^H
             ger(-tau, x, w, C1);
@@ -200,7 +200,7 @@ void larf(side_t side,
             // w := C0^t + C1^t*x
             for (idx_t i = 0; i < k; ++i)
                 w[i] = C0[i];
-            gemv(Op::Trans, one, C1, x, one, w);
+            gemv(TRANSPOSE, one, C1, x, one, w);
 
             // C1 := C1 - tau*conj(x)*w^t
             for (idx_t j = 0; j < n; ++j)
@@ -217,7 +217,7 @@ void larf(side_t side,
             // w := C0 + C1*x
             for (idx_t i = 0; i < k; ++i)
                 w[i] = C0[i];
-            gemv(Op::NoTrans, one, C1, x, one, w);
+            gemv(NO_TRANS, one, C1, x, one, w);
 
             // C1 := C1 - tau*w*x^H
             ger(-tau, w, x, C1);
@@ -377,11 +377,11 @@ inline void larf(side_t side,
     // The following code was changed from:
     //
     // if( side == Side::Left ) {
-    //     gemv(Op::ConjTrans, one, C, v, work);
+    //     gemv(CONJ_TRANS, one, C, v, work);
     //     ger(-tau, v, work, C);
     // }
     // else{
-    //     gemv(Op::NoTrans, one, C, v, work);
+    //     gemv(NO_TRANS, one, C, v, work);
     //     ger(-tau, work, v, C);
     // }
     //
@@ -394,7 +394,7 @@ inline void larf(side_t side,
                                                     : rows(C, range{0, m - 1});
         auto x = (direction == Direction::Forward) ? slice(v, range{1, m})
                                                    : slice(v, range{0, m - 1});
-        larf(side, storeMode, x, tau, C0, C1, opts);
+        larf(LEFT_SIDE, storeMode, x, tau, C0, C1, opts);
     }
     else {  // side == Side::Right
         auto C0 = (direction == Direction::Forward) ? col(C, 0) : col(C, n - 1);
@@ -402,7 +402,7 @@ inline void larf(side_t side,
                                                     : cols(C, range{0, n - 1});
         auto x = (direction == Direction::Forward) ? slice(v, range{1, n})
                                                    : slice(v, range{0, n - 1});
-        larf(side, storeMode, x, tau, C0, C1, opts);
+        larf(RIGHT_SIDE, storeMode, x, tau, C0, C1, opts);
     }
 }
 

--- a/include/tlapack/lapack/larfb.hpp
+++ b/include/tlapack/lapack/larfb.hpp
@@ -268,17 +268,20 @@ int larfb(side_t side,
                 // W := C1
                 lacpy(GENERAL, C1, W);
                 // W := V1^H W
-                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, one, V1, W);
+                trmm(LEFT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, one, V1,
+                     W);
                 if (m > k)
                     // W := W + V2^H C2
-                    gemm(Op::ConjTrans, Op::NoTrans, one, V2, C2, one, W);
+                    gemm(CONJ_TRANS, NO_TRANS, one, V2, C2, one, W);
                 // W := op(Tmatrix) W
-                trmm(side, Uplo::Upper, trans, Diag::NonUnit, one, Tmatrix, W);
+                trmm(LEFT_SIDE, UPPER_TRIANGLE, trans, NON_UNIT_DIAG, one,
+                     Tmatrix, W);
                 if (m > k)
                     // C2 := C2 - V2 W
-                    gemm(Op::NoTrans, Op::NoTrans, -one, V2, W, one, C2);
+                    gemm(NO_TRANS, NO_TRANS, -one, V2, W, one, C2);
                 // W := - V1 W
-                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, -one, V1, W);
+                trmm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, -one, V1,
+                     W);
 
                 // C1 := C1 + W
                 for (idx_t j = 0; j < n; ++j)
@@ -299,18 +302,20 @@ int larfb(side_t side,
                 // W := C1
                 lacpy(GENERAL, C1, W);
                 // W := W V1
-                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, one, V1, W);
+                trmm(RIGHT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, one, V1,
+                     W);
                 if (n > k)
                     // W := W + C2 V2
-                    gemm(Op::NoTrans, Op::NoTrans, one, C2, V2, one, W);
+                    gemm(NO_TRANS, NO_TRANS, one, C2, V2, one, W);
                 // W := W op(Tmatrix)
-                trmm(Side::Right, Uplo::Upper, trans, Diag::NonUnit, one,
+                trmm(RIGHT_SIDE, UPPER_TRIANGLE, trans, NON_UNIT_DIAG, one,
                      Tmatrix, W);
                 if (n > k)
                     // C2 := C2 - W V2^H
-                    gemm(Op::NoTrans, Op::ConjTrans, -one, W, V2, one, C2);
+                    gemm(NO_TRANS, CONJ_TRANS, -one, W, V2, one, C2);
                 // W := - W V1^H
-                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, -one, V1, W);
+                trmm(RIGHT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, -one,
+                     V1, W);
 
                 // C1 := C1 + W
                 for (idx_t j = 0; j < k; ++j)
@@ -333,17 +338,20 @@ int larfb(side_t side,
                 // W := C2
                 lacpy(GENERAL, C2, W);
                 // W := V2^H W
-                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, one, V2, W);
+                trmm(LEFT_SIDE, UPPER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, one, V2,
+                     W);
                 if (m > k)
                     // W := W + V1^H C1
-                    gemm(Op::ConjTrans, Op::NoTrans, one, V1, C1, one, W);
+                    gemm(CONJ_TRANS, NO_TRANS, one, V1, C1, one, W);
                 // W := op(Tmatrix) W
-                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                trmm(LEFT_SIDE, LOWER_TRIANGLE, trans, NON_UNIT_DIAG, one,
+                     Tmatrix, W);
                 if (m > k)
                     // C1 := C1 - V1 W
-                    gemm(Op::NoTrans, Op::NoTrans, -one, V1, W, one, C1);
+                    gemm(NO_TRANS, NO_TRANS, -one, V1, W, one, C1);
                 // W := - V2 W
-                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, -one, V2, W);
+                trmm(LEFT_SIDE, UPPER_TRIANGLE, NO_TRANS, UNIT_DIAG, -one, V2,
+                     W);
 
                 // C2 := C2 + W
                 for (idx_t j = 0; j < n; ++j)
@@ -364,17 +372,20 @@ int larfb(side_t side,
                 // W := C2
                 lacpy(GENERAL, C2, W);
                 // W := W V2
-                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, one, V2, W);
+                trmm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS, UNIT_DIAG, one, V2,
+                     W);
                 if (n > k)
                     // W := W + C1 V1
-                    gemm(Op::NoTrans, Op::NoTrans, one, C1, V1, one, W);
+                    gemm(NO_TRANS, NO_TRANS, one, C1, V1, one, W);
                 // W := W op(Tmatrix)
-                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                trmm(RIGHT_SIDE, LOWER_TRIANGLE, trans, NON_UNIT_DIAG, one,
+                     Tmatrix, W);
                 if (n > k)
                     // C1 := C1 - W V1^H
-                    gemm(Op::NoTrans, Op::ConjTrans, -one, W, V1, one, C1);
+                    gemm(NO_TRANS, CONJ_TRANS, -one, W, V1, one, C1);
                 // W := - W V2^H
-                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, -one, V2, W);
+                trmm(RIGHT_SIDE, UPPER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, -one,
+                     V2, W);
 
                 // C2 := C2 + W
                 for (idx_t j = 0; j < k; ++j)
@@ -399,17 +410,20 @@ int larfb(side_t side,
                 // W := C1
                 lacpy(GENERAL, C1, W);
                 // W := V1 W
-                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, one, V1, W);
+                trmm(LEFT_SIDE, UPPER_TRIANGLE, NO_TRANS, UNIT_DIAG, one, V1,
+                     W);
                 if (m > k)
                     // W := W + V2 C2
-                    gemm(Op::NoTrans, Op::NoTrans, one, V2, C2, one, W);
+                    gemm(NO_TRANS, NO_TRANS, one, V2, C2, one, W);
                 // W := op(Tmatrix) W
-                trmm(side, Uplo::Upper, trans, Diag::NonUnit, one, Tmatrix, W);
+                trmm(LEFT_SIDE, UPPER_TRIANGLE, trans, NON_UNIT_DIAG, one,
+                     Tmatrix, W);
                 if (m > k)
                     // C2 := C2 - V2^H W
-                    gemm(Op::ConjTrans, Op::NoTrans, -one, V2, W, one, C2);
+                    gemm(CONJ_TRANS, NO_TRANS, -one, V2, W, one, C2);
                 // W := - V1^H W
-                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, -one, V1, W);
+                trmm(LEFT_SIDE, UPPER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, -one, V1,
+                     W);
 
                 // C1 := C1 - W
                 for (idx_t j = 0; j < n; ++j)
@@ -430,17 +444,20 @@ int larfb(side_t side,
                 // W := C1
                 lacpy(GENERAL, C1, W);
                 // W := W V1^H
-                trmm(side, Uplo::Upper, Op::ConjTrans, Diag::Unit, one, V1, W);
+                trmm(RIGHT_SIDE, UPPER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, one, V1,
+                     W);
                 if (n > k)
                     // W := W + C2 V2^H
-                    gemm(Op::NoTrans, Op::ConjTrans, one, C2, V2, one, W);
+                    gemm(NO_TRANS, CONJ_TRANS, one, C2, V2, one, W);
                 // W := W op(Tmatrix)
-                trmm(side, Uplo::Upper, trans, Diag::NonUnit, one, Tmatrix, W);
+                trmm(RIGHT_SIDE, UPPER_TRIANGLE, trans, NON_UNIT_DIAG, one,
+                     Tmatrix, W);
                 if (n > k)
                     // C2 := C2 - W V2
-                    gemm(Op::NoTrans, Op::NoTrans, -one, W, V2, one, C2);
+                    gemm(NO_TRANS, NO_TRANS, -one, W, V2, one, C2);
                 // W := - W V1
-                trmm(side, Uplo::Upper, Op::NoTrans, Diag::Unit, -one, V1, W);
+                trmm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS, UNIT_DIAG, -one, V1,
+                     W);
 
                 // C1 := C1 + W
                 for (idx_t j = 0; j < k; ++j)
@@ -463,17 +480,20 @@ int larfb(side_t side,
                 // W := C2
                 lacpy(GENERAL, C2, W);
                 // W := V2 W
-                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, one, V2, W);
+                trmm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, one, V2,
+                     W);
                 if (m > k)
                     // W := W + V1 C1
-                    gemm(Op::NoTrans, Op::NoTrans, one, V1, C1, one, W);
+                    gemm(NO_TRANS, NO_TRANS, one, V1, C1, one, W);
                 // W := op(Tmatrix) W
-                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                trmm(LEFT_SIDE, LOWER_TRIANGLE, trans, NON_UNIT_DIAG, one,
+                     Tmatrix, W);
                 if (m > k)
                     // C1 := C1 - V1^H W
-                    gemm(Op::ConjTrans, Op::NoTrans, -one, V1, W, one, C1);
+                    gemm(CONJ_TRANS, NO_TRANS, -one, V1, W, one, C1);
                 // W := - V2^H W
-                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, -one, V2, W);
+                trmm(LEFT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, -one, V2,
+                     W);
 
                 // C2 := C2 + W
                 for (idx_t j = 0; j < n; ++j)
@@ -494,17 +514,20 @@ int larfb(side_t side,
                 // W := C2
                 lacpy(GENERAL, C2, W);
                 // W := W V2^H
-                trmm(side, Uplo::Lower, Op::ConjTrans, Diag::Unit, one, V2, W);
+                trmm(RIGHT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, UNIT_DIAG, one, V2,
+                     W);
                 if (n > k)
                     // W := W + C1 V1^H
-                    gemm(Op::NoTrans, Op::ConjTrans, one, C1, V1, one, W);
+                    gemm(NO_TRANS, CONJ_TRANS, one, C1, V1, one, W);
                 // W := W op(Tmatrix)
-                trmm(side, Uplo::Lower, trans, Diag::NonUnit, one, Tmatrix, W);
+                trmm(RIGHT_SIDE, LOWER_TRIANGLE, trans, NON_UNIT_DIAG, one,
+                     Tmatrix, W);
                 if (n > k)
                     // C1 := C1 - W V1
-                    gemm(Op::NoTrans, Op::NoTrans, -one, W, V1, one, C1);
+                    gemm(NO_TRANS, NO_TRANS, -one, W, V1, one, C1);
                 // W := - W V2
-                trmm(side, Uplo::Lower, Op::NoTrans, Diag::Unit, -one, V2, W);
+                trmm(RIGHT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, -one, V2,
+                     W);
 
                 // C2 := C2 + W
                 for (idx_t j = 0; j < k; ++j)

--- a/include/tlapack/lapack/lauum_recursive.hpp
+++ b/include/tlapack/lapack/lauum_recursive.hpp
@@ -77,8 +77,8 @@ int lauum_recursive(const Uplo& uplo, matrix_t& C)
             auto C11 = slice(C, range(n0, n), range(n0, n));
 
             lauum_recursive(uplo, C00);
-            herk(Uplo::Lower, Op::ConjTrans, real_t(1), C10, real_t(1), C00);
-            trmm(Side::Left, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1), C11,
+            herk(LOWER_TRIANGLE, CONJ_TRANS, real_t(1), C10, real_t(1), C00);
+            trmm(LEFT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, real_t(1), C11,
                  C10);
             lauum_recursive(uplo, C11);
         }
@@ -89,10 +89,10 @@ int lauum_recursive(const Uplo& uplo, matrix_t& C)
             auto C11 = slice(C, range(n0, n), range(n0, n));
 
             lauum_recursive(uplo, C00);
-            herk(Uplo::Upper, Op::NoTrans, real_t(1), C01, real_t(1), C00);
-            trmm(Side::Right, uplo, Op::ConjTrans, Diag::NonUnit, real_t(1),
-                 C11, C01);
-            lauum_recursive(Uplo::Upper, C11);
+            herk(UPPER_TRIANGLE, NO_TRANS, real_t(1), C01, real_t(1), C00);
+            trmm(RIGHT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, real_t(1), C11,
+                 C01);
+            lauum_recursive(UPPER_TRIANGLE, C11);
         }
     }
 

--- a/include/tlapack/lapack/lu_mult.hpp
+++ b/include/tlapack/lapack/lu_mult.hpp
@@ -92,13 +92,13 @@ void lu_mult(matrix_t& A, const LuMultOpts<size_type<matrix_t>>& opts = {})
     lu_mult(A11, opts);
 
     // A11 = A10*A01 + L11*U11
-    gemm(Op::NoTrans, Op::NoTrans, T(1), A10, A01, T(1), A11);
+    gemm(NO_TRANS, NO_TRANS, T(1), A10, A01, T(1), A11);
 
     // A01 = L00*A01
-    trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, real_t(1), A00, A01);
+    trmm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, real_t(1), A00, A01);
 
     // A10 = A10*U00
-    trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, real_t(1), A00,
+    trmm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, real_t(1), A00,
          A10);
 
     // A00 = L00*U00

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -177,7 +177,7 @@ void multishift_QR_sweep(bool want_t,
         idx_t istart_m = ilo;
         idx_t istop_m = ilo + n_block;
         auto U2 = slice(U, range{0, n_block}, range{0, n_block});
-        laset(Uplo::General, zero, one, U2);
+        laset(GENERAL, zero, one, U2);
 
         for (idx_t i_pos_last = ilo; i_pos_last < ilo + n_block - 2;
              ++i_pos_last) {
@@ -341,8 +341,8 @@ void multishift_QR_sweep(bool want_t,
                     slice(A, range{ilo, ilo + n_block}, range{i, i + iblock});
                 auto WH_slice = slice(WH, range{0, nrows(A_slice)},
                                       range{0, ncols(A_slice)});
-                gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
-                lacpy(Uplo::General, WH_slice, A_slice);
+                gemm(CONJ_TRANS, NO_TRANS, one, U2, A_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, A_slice);
                 i = i + iblock;
             }
         }
@@ -355,8 +355,8 @@ void multishift_QR_sweep(bool want_t,
                     slice(A, range{i, i + iblock}, range{ilo, ilo + n_block});
                 auto WV_slice = slice(WV, range{0, nrows(A_slice)},
                                       range{0, ncols(A_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
-                lacpy(Uplo::General, WV_slice, A_slice);
+                gemm(NO_TRANS, NO_TRANS, one, A_slice, U2, WV_slice);
+                lacpy(GENERAL, WV_slice, A_slice);
                 i = i + iblock;
             }
         }
@@ -369,8 +369,8 @@ void multishift_QR_sweep(bool want_t,
                     slice(Z, range{i, i + iblock}, range{ilo, ilo + n_block});
                 auto WV_slice = slice(WV, range{0, nrows(Z_slice)},
                                       range{0, ncols(Z_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
-                lacpy(Uplo::General, WV_slice, Z_slice);
+                gemm(NO_TRANS, NO_TRANS, one, Z_slice, U2, WV_slice);
+                lacpy(GENERAL, WV_slice, Z_slice);
                 i = i + iblock;
             }
         }
@@ -390,7 +390,7 @@ void multishift_QR_sweep(bool want_t,
         idx_t n_block = n_shifts + n_pos;
 
         auto U2 = slice(U, range{0, n_block}, range{0, n_block});
-        laset(Uplo::General, zero, one, U2);
+        laset(GENERAL, zero, one, U2);
 
         // Near-the-diagonal bulge chase
         // The calculations are initially limited to the window:
@@ -554,8 +554,8 @@ void multishift_QR_sweep(bool want_t,
                           range{i, i + iblock});
                 auto WH_slice = slice(WH, range{0, nrows(A_slice)},
                                       range{0, ncols(A_slice)});
-                gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
-                lacpy(Uplo::General, WH_slice, A_slice);
+                gemm(CONJ_TRANS, NO_TRANS, one, U2, A_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, A_slice);
                 i = i + iblock;
             }
         }
@@ -568,8 +568,8 @@ void multishift_QR_sweep(bool want_t,
                                      range{i_pos_block, i_pos_block + n_block});
                 auto WV_slice = slice(WV, range{0, nrows(A_slice)},
                                       range{0, ncols(A_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
-                lacpy(Uplo::General, WV_slice, A_slice);
+                gemm(NO_TRANS, NO_TRANS, one, A_slice, U2, WV_slice);
+                lacpy(GENERAL, WV_slice, A_slice);
                 i = i + iblock;
             }
         }
@@ -582,8 +582,8 @@ void multishift_QR_sweep(bool want_t,
                                      range{i_pos_block, i_pos_block + n_block});
                 auto WV_slice = slice(WV, range{0, nrows(Z_slice)},
                                       range{0, ncols(Z_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
-                lacpy(Uplo::General, WV_slice, Z_slice);
+                gemm(NO_TRANS, NO_TRANS, one, Z_slice, U2, WV_slice);
+                lacpy(GENERAL, WV_slice, Z_slice);
                 i = i + iblock;
             }
         }
@@ -598,7 +598,7 @@ void multishift_QR_sweep(bool want_t,
         idx_t n_block = ihi - i_pos_block;
 
         auto U2 = slice(U, range{0, n_block}, range{0, n_block});
-        laset(Uplo::General, zero, one, U2);
+        laset(GENERAL, zero, one, U2);
 
         // Near-the-diagonal bulge chase
         // The calculations are initially limited to the window:
@@ -813,8 +813,8 @@ void multishift_QR_sweep(bool want_t,
                     slice(A, range{i_pos_block, ihi}, range{i, i + iblock});
                 auto WH_slice = slice(WH, range{0, nrows(A_slice)},
                                       range{0, ncols(A_slice)});
-                gemm(Op::ConjTrans, Op::NoTrans, one, U2, A_slice, WH_slice);
-                lacpy(Uplo::General, WH_slice, A_slice);
+                gemm(CONJ_TRANS, NO_TRANS, one, U2, A_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, A_slice);
                 i = i + iblock;
             }
         }
@@ -827,8 +827,8 @@ void multishift_QR_sweep(bool want_t,
                     slice(A, range{i, i + iblock}, range{i_pos_block, ihi});
                 auto WV_slice = slice(WV, range{0, nrows(A_slice)},
                                       range{0, ncols(A_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, A_slice, U2, WV_slice);
-                lacpy(Uplo::General, WV_slice, A_slice);
+                gemm(NO_TRANS, NO_TRANS, one, A_slice, U2, WV_slice);
+                lacpy(GENERAL, WV_slice, A_slice);
                 i = i + iblock;
             }
         }
@@ -841,8 +841,8 @@ void multishift_QR_sweep(bool want_t,
                     slice(Z, range{i, i + iblock}, range{i_pos_block, ihi});
                 auto WV_slice = slice(WV, range{0, nrows(Z_slice)},
                                       range{0, ncols(Z_slice)});
-                gemm(Op::NoTrans, Op::NoTrans, one, Z_slice, U2, WV_slice);
-                lacpy(Uplo::General, WV_slice, Z_slice);
+                gemm(NO_TRANS, NO_TRANS, one, Z_slice, U2, WV_slice);
+                lacpy(GENERAL, WV_slice, Z_slice);
                 i = i + iblock;
             }
         }

--- a/include/tlapack/lapack/potrf2.hpp
+++ b/include/tlapack/lapack/potrf2.hpp
@@ -127,20 +127,20 @@ int potrf2(uplo_t uplo, matrix_t& A, const EcOpts& opts = {})
         if (uplo == Uplo::Upper) {
             // Update and scale A12
             auto A12 = slice(A, range{0, n1}, range{n1, n});
-            trsm(Side::Left, Uplo::Upper, Op::ConjTrans, Diag::NonUnit, one,
-                 A11, A12);
+            trsm(LEFT_SIDE, Uplo::Upper, CONJ_TRANS, NON_UNIT_DIAG, one, A11,
+                 A12);
 
             // Update A22
-            herk(uplo, Op::ConjTrans, -one, A12, one, A22);
+            herk(UPPER_TRIANGLE, CONJ_TRANS, -one, A12, one, A22);
         }
         else {
             // Update and scale A21
             auto A21 = slice(A, range{n1, n}, range{0, n1});
-            trsm(Side::Right, Uplo::Lower, Op::ConjTrans, Diag::NonUnit, one,
-                 A11, A21);
+            trsm(RIGHT_SIDE, Uplo::Lower, CONJ_TRANS, NON_UNIT_DIAG, one, A11,
+                 A21);
 
             // Update A22
-            herk(uplo, Op::NoTrans, -one, A21, one, A22);
+            herk(LOWER_TRIANGLE, NO_TRANS, -one, A21, one, A22);
         }
 
         // Factor A22

--- a/include/tlapack/lapack/potrf_blocked.hpp
+++ b/include/tlapack/lapack/potrf_blocked.hpp
@@ -100,9 +100,9 @@ int potrf_blocked(uplo_t uplo,
                 auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
                 auto A1J = slice(A, range{0, j}, range{j, j + jb});
 
-                herk(uplo, CONJ_TRANS, -one, A1J, one, AJJ);
+                herk(UPPER_TRIANGLE, CONJ_TRANS, -one, A1J, one, AJJ);
 
-                int info = potf2(uplo, AJJ);
+                int info = potf2(UPPER_TRIANGLE, AJJ);
                 if (info != 0) {
                     tlapack_error(
                         info + j,
@@ -119,8 +119,8 @@ int potrf_blocked(uplo_t uplo,
 
                     // Compute the current block row
                     gemm(CONJ_TRANS, NO_TRANS, -one, A1J, B, one, C);
-                    trsm(LEFT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, one, AJJ,
-                         C);
+                    trsm(LEFT_SIDE, UPPER_TRIANGLE, CONJ_TRANS, NON_UNIT_DIAG,
+                         one, AJJ, C);
                 }
             }
         }
@@ -132,9 +132,9 @@ int potrf_blocked(uplo_t uplo,
                 auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
                 auto AJ1 = slice(A, range{j, j + jb}, range{0, j});
 
-                herk(uplo, NO_TRANS, -one, AJ1, one, AJJ);
+                herk(LOWER_TRIANGLE, NO_TRANS, -one, AJ1, one, AJJ);
 
-                int info = potf2(uplo, AJJ);
+                int info = potf2(LOWER_TRIANGLE, AJJ);
                 if (info != 0) {
                     tlapack_error(
                         info + j,
@@ -151,8 +151,8 @@ int potrf_blocked(uplo_t uplo,
 
                     // Compute the current block row
                     gemm(NO_TRANS, CONJ_TRANS, -one, B, AJ1, one, C);
-                    trsm(RIGHT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, one, AJJ,
-                         C);
+                    trsm(RIGHT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, NON_UNIT_DIAG,
+                         one, AJJ, C);
                 }
             }
         }

--- a/include/tlapack/lapack/potrf_blocked_right_looking.hpp
+++ b/include/tlapack/lapack/potrf_blocked_right_looking.hpp
@@ -93,7 +93,7 @@ int potrf_rl(uplo_t uplo,
                 // Define AJJ
                 auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
 
-                int info = potf2(uplo, AJJ);
+                int info = potf2(UPPER_TRIANGLE, AJJ);
                 if (info != 0) {
                     tlapack_error(
                         info + j,
@@ -107,9 +107,9 @@ int potrf_rl(uplo_t uplo,
                     auto B = slice(A, range{j, j + jb}, range{j + jb, n});
                     auto C = slice(A, range{j + jb, n}, range{j + jb, n});
 
-                    trsm(LEFT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, one, AJJ,
-                         B);
-                    herk(uplo, CONJ_TRANS, -one, B, one, C);
+                    trsm(LEFT_SIDE, UPPER_TRIANGLE, CONJ_TRANS, NON_UNIT_DIAG,
+                         one, AJJ, B);
+                    herk(UPPER_TRIANGLE, CONJ_TRANS, -one, B, one, C);
                 }
             }
         }
@@ -120,7 +120,7 @@ int potrf_rl(uplo_t uplo,
                 // Define AJJ
                 auto AJJ = slice(A, range{j, j + jb}, range{j, j + jb});
 
-                int info = potf2(uplo, AJJ);
+                int info = potf2(LOWER_TRIANGLE, AJJ);
                 if (info != 0) {
                     tlapack_error(
                         info + j,
@@ -134,9 +134,9 @@ int potrf_rl(uplo_t uplo,
                     auto B = slice(A, range{j + jb, n}, range{j, j + jb});
                     auto C = slice(A, range{j + jb, n}, range{j + jb, n});
 
-                    trsm(RIGHT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, one, AJJ,
-                         B);
-                    herk(uplo, NO_TRANS, -one, B, one, C);
+                    trsm(RIGHT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, NON_UNIT_DIAG,
+                         one, AJJ, B);
+                    herk(LOWER_TRIANGLE, NO_TRANS, -one, B, one, C);
                 }
             }
         }

--- a/include/tlapack/lapack/potrs.hpp
+++ b/include/tlapack/lapack/potrs.hpp
@@ -68,13 +68,13 @@ int potrs(uplo_t uplo, const matrixA_t& A, matrixB_t& B)
 
     if (uplo == Uplo::Upper) {
         // Solve A*X = B where A = U**H *U.
-        trsm(LEFT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, one, A, B);
-        trsm(LEFT_SIDE, uplo, NO_TRANS, NON_UNIT_DIAG, one, A, B);
+        trsm(LEFT_SIDE, UPPER_TRIANGLE, CONJ_TRANS, NON_UNIT_DIAG, one, A, B);
+        trsm(LEFT_SIDE, UPPER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, one, A, B);
     }
     else {
         // Solve A*X = B where A = L*L**H.
-        trsm(LEFT_SIDE, uplo, NO_TRANS, NON_UNIT_DIAG, one, A, B);
-        trsm(LEFT_SIDE, uplo, CONJ_TRANS, NON_UNIT_DIAG, one, A, B);
+        trsm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, one, A, B);
+        trsm(LEFT_SIDE, LOWER_TRIANGLE, CONJ_TRANS, NON_UNIT_DIAG, one, A, B);
     }
     return 0;
 }

--- a/include/tlapack/lapack/schur_swap.hpp
+++ b/include/tlapack/lapack/schur_swap.hpp
@@ -269,8 +269,8 @@ int schur_swap(bool want_q,
         auto D = new_matrix(D_, 4, 4);
 
         auto AD_slice = slice(A, range{j0, j0 + 4}, range{j0, j0 + 4});
-        lacpy(Uplo::General, AD_slice, D);
-        auto dnorm = lange(Norm::Max, D);
+        lacpy(GENERAL, AD_slice, D);
+        auto dnorm = lange(MAX_NORM, D);
 
         const T eps = ulp<T>();
         const T small_num = safe_min<T>() / eps;
@@ -284,7 +284,7 @@ int schur_swap(bool want_q,
         auto TR = slice(D, range{2, 4}, range{2, 4});
         auto B = slice(D, range{0, 2}, range{2, 4});
         T scale, xnorm;
-        lasy2(Op::NoTrans, Op::NoTrans, -1, TL, TR, B, scale, X, xnorm);
+        lasy2(NO_TRANS, NO_TRANS, -1, TL, TR, B, scale, X, xnorm);
 
         V(2, 0) = -scale;
         V(2, 1) = zero;

--- a/include/tlapack/lapack/trtri_recursive.hpp
+++ b/include/tlapack/lapack/trtri_recursive.hpp
@@ -91,9 +91,9 @@ int trtri_recursive(uplo_t uplo,
             auto C10 = slice(C, range(n0, n), range(0, n0));
             auto C11 = slice(C, range(n0, n), range(n0, n));
 
-            trsm(Side::Right, Uplo::Lower, Op::NoTrans, diag, T(-1), C00, C10);
-            trsm(Side::Left, Uplo::Lower, Op::NoTrans, diag, T(+1), C11, C10);
-            int info = trtri_recursive(Uplo::Lower, diag, C00, opts);
+            trsm(RIGHT_SIDE, LOWER_TRIANGLE, NO_TRANS, diag, T(-1), C00, C10);
+            trsm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, diag, T(+1), C11, C10);
+            int info = trtri_recursive(LOWER_TRIANGLE, diag, C00, opts);
 
             if (info != 0) {
                 tlapack_error_internal(opts.ec, info,
@@ -101,7 +101,7 @@ int trtri_recursive(uplo_t uplo,
                                        "matrix is exactly zero.");
                 return info;
             }
-            info = trtri_recursive(Uplo::Lower, diag, C11, opts);
+            info = trtri_recursive(LOWER_TRIANGLE, diag, C11, opts);
             if (info == 0)
                 return 0;
             else {
@@ -113,27 +113,27 @@ int trtri_recursive(uplo_t uplo,
 
             // there are two variants, the code below also works
 
-            // trtri_recursive( Uplo::Lower, C00);
-            // trtri_recursive( Uplo::Lower, C11);
-            // trmm(Side::Right, Uplo::Lower, Op::NoTrans, Diag::NonUnit, T(-1),
-            // C00, C10); trmm(Side::Left, Uplo::Lower, Op::NoTrans,
-            // Diag::NonUnit, T(+1), C11, C10);
+            // trtri_recursive( LOWER_TRIANGLE, C00);
+            // trtri_recursive( LOWER_TRIANGLE, C11);
+            // trmm(RIGHT_SIDE, LOWER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, T(-1),
+            // C00, C10); trmm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS,
+            // NON_UNIT_DIAG, T(+1), C11, C10);
         }
         else {
             auto C00 = slice(C, range(0, n0), range(0, n0));
             auto C01 = slice(C, range(0, n0), range(n0, n));
             auto C11 = slice(C, range(n0, n), range(n0, n));
 
-            trsm(Side::Left, Uplo::Upper, Op::NoTrans, diag, T(-1), C00, C01);
-            trsm(Side::Right, Uplo::Upper, Op::NoTrans, diag, T(+1), C11, C01);
-            int info = trtri_recursive(Uplo::Upper, diag, C00, opts);
+            trsm(LEFT_SIDE, UPPER_TRIANGLE, NO_TRANS, diag, T(-1), C00, C01);
+            trsm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS, diag, T(+1), C11, C01);
+            int info = trtri_recursive(UPPER_TRIANGLE, diag, C00, opts);
             if (info != 0) {
                 tlapack_error_internal(opts.ec, info,
                                        "A diagonal of entry of triangular "
                                        "matrix is exactly zero.");
                 return info;
             }
-            info = trtri_recursive(Uplo::Upper, diag, C11, opts);
+            info = trtri_recursive(UPPER_TRIANGLE, diag, C11, opts);
             if (info == 0)
                 return 0;
             else {
@@ -147,9 +147,9 @@ int trtri_recursive(uplo_t uplo,
 
             // trtri_recursive( C00, Uplo::Upper);
             // trtri_recursive( C11, Uplo::Upper);
-            // trmm(Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(-1),
-            // C00, C01); trmm(Side::Right, Uplo::Upper, Op::NoTrans,
-            // Diag::NonUnit, T(+1), C11, C01);
+            // trmm(LEFT_SIDE, UPPER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, T(-1),
+            // C00, C01); trmm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS,
+            // NON_UNIT_DIAG, T(+1), C11, C01);
         }
     }
 }

--- a/include/tlapack/lapack/ul_mult.hpp
+++ b/include/tlapack/lapack/ul_mult.hpp
@@ -57,14 +57,14 @@ int ul_mult(matrix_t& A)
 
     // calculate top left corner
     ul_mult(A00);
-    tlapack::gemm(Op::NoTrans, Op::NoTrans, T(1), A01, A10, T(1), A00);
+    tlapack::gemm(NO_TRANS, NO_TRANS, T(1), A01, A10, T(1), A00);
 
     // calculate bottom left corner
-    tlapack::trmm(Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(1),
-                  A11, A10);
+    tlapack::trmm(LEFT_SIDE, UPPER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, T(1), A11,
+                  A10);
 
     // calculate top right
-    tlapack::trmm(Side::Right, Uplo::Lower, Op::NoTrans, Diag::Unit, T(1), A11,
+    tlapack::trmm(RIGHT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, T(1), A11,
                   A01);
 
     // calculate bottom right

--- a/include/tlapack/lapack/ung2l.hpp
+++ b/include/tlapack/lapack/ung2l.hpp
@@ -44,8 +44,8 @@ inline constexpr WorkInfo ung2l_worksize(const matrix_t& A,
 
     if (n > 1) {
         auto C = cols(A, range{1, n});
-        return larf_worksize(Side::Left, Direction::Backward,
-                             StoreV::Columnwise, col(A, 0), tau[0], C, opts);
+        return larf_worksize(LEFT_SIDE, BACKWARD, COLUMNWISE_STORAGE, col(A, 0),
+                             tau[0], C, opts);
     }
     return WorkInfo{};
 }
@@ -118,8 +118,7 @@ int ung2l(matrix_t& A, const vector_t& tau, const WorkspaceOpts<>& opts = {})
         idx_t ii = n - k + i;
         auto v = slice(A, range{0, m - k + i + 1}, ii);
         auto C = slice(A, range{0, m - k + i + 1}, range{0, ii});
-        larf(Side::Left, Direction::Backward, StoreV::Columnwise, v, tau[i], C,
-             larfOpts);
+        larf(LEFT_SIDE, BACKWARD, COLUMNWISE_STORAGE, v, tau[i], C, larfOpts);
         auto x = slice(A, range{0, m - k + i}, ii);
         scal(-tau[i], x);
         A(m - k + i, ii) = one - tau[i];

--- a/include/tlapack/lapack/ungl2.hpp
+++ b/include/tlapack/lapack/ungl2.hpp
@@ -129,7 +129,7 @@ int ungl2(matrix_t& Q, const vector_t& tauw, const WorkspaceOpts<>& opts = {})
                 // both conditions are satisfied
 
                 auto Q11 = slice(Q, range(j + 1, k), range(j, n));
-                larf(Side::Right, FORWARD, ROWWISE_STORAGE, w, conj(tauw[j]),
+                larf(RIGHT_SIDE, FORWARD, ROWWISE_STORAGE, w, conj(tauw[j]),
                      Q11, larfOpts);
             }
 

--- a/include/tlapack/lapack/ungr2.hpp
+++ b/include/tlapack/lapack/ungr2.hpp
@@ -118,8 +118,8 @@ int ungr2(matrix_t& A, const vector_t& tau, const WorkspaceOpts<>& opts = {})
         idx_t ii = m - k + i;
         auto v = slice(A, ii, range{0, n - k + 1 + i});
         auto C = slice(A, range{0, ii}, range{0, n - k + 1 + i});
-        larf(Side::Right, Direction::Backward, StoreV::Rowwise, v, conj(tau[i]),
-             C, larfOpts);
+        larf(RIGHT_SIDE, BACKWARD, ROWWISE_STORAGE, v, conj(tau[i]), C,
+             larfOpts);
         auto x = slice(A, ii, range{0, n - k + i});
         scal(-conj(tau[i]), x);
         A(ii, n - k + i) = one - conj(tau[i]);

--- a/include/tlapack/legacy_api/lapack/lacpy.hpp
+++ b/include/tlapack/legacy_api/lapack/lacpy.hpp
@@ -83,13 +83,13 @@ namespace legacy {
                       idx_t ldb)
     {
         if (matrixtype == MatrixType::Upper) {
-            lacpy(Uplo::Upper, m, n, A, lda, B, ldb);
+            lacpy(UPPER_TRIANGLE, m, n, A, lda, B, ldb);
         }
         else if (matrixtype == MatrixType::Lower) {
-            lacpy(Uplo::Lower, m, n, A, lda, B, ldb);
+            lacpy(LOWER_TRIANGLE, m, n, A, lda, B, ldb);
         }
         else {
-            lacpy(Uplo::General, m, n, A, lda, B, ldb);
+            lacpy(GENERAL, m, n, A, lda, B, ldb);
         }
     }
 

--- a/include/tlapack/legacy_api/lapack/lascl.hpp
+++ b/include/tlapack/legacy_api/lapack/lascl.hpp
@@ -119,17 +119,17 @@ namespace legacy {
             auto A_ = create_matrix<T>(A, m, n, lda);
 
             if (matrixtype == MatrixType::General) {
-                return lascl(Uplo::General, b, a, A_);
+                return lascl(GENERAL, b, a, A_);
             }
             else if (matrixtype == MatrixType::Lower) {
-                return lascl(Uplo::Lower, b, a, A_);
+                return lascl(LOWER_TRIANGLE, b, a, A_);
             }
             else if (matrixtype == MatrixType::Upper) {
-                return lascl(Uplo::Upper, b, a, A_);
+                return lascl(UPPER_TRIANGLE, b, a, A_);
             }
             else  // if (matrixtype == MatrixType::Hessenberg)
             {
-                return lascl(Uplo::UpperHessenberg, b, a, A_);
+                return lascl(UPPER_HESSENBERG, b, a, A_);
             }
         }
     }

--- a/include/tlapack/legacy_api/lapack/laset.hpp
+++ b/include/tlapack/legacy_api/lapack/laset.hpp
@@ -83,13 +83,13 @@ namespace legacy {
                       idx_t lda)
     {
         if (matrixtype == MatrixType::Upper) {
-            laset(Uplo::Upper, m, n, alpha, beta, A, lda);
+            laset(UPPER_TRIANGLE, m, n, alpha, beta, A, lda);
         }
         else if (matrixtype == MatrixType::Lower) {
-            laset(Uplo::Lower, m, n, alpha, beta, A, lda);
+            laset(LOWER_TRIANGLE, m, n, alpha, beta, A, lda);
         }
         else {
-            laset(Uplo::General, m, n, alpha, beta, A, lda);
+            laset(GENERAL, m, n, alpha, beta, A, lda);
         }
     }
 

--- a/test/include/testutils.hpp
+++ b/test/include/testutils.hpp
@@ -23,6 +23,7 @@
 #include <tlapack/base/utils.hpp>
 #include <tlapack/blas/gemm.hpp>
 #include <tlapack/blas/herk.hpp>
+#include <tlapack/lapack/lacpy.hpp>
 #include <tlapack/lapack/lange.hpp>
 #include <tlapack/lapack/lanhe.hpp>
 #include <tlapack/lapack/laset.hpp>
@@ -103,18 +104,18 @@ real_type<type_t<matrix_t>> check_orthogonality(matrix_t& Q, matrix_t& res)
     tlapack_check(nrows(res) == min(m, n));
 
     // res = I
-    laset(Uplo::Upper, (T)0.0, (T)1.0, res);
+    laset(UPPER_TRIANGLE, (T)0.0, (T)1.0, res);
     if (n <= m) {
         // res = Q'Q - I
-        herk(Uplo::Upper, Op::ConjTrans, (real_t)1.0, Q, (real_t)-1.0, res);
+        herk(UPPER_TRIANGLE, CONJ_TRANS, (real_t)1.0, Q, (real_t)-1.0, res);
     }
     else {
         // res = QQ' - I
-        herk(Uplo::Upper, Op::NoTrans, (real_t)1.0, Q, (real_t)-1.0, res);
+        herk(UPPER_TRIANGLE, NO_TRANS, (real_t)1.0, Q, (real_t)-1.0, res);
     }
 
     // Compute ||res||_F
-    return lanhe(FROB_NORM, Uplo::Upper, res);
+    return lanhe(FROB_NORM, UPPER_TRIANGLE, res);
 }
 
 /** Calculates ||Q'*Q - I||_F if m <= n or ||Q*Q' - I||_F otherwise
@@ -171,9 +172,9 @@ real_type<type_t<matrix_t>> check_similarity_transform(
     tlapack_check(nrows(A) == nrows(work));
 
     // res = Q'*A*Q - B
-    lacpy(Uplo::General, B, res);
-    gemm(Op::ConjTrans, Op::NoTrans, (real_t)1.0, Q, A, work);
-    gemm(Op::NoTrans, Op::NoTrans, (real_t)1.0, work, Q, (real_t)-1.0, res);
+    lacpy(GENERAL, B, res);
+    gemm(CONJ_TRANS, NO_TRANS, (real_t)1.0, Q, A, work);
+    gemm(NO_TRANS, NO_TRANS, (real_t)1.0, work, Q, (real_t)-1.0, res);
 
     // Compute ||res||_F
     return lange(FROB_NORM, res);

--- a/test/src/test_blocked_francis.cpp
+++ b/test/src/test_blocked_francis.cpp
@@ -116,9 +116,9 @@ TEMPLATE_TEST_CASE("Multishift QR",
         for (idx_t j = 0; j < i; ++j)
             A(i, j) = (T)0.0;
 
-    lacpy(Uplo::General, A, H);
+    lacpy(GENERAL, A, H);
     std::vector<complex_t> s(n);
-    laset(Uplo::General, zero, one, Q);
+    laset(GENERAL, zero, one, Q);
 
     idx_t ns = GENERATE(4, 2);
     idx_t nw = GENERATE(4, 2);

--- a/test/src/test_gebd2.cpp
+++ b/test/src/test_gebd2.cpp
@@ -73,8 +73,8 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
-    real_t normA = lange(Norm::Max, A);
+    lacpy(GENERAL, A, A_copy);
+    real_t normA = lange(MAX_NORM, A);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n)
     {
@@ -83,7 +83,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Get bidiagonal B
         std::vector<T> B_;
         auto B = new_matrix(B_, k, k);
-        laset(Uplo::General, zero, zero, B);
+        laset(GENERAL, zero, zero, B);
 
         if (m >= n) {
             // copy upper bidiagonal matrix
@@ -105,7 +105,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Generate m-by-k unitary matrix Q
         UngbrOpts<matrix_t> ungbrOpts;
         ungbrOpts.nb = 2;
-        lacpy(Uplo::Lower, slice(A, range{0, m}, range{0, k}), Q);
+        lacpy(LOWER_TRIANGLE, slice(A, range{0, m}, range{0, k}), Q);
         ungbr_q(n, Q, tauv, ungbrOpts);
 
         // Test for Q's orthogonality
@@ -114,7 +114,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         auto orth_Q = check_orthogonality(Q, Wq);
         CHECK(orth_Q <= tol);
 
-        lacpy(Uplo::Upper, slice(A, range{0, k}, range{0, n}), Z);
+        lacpy(UPPER_TRIANGLE, slice(A, range{0, k}, range{0, n}), Z);
         ungbr_p(m, Z, tauw, ungbrOpts);
 
         // Test for Z's orthogonality
@@ -126,9 +126,9 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Test Q * B * Z^H = A
         std::vector<T> K_;
         auto K = new_matrix(K_, m, k);
-        gemm(Op::NoTrans, Op::NoTrans, real_t(1.), Q, B, K);
-        gemm(Op::NoTrans, Op::NoTrans, real_t(1.), K, Z, real_t(-1.), A_copy);
-        real_t repres = lange(Norm::Max, A_copy);
+        gemm(NO_TRANS, NO_TRANS, real_t(1.), Q, B, K);
+        gemm(NO_TRANS, NO_TRANS, real_t(1.), K, Z, real_t(-1.), A_copy);
+        real_t repres = lange(MAX_NORM, A_copy);
         CHECK(repres <= tol * normA);
     }
 }

--- a/test/src/test_gebrd.cpp
+++ b/test/src/test_gebrd.cpp
@@ -75,8 +75,8 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
-    real_t normA = lange(Norm::Max, A);
+    lacpy(GENERAL, A, A_copy);
+    real_t normA = lange(MAX_NORM, A);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n << " nb = " << nb)
     {
@@ -87,7 +87,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Get bidiagonal B
         std::vector<T> B_;
         auto B = new_matrix(B_, k, k);
-        laset(Uplo::General, zero, zero, B);
+        laset(GENERAL, zero, zero, B);
 
         if (m >= n) {
             // copy upper bidiagonal matrix
@@ -109,7 +109,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Generate m-by-k unitary matrix Q
         UngbrOpts<matrix_t> ungbrOpts;
         ungbrOpts.nb = nb;
-        lacpy(Uplo::Lower, slice(A, range{0, m}, range{0, k}), Q);
+        lacpy(LOWER_TRIANGLE, slice(A, range{0, m}, range{0, k}), Q);
         ungbr_q(n, Q, tauv, ungbrOpts);
 
         // Test for Q's orthogonality
@@ -118,7 +118,7 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         auto orth_Q = check_orthogonality(Q, Wq);
         CHECK(orth_Q <= tol);
 
-        lacpy(Uplo::Upper, slice(A, range{0, k}, range{0, n}), Z);
+        lacpy(UPPER_TRIANGLE, slice(A, range{0, k}, range{0, n}), Z);
         ungbr_p(m, Z, tauw, ungbrOpts);
 
         // Test for Z's orthogonality
@@ -130,10 +130,10 @@ TEMPLATE_TEST_CASE("bidiagonal reduction is backward stable",
         // Test Q * B * Z^H = A
         std::vector<T> K_;
         auto K = new_matrix(K_, m, k);
-        laset(Uplo::General, zero, zero, K);
-        gemm(Op::NoTrans, Op::NoTrans, real_t(1.), Q, B, real_t(0), K);
-        gemm(Op::NoTrans, Op::NoTrans, real_t(1.), K, Z, real_t(-1.), A_copy);
-        real_t repres = lange(Norm::Max, A_copy);
+        laset(GENERAL, zero, zero, K);
+        gemm(NO_TRANS, NO_TRANS, real_t(1.), Q, B, real_t(0), K);
+        gemm(NO_TRANS, NO_TRANS, real_t(1.), K, Z, real_t(-1.), A_copy);
+        real_t repres = lange(MAX_NORM, A_copy);
         CHECK(repres <= tol * normA);
     }
 }

--- a/test/src/test_gehrd.cpp
+++ b/test/src/test_gehrd.cpp
@@ -50,7 +50,7 @@ void check_hess_reduction(size_type<matrix_t> ilo,
     auto work = new_matrix(work_, n, n);
 
     // Generate orthogonal matrix Q
-    tlapack::lacpy(Uplo::General, H, Q);
+    tlapack::lacpy(GENERAL, H, Q);
     tlapack::unghr(ilo, ihi, Q, tau);
 
     // Remove junk from lower half of H
@@ -126,7 +126,7 @@ TEMPLATE_TEST_CASE("Hessenberg reduction is backward stable",
     for (idx_t i = ihi; i < n; ++i)
         for (idx_t j = 0; j < i; ++j)
             A(i, j) = (T)0.0;
-    tlapack::lacpy(Uplo::General, A, H);
+    tlapack::lacpy(GENERAL, A, H);
 
     DYNAMIC_SECTION("matrix = " << matrix_type << " n = " << n
                                 << " ilo = " << ilo << " ihi = " << ihi)

--- a/test/src/test_gelq2.cpp
+++ b/test/src/test_gelq2.cpp
@@ -66,7 +66,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
+    lacpy(GENERAL, A, A_copy);
 
     if (k <= n)  // k must be less than or equal to n, because we cannot get a Q
                  // bigger than n-by-n
@@ -78,7 +78,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix",
             // Q is sliced down to the desired size of output Q (k-by-n).
             // It stores the desired number of Householder reflectors that UNGL2
             // will use.
-            lacpy(Uplo::General, slice(A, range(0, min(m, k)), range(0, n)), Q);
+            lacpy(GENERAL, slice(A, range(0, min(m, k)), range(0, n)), Q);
 
             ungl2(Q, tauw);
 
@@ -91,21 +91,22 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix",
             // L is sliced from A after GELQ2
             std::vector<T> L_;
             auto L = new_matrix(L_, min(k, m), k);
-            laset(Uplo::Upper, zero, zero, L);
-            lacpy(Uplo::Lower, slice(A, range(0, min(m, k)), range(0, k)), L);
+            laset(UPPER_TRIANGLE, zero, zero, L);
+            lacpy(LOWER_TRIANGLE, slice(A, range(0, min(m, k)), range(0, k)),
+                  L);
 
             // R stores the product of L and Q
             std::vector<T> R_;
             auto R = new_matrix(R_, min(k, m), n);
 
             // Test A = L * Q
-            gemm(Op::NoTrans, Op::NoTrans, real_t(1.), L, Q, R);
+            gemm(NO_TRANS, NO_TRANS, real_t(1.), L, Q, R);
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < min(m, k); ++i)
                     A_copy(i, j) -= R(i, j);
 
             real_t repres = lange(
-                Norm::Max, slice(A_copy, range(0, min(m, k)), range(0, n)));
+                MAX_NORM, slice(A_copy, range(0, min(m, k)), range(0, n)));
             CHECK(repres <= tol);
         }
     }

--- a/test/src/test_gelqf.cpp
+++ b/test/src/test_gelqf.cpp
@@ -72,7 +72,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
+    lacpy(GENERAL, A, A_copy);
 
     if (k <= n)  // k must be less than or equal to n, because we cannot get a Q
                  // bigger than n-by-n
@@ -85,7 +85,7 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
             // Q is sliced down to the desired size of output Q (k-by-n).
             // It stores the desired number of Householder reflectors that UNGL2
             // will use.
-            lacpy(Uplo::General, slice(A, range(0, min(m, k)), range(0, n)), Q);
+            lacpy(GENERAL, slice(A, range(0, min(m, k)), range(0, n)), Q);
 
             ungl2(Q, tau);
 
@@ -98,21 +98,22 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
             // L is sliced from A after GELQ2
             std::vector<T> L_;
             auto L = new_matrix(L_, min(k, m), k);
-            laset(Uplo::Upper, zero, zero, L);
-            lacpy(Uplo::Lower, slice(A, range(0, min(m, k)), range(0, k)), L);
+            laset(UPPER_TRIANGLE, zero, zero, L);
+            lacpy(LOWER_TRIANGLE, slice(A, range(0, min(m, k)), range(0, k)),
+                  L);
 
             // R stores the product of L and Q
             std::vector<T> R_;
             auto R = new_matrix(R_, min(k, m), n);
 
             // Test A = L * Q
-            gemm(Op::NoTrans, Op::NoTrans, real_t(1.), L, Q, R);
+            gemm(NO_TRANS, NO_TRANS, real_t(1.), L, Q, R);
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < min(m, k); ++i)
                     A_copy(i, j) -= R(i, j);
 
             real_t repres =
-                tlapack::lange(tlapack::Norm::Max,
+                tlapack::lange(tlapack::MAX_NORM,
                                slice(A_copy, range(0, min(m, k)), range(0, n)));
             CHECK(repres <= tol);
         }

--- a/test/src/test_geql2.cpp
+++ b/test/src/test_geql2.cpp
@@ -65,7 +65,7 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
+    lacpy(GENERAL, A, A_copy);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n)
     {
@@ -73,7 +73,7 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
         geql2(A, tau);
 
         // Generate Q
-        lacpy(Uplo::General, slice(A, range(0, m), range(n - k, n)), Q);
+        lacpy(GENERAL, slice(A, range(0, m), range(n - k, n)), Q);
         ung2l(Q, tau);
 
         // Check orthogonality of Q
@@ -92,12 +92,12 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
         // Test A_copy = Q * L
         std::vector<T> A2_;
         auto A2 = new_matrix(A2_, k, n);
-        gemm(Op::ConjTrans, Op::NoTrans, real_t(1.), Q, A_copy, A2);
+        gemm(CONJ_TRANS, NO_TRANS, real_t(1.), Q, A_copy, A2);
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < k; ++i)
                 A2(i, j) -= L(i, j);
 
-        real_t repres = lange(Norm::Max, A2);
+        real_t repres = lange(MAX_NORM, A2);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_geqlf.cpp
+++ b/test/src/test_geqlf.cpp
@@ -70,7 +70,7 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
+    lacpy(GENERAL, A, A_copy);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n)
     {
@@ -78,7 +78,7 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
         geqlf(A, tau, geqlfOpts);
 
         // Generate Q
-        lacpy(Uplo::General, slice(A, range(0, m), range(n - k, n)), Q);
+        lacpy(GENERAL, slice(A, range(0, m), range(n - k, n)), Q);
         ung2l(Q, tau);
 
         // Check orthogonality of Q
@@ -97,12 +97,12 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
         // Test A_copy = Q * L
         std::vector<T> A2_;
         auto A2 = new_matrix(A2_, k, n);
-        gemm(Op::ConjTrans, Op::NoTrans, real_t(1.), Q, A_copy, A2);
+        gemm(CONJ_TRANS, NO_TRANS, real_t(1.), Q, A_copy, A2);
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < k; ++i)
                 A2(i, j) -= L(i, j);
 
-        real_t repres = lange(Norm::Max, A2);
+        real_t repres = lange(MAX_NORM, A2);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_geqr2.cpp
+++ b/test/src/test_geqr2.cpp
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE("QR factorization of a general m-by-n matrix",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
+    lacpy(GENERAL, A, A_copy);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n)
     {
@@ -73,7 +73,7 @@ TEMPLATE_TEST_CASE("QR factorization of a general m-by-n matrix",
         // Q is sliced down to the desired size of output Q (m-by-k).
         // It stores the desired number of Householder reflectors that UNG2R
         // will use.
-        lacpy(Uplo::General, slice(A, range(0, m), range(0, k)), Q);
+        lacpy(GENERAL, slice(A, range(0, m), range(0, k)), Q);
 
         ung2r(Q, tau);
 
@@ -85,13 +85,13 @@ TEMPLATE_TEST_CASE("QR factorization of a general m-by-n matrix",
         // R is sliced from A after
         std::vector<T> R_;
         auto R = new_matrix(R_, k, n);
-        laset(Uplo::Lower, zero, zero, R);
-        lacpy(Uplo::Upper, slice(A, range(0, k), range(0, n)), R);
+        laset(LOWER_TRIANGLE, zero, zero, R);
+        lacpy(UPPER_TRIANGLE, slice(A, range(0, k), range(0, n)), R);
 
         // Test A = Q * R
-        gemm(Op::NoTrans, Op::NoTrans, real_t(1.), Q, R, real_t(-1.), A_copy);
+        gemm(NO_TRANS, NO_TRANS, real_t(1.), Q, R, real_t(-1.), A_copy);
 
-        real_t repres = tlapack::lange(tlapack::Norm::Max, A_copy);
+        real_t repres = tlapack::lange(tlapack::MAX_NORM, A_copy);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_geqrf.cpp
+++ b/test/src/test_geqrf.cpp
@@ -70,24 +70,24 @@ TEMPLATE_TEST_CASE("QR factorization of a general m-by-n matrix",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
-    real_t anorm = tlapack::lange(tlapack::Norm::Max, A_copy);
+    lacpy(GENERAL, A, A_copy);
+    real_t anorm = tlapack::lange(tlapack::MAX_NORM, A_copy);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n << " nb = " << nb)
     {
         geqrf(A, tau, geqrfOpts);
 
         // Copy upper triangular part of A to R
-        laset(Uplo::Lower, zero, zero, R);
-        lacpy(Uplo::Upper, slice(A, range(0, m), range(0, n)), R);
+        laset(LOWER_TRIANGLE, zero, zero, R);
+        lacpy(UPPER_TRIANGLE, slice(A, range(0, m), range(0, n)), R);
 
         // Test A == Q * R
-        unmqr(Side::Left, Op::NoTrans, A, tau, R, unmqrOpts);
+        unmqr(LEFT_SIDE, NO_TRANS, A, tau, R, unmqrOpts);
         for (idx_t j = 0; j < n; ++j)
             for (idx_t i = 0; i < m; ++i)
                 A_copy(i, j) -= R(i, j);
 
-        real_t repres = tlapack::lange(tlapack::Norm::Max, A_copy);
+        real_t repres = tlapack::lange(tlapack::MAX_NORM, A_copy);
         CHECK(repres <= tol * anorm);
     }
 }

--- a/test/src/test_gerq2.cpp
+++ b/test/src/test_gerq2.cpp
@@ -65,7 +65,7 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
+    lacpy(GENERAL, A, A_copy);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n)
     {
@@ -73,7 +73,7 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
         gerq2(A, tau);
 
         // Generate Q
-        lacpy(Uplo::General, slice(A, range(m - k, m), range(0, n)), Q);
+        lacpy(GENERAL, slice(A, range(m - k, m), range(0, n)), Q);
         ungr2(Q, tau);
 
         // Check orthogonality of Q
@@ -91,12 +91,12 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
         // Test A_copy = R * Q
         std::vector<T> A2_;
         auto A2 = new_matrix(A2_, m, k);
-        gemm(Op::NoTrans, Op::ConjTrans, real_t(1.), A_copy, Q, A2);
+        gemm(NO_TRANS, CONJ_TRANS, real_t(1.), A_copy, Q, A2);
         for (idx_t j = 0; j < k; ++j)
             for (idx_t i = 0; i < m; ++i)
                 A2(i, j) -= R(i, j);
 
-        real_t repres = lange(Norm::Max, A2);
+        real_t repres = lange(MAX_NORM, A2);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_gerqf.cpp
+++ b/test/src/test_gerqf.cpp
@@ -70,7 +70,7 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
         for (idx_t i = 0; i < m; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, A_copy);
+    lacpy(GENERAL, A, A_copy);
 
     DYNAMIC_SECTION("m = " << m << " n = " << n)
     {
@@ -78,7 +78,7 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
         gerqf(A, tau, gerqfOpts);
 
         // Generate Q
-        lacpy(Uplo::General, slice(A, range(m - k, m), range(0, n)), Q);
+        lacpy(GENERAL, slice(A, range(m - k, m), range(0, n)), Q);
         ungr2(Q, tau);
 
         // Check orthogonality of Q
@@ -96,12 +96,12 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
         // Test A_copy = R * Q
         std::vector<T> A2_;
         auto A2 = new_matrix(A2_, m, k);
-        gemm(Op::NoTrans, Op::ConjTrans, real_t(1.), A_copy, Q, A2);
+        gemm(NO_TRANS, CONJ_TRANS, real_t(1.), A_copy, Q, A2);
         for (idx_t j = 0; j < k; ++j)
             for (idx_t i = 0; i < m; ++i)
                 A2(i, j) -= R(i, j);
 
-        real_t repres = lange(Norm::Max, A2);
+        real_t repres = lange(MAX_NORM, A2);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_getrf.cpp
+++ b/test/src/test_getrf.cpp
@@ -73,9 +73,9 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
         // We intend to test A=LU, however, since after calling getrf, A will be
         // udpated then to test A=LU, we'll make a deep copy of A prior to
         // calling getrf
-        lacpy(Uplo::General, A, A_copy);
+        lacpy(GENERAL, A, A_copy);
 
-        real_t norma = tlapack::lange(tlapack::Norm::Max, A);
+        real_t norma = tlapack::lange(tlapack::MAX_NORM, A);
         // Initialize piv vector to all zeros
         std::vector<idx_t> piv(k, idx_t(0));
         // Run getrf and both A and piv will be update
@@ -85,15 +85,15 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
         if (m > n) {
             auto A0 = tlapack::slice(A, range(0, n), range(0, n));
             auto A1 = tlapack::slice(A, range(n, m), range(0, n));
-            trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit,
-                 real_t(1), A0, A1);
+            trmm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, real_t(1),
+                 A0, A1);
             lu_mult(A0);
         }
         else if (m < n) {
             auto A0 = tlapack::slice(A, range(0, m), range(0, m));
             auto A1 = tlapack::slice(A, range(0, m), range(m, n));
-            trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::Unit, real_t(1),
-                 A0, A1);
+            trmm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, real_t(1), A0,
+                 A1);
             lu_mult(A0);
         }
         else
@@ -113,7 +113,7 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix",
                 A(i, j) -= A_copy(i, j);
 
         // Check for relative error: norm(A-LU)/norm(A)
-        real_t error = tlapack::lange(tlapack::Norm::Max, A) / norma;
+        real_t error = tlapack::lange(tlapack::MAX_NORM, A) / norma;
         CHECK(error <= tol);
     }
 }

--- a/test/src/test_getri.cpp
+++ b/test/src/test_getri.cpp
@@ -64,10 +64,10 @@ TEMPLATE_TEST_CASE("Inversion of a general m-by-n matrix",
             }
 
         // make a deep copy A
-        lacpy(Uplo::General, A, invA);
+        lacpy(GENERAL, A, invA);
 
         // calculate norm of A for later use in relative error
-        real_t norma = tlapack::lange(tlapack::Norm::Max, A);
+        real_t norma = tlapack::lange(tlapack::MAX_NORM, A);
 
         // LU factorize Pivoted A
         std::vector<idx_t> piv(n, idx_t(0));
@@ -83,25 +83,25 @@ TEMPLATE_TEST_CASE("Inversion of a general m-by-n matrix",
         auto E = new_matrix(E_, n, n);
 
         // E <----- inv(A)*A - I
-        gemm(Op::NoTrans, Op::NoTrans, real_t(1), A, invA, E);
+        gemm(NO_TRANS, NO_TRANS, real_t(1), A, invA, E);
         for (idx_t i = 0; i < n; i++)
             E(i, i) -= real_t(1);
 
         // error is  || inv(A)*A - I || / ( ||A|| * ||inv(A)|| )
-        real_t error = tlapack::lange(tlapack::Norm::Max, E) /
-                       (norma * tlapack::lange(tlapack::Norm::Max, invA));
+        real_t error = tlapack::lange(tlapack::MAX_NORM, E) /
+                       (norma * tlapack::lange(tlapack::MAX_NORM, invA));
 
         UNSCOPED_INFO("|| inv(A)*A - I || / ( ||A|| * ||inv(A)|| )");
         CHECK(error / tol <= real_t(1));  // tests if error<=tol
 
         // E <----- A*inv(A) - I
-        gemm(Op::NoTrans, Op::NoTrans, real_t(1), invA, A, E);
+        gemm(NO_TRANS, NO_TRANS, real_t(1), invA, A, E);
         for (idx_t i = 0; i < n; i++)
             E(i, i) -= real_t(1);
 
         // error is  || A*inv(A) - I || / ( ||A|| * ||inv(A)|| )
-        error = tlapack::lange(tlapack::Norm::Max, E) /
-                (norma * tlapack::lange(tlapack::Norm::Max, invA));
+        error = tlapack::lange(tlapack::MAX_NORM, E) /
+                (norma * tlapack::lange(tlapack::MAX_NORM, invA));
 
         UNSCOPED_INFO("|| A*inv(A) - I || / ( ||A|| * ||inv(A)|| )");
         CHECK(error / tol <= real_t(1));  // tests if error<=tol

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -70,14 +70,14 @@ TEMPLATE_TEST_CASE("sylvester solver gives correct result",
     real_t sign(1);
 
     // Calculate op(TL)*X + ISGN*X*op(TR)
-    gemm(trans_l, Op::NoTrans, one, TL, X_exact, B);
-    gemm(Op::NoTrans, trans_r, sign, X_exact, TR, one, B);
+    gemm(trans_l, NO_TRANS, one, TL, X_exact, B);
+    gemm(NO_TRANS, trans_r, sign, X_exact, TR, one, B);
 
     DYNAMIC_SECTION("n1 = " << n1 << " n2 =" << n2)
     {
         // Solve sylvester equation
         T scale(0), xnorm;
-        lasy2(Op::NoTrans, Op::NoTrans, 1, TL, TR, B, scale, X, xnorm);
+        lasy2(NO_TRANS, NO_TRANS, 1, TL, TR, B, scale, X, xnorm);
 
         // Check that X_exact == X
         for (idx_t i = 0; i < n1; ++i)

--- a/test/src/test_lauum.cpp
+++ b/test/src/test_lauum.cpp
@@ -51,26 +51,26 @@ TEMPLATE_TEST_CASE("LAUUM is stable", "[lauum]", TLAPACK_TYPES_TO_TEST)
         for (idx_t i = 0; i < n; ++i)
             A(i, j) = rand_helper<T>();
 
-    lacpy(Uplo::General, A, C);
+    lacpy(GENERAL, A, C);
 
     DYNAMIC_SECTION("n = " << n << " uplo = " << uplo)
     {
         lauum_recursive(uplo, A);
 
         // Calculate residual
-        real_t normC = lantr(MAX_NORM, uplo, Diag::NonUnit, C);
+        real_t normC = lantr(MAX_NORM, uplo, NON_UNIT_DIAG, C);
 
         if (uplo == Uplo::Lower) {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = 0; i < j; ++i)
                     C(i, j) = T(0.);
-            herk(Uplo::Lower, Op::ConjTrans, real_t(1), C, real_t(-1), A);
+            herk(LOWER_TRIANGLE, CONJ_TRANS, real_t(1), C, real_t(-1), A);
         }
         else {
             for (idx_t j = 0; j < n; ++j)
                 for (idx_t i = j + 1; i < n; ++i)
                     C(i, j) = T(0.);
-            herk(Uplo::Upper, Op::NoTrans, real_t(1), C, real_t(-1), A);
+            herk(UPPER_TRIANGLE, NO_TRANS, real_t(1), C, real_t(-1), A);
         }
 
         real_t res = lanhe(MAX_NORM, uplo, A) / normC / normC;

--- a/test/src/test_lu_mult.cpp
+++ b/test/src/test_lu_mult.cpp
@@ -61,11 +61,11 @@ TEMPLATE_TEST_CASE("lu multiplication is backward stable",
                 for (idx_t i = 0; i < n; ++i)
                     A(i, j) = rand_helper<T>();
 
-            lacpy(Uplo::Lower, A, L);
-            laset(Uplo::Upper, real_t(0), real_t(1), L);
+            lacpy(LOWER_TRIANGLE, A, L);
+            laset(UPPER_TRIANGLE, real_t(0), real_t(1), L);
 
-            laset(Uplo::Lower, real_t(0), real_t(0), U);
-            lacpy(Uplo::Upper, A, U);
+            laset(LOWER_TRIANGLE, real_t(0), real_t(0), U);
+            lacpy(UPPER_TRIANGLE, A, U);
 
             real_t norma = lange(MAX_NORM, A);
 
@@ -74,7 +74,7 @@ TEMPLATE_TEST_CASE("lu multiplication is backward stable",
 
                 // Calculate residual
 
-                gemm(Op::NoTrans, Op::NoTrans, real_t(1), L, U, real_t(-1), A);
+                gemm(NO_TRANS, NO_TRANS, real_t(1), L, U, real_t(-1), A);
 
                 real_t lu_mult_res_norm = lange(MAX_NORM, A) / norma;
                 CHECK(lu_mult_res_norm <= tol);

--- a/test/src/test_potrf.cpp
+++ b/test/src/test_potrf.cpp
@@ -85,7 +85,7 @@ TEMPLATE_TEST_CASE(
         }
 
         lacpy(GENERAL, A, L);
-        real_t normA = tlapack::lanhe(tlapack::Norm::Max, uplo, A);
+        real_t normA = tlapack::lanhe(tlapack::MAX_NORM, uplo, A);
 
         // Run the Cholesky factorization
         PotrfOpts<idx_t> opts;
@@ -109,11 +109,11 @@ TEMPLATE_TEST_CASE(
 
         // Compute E = L*L^H or E = L^H*L
         if (uplo == Uplo::Lower)
-            trmm(Side::Left, Uplo::Lower, Op::NoTrans, Diag::NonUnit, real_t(1),
+            trmm(LEFT_SIDE, LOWER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, real_t(1),
                  L, E);
         else
-            trmm(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit,
-                 real_t(1), L, E);
+            trmm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, real_t(1),
+                 L, E);
 
         // Check that the factorization is correct
         for (idx_t i = 0; i < n; i++)
@@ -125,7 +125,7 @@ TEMPLATE_TEST_CASE(
             }
 
         // Check for relative error: norm(A-cholesky(A))/norm(A)
-        real_t error = tlapack::lanhe(tlapack::Norm::Max, uplo, E) / normA;
+        real_t error = tlapack::lanhe(tlapack::MAX_NORM, uplo, E) / normA;
         CHECK(error <= tol);
     }
 }

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -88,8 +88,8 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results",
             A(5, 4) = rand_helper<T>();
         }
 
-        lacpy(Uplo::General, A, A_copy);
-        laset(Uplo::General, zero, one, Q);
+        lacpy(GENERAL, A, A_copy);
+        laset(GENERAL, zero, one, Q);
 
         DYNAMIC_SECTION("ifst = " << ifst << " n1 = " << n1
                                   << " ilst = " << ilst << " n2 =" << n2)

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -68,8 +68,8 @@ TEMPLATE_TEST_CASE("schur swap gives correct result",
         if (n1 == 2) A(j + 1, j) = rand_helper<T>();
         if (n2 == 2) A(j + n1 + 1, j + n1) = rand_helper<T>();
 
-        lacpy(Uplo::General, A, A_copy);
-        laset(Uplo::General, zero, one, Q);
+        lacpy(GENERAL, A, A_copy);
+        laset(GENERAL, zero, one, Q);
 
         DYNAMIC_SECTION("j = " << j << " n1 = " << n1 << " n2 =" << n2)
         {

--- a/test/src/test_trtri.cpp
+++ b/test/src/test_trtri.cpp
@@ -82,12 +82,12 @@ TEMPLATE_TEST_CASE("TRTRI is stable", "[trtri]", TLAPACK_TYPES_TO_TEST)
             // TRMM with X starting as the inverse of C and leaving as the
             // identity. This checks that the inverse is correct. Note: it would
             // be nice to have a ``upper * upper`` MM function to do this
-            trmm(Side::Left, uplo, Op::NoTrans, diag, T(1), A, C);
+            trmm(LEFT_SIDE, uplo, NO_TRANS, diag, T(1), A, C);
 
             for (idx_t i = 0; i < n; ++i)
                 C(i, i) = C(i, i) - T(1);
 
-            real_t normres = lantr(MAX_NORM, uplo, Diag::NonUnit, C) /
+            real_t normres = lantr(MAX_NORM, uplo, NON_UNIT_DIAG, C) /
                              (lantr(MAX_NORM, uplo, diag, A));
             CHECK(normres <= tol);
         }

--- a/test/src/test_ul_mult.cpp
+++ b/test/src/test_ul_mult.cpp
@@ -67,8 +67,8 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix, blocked",
             }
 
         // We will make a deep copy A
-        lacpy(Uplo::General, A, A_copy);
-        real_t norma = tlapack::lange(tlapack::Norm::Max, A);
+        lacpy(GENERAL, A, A_copy);
+        real_t norma = tlapack::lange(tlapack::MAX_NORM, A);
 
         // Put diagonal and super-diagonal of A into U and sub-diagonal in L
         std::vector<T> L_;
@@ -97,9 +97,9 @@ TEMPLATE_TEST_CASE("LU factorization of a general m-by-n matrix, blocked",
         ul_mult(A);
 
         // store UL-A ---> A
-        gemm(Op::NoTrans, Op::NoTrans, T(1), U, L, T(-1), A);
+        gemm(NO_TRANS, NO_TRANS, T(1), U, L, T(-1), A);
 
-        real_t error1 = tlapack::lange(tlapack::Norm::Max, A) / norma;
+        real_t error1 = tlapack::lange(tlapack::MAX_NORM, A) / norma;
         CHECK(error1 / tol <= real_t(1));
     }
 }

--- a/test/src/test_unblocked_francis.cpp
+++ b/test/src/test_unblocked_francis.cpp
@@ -91,9 +91,9 @@ TEMPLATE_TEST_CASE("Double shift QR",
         for (idx_t j = 0; j < i; ++j)
             A(i, j) = (T)0.0;
 
-    tlapack::lacpy(Uplo::General, A, H);
+    lacpy(GENERAL, A, H);
     std::vector<complex_t> s(n);
-    laset(Uplo::General, zero, one, Q);
+    laset(GENERAL, zero, one, Q);
 
     DYNAMIC_SECTION("matrix = " << matrix_type << " n = " << n
                                 << " ilo = " << ilo << " ihi = " << ihi)

--- a/test/src/test_unm2l.cpp
+++ b/test/src/test_unm2l.cpp
@@ -99,11 +99,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QL factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         unm2l(side, trans, cols(A, range(n - k, n)), tau, C);
@@ -112,7 +112,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QL factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_unm2r.cpp
+++ b/test/src/test_unm2r.cpp
@@ -94,11 +94,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QR factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         unm2r(side, trans, cols(A, range(0, k)), tau, C);
@@ -107,7 +107,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QR factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_unmhr.cpp
+++ b/test/src/test_unmhr.cpp
@@ -74,7 +74,7 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr",
             for (idx_t i = 0; i < m; ++i)
                 C(i, j) = rand_helper<T>();
     }
-    lacpy(Uplo::General, C, C_copy);
+    lacpy(GENERAL, C, C_copy);
 
     // Make sure ilo and ihi correspond to the actual matrix
     for (idx_t j = 0; j < ilo; ++j)
@@ -105,7 +105,7 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr",
             auto C_copy_s =
                 slice(C_copy, range{ilo + 1, ihi}, range{0, ncols(C)});
             auto C_s = slice(C, range{ilo + 1, ihi}, range{0, ncols(C)});
-            gemm(op, Op::NoTrans, one, Q, C_copy_s, -one, C_s);
+            gemm(op, NO_TRANS, one, Q, C_copy_s, -one, C_s);
             for (idx_t i = 0; i < ilo + 1; ++i)
                 for (idx_t j = 0; j < ncols(C); ++j)
                     C(i, j) = C(i, j) - C_copy(i, j);
@@ -117,7 +117,7 @@ TEMPLATE_TEST_CASE("Result of unmhr matches result from unghr",
             auto C_copy_s =
                 slice(C_copy, range{0, nrows(C)}, range{ilo + 1, ihi});
             auto C_s = slice(C, range{0, nrows(C)}, range{ilo + 1, ihi});
-            gemm(Op::NoTrans, op, one, C_copy_s, Q, -one, C_s);
+            gemm(NO_TRANS, op, one, C_copy_s, Q, -one, C_s);
             for (idx_t j = 0; j < ilo + 1; ++j)
                 for (idx_t i = 0; i < nrows(C); ++i)
                     C(i, j) = C(i, j) - C_copy(i, j);

--- a/test/src/test_unml2.cpp
+++ b/test/src/test_unml2.cpp
@@ -99,11 +99,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal LQ factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         unml2(side, trans, rows(A, range(0, k)), tau, C);
@@ -112,7 +112,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal LQ factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_unmlq.cpp
+++ b/test/src/test_unmlq.cpp
@@ -103,11 +103,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal LQ factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         UnmlqOpts<> unmlqOpts;
@@ -118,7 +118,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal LQ factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_unmql.cpp
+++ b/test/src/test_unmql.cpp
@@ -103,11 +103,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QL factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         UnmqlOpts<> unmqlOpts;
@@ -118,7 +118,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QL factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_unmqr.cpp
+++ b/test/src/test_unmqr.cpp
@@ -98,11 +98,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QR factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         UnmqrOpts<> unmqrOpts;
@@ -113,7 +113,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal QR factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_unmr2.cpp
+++ b/test/src/test_unmr2.cpp
@@ -94,11 +94,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal RQ factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         unmr2(side, trans, rows(A, range(m - k, m)), tau, C);
@@ -107,7 +107,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal RQ factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }

--- a/test/src/test_unmrq.cpp
+++ b/test/src/test_unmrq.cpp
@@ -104,11 +104,11 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal RQ factor",
 
         std::vector<T> Cq_;
         auto Cq = new_matrix(Cq_, mc, nc);
-        laset(Uplo::General, T(0.), T(0.), Cq);
+        laset(GENERAL, T(0.), T(0.), Cq);
         if (side == Side::Left)
-            gemm(trans, Op::NoTrans, T(1.), Q, C, T(0.), Cq);
+            gemm(trans, NO_TRANS, T(1.), Q, C, T(0.), Cq);
         else
-            gemm(Op::NoTrans, trans, T(1.), C, Q, T(0.), Cq);
+            gemm(NO_TRANS, trans, T(1.), C, Q, T(0.), Cq);
 
         // Run the routine we are testing
         UnmrqOpts<> unmrqOpts;
@@ -119,7 +119,7 @@ TEMPLATE_TEST_CASE("Multiply m-by-n matrix with orthogonal RQ factor",
         for (idx_t j = 0; j < nc; ++j)
             for (idx_t i = 0; i < mc; ++i)
                 C(i, j) -= Cq(i, j);
-        real_t repres = lange(Norm::Max, C);
+        real_t repres = lange(MAX_NORM, C);
         CHECK(repres <= tol);
     }
 }


### PR DESCRIPTION
Constant expressions are preferable for internal calls since they are evaluated at compile time.