### PR TITLE
Adds compatibility with GNU quad precision

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -246,6 +246,7 @@ jobs:
         -D BUILD_TESTING=ON
         -D BUILD_testBLAS_TESTS=OFF
         -D TLAPACK_TEST_MPFR=ON
+        -D TLAPACK_TEST_QUAD=ON
 
     - name: Build <T>LAPACK
       run: cmake --build build --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ option( TLAPACK_BUILD_SINGLE_TESTER "Build one additional executable that contai
 option( TLAPACK_TEST_EIGEN "Add Eigen matrices to the types to test" OFF )
 option( TLAPACK_TEST_MDSPAN "Add mdspan matrices to the types to test" OFF )
 option( TLAPACK_TEST_MPFR "Add GNU multiprecision type to test" OFF )
+option( TLAPACK_TEST_QUAD "Add a quad-precision type to test" OFF )
 
 # Wrappers to <T>LAPACK
 option( BUILD_C_WRAPPERS       "Build and install C wrappers (WIP)" OFF )

--- a/include/tlapack/base/concepts.hpp
+++ b/include/tlapack/base/concepts.hpp
@@ -152,8 +152,8 @@ namespace concepts {
      * latter returns a complex type of the same type as the input. Those
      * functions must be callable from the namespace @c tlapack.
      *
-     * - it must support the math function @c abs(). This function must be
-     * callable from the namespace @c tlapack.
+     * - it must support the math functions @c abs() and @c sqrt(). These
+     * functions must be callable from the namespace @c tlapack.
      *
      * @tparam T Type.
      *
@@ -187,6 +187,7 @@ namespace concepts {
 
         // Math functions
         abs(a);
+        sqrt(a);
     };
 
     /** @interface tlapack::concepts::Scalar
@@ -199,8 +200,8 @@ namespace concepts {
      *
      * - it must be move assignable.
      *
-     * - it must support the math function @c abs(). This function must be
-     * callable from the namespace @c tlapack.
+     * - it must support the math functions @c abs() and @c sqrt(). These
+     * functions must be callable from the namespace @c tlapack.
      *
      * @tparam T Scalar type.
      *
@@ -215,6 +216,7 @@ namespace concepts {
 
         // Math functions
         abs(a);
+        sqrt(a);
     };
 
     /** @interface tlapack::concepts::Vector

--- a/include/tlapack/plugins/gnuquad.hpp
+++ b/include/tlapack/plugins/gnuquad.hpp
@@ -1,21 +1,24 @@
-// using std::abs;
-// using std::ceil;
-// using std::floor;
-// using std::isinf;
-// using std::isnan;
-// using std::log2;
-// using std::max;
-// using std::min;
-// using std::pow;  // We only use pow(int, T), see below in the concept Real.
-// using std::sqrt;
+/// @file gnuquad.hpp Compatibility layer for the GNU type __float128
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_GNUQUAD_HH
+#define TLAPACK_GNUQUAD_HH
 
 #include <quadmath.h>
 
+#include <complex>
 #include <limits>
+#include <ostream>
 
 namespace std {
 
-inline constexpr __float128 abs(__float128 x);  // See include/bits/std_abs.h
+constexpr __float128 abs(__float128 x);  // See include/bits/std_abs.h
 inline __float128 ceil(__float128 x) noexcept { return ceilq(x); }
 inline __float128 floor(__float128 x) noexcept { return floorq(x); }
 inline bool isinf(__float128 x) noexcept { return isinfq(x); }
@@ -31,6 +34,38 @@ inline __float128 min(__float128 x, __float128 y) noexcept
 }
 inline __float128 pow(int x, __float128 y) noexcept { return powq(x, y); }
 inline __float128 sqrt(__float128 x) noexcept { return sqrtq(x); }
+
+inline __float128 abs(complex<__float128> z)
+{
+    __float128 x = z.real();
+    __float128 y = z.imag();
+    const __float128 __s = max(abs(x), abs(y));
+    if (__s == __float128())  // well ...
+        return __s;
+    x /= __s;
+    y /= __s;
+    return __s * sqrt(x * x + y * y);
+}
+inline complex<__float128> sqrt(complex<__float128> z)
+{
+    const __float128 x = real(z);
+    const __float128 y = imag(z);
+    const __float128 zero(0);
+    const __float128 two(2);
+    const __float128 half(0.5);
+
+    if (x == zero) {
+        __float128 t = sqrt(half * abs(y));
+        return complex<__float128>(t, (y < zero) ? -t : t);
+    }
+    else {
+        __float128 t = sqrt(two * (abs(z) + abs(x)));
+        __float128 u = half * t;
+        return (x > zero)
+                   ? complex<__float128>(u, y / t)
+                   : complex<__float128>(abs(y) / t, (y < zero) ? -u : u);
+    }
+}
 
 template <>
 struct numeric_limits<__float128> {
@@ -83,4 +118,14 @@ struct numeric_limits<__float128> {
     static constexpr float_round_style round_style = round_to_nearest;
 };
 
+ostream& operator<<(ostream& out, const __float128& x)
+{
+    char buf[128];
+    quadmath_snprintf(buf, 128, "%+-#*.20Qe", x);
+    out << buf;
+    return out;
+}
+
 }  // namespace std
+
+#endif

--- a/include/tlapack/plugins/gnuquad.hpp
+++ b/include/tlapack/plugins/gnuquad.hpp
@@ -1,0 +1,86 @@
+// using std::abs;
+// using std::ceil;
+// using std::floor;
+// using std::isinf;
+// using std::isnan;
+// using std::log2;
+// using std::max;
+// using std::min;
+// using std::pow;  // We only use pow(int, T), see below in the concept Real.
+// using std::sqrt;
+
+#include <quadmath.h>
+
+#include <limits>
+
+namespace std {
+
+inline constexpr __float128 abs(__float128 x);  // See include/bits/std_abs.h
+inline __float128 ceil(__float128 x) noexcept { return ceilq(x); }
+inline __float128 floor(__float128 x) noexcept { return floorq(x); }
+inline bool isinf(__float128 x) noexcept { return isinfq(x); }
+inline bool isnan(__float128 x) noexcept { return isnanq(x); }
+inline __float128 log2(__float128 x) noexcept { return log2q(x); }
+inline __float128 max(__float128 x, __float128 y) noexcept
+{
+    return fmaxq(x, y);
+}
+inline __float128 min(__float128 x, __float128 y) noexcept
+{
+    return fminq(x, y);
+}
+inline __float128 pow(int x, __float128 y) noexcept { return powq(x, y); }
+inline __float128 sqrt(__float128 x) noexcept { return sqrtq(x); }
+
+template <>
+struct numeric_limits<__float128> {
+    static constexpr bool is_specialized = true;
+
+    static constexpr __float128 min() noexcept { return FLT128_MIN; }
+    static constexpr __float128 max() noexcept { return FLT128_MAX; }
+    static constexpr __float128 lowest() noexcept { return -FLT128_MAX; }
+
+    static constexpr int digits = FLT128_MANT_DIG;
+    static constexpr int digits10 = FLT128_DIG;
+    static constexpr int max_digits10 = (2 + FLT128_MANT_DIG * 643L / 2136);
+
+    static constexpr bool is_signed = true;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+
+    static constexpr int radix = 2;
+    static constexpr __float128 epsilon() noexcept { return FLT128_EPSILON; }
+    static constexpr __float128 round_error() noexcept { return 0.5F; }
+
+    static constexpr int min_exponent = FLT128_MIN_EXP;
+    static constexpr int min_exponent10 = FLT128_MIN_10_EXP;
+    static constexpr int max_exponent = FLT128_MAX_EXP;
+    static constexpr int max_exponent10 = FLT128_MAX_10_EXP;
+
+    static constexpr bool has_infinity = true;
+    static constexpr bool has_quiet_NaN = true;
+    // static constexpr bool has_signaling_NaN = ;
+    static constexpr float_denorm_style has_denorm = denorm_present;
+    static constexpr bool has_denorm_loss = false;
+
+    static constexpr __float128 infinity() noexcept
+    {
+        return __builtin_huge_valq();
+    }
+    static __float128 quiet_NaN() noexcept { return nanq(""); }
+    // static constexpr __float128 signaling_NaN() noexcept {}
+    static constexpr __float128 denorm_min() noexcept
+    {
+        return FLT128_DENORM_MIN;
+    }
+
+    // static constexpr bool is_iec559 = ;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
+
+    // static constexpr bool traps = ;
+    // static constexpr bool tinyness_before = ;
+    static constexpr float_round_style round_style = round_to_nearest;
+};
+
+}  // namespace std

--- a/include/tlapack/plugins/gnuquad.hpp
+++ b/include/tlapack/plugins/gnuquad.hpp
@@ -118,7 +118,7 @@ struct numeric_limits<__float128> {
     static constexpr float_round_style round_style = round_to_nearest;
 };
 
-ostream& operator<<(ostream& out, const __float128& x)
+inline ostream& operator<<(ostream& out, const __float128& x)
 {
     char buf[128];
     quadmath_snprintf(buf, 128, "%+-#*.20Qe", x);

--- a/test/include/testdefinitions.hpp
+++ b/test/include/testdefinitions.hpp
@@ -30,6 +30,10 @@
     #include <tlapack/plugins/mpreal.hpp>
 #endif
 
+#ifdef TLAPACK_TEST_QUAD
+    #include <tlapack/plugins/gnuquad.hpp>
+#endif
+
 //
 // The matrix types that will be tested for routines
 // that only accept real matrices
@@ -47,6 +51,13 @@
             , LegacyMatrix<mpfr::mpreal>
     #else
         #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_MPREAL
+    #endif
+
+    #ifdef TLAPACK_TEST_QUAD
+        #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_QUAD \
+            , LegacyMatrix<__float128>
+    #else
+        #define TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_QUAD
     #endif
 
     #ifdef TLAPACK_TEST_EIGEN
@@ -76,7 +87,8 @@
         TLAPACK_LEGACY_REAL_TYPES_TO_TEST             \
         TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_MPREAL \
         TLAPACK_EIGEN_REAL_TYPES_TO_TEST              \
-        TLAPACK_MDSPAN_REAL_TYPES_TO_TEST
+        TLAPACK_MDSPAN_REAL_TYPES_TO_TEST             \
+        TLAPACK_LEGACY_REAL_TYPES_TO_TEST_WITH_QUAD
 #endif
 
 //

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -33,6 +33,12 @@ if(TLAPACK_TEST_MPFR)
   target_compile_definitions(testutils PUBLIC TLAPACK_TEST_MPFR)
 endif()
 
+if(TLAPACK_TEST_QUAD)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    target_compile_definitions(testutils PUBLIC TLAPACK_TEST_QUAD)
+  endif()
+endif()
+
 # Use this library on all tests
 link_libraries(testutils)
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -36,6 +36,8 @@ endif()
 if(TLAPACK_TEST_QUAD)
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_definitions(testutils PUBLIC TLAPACK_TEST_QUAD)
+    target_compile_options(testutils PUBLIC -fext-numeric-literals)
+    target_link_libraries(testutils PUBLIC -lquadmath)
   endif()
 endif()
 


### PR DESCRIPTION
This PR adds compatibility with the GNU quadruple precision type `__float128`. See https://gcc.gnu.org/onlinedocs/gcc-6.5.0/libquadmath.pdf

More functionality -> more tests -> more bugs solved. In this case, I realized we actually need `sqrt()` for complex data types. So, this PR also adds `sqrt()` to the `Complex` concept.

Closes #240