### PR TITLE
Adds example for building a static library from \<T\>LAPACK

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -107,6 +107,15 @@ if( Eigen3_FOUND )
       "${CMAKE_CURRENT_BINARY_DIR}/performance_eigen/performance_tlapack${CMAKE_EXECUTABLE_SUFFIX}"
       && echo ""
   )
+  # add the example create_float_library
+  add_subdirectory( create_float_library )
+  add_custom_command(
+    OUTPUT run-all-examples-cmd APPEND
+    COMMAND
+      echo "- example_create_float_library ----------------" &&
+      "${CMAKE_CURRENT_BINARY_DIR}/create_float_library/example_create_float_library${CMAKE_EXECUTABLE_SUFFIX}"
+      && echo ""
+  )
 else()
   mark_as_advanced( FORCE Eigen3_DIR )
 endif()

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,3 +35,7 @@ This is the list of examples and brief descriptions:
 - [eigen](eigen/README.md)
 
   Compare the QR factorization from Eigen and \<T\>LAPACK. We use Eigen::Matrix as the data structure.
+
+- [create_float_library](create_float_library/README.md)
+
+  Create a static library with single precision from the \<T\>LAPACK library.

--- a/examples/create_float_library/CMakeLists.txt
+++ b/examples/create_float_library/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+#
+# This file is part of <T>LAPACK.
+# <T>LAPACK is free software: you can redistribute it and/or modify it under
+# the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+cmake_minimum_required(VERSION 3.1)
+
+project( create_float_library CXX )
+
+# Load <T>LAPACK
+if( NOT TARGET tlapack )
+  find_package( tlapack REQUIRED )
+endif()
+
+find_package( Eigen3 REQUIRED )
+
+# Create the library
+add_library( tlapack_EigenMatrixXf STATIC tlapack_EigenMatrixXf.cpp )
+target_link_libraries( tlapack_EigenMatrixXf PUBLIC Eigen3::Eigen tlapack )
+
+# add the example eigen
+add_executable( example_create_float_library main.cpp )
+target_link_libraries( example_create_float_library PRIVATE tlapack_EigenMatrixXf )

--- a/examples/create_float_library/Makefile
+++ b/examples/create_float_library/Makefile
@@ -1,0 +1,25 @@
+-include make.inc
+
+#-------------------------------------------------------------------------------
+# Executables
+
+all: example_create_float_library
+
+# Create library tlapack_EigenMatrixXf.a
+tlapack_EigenMatrixXf.a: tlapack_EigenMatrixXf.o
+	$(AR) $(ARFLAGS) $@ $<
+
+example_create_float_library: main.o tlapack_EigenMatrixXf.a
+	$(CXX) $(CXXFLAGS) -o $@ $< $(LDFLAGS) tlapack_EigenMatrixXf.a
+
+#-------------------------------------------------------------------------------
+# Rules
+
+.PHONY: all
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+clean:
+	rm -f *.o
+	rm -f example_create_float_library tlapack_EigenMatrixXf.a

--- a/examples/create_float_library/README.md
+++ b/examples/create_float_library/README.md
@@ -1,0 +1,27 @@
+# Example: create_float_library
+
+In this example, we show how to create a static library with single precision from the \<T\>LAPACK library. We use single precision `float` and the data structures from the [Eigen](https://eigen.tuxfamily.org) library, namely, `Eigen::MatrixXf` and `Eigen::VectorXf`.
+
+## Build
+
+We provide two options for building this example:
+
+1. Following the standard CMake recipe
+
+```sh
+mkdir build
+cmake -B build      # configuration step
+cmake --build build # build step
+```
+
+You will find the static library and executable inside the `build` directory.
+
+2. Using `make` on the same directory of [tlapack_EigenMatrixXf.hpp](tlapack_EigenMatrixXf.hpp). In this case, you should edit `make.inc` to set the \<T\>LAPACK include and Eigen include directories. After a successful build, the static library and executable will be in the current directory.
+
+## Run
+
+You can run the executable from the command line.
+
+---
+
+[Examples](../README.md#create_float_library)

--- a/examples/create_float_library/main.cpp
+++ b/examples/create_float_library/main.cpp
@@ -1,0 +1,24 @@
+/// @file create_float_library/main.cpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <iostream>
+
+#include "tlapack_EigenMatrixXf.hpp"
+
+int main()
+{
+    Eigen::VectorXf x(3);
+    x << 1, 2, 3;
+
+    float sum = tlapack_eigenmatrixxf::asum(x);
+    std::cout << "sum is equal to 6? " << (sum == 6 ? "yes" : "no")
+              << std::endl;
+
+    return 0;
+}

--- a/examples/create_float_library/make.inc
+++ b/examples/create_float_library/make.inc
@@ -1,0 +1,7 @@
+#-------------------------------------------------------------------------------
+# <T>LAPACK library
+tlapack_inc = ../../include
+eigen_inc   = /usr/include/eigen3
+
+CXXFLAGS = -g -I$(tlapack_inc) -I$(eigen_inc) -Wall -pedantic
+LDFLAGS  = 

--- a/examples/create_float_library/tlapack_EigenMatrixXf.cpp
+++ b/examples/create_float_library/tlapack_EigenMatrixXf.cpp
@@ -1,0 +1,274 @@
+/// @file tlapack_EigenMatrixXf.cpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "tlapack_EigenMatrixXf.hpp"
+
+// clang-format off
+#include <tlapack/plugins/eigen.hpp>
+#include <tlapack.hpp>
+// clang-format on
+
+namespace impl = tlapack_eigenmatrixxf;
+
+using tlapack::Diag;
+using tlapack::Op;
+using tlapack::Side;
+using tlapack::Uplo;
+
+// =============================================================================
+// Level 1 BLAS template implementations
+
+float impl::asum(const Eigen::VectorXf& x) { return tlapack::asum(x); }
+
+void impl::axpy(float alpha, const Eigen::VectorXf& x, Eigen::VectorXf& y)
+{
+    tlapack::axpy(alpha, x, y);
+}
+
+void impl::copy(const Eigen::VectorXf& x, Eigen::VectorXf& y)
+{
+    tlapack::copy(x, y);
+}
+
+float impl::dot(const Eigen::VectorXf& x, const Eigen::VectorXf& y)
+{
+    return tlapack::dot(x, y);
+}
+
+float impl::dotu(const Eigen::VectorXf& x, const Eigen::VectorXf& y)
+{
+    return tlapack::dotu(x, y);
+}
+
+int impl::iamax(const Eigen::VectorXf& x) { return tlapack::iamax(x); }
+
+float impl::nrm2(const Eigen::VectorXf& x) { return tlapack::nrm2(x); }
+
+void impl::rot(Eigen::VectorXf& x, Eigen::VectorXf& y, float c, float s)
+{
+    tlapack::rot(x, y, c, s);
+}
+
+template <>
+void impl::rotm<-1>(Eigen::VectorXf& x, Eigen::VectorXf& y, const float h[4])
+{
+    tlapack::rotm<-1>(x, y, h);
+}
+template <>
+void impl::rotm<0>(Eigen::VectorXf& x, Eigen::VectorXf& y, const float h[4])
+{
+    tlapack::rotm<0>(x, y, h);
+}
+template <>
+void impl::rotm<1>(Eigen::VectorXf& x, Eigen::VectorXf& y, const float h[4])
+{
+    tlapack::rotm<1>(x, y, h);
+}
+template <>
+void impl::rotm<-2>(Eigen::VectorXf& x, Eigen::VectorXf& y, const float h[4])
+{
+    tlapack::rotm<-2>(x, y, h);
+}
+
+void impl::scal(float alpha, Eigen::VectorXf& x) { tlapack::scal(alpha, x); }
+
+void impl::swap(Eigen::VectorXf& x, Eigen::VectorXf& y) { tlapack::swap(x, y); }
+
+// =============================================================================
+// Level 2 BLAS template implementations
+
+void impl::gemv(Op trans,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                const Eigen::VectorXf& x,
+                float beta,
+                Eigen::VectorXf& y)
+{
+    tlapack::gemv(trans, alpha, A, x, beta, y);
+}
+
+void impl::ger(float alpha,
+               const Eigen::VectorXf& x,
+               const Eigen::VectorXf& y,
+               Eigen::MatrixXf& A)
+{
+    tlapack::ger(alpha, x, y, A);
+}
+
+void impl::hemv(Uplo uplo,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                const Eigen::VectorXf& x,
+                float beta,
+                Eigen::VectorXf& y)
+{
+    tlapack::hemv(uplo, alpha, A, x, beta, y);
+}
+
+void impl::her(Uplo uplo,
+               float alpha,
+               const Eigen::VectorXf& x,
+               Eigen::MatrixXf& A)
+{
+    tlapack::her(uplo, alpha, x, A);
+}
+
+void impl::her2(Uplo uplo,
+                float alpha,
+                const Eigen::VectorXf& x,
+                const Eigen::VectorXf& y,
+                Eigen::MatrixXf& A)
+{
+    tlapack::her2(uplo, alpha, x, y, A);
+}
+
+void impl::symv(Uplo uplo,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                const Eigen::VectorXf& x,
+                float beta,
+                Eigen::VectorXf& y)
+{
+    tlapack::symv(uplo, alpha, A, x, beta, y);
+}
+
+void impl::syr(Uplo uplo,
+               float alpha,
+               const Eigen::VectorXf& x,
+               Eigen::MatrixXf& A)
+{
+    tlapack::syr(uplo, alpha, x, A);
+}
+
+void impl::syr2(Uplo uplo,
+                float alpha,
+                const Eigen::VectorXf& x,
+                const Eigen::VectorXf& y,
+                Eigen::MatrixXf& A)
+{
+    tlapack::syr2(uplo, alpha, x, y, A);
+}
+
+void impl::trmv(Uplo uplo,
+                Op trans,
+                Diag diag,
+                const Eigen::MatrixXf& A,
+                Eigen::VectorXf& x)
+{
+    tlapack::trmv(uplo, trans, diag, A, x);
+}
+
+void impl::trsv(Uplo uplo,
+                Op trans,
+                Diag diag,
+                const Eigen::MatrixXf& A,
+                Eigen::VectorXf& x)
+{
+    tlapack::trsv(uplo, trans, diag, A, x);
+}
+
+// =============================================================================
+// Level 3 BLAS template implementations
+
+void impl::gemm(Op transA,
+                Op transB,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                const Eigen::MatrixXf& B,
+                float beta,
+                Eigen::MatrixXf& C)
+{
+    tlapack::gemm(transA, transB, alpha, A, B, beta, C);
+}
+
+void impl::hemm(Side side,
+                Uplo uplo,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                const Eigen::MatrixXf& B,
+                float beta,
+                Eigen::MatrixXf& C)
+{
+    tlapack::hemm(side, uplo, alpha, A, B, beta, C);
+}
+
+void impl::herk(Uplo uplo,
+                Op trans,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                float beta,
+                Eigen::MatrixXf& C)
+{
+    tlapack::herk(uplo, trans, alpha, A, beta, C);
+}
+
+void impl::her2k(Uplo uplo,
+                 Op trans,
+                 float alpha,
+                 const Eigen::MatrixXf& A,
+                 const Eigen::MatrixXf& B,
+                 float beta,
+                 Eigen::MatrixXf& C)
+{
+    tlapack::her2k(uplo, trans, alpha, A, B, beta, C);
+}
+
+void impl::symm(Side side,
+                Uplo uplo,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                const Eigen::MatrixXf& B,
+                float beta,
+                Eigen::MatrixXf& C)
+{
+    tlapack::symm(side, uplo, alpha, A, B, beta, C);
+}
+
+void impl::syrk(Uplo uplo,
+                Op trans,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                float beta,
+                Eigen::MatrixXf& C)
+{
+    tlapack::syrk(uplo, trans, alpha, A, beta, C);
+}
+
+void impl::syr2k(Uplo uplo,
+                 Op trans,
+                 float alpha,
+                 const Eigen::MatrixXf& A,
+                 const Eigen::MatrixXf& B,
+                 float beta,
+                 Eigen::MatrixXf& C)
+{
+    tlapack::syr2k(uplo, trans, alpha, A, B, beta, C);
+}
+
+void impl::trmm(Side side,
+                Uplo uplo,
+                Op trans,
+                Diag diag,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                Eigen::MatrixXf& B)
+{
+    tlapack::trmm(side, uplo, trans, diag, alpha, A, B);
+}
+
+void impl::trsm(Side side,
+                Uplo uplo,
+                Op trans,
+                Diag diag,
+                float alpha,
+                const Eigen::MatrixXf& A,
+                Eigen::MatrixXf& B)
+{
+    tlapack::trsm(side, uplo, trans, diag, alpha, A, B);
+}

--- a/examples/create_float_library/tlapack_EigenMatrixXf.hpp
+++ b/examples/create_float_library/tlapack_EigenMatrixXf.hpp
@@ -1,0 +1,158 @@
+/// @file tlapack_EigenMatrixXf.hpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_EIGENMATRIXXF_HH
+#define TLAPACK_EIGENMATRIXXF_HH
+
+#include <Eigen/Dense>
+#include <tlapack/base/types.hpp>
+
+namespace tlapack_eigenmatrixxf {
+
+using tlapack::Diag;
+using tlapack::Op;
+using tlapack::Side;
+using tlapack::Uplo;
+
+// =============================================================================
+// Level 1 BLAS template implementations
+
+float asum(const Eigen::VectorXf& x);
+void axpy(float alpha, const Eigen::VectorXf& x, Eigen::VectorXf& y);
+void copy(const Eigen::VectorXf& x, Eigen::VectorXf& y);
+float dot(const Eigen::VectorXf& x, const Eigen::VectorXf& y);
+float dotu(const Eigen::VectorXf& x, const Eigen::VectorXf& y);
+int iamax(const Eigen::VectorXf& x);
+float nrm2(const Eigen::VectorXf& x);
+void rot(Eigen::VectorXf& x, Eigen::VectorXf& y, float c, float s);
+template <int flag>
+void rotm(Eigen::VectorXf& x, Eigen::VectorXf& y, const float h[4]);
+void scal(float alpha, Eigen::VectorXf& x);
+void swap(Eigen::VectorXf& x, Eigen::VectorXf& y);
+
+// =============================================================================
+// Level 2 BLAS template implementations
+
+void gemv(Op trans,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          const Eigen::VectorXf& x,
+          float beta,
+          Eigen::VectorXf& y);
+void ger(float alpha,
+         const Eigen::VectorXf& x,
+         const Eigen::VectorXf& y,
+         Eigen::MatrixXf& A);
+void geru(float alpha,
+          const Eigen::VectorXf& x,
+          const Eigen::VectorXf& y,
+          Eigen::MatrixXf& A);
+void hemv(Uplo uplo,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          const Eigen::VectorXf& x,
+          float beta,
+          Eigen::VectorXf& y);
+void her(Uplo uplo, float alpha, const Eigen::VectorXf& x, Eigen::MatrixXf& A);
+void her2(Uplo uplo,
+          float alpha,
+          const Eigen::VectorXf& x,
+          const Eigen::VectorXf& y,
+          Eigen::MatrixXf& A);
+void symv(Uplo uplo,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          const Eigen::VectorXf& x,
+          float beta,
+          Eigen::VectorXf& y);
+void syr(Uplo uplo, float alpha, const Eigen::VectorXf& x, Eigen::MatrixXf& A);
+void syr2(Uplo uplo,
+          float alpha,
+          const Eigen::VectorXf& x,
+          const Eigen::VectorXf& y,
+          Eigen::MatrixXf& A);
+void trmv(Uplo uplo,
+          Op trans,
+          Diag diag,
+          const Eigen::MatrixXf& A,
+          Eigen::VectorXf& x);
+void trsv(Uplo uplo,
+          Op trans,
+          Diag diag,
+          const Eigen::MatrixXf& A,
+          Eigen::VectorXf& x);
+
+// =============================================================================
+// Level 3 BLAS template implementations
+
+void gemm(Op transA,
+          Op transB,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          const Eigen::MatrixXf& B,
+          float beta,
+          Eigen::MatrixXf& C);
+void hemm(Side side,
+          Uplo uplo,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          const Eigen::MatrixXf& B,
+          float beta,
+          Eigen::MatrixXf& C);
+void herk(Uplo uplo,
+          Op trans,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          float beta,
+          Eigen::MatrixXf& C);
+void her2k(Uplo uplo,
+           Op trans,
+           float alpha,
+           const Eigen::MatrixXf& A,
+           const Eigen::MatrixXf& B,
+           float beta,
+           Eigen::MatrixXf& C);
+void symm(Side side,
+          Uplo uplo,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          const Eigen::MatrixXf& B,
+          float beta,
+          Eigen::MatrixXf& C);
+void syrk(Uplo uplo,
+          Op trans,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          float beta,
+          Eigen::MatrixXf& C);
+void syr2k(Uplo uplo,
+           Op trans,
+           float alpha,
+           const Eigen::MatrixXf& A,
+           const Eigen::MatrixXf& B,
+           float beta,
+           Eigen::MatrixXf& C);
+void trmm(Side side,
+          Uplo uplo,
+          Op trans,
+          Diag diag,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          Eigen::MatrixXf& B);
+void trsm(Side side,
+          Uplo uplo,
+          Op trans,
+          Diag diag,
+          float alpha,
+          const Eigen::MatrixXf& A,
+          Eigen::MatrixXf& B);
+
+}  // namespace tlapack_eigenmatrixxf
+
+#endif  // TLAPACK_EIGENMATRIXXF_HH

--- a/include/tlapack/plugins/gnuquad.hpp
+++ b/include/tlapack/plugins/gnuquad.hpp
@@ -55,12 +55,12 @@ inline complex<__float128> sqrt(complex<__float128> z)
     const __float128 half(0.5);
 
     if (x == zero) {
-        __float128 t = sqrt(half * abs(y));
+        const __float128 t = sqrt(half * abs(y));
         return complex<__float128>(t, (y < zero) ? -t : t);
     }
     else {
-        __float128 t = sqrt(two * (abs(z) + abs(x)));
-        __float128 u = half * t;
+        const __float128 t = sqrt(two * (abs(z) + abs(x)));
+        const __float128 u = half * t;
         return (x > zero)
                    ? complex<__float128>(u, y / t)
                    : complex<__float128>(abs(y) / t, (y < zero) ? -u : u);

--- a/include/tlapack/starpu/filters.hpp
+++ b/include/tlapack/starpu/filters.hpp
@@ -37,11 +37,11 @@ namespace starpu {
         struct starpu_matrix_interface* matrix_child =
             (struct starpu_matrix_interface*)child_interface;
 
-        idx_t* aux = (idx_t*)(f->filter_arg_ptr);
-        idx_t row0 = aux[0];
-        idx_t col0 = aux[1];
-        idx_t nrows = aux[2];
-        idx_t ncols = aux[3];
+        const idx_t* aux = (const idx_t*)(f->filter_arg_ptr);
+        const idx_t row0 = aux[0];
+        const idx_t col0 = aux[1];
+        const idx_t nrows = aux[2];
+        const idx_t ncols = aux[3];
 
         matrix_child->id = matrix_father->id;
         matrix_child->elemsize = matrix_father->elemsize;


### PR DESCRIPTION
# Example: create_float_library

In this example, we show how to create a static library with single precision from the \<T\>LAPACK library. We use single precision `float` and the data structures from the [Eigen](https://eigen.tuxfamily.org) library, namely, `Eigen::MatrixXf` and `Eigen::VectorXf`.