### PR TITLE
Use noexcept, assert() and tlapack_check() consistently

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,14 @@ We recommend the usage of `auto` in the following cases:
 
 2. In the return type of functions like `tlapack::asum`, `tlapack::dot`, `tlapack::nrm2` and `tlapack::lange`. By defining the output as `auto`, we enable overloading of those functions using mixed precision. For instance, one may write a overloading of `tlapack::lange` for matrices `Eigen::MatrixXf` that returns `double`.
 
+### assert vs check
+
+- `assert()`: Used on checks related to the logic of an algorithm. The assertion is supposed to check that the logic is correct, and so they are active only on debug mode. The function `assert()` does nothing if the `NDEBUG` flag is defined. Some examples of usage in \<T\>LAPACK are:
+  - check the range of (i,j) before access A(i,j) in the legacy classes for matrices and vectors.
+  - check if `x` is zero when calling the constructor `StrongZero(x)`.
+  
+- `tlapack_check()`: Used on checks related to the validity of an input of a function. It is enabled if TLAPACK_CHECK_INPUT is defined and TLAPACK_NDEBUG is not. Also used to test the input parameters when creating new legacy matrices and vectors, see `LegacyMatrix.hpp`. THe reason to use `tlapack_check()` instead of assert for matrix and vector creation is to be in the same page as LAPACK. LAPACK routines check the dimensions `m`, `n` and `ldim` the same way it checks other input parameters. `tlapack_check_false(cond)` is the same as `tlapack_check(!cond)`.
+
 ### Good practices when writing code inside the library
 
 1. Declare real-valued constants using real types. For instance, use `const real_type<T> zero(0)` instead of `const T zero(0)`. This is because the type `T` may be a complex type, and the constant `zero` is real. Avoid constants like `const real_type<T> rzero(0)` and `const T czero(0)` in the same function, because it is confusing.

--- a/include/tlapack/base/StrongZero.hpp
+++ b/include/tlapack/base/StrongZero.hpp
@@ -46,22 +46,22 @@ struct StrongZero {
     constexpr StrongZero() {}
 
     template <typename T>
-    constexpr StrongZero(const T& x)
+    constexpr StrongZero(const T& x) noexcept
     {
         assert(x == T(0));
     }
 
     template <typename T, typename U>
-    constexpr StrongZero(const T& x, const U& y)
+    constexpr StrongZero(const T& x, const U& y) noexcept
     {
         assert(x == T(0));
-        assert(y == T(0));
+        assert(y == U(0));
     }
 
     // Conversion operators
 
     template <typename T>
-    explicit constexpr operator T() const
+    explicit constexpr operator T() const noexcept
     {
         return T(0);
     }
@@ -69,121 +69,137 @@ struct StrongZero {
     // Assignment operators
 
     template <typename T>
-    friend constexpr T& operator+=(T& lhs, StrongZero)
+    friend constexpr T& operator+=(T& lhs, StrongZero) noexcept
     {
         return lhs;
     }
 
     template <typename T>
-    friend constexpr T& operator-=(T& lhs, StrongZero)
+    friend constexpr T& operator-=(T& lhs, StrongZero) noexcept
     {
         return lhs;
     }
 
     template <typename T>
-    friend constexpr T& operator*=(T& lhs, StrongZero)
+    friend constexpr T& operator*=(T& lhs, StrongZero) noexcept
     {
         return (lhs = T(0));
     }
 
     template <typename T>
-    friend constexpr T& operator/=(T& lhs, StrongZero)
+    friend constexpr T& operator/=(T& lhs, StrongZero) noexcept
     {
         return (lhs = std::numeric_limits<T>::infinity());
     }
 
     // Arithmetic operators
 
-    friend constexpr StrongZero operator+(StrongZero, StrongZero)
+    friend constexpr StrongZero operator+(StrongZero, StrongZero) noexcept
     {
         return StrongZero();
     }
 
     template <typename T>
-    friend constexpr T operator+(StrongZero, const T& rhs)
+    friend constexpr T operator+(StrongZero, const T& rhs) noexcept
     {
         return rhs;
     }
 
     template <typename T>
-    friend constexpr T operator+(const T& lhs, StrongZero)
+    friend constexpr T operator+(const T& lhs, StrongZero) noexcept
     {
         return lhs;
     }
 
-    friend constexpr StrongZero operator-(StrongZero, StrongZero)
+    friend constexpr StrongZero operator-(StrongZero, StrongZero) noexcept
     {
         return StrongZero();
     }
 
     template <typename T>
-    friend constexpr T operator-(StrongZero, const T& rhs)
+    friend constexpr T operator-(StrongZero, const T& rhs) noexcept
     {
         return -rhs;
     }
 
     template <typename T>
-    friend constexpr T operator-(const T& lhs, StrongZero)
+    friend constexpr T operator-(const T& lhs, StrongZero) noexcept
     {
         return lhs;
     }
 
-    friend constexpr StrongZero operator*(StrongZero, StrongZero)
+    friend constexpr StrongZero operator*(StrongZero, StrongZero) noexcept
     {
         return StrongZero();
     }
 
     template <typename T>
-    friend constexpr StrongZero operator*(StrongZero, const T&)
+    friend constexpr StrongZero operator*(StrongZero, const T&) noexcept
     {
         return StrongZero();
     }
 
     template <typename T>
-    friend constexpr StrongZero operator*(const T&, StrongZero)
+    friend constexpr StrongZero operator*(const T&, StrongZero) noexcept
     {
         return StrongZero();
     }
 
-    friend constexpr float operator/(StrongZero, StrongZero)
+    friend constexpr float operator/(StrongZero, StrongZero) noexcept
     {
         return std::numeric_limits<float>::quiet_NaN();
     }
 
     template <typename T>
-    friend constexpr StrongZero operator/(StrongZero, const T&)
+    friend constexpr StrongZero operator/(StrongZero, const T&) noexcept
     {
         return StrongZero();
     }
 
     template <typename T>
-    friend constexpr T operator/(const T&, StrongZero)
+    friend constexpr T operator/(const T&, StrongZero) noexcept
     {
         return std::numeric_limits<T>::infinity();
     }
 
+    // Change of sign
+
+    constexpr StrongZero operator-() const noexcept { return StrongZero(); }
+
     // Comparison operators
 
-    constexpr bool operator==(StrongZero) const { return true; }
-    constexpr bool operator!=(StrongZero) const { return false; }
-    constexpr bool operator>(StrongZero) const { return false; }
-    constexpr bool operator<(StrongZero) const { return false; }
-    constexpr bool operator>=(StrongZero) const { return true; }
-    constexpr bool operator<=(StrongZero) const { return true; }
-    friend constexpr bool isinf(StrongZero) { return false; }
-    friend constexpr bool isnan(StrongZero) { return false; }
+    constexpr bool operator==(StrongZero) const noexcept { return true; }
+    constexpr bool operator!=(StrongZero) const noexcept { return false; }
+    constexpr bool operator>(StrongZero) const noexcept { return false; }
+    constexpr bool operator<(StrongZero) const noexcept { return false; }
+    constexpr bool operator>=(StrongZero) const noexcept { return true; }
+    constexpr bool operator<=(StrongZero) const noexcept { return true; }
+    friend constexpr bool isinf(StrongZero) noexcept { return false; }
+    friend constexpr bool isnan(StrongZero) noexcept { return false; }
 
     // Math functions
 
-    friend constexpr StrongZero abs(StrongZero) { return StrongZero(); }
-    friend constexpr StrongZero sqrt(StrongZero) { return StrongZero(); }
-    friend constexpr int pow(int, StrongZero) { return 1; }
-    friend constexpr float log2(StrongZero)
+    friend constexpr StrongZero abs(StrongZero) noexcept
+    {
+        return StrongZero();
+    }
+    friend constexpr StrongZero sqrt(StrongZero) noexcept
+    {
+        return StrongZero();
+    }
+    friend constexpr int pow(int, StrongZero) noexcept { return 1; }
+    friend constexpr float log2(StrongZero) noexcept
     {
         return -std::numeric_limits<float>::infinity();
     }
-    friend constexpr StrongZero ceil(StrongZero) { return StrongZero(); }
-    friend constexpr StrongZero floor(StrongZero) { return StrongZero(); }
+    friend constexpr StrongZero ceil(StrongZero) noexcept
+    {
+        return StrongZero();
+    }
+    friend constexpr StrongZero floor(StrongZero) noexcept
+    {
+        return StrongZero();
+    }
 };
 
 namespace traits {

--- a/include/tlapack/base/concepts.hpp
+++ b/include/tlapack/base/concepts.hpp
@@ -43,7 +43,8 @@ namespace concepts {
      *
      * An arithmetic type must implement the operators @c +, @c -, @c *, and
      * @c /,, with constant operands, and @c =, @c +=, @c -=, @c *=, and @c /=
-     * with a constant second operand.
+     * with a constant second operand. It must also implement the unary operator
+     * @c - for the change of sign.
      *
      * @tparam T Type.
      *
@@ -52,11 +53,12 @@ namespace concepts {
     template <typename T>
     concept Arithmetic = requires(const T& a, const T& b, T& c)
     {
-        // Arithmetic operations
+        // Arithmetic and assignment operations
         c = a + b;
         c = a - b;
         c = a * b;
         c = a / b;
+        c = -a;
 
         // Arithmetic operations with assignment
         c += a;

--- a/include/tlapack/base/constants.hpp
+++ b/include/tlapack/base/constants.hpp
@@ -29,7 +29,7 @@ namespace tlapack {
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t ulp()
+inline constexpr real_t ulp() noexcept
 {
     return std::numeric_limits<real_t>::epsilon();
 }
@@ -48,7 +48,7 @@ inline constexpr real_t ulp()
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t uroundoff()
+inline constexpr real_t uroundoff() noexcept
 {
     return ulp<real_t>() * std::numeric_limits<real_t>::round_error();
 }
@@ -61,7 +61,7 @@ inline constexpr real_t uroundoff()
  * @ingroup constants
  */
 template <typename real_t>
-inline int digits()
+inline int digits() noexcept
 {
     return std::numeric_limits<real_t>::digits;
 }
@@ -74,7 +74,7 @@ inline int digits()
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t safe_min()
+inline constexpr real_t safe_min() noexcept
 {
     constexpr int fradix = std::numeric_limits<real_t>::radix;
     constexpr int expm = std::numeric_limits<real_t>::min_exponent;
@@ -90,7 +90,7 @@ inline constexpr real_t safe_min()
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t safe_max()
+inline constexpr real_t safe_max() noexcept
 {
     return real_t(1) / safe_min<real_t>();
 }
@@ -100,7 +100,7 @@ inline constexpr real_t safe_max()
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t blue_min()
+inline constexpr real_t blue_min() noexcept
 {
     const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;
@@ -114,7 +114,7 @@ inline constexpr real_t blue_min()
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t blue_max()
+inline constexpr real_t blue_max() noexcept
 {
     const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;
@@ -132,7 +132,7 @@ inline constexpr real_t blue_max()
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t blue_scalingMin()
+inline constexpr real_t blue_scalingMin() noexcept
 {
     const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;
@@ -147,7 +147,7 @@ inline constexpr real_t blue_scalingMin()
  * @ingroup constants
  */
 template <TLAPACK_REAL real_t>
-inline constexpr real_t blue_scalingMax()
+inline constexpr real_t blue_scalingMax() noexcept
 {
     const real_t half(0.5);
     constexpr int fradix = std::numeric_limits<real_t>::radix;

--- a/include/tlapack/base/types.hpp
+++ b/include/tlapack/base/types.hpp
@@ -113,7 +113,7 @@ namespace internal {
      *      x x x x x
      */
     struct GeneralAccess {
-        constexpr operator Uplo() const { return Uplo::General; }
+        constexpr operator Uplo() const noexcept { return Uplo::General; }
     };
 
     /**
@@ -127,7 +127,7 @@ namespace internal {
      *      0 0 0 x x
      */
     struct UpperTriangle {
-        constexpr operator Uplo() const { return Uplo::Upper; }
+        constexpr operator Uplo() const noexcept { return Uplo::Upper; }
     };
 
     /**
@@ -141,7 +141,7 @@ namespace internal {
      *      x x x x 0
      */
     struct LowerTriangle {
-        constexpr operator Uplo() const { return Uplo::Lower; }
+        constexpr operator Uplo() const noexcept { return Uplo::Lower; }
     };
 
     /**
@@ -155,7 +155,10 @@ namespace internal {
      *      0 0 x x x
      */
     struct UpperHessenberg {
-        constexpr operator Uplo() const { return Uplo::UpperHessenberg; }
+        constexpr operator Uplo() const noexcept
+        {
+            return Uplo::UpperHessenberg;
+        }
     };
 
     /**
@@ -169,7 +172,10 @@ namespace internal {
      *      x x x x x
      */
     struct LowerHessenberg {
-        constexpr operator Uplo() const { return Uplo::LowerHessenberg; }
+        constexpr operator Uplo() const noexcept
+        {
+            return Uplo::LowerHessenberg;
+        }
     };
 
     /**
@@ -183,7 +189,7 @@ namespace internal {
      *      0 0 0 0 x
      */
     struct StrictUpper {
-        constexpr operator Uplo() const { return Uplo::StrictUpper; }
+        constexpr operator Uplo() const noexcept { return Uplo::StrictUpper; }
     };
 
     /**
@@ -197,7 +203,7 @@ namespace internal {
      *      x x x 0 0
      */
     struct StrictLower {
-        constexpr operator Uplo() const { return Uplo::StrictLower; }
+        constexpr operator Uplo() const noexcept { return Uplo::StrictLower; }
     };
 }  // namespace internal
 
@@ -229,10 +235,10 @@ TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Diag, NonUnit, Unit)
 
 namespace internal {
     struct NonUnitDiagonal {
-        constexpr operator Diag() const { return Diag::NonUnit; }
+        constexpr operator Diag() const noexcept { return Diag::NonUnit; }
     };
     struct UnitDiagonal {
-        constexpr operator Diag() const { return Diag::Unit; }
+        constexpr operator Diag() const noexcept { return Diag::Unit; }
     };
 }  // namespace internal
 
@@ -256,16 +262,16 @@ TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_4_VALUES(Op, NoTrans, Trans, ConjTrans, Conj)
 
 namespace internal {
     struct NoTranspose {
-        constexpr operator Op() const { return Op::NoTrans; }
+        constexpr operator Op() const noexcept { return Op::NoTrans; }
     };
     struct Transpose {
-        constexpr operator Op() const { return Op::Trans; }
+        constexpr operator Op() const noexcept { return Op::Trans; }
     };
     struct ConjTranspose {
-        constexpr operator Op() const { return Op::ConjTrans; }
+        constexpr operator Op() const noexcept { return Op::ConjTrans; }
     };
     struct Conjugate {
-        constexpr operator Op() const { return Op::Conj; }
+        constexpr operator Op() const noexcept { return Op::Conj; }
     };
 }  // namespace internal
 
@@ -291,10 +297,10 @@ TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Side, Left, Right)
 
 namespace internal {
     struct LeftSide {
-        constexpr operator Side() const { return Side::Left; }
+        constexpr operator Side() const noexcept { return Side::Left; }
     };
     struct RightSide {
-        constexpr operator Side() const { return Side::Right; }
+        constexpr operator Side() const noexcept { return Side::Right; }
     };
 }  // namespace internal
 
@@ -319,19 +325,19 @@ TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_5_VALUES(Norm, One, Two, Inf, Fro, Max)
 
 namespace internal {
     struct MaxNorm {
-        constexpr operator Norm() const { return Norm::Max; }
+        constexpr operator Norm() const noexcept { return Norm::Max; }
     };
     struct OneNorm {
-        constexpr operator Norm() const { return Norm::One; }
+        constexpr operator Norm() const noexcept { return Norm::One; }
     };
     struct TwoNorm {
-        constexpr operator Norm() const { return Norm::Two; }
+        constexpr operator Norm() const noexcept { return Norm::Two; }
     };
     struct InfNorm {
-        constexpr operator Norm() const { return Norm::Inf; }
+        constexpr operator Norm() const noexcept { return Norm::Inf; }
     };
     struct FrobNorm {
-        constexpr operator Norm() const { return Norm::Fro; }
+        constexpr operator Norm() const noexcept { return Norm::Fro; }
     };
 }  // namespace internal
 
@@ -359,10 +365,16 @@ TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(Direction, Forward, Backward)
 
 namespace internal {
     struct Forward {
-        constexpr operator Direction() const { return Direction::Forward; }
+        constexpr operator Direction() const noexcept
+        {
+            return Direction::Forward;
+        }
     };
     struct Backward {
-        constexpr operator Direction() const { return Direction::Backward; }
+        constexpr operator Direction() const noexcept
+        {
+            return Direction::Backward;
+        }
     };
 }  // namespace internal
 
@@ -384,10 +396,13 @@ TLAPACK_DEF_OSTREAM_FOR_ENUM_WITH_2_VALUES(StoreV, Columnwise, Rowwise)
 
 namespace internal {
     struct ColumnwiseStorage {
-        constexpr operator StoreV() const { return StoreV::Columnwise; }
+        constexpr operator StoreV() const noexcept
+        {
+            return StoreV::Columnwise;
+        }
     };
     struct RowwiseStorage {
-        constexpr operator StoreV() const { return StoreV::Rowwise; }
+        constexpr operator StoreV() const noexcept { return StoreV::Rowwise; }
     };
 }  // namespace internal
 
@@ -415,16 +430,6 @@ constexpr internal::RowwiseStorage ROWWISE_STORAGE{};
 struct BandAccess {
     std::size_t lower_bandwidth;  ///< Number of subdiagonals.
     std::size_t upper_bandwidth;  ///< Number of superdiagonals.
-
-    /**
-     * @brief Construct a new Band Access object
-     *
-     * @param kl Number of subdiagonals.
-     * @param ku Number of superdiagonals.
-     */
-    constexpr BandAccess(std::size_t kl, std::size_t ku)
-        : lower_bandwidth(kl), upper_bandwidth(ku)
-    {}
 };
 
 // -----------------------------------------------------------------------------

--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -50,13 +50,13 @@ using std::pair;
 //------------------------------------------------------------------------------
 
 template <typename T, enable_if_t<is_real<T>, int> = 0>
-inline constexpr real_type<T> real(const T& x)
+inline constexpr real_type<T> real(const T& x) noexcept
 {
     return x;
 }
 
 template <typename T, enable_if_t<is_real<T>, int> = 0>
-inline constexpr real_type<T> imag(const T& x)
+inline constexpr real_type<T> imag(const T& x) noexcept
 {
     return real_type<T>(0);
 }
@@ -76,7 +76,7 @@ inline constexpr real_type<T> imag(const T& x)
  * std::conj
  */
 template <typename T, enable_if_t<is_real<T>, int> = 0>
-inline constexpr T conj(const T& x)
+inline constexpr T conj(const T& x) noexcept
 {
     return x;
 }
@@ -86,7 +86,7 @@ inline constexpr T conj(const T& x)
 /// @see Source: https://stackoverflow.com/a/4609795/5253097
 ///
 template <typename real_t>
-inline int sgn(const real_t& val)
+constexpr int sgn(const real_t& val)
 {
     return (real_t(0) < val) - (val < real_t(0));
 }
@@ -94,7 +94,7 @@ inline int sgn(const real_t& val)
 // -----------------------------------------------------------------------------
 /// isinf for complex numbers
 template <typename T, enable_if_t<is_complex<T>, int> = 0>
-inline bool isinf(const T& x)
+constexpr bool isinf(const T& x) noexcept
 {
     return isinf(real(x)) || isinf(imag(x));
 }
@@ -246,7 +246,7 @@ bool hasinf(uplo_t uplo, const matrix_t& A)
  * @see tlapack::hasinf(uplo_t uplo, const matrix_t& A).
  */
 template <TLAPACK_MATRIX matrix_t>
-bool hasinf(BandAccess accessType, const matrix_t& A)
+bool hasinf(BandAccess accessType, const matrix_t& A) noexcept
 {
     using idx_t = size_type<matrix_t>;
 
@@ -271,7 +271,7 @@ bool hasinf(BandAccess accessType, const matrix_t& A)
  * @return false if x has no infinite entry.
  */
 template <TLAPACK_VECTOR vector_t>
-bool hasinf(const vector_t& x)
+bool hasinf(const vector_t& x) noexcept
 {
     using idx_t = size_type<vector_t>;
 
@@ -286,7 +286,7 @@ bool hasinf(const vector_t& x)
 // -----------------------------------------------------------------------------
 /// isnan for complex numbers
 template <typename T, enable_if_t<is_complex<T>, int> = 0>
-inline bool isnan(const T& x)
+constexpr bool isnan(const T& x) noexcept
 {
     return isnan(real(x)) || isnan(imag(x));
 }
@@ -379,7 +379,7 @@ bool hasnan(uplo_t uplo, const matrix_t& A)
  * @see tlapack::hasnan(uplo_t uplo, const matrix_t& A).
  */
 template <TLAPACK_MATRIX matrix_t>
-bool hasnan(BandAccess accessType, const matrix_t& A)
+bool hasnan(BandAccess accessType, const matrix_t& A) noexcept
 {
     using idx_t = size_type<matrix_t>;
 
@@ -404,7 +404,7 @@ bool hasnan(BandAccess accessType, const matrix_t& A)
  * @return false if x has no NaN entry.
  */
 template <TLAPACK_VECTOR vector_t>
-bool hasnan(const vector_t& x)
+bool hasnan(const vector_t& x) noexcept
 {
     using idx_t = size_type<vector_t>;
 

--- a/include/tlapack/base/workspace.hpp
+++ b/include/tlapack/base/workspace.hpp
@@ -103,7 +103,7 @@ struct WorkInfo {
         return *this;
     }
 
-    constexpr WorkInfo transpose() noexcept { return WorkInfo(n, m); }
+    constexpr WorkInfo transpose() const noexcept { return WorkInfo(n, m); }
 };
 
 }  // namespace tlapack

--- a/include/tlapack/lapack/aggressive_early_deflation.hpp
+++ b/include/tlapack/lapack/aggressive_early_deflation.hpp
@@ -224,13 +224,13 @@ void aggressive_early_deflation_work(bool want_t,
     // First row index in the deflation window
     const idx_t kwtop = ihi - jw;
 
-    // Assertions
-    assert(nrows(A) == n);
+    // check arguments
+    tlapack_check(nrows(A) == n);
     if (want_z) {
-        assert(ncols(Z) == n);
-        assert(nrows(Z) == n);
+        tlapack_check(ncols(Z) == n);
+        tlapack_check(nrows(Z) == n);
     }
-    assert((idx_t)size(s) == n);
+    tlapack_check((idx_t)size(s) == n);
 
     // s is the value just outside the window. It determines the spike
     // together with the orthogonal schur factors.
@@ -651,13 +651,13 @@ void aggressive_early_deflation(bool want_t,
     // First row index in the deflation window
     const idx_t kwtop = ihi - jw;
 
-    // Assertions
-    assert(nrows(A) == n);
+    // check arguments
+    tlapack_check(nrows(A) == n);
     if (want_z) {
-        assert(ncols(Z) == n);
-        assert(nrows(Z) == n);
+        tlapack_check(ncols(Z) == n);
+        tlapack_check(nrows(Z) == n);
     }
-    assert((idx_t)size(s) == n);
+    tlapack_check((idx_t)size(s) == n);
 
     // s is the value just outside the window. It determines the spike
     // together with the orthogonal schur factors.

--- a/include/tlapack/lapack/lu_mult.hpp
+++ b/include/tlapack/lapack/lu_mult.hpp
@@ -51,7 +51,7 @@ void lu_mult(matrix_t& A, const LuMultOpts& opts = {})
     // quick return
     if (n == 0) return;
 
-    if (n <= opts.nx) {  // Matrix is small, use for loops instead of recursion
+    if (n <= (idx_t)opts.nx) {  // Matrix is small, do not use recursion
         for (idx_t i2 = n; i2 > 0; --i2) {
             idx_t i = i2 - 1;
             for (idx_t j2 = n; j2 > 0; --j2) {

--- a/include/tlapack/lapack/multishift_qr_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qr_sweep.hpp
@@ -115,12 +115,12 @@ void multishift_QR_sweep_work(bool want_t,
     const real_t eps = ulp<real_t>();
     const real_t small_num = safe_min<real_t>() * ((real_t)n / eps);
 
-    // Assertions
-    assert(n >= 12);
-    assert(nrows(A) == n);
+    // check arguments
+    tlapack_check(n >= 12);
+    tlapack_check(nrows(A) == n);
     if (want_z) {
-        assert(ncols(Z) == n);
-        assert(nrows(Z) == n);
+        tlapack_check(ncols(Z) == n);
+        tlapack_check(nrows(Z) == n);
     }
 
     // Workspace matrix

--- a/include/tlapack/plugins/eigen.hpp
+++ b/include/tlapack/plugins/eigen.hpp
@@ -148,19 +148,19 @@ template <
                      int> = 0
 #endif
     >
-inline constexpr auto size(const Eigen::EigenBase<Derived>& x)
+inline constexpr auto size(const Eigen::EigenBase<Derived>& x) noexcept
 {
     return x.size();
 }
 // Number of rows
 template <class T>
-inline constexpr auto nrows(const Eigen::EigenBase<T>& x)
+inline constexpr auto nrows(const Eigen::EigenBase<T>& x) noexcept
 {
     return x.rows();
 }
 // Number of columns
 template <class T>
-inline constexpr auto ncols(const Eigen::EigenBase<T>& x)
+inline constexpr auto ncols(const Eigen::EigenBase<T>& x) noexcept
 {
     return x.cols();
 }
@@ -607,7 +607,7 @@ inline constexpr auto transpose_view(matrix_t& A) noexcept
 template <
     class matrix_t,
     typename std::enable_if<eigen::is_eigen_type<matrix_t>, int>::type = 0>
-auto reshape(matrix_t& A, Eigen::Index m, Eigen::Index n)
+auto reshape(matrix_t& A, Eigen::Index m, Eigen::Index n) noexcept
 {
     using T = typename matrix_t::Scalar;
     using Stride = Eigen::OuterStride<>;
@@ -621,17 +621,14 @@ auto reshape(matrix_t& A, Eigen::Index m, Eigen::Index n)
     if (m == A.rows() && n == A.cols())
         return map_t((T*)A.data(), m, n, A.outerStride());
     else {
-        if (m * n != A.size())
-            throw std::invalid_argument(
-                "reshape: new shape must have the same "
-                "number of elements as the original one");
-        if (!(!matrix_t::IsRowMajor &&
-              (A.outerStride() == A.rows() || A.cols() <= 1)) &&
-            !(matrix_t::IsRowMajor &&
-              (A.outerStride() == A.cols() || A.rows() <= 1)))
-            throw std::invalid_argument(
-                "reshape: data must be contiguous in memory");
-
+        assert((m * n == A.size()) &&
+               "reshape: new shape must have the same "
+               "number of elements as the original one");
+        assert(((!matrix_t::IsRowMajor &&
+                 (A.outerStride() == A.rows() || A.cols() <= 1)) ||
+                (matrix_t::IsRowMajor &&
+                 (A.outerStride() == A.cols() || A.rows() <= 1))) &&
+               "reshape: data must be contiguous in memory");
         return map_t((T*)A.data(), m, n, (matrix_t::IsRowMajor ? n : m));
     }
 }

--- a/include/tlapack/plugins/legacyArray.hpp
+++ b/include/tlapack/plugins/legacyArray.hpp
@@ -109,63 +109,64 @@ namespace traits {
 
 // Number of rows of LegacyMatrix
 template <typename T, class idx_t, Layout layout>
-inline constexpr auto nrows(const LegacyMatrix<T, idx_t, layout>& A)
+inline constexpr auto nrows(const LegacyMatrix<T, idx_t, layout>& A) noexcept
 {
     return A.m;
 }
 
 // Number of columns of LegacyMatrix
 template <typename T, class idx_t, Layout layout>
-inline constexpr auto ncols(const LegacyMatrix<T, idx_t, layout>& A)
+inline constexpr auto ncols(const LegacyMatrix<T, idx_t, layout>& A) noexcept
 {
     return A.n;
 }
 
 // Size of LegacyMatrix
 template <typename T, class idx_t, Layout layout>
-inline constexpr auto size(const LegacyMatrix<T, idx_t, layout>& A)
+inline constexpr auto size(const LegacyMatrix<T, idx_t, layout>& A) noexcept
 {
     return A.m * A.n;
 }
 
 // Size of LegacyVector
 template <typename T, class idx_t, typename int_t, Direction direction>
-inline constexpr auto size(const LegacyVector<T, idx_t, int_t, direction>& x)
+inline constexpr auto size(
+    const LegacyVector<T, idx_t, int_t, direction>& x) noexcept
 {
     return x.n;
 }
 
 // Number of rows of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto nrows(const LegacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto nrows(const LegacyBandedMatrix<T, idx_t>& A) noexcept
 {
     return A.m;
 }
 
 // Number of columns of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto ncols(const LegacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto ncols(const LegacyBandedMatrix<T, idx_t>& A) noexcept
 {
     return A.n;
 }
 
 // Size of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto size(const LegacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto size(const LegacyBandedMatrix<T, idx_t>& A) noexcept
 {
     return A.m * A.n;
 }
 
 // Lowerband of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto lowerband(const LegacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto lowerband(const LegacyBandedMatrix<T, idx_t>& A) noexcept
 {
     return A.kl;
 }
 
 // Upperband of LegacyBandedMatrix
 template <typename T, class idx_t>
-inline constexpr auto upperband(const LegacyBandedMatrix<T, idx_t>& A)
+inline constexpr auto upperband(const LegacyBandedMatrix<T, idx_t>& A) noexcept
 {
     return A.ku;
 }
@@ -556,20 +557,17 @@ inline constexpr auto slice(LegacyVector<T, idx_t, int_t, direction>& v,
 template <typename T, class idx_t, Layout layout>
 auto reshape(LegacyMatrix<T, idx_t, layout>& A,
              size_type<LegacyMatrix<T, idx_t>> m,
-             size_type<LegacyMatrix<T, idx_t>> n)
+             size_type<LegacyMatrix<T, idx_t>> n) noexcept
 {
     if (m == A.m && n == A.n)
         return A;
     else {
-        if (m * n != A.m * A.n)
-            throw std::invalid_argument(
-                "reshape: new shape must have the same "
-                "number of elements as the original one");
-        if (!(layout == Layout::ColMajor && (A.ldim == A.m || A.n <= 1)) &&
-            !(layout == Layout::RowMajor && (A.ldim == A.n || A.m <= 1)))
-            throw std::invalid_argument(
-                "reshape: data must be contiguous in memory");
-
+        assert((m * n == A.m * A.n) &&
+               "reshape: new shape must have the same "
+               "number of elements as the original one");
+        assert(((layout == Layout::ColMajor && (A.ldim == A.m || A.n <= 1)) ||
+                (layout == Layout::RowMajor && (A.ldim == A.n || A.m <= 1))) &&
+               "reshape: data must be contiguous in memory");
         return LegacyMatrix<T, idx_t, layout>(m, n, &A.ptr[0]);
     }
 }

--- a/include/tlapack/plugins/mdspan.hpp
+++ b/include/tlapack/plugins/mdspan.hpp
@@ -332,7 +332,7 @@ template <
                      int> = 0>
 auto reshape(std::experimental::mdspan<ET, Exts, LP, AP>& A,
              std::size_t m,
-             std::size_t n)
+             std::size_t n) noexcept
 {
     using size_type =
         typename std::experimental::mdspan<ET, Exts, LP, AP>::size_type;
@@ -340,10 +340,9 @@ auto reshape(std::experimental::mdspan<ET, Exts, LP, AP>& A,
     using matrix_t = std::experimental::mdspan<ET, extents_t, LP, AP>;
     using mapping_t = typename LP::template mapping<extents_t>;
 
-    if (m * n != A.size())
-        throw std::invalid_argument(
-            "reshape: new shape must have the same "
-            "number of elements as the original one");
+    assert((m * n == A.size()) &&
+           "reshape: new shape must have the same "
+           "number of elements as the original one");
 
     return matrix_t(A.data(), mapping_t(extents_t(m, n)));
 }
@@ -352,7 +351,7 @@ auto reshape(
     std::experimental::mdspan<ET, Exts, std::experimental::layout_stride, AP>&
         A,
     std::size_t m,
-    std::size_t n)
+    std::size_t n) noexcept
 {
     using LP = std::experimental::layout_stride;
     using idx_t =
@@ -366,16 +365,14 @@ auto reshape(
                                             std::array<idx_t, 2>{A.stride(0),
                                                                  A.stride(1)}));
     else {
-        if (m * n != A.size())
-            throw std::invalid_argument(
-                "reshape: new shape must have the same "
-                "number of elements as the original one");
-        if (!(A.stride(0) == 1 &&
-              (A.stride(1) == A.extent(0) || A.extent(1) <= 1)) &&
-            !(A.stride(1) == 1 &&
-              (A.stride(0) == A.extent(1) || A.extent(0) <= 1)))
-            throw std::invalid_argument(
-                "reshape: data must be contiguous in memory");
+        assert((m * n == A.size()) &&
+               "reshape: new shape must have the same "
+               "number of elements as the original one");
+        assert(((A.stride(0) == 1 &&
+                 (A.stride(1) == A.extent(0) || A.extent(1) <= 1)) ||
+                (A.stride(1) == 1 &&
+                 (A.stride(0) == A.extent(1) || A.extent(0) <= 1))) &&
+               "reshape: data must be contiguous in memory");
 
         return matrix_t(A.data(), mapping_t(extents_t(m, n),
                                             (A.stride(0) == 1)

--- a/include/tlapack/plugins/mpreal.hpp
+++ b/include/tlapack/plugins/mpreal.hpp
@@ -40,11 +40,11 @@ namespace traits {
 
 // Forward declaration
 template <typename real_t>
-inline int digits();
+inline int digits() noexcept;
 
 // Specialization for the mpfr::mpreal datatype
 template <>
-inline int digits<mpfr::mpreal>()
+inline int digits<mpfr::mpreal>() noexcept
 {
     return std::numeric_limits<mpfr::mpreal>::digits();
 }

--- a/include/tlapack/plugins/starpu.hpp
+++ b/include/tlapack/plugins/starpu.hpp
@@ -17,26 +17,26 @@ namespace tlapack {
 
 // Forward declarations
 template <class T, std::enable_if_t<is_real<T>, int> = 0>
-inline constexpr real_type<T> real(const T& x);
+inline constexpr real_type<T> real(const T& x) noexcept;
 template <class T, std::enable_if_t<is_real<T>, int> = 0>
-inline constexpr real_type<T> imag(const T& x);
+inline constexpr real_type<T> imag(const T& x) noexcept;
 template <class T, std::enable_if_t<is_real<T>, int> = 0>
-inline constexpr T conj(const T& x);
+inline constexpr T conj(const T& x) noexcept;
 
 template <class T>
-inline constexpr real_type<T> real(const starpu::MatrixEntry<T>& x)
+inline constexpr real_type<T> real(const starpu::MatrixEntry<T>& x) noexcept
 {
     return real(T(x));
 }
 
 template <class T>
-inline constexpr real_type<T> imag(const starpu::MatrixEntry<T>& x)
+inline constexpr real_type<T> imag(const starpu::MatrixEntry<T>& x) noexcept
 {
     return imag(T(x));
 }
 
 template <class T>
-inline constexpr T conj(const starpu::MatrixEntry<T>& x)
+inline constexpr T conj(const starpu::MatrixEntry<T>& x) noexcept
 {
     return conj(T(x));
 }
@@ -59,19 +59,19 @@ namespace tlapack {
 
 // Number of rows
 template <class T>
-constexpr auto nrows(const starpu::Matrix<T>& A)
+constexpr auto nrows(const starpu::Matrix<T>& A) noexcept
 {
     return A.nrows();
 }
 // Number of columns
 template <class T>
-constexpr auto ncols(const starpu::Matrix<T>& A)
+constexpr auto ncols(const starpu::Matrix<T>& A) noexcept
 {
     return A.ncols();
 }
 // Size
 template <class T>
-constexpr auto size(const starpu::Matrix<T>& A)
+constexpr auto size(const starpu::Matrix<T>& A) noexcept
 {
     return A.nrows() * A.ncols();
 }
@@ -91,7 +91,7 @@ template <
                             int>::type = 0>
 constexpr auto slice(const starpu::Matrix<T>& A,
                      SliceSpecRow&& rows,
-                     SliceSpecCol&& cols)
+                     SliceSpecCol&& cols) noexcept
 {
     using starpu::idx_t;
 
@@ -110,7 +110,7 @@ template <
                             int>::type = 0>
 constexpr auto slice(starpu::Matrix<T>& A,
                      SliceSpecRow&& rows,
-                     SliceSpecCol&& cols)
+                     SliceSpecCol&& cols) noexcept
 {
     using starpu::idx_t;
 
@@ -127,7 +127,7 @@ constexpr auto slice(starpu::Matrix<T>& A,
 template <class T, class SliceSpec>
 constexpr auto slice(const starpu::Matrix<T>& v,
                      SliceSpec&& range,
-                     starpu::idx_t colIdx)
+                     starpu::idx_t colIdx) noexcept
 {
     return slice(v, std::forward<SliceSpec>(range),
                  std::make_tuple(colIdx, colIdx + 1));
@@ -135,7 +135,7 @@ constexpr auto slice(const starpu::Matrix<T>& v,
 template <class T, class SliceSpec>
 constexpr auto slice(starpu::Matrix<T>& v,
                      SliceSpec&& range,
-                     starpu::idx_t colIdx)
+                     starpu::idx_t colIdx) noexcept
 {
     return slice(v, std::forward<SliceSpec>(range),
                  std::make_tuple(colIdx, colIdx + 1));
@@ -144,7 +144,7 @@ constexpr auto slice(starpu::Matrix<T>& v,
 template <class T, class SliceSpec>
 constexpr auto slice(const starpu::Matrix<T>& v,
                      starpu::idx_t rowIdx,
-                     SliceSpec&& range)
+                     SliceSpec&& range) noexcept
 {
     return slice(v, std::make_tuple(rowIdx, rowIdx + 1),
                  std::forward<SliceSpec>(range));
@@ -152,14 +152,14 @@ constexpr auto slice(const starpu::Matrix<T>& v,
 template <class T, class SliceSpec>
 constexpr auto slice(starpu::Matrix<T>& v,
                      starpu::idx_t rowIdx,
-                     SliceSpec&& range)
+                     SliceSpec&& range) noexcept
 {
     return slice(v, std::make_tuple(rowIdx, rowIdx + 1),
                  std::forward<SliceSpec>(range));
 }
 
 template <class T, class SliceSpec>
-constexpr auto slice(const starpu::Matrix<T>& v, SliceSpec&& range)
+constexpr auto slice(const starpu::Matrix<T>& v, SliceSpec&& range) noexcept
 {
     assert((v.nrows() <= 1 || v.ncols() <= 1) && "Matrix is not a vector");
 
@@ -169,7 +169,7 @@ constexpr auto slice(const starpu::Matrix<T>& v, SliceSpec&& range)
         return slice(v, std::make_tuple(0, 1), std::forward<SliceSpec>(range));
 }
 template <class T, class SliceSpec>
-constexpr auto slice(starpu::Matrix<T>& v, SliceSpec&& range)
+constexpr auto slice(starpu::Matrix<T>& v, SliceSpec&& range) noexcept
 {
     assert((v.nrows() <= 1 || v.ncols() <= 1) && "Matrix is not a vector");
 
@@ -180,52 +180,52 @@ constexpr auto slice(starpu::Matrix<T>& v, SliceSpec&& range)
 }
 
 template <class T>
-constexpr auto col(const starpu::Matrix<T>& A, starpu::idx_t colIdx)
+constexpr auto col(const starpu::Matrix<T>& A, starpu::idx_t colIdx) noexcept
 {
     return slice(A, std::make_tuple(0, A.nrows()),
                  std::make_tuple(colIdx, colIdx + 1));
 }
 template <class T>
-constexpr auto col(starpu::Matrix<T>& A, starpu::idx_t colIdx)
+constexpr auto col(starpu::Matrix<T>& A, starpu::idx_t colIdx) noexcept
 {
     return slice(A, std::make_tuple(0, A.nrows()),
                  std::make_tuple(colIdx, colIdx + 1));
 }
 
 template <class T, class SliceSpec>
-constexpr auto cols(const starpu::Matrix<T>& A, SliceSpec&& cols)
+constexpr auto cols(const starpu::Matrix<T>& A, SliceSpec&& cols) noexcept
 {
     return slice(A, std::make_tuple(0, A.nrows()),
                  std::forward<SliceSpec>(cols));
 }
 template <class T, class SliceSpec>
-constexpr auto cols(starpu::Matrix<T>& A, SliceSpec&& cols)
+constexpr auto cols(starpu::Matrix<T>& A, SliceSpec&& cols) noexcept
 {
     return slice(A, std::make_tuple(0, A.nrows()),
                  std::forward<SliceSpec>(cols));
 }
 
 template <class T>
-constexpr auto row(const starpu::Matrix<T>& A, starpu::idx_t rowIdx)
+constexpr auto row(const starpu::Matrix<T>& A, starpu::idx_t rowIdx) noexcept
 {
     return slice(A, std::make_tuple(rowIdx, rowIdx + 1),
                  std::make_tuple(0, A.ncols()));
 }
 template <class T>
-constexpr auto row(starpu::Matrix<T>& A, starpu::idx_t rowIdx)
+constexpr auto row(starpu::Matrix<T>& A, starpu::idx_t rowIdx) noexcept
 {
     return slice(A, std::make_tuple(rowIdx, rowIdx + 1),
                  std::make_tuple(0, A.ncols()));
 }
 
 template <class T, class SliceSpec>
-constexpr auto rows(const starpu::Matrix<T>& A, SliceSpec&& rows)
+constexpr auto rows(const starpu::Matrix<T>& A, SliceSpec&& rows) noexcept
 {
     return slice(A, std::forward<SliceSpec>(rows),
                  std::make_tuple(0, A.ncols()));
 }
 template <class T, class SliceSpec>
-constexpr auto rows(starpu::Matrix<T>& A, SliceSpec&& rows)
+constexpr auto rows(starpu::Matrix<T>& A, SliceSpec&& rows) noexcept
 {
     return slice(A, std::forward<SliceSpec>(rows),
                  std::make_tuple(0, A.ncols()));

--- a/include/tlapack/plugins/stdvector.hpp
+++ b/include/tlapack/plugins/stdvector.hpp
@@ -25,7 +25,7 @@ namespace tlapack {
 
 // Size
 template <class T, class Allocator>
-inline constexpr auto size(const std::vector<T, Allocator>& x)
+inline constexpr auto size(const std::vector<T, Allocator>& x) noexcept
 {
     return x.size();
 }
@@ -36,7 +36,7 @@ inline constexpr auto size(const std::vector<T, Allocator>& x)
 // slice
 template <class T, class Allocator, class SliceSpec>
 inline constexpr auto slice(const std::vector<T, Allocator>& v,
-                            SliceSpec&& rows)
+                            SliceSpec&& rows) noexcept
 {
     assert((rows.first >= 0 && (std::size_t)rows.first < size(v)) ||
            rows.first == rows.second);

--- a/include/tlapack/starpu/filters.hpp
+++ b/include/tlapack/starpu/filters.hpp
@@ -30,7 +30,7 @@ namespace starpu {
                             void* child_interface,
                             struct starpu_data_filter* f,
                             STARPU_ATTRIBUTE_UNUSED unsigned id,
-                            STARPU_ATTRIBUTE_UNUSED unsigned nparts)
+                            STARPU_ATTRIBUTE_UNUSED unsigned nparts) noexcept
     {
         struct starpu_matrix_interface* matrix_father =
             (struct starpu_matrix_interface*)father_interface;
@@ -83,7 +83,7 @@ namespace starpu {
                               void* child_interface,
                               struct starpu_data_filter* f,
                               unsigned id,
-                              STARPU_ATTRIBUTE_UNUSED unsigned nparts)
+                              STARPU_ATTRIBUTE_UNUSED unsigned nparts) noexcept
     {
         struct starpu_data_filter f_tile {
             .filter_arg_ptr = (void*)((idx_t*)f->filter_arg_ptr + 4 * id),
@@ -107,7 +107,7 @@ namespace starpu {
         void* child_interface,
         STARPU_ATTRIBUTE_UNUSED struct starpu_data_filter* f,
         unsigned id,
-        unsigned nparts)
+        unsigned nparts) noexcept
     {
         struct starpu_matrix_interface* matrix_father =
             (struct starpu_matrix_interface*)father_interface;
@@ -156,7 +156,7 @@ namespace starpu {
                             void* child_interface,
                             struct starpu_data_filter* f,
                             unsigned id,
-                            unsigned nparts)
+                            unsigned nparts) noexcept
     {
         struct starpu_matrix_interface* matrix_father =
             (struct starpu_matrix_interface*)father_interface;

--- a/include/tlapack/starpu/utils.hpp
+++ b/include/tlapack/starpu/utils.hpp
@@ -64,7 +64,7 @@ namespace starpu {
                                           std::is_constructible_v<T, T1>;
         };
 
-        inline cublasOperation_t op2cublas(Op op)
+        inline cublasOperation_t op2cublas(Op op) noexcept
         {
             switch (op) {
                 case Op::NoTrans:
@@ -76,11 +76,11 @@ namespace starpu {
                 case Op::Conj:
                     return CUBLAS_OP_CONJG;
                 default:
-                    throw std::invalid_argument("Invalid value for Op");
+                    return cublasOperation_t(-1);
             }
         }
 
-        inline cublasFillMode_t uplo2cublas(Uplo uplo)
+        inline cublasFillMode_t uplo2cublas(Uplo uplo) noexcept
         {
             switch (uplo) {
                 case Uplo::Upper:
@@ -88,11 +88,11 @@ namespace starpu {
                 case Uplo::Lower:
                     return CUBLAS_FILL_MODE_LOWER;
                 default:
-                    throw std::invalid_argument("Invalid value for Uplo");
+                    return cublasFillMode_t(-1);
             }
         }
 
-        inline cublasDiagType_t diag2cublas(Diag diag)
+        inline cublasDiagType_t diag2cublas(Diag diag) noexcept
         {
             switch (diag) {
                 case Diag::NonUnit:
@@ -100,11 +100,11 @@ namespace starpu {
                 case Diag::Unit:
                     return CUBLAS_DIAG_UNIT;
                 default:
-                    throw std::invalid_argument("Invalid value for Diag");
+                    return cublasDiagType_t(-1);
             }
         }
 
-        inline cublasSideMode_t side2cublas(Side side)
+        inline cublasSideMode_t side2cublas(Side side) noexcept
         {
             switch (side) {
                 case Side::Left:
@@ -112,7 +112,7 @@ namespace starpu {
                 case Side::Right:
                     return CUBLAS_SIDE_RIGHT;
                 default:
-                    throw std::invalid_argument("Invalid value for Side");
+                    return cublasSideMode_t(-1);
             }
         }
 #endif


### PR DESCRIPTION
Establishes directions to when using `assert()` and `tlapack_check()` in CONTRIBUTING.md. Also, use noexcept more consistently throughout the code.

Helpful links:
- https://en.cppreference.com/w/cpp/error/assert
- https://en.cppreference.com/w/cpp/language/noexcept_spec