### PR TITLE
Some cleanup.

### DIFF
--- a/include/tlapack/base/exceptionHandling.hpp
+++ b/include/tlapack/base/exceptionHandling.hpp
@@ -164,10 +164,9 @@ struct EcOpts {
                   << std::endl;
 
     /**
-     * @brief Error handler with conditional for internal checks
+     * @brief Error handler with conditional
      *
-     * @param[in] ec Exception handling configuration at runtime.
-     *      Default options are defined in ErrorCheck.
+     * @param[in] cond If true, tlapack error is thrown.
      * @param[in] info Code of the error.
      * @param[in] detailedInfo String with information about the error.
      *
@@ -175,10 +174,9 @@ struct EcOpts {
      *
      * @ingroup exception
      */
-    #define tlapack_error_internal(ec, info, detailedInfo) \
-        do {                                               \
-            if (static_cast<bool>(ec.internal))            \
-                tlapack_error(info, detailedInfo);         \
+    #define tlapack_error_if(cond, info, detailedInfo)                      \
+        do {                                                                \
+            if (static_cast<bool>(cond)) tlapack_error(info, detailedInfo); \
         } while (false)
 
 #else
@@ -187,93 +185,7 @@ struct EcOpts {
 
     #define tlapack_error(info, detailedInfo) ((void)0)
     #define tlapack_warning(info, detailedInfo) ((void)0)
-    #define tlapack_error_internal(ec, info, detailedInfo) ((void)0)
-
-#endif
-
-// -----------------------------------------------------------------------------
-// Macros to handle Infs warnings
-
-#if defined(TLAPACK_ENABLE_INFCHECK) && !defined(TLAPACK_NDEBUG)
-
-    /**
-     * @brief Run tlapack_warning if there is an inf in the matrix.
-     *
-     * @note Disable the warning by defining TLAPACK_NDEBUG
-     *  or undefining TLAPACK_ENABLE_INFCHECK
-     *
-     * @ingroup exception
-     */
-    #define tlapack_warn_infs_in_matrix(ec, accessType, A, info, detailedInfo) \
-        do {                                                                   \
-            if (static_cast<bool>(ec.inf) && hasinf(accessType, A))            \
-                tlapack_warning(info, detailedInfo);                           \
-        } while (false)
-
-    /**
-     * @brief Run tlapack_warning if there is an inf in the vector.
-     *
-     * @note Disable the warning by defining TLAPACK_NDEBUG
-     *  or undefining TLAPACK_ENABLE_INFCHECK
-     *
-     * @ingroup exception
-     */
-    #define tlapack_warn_infs_in_vector(ec, x, info, detailedInfo) \
-        do {                                                       \
-            if (static_cast<bool>(ec.inf) && hasinf(x))            \
-                tlapack_warning(info, detailedInfo);               \
-        } while (false)
-
-#else  // !defined(TLAPACK_ENABLE_INFCHECK) || defined(TLAPACK_NDEBUG)
-
-    // <T>LAPACK does not check for infs
-
-    #define tlapack_warn_infs_in_matrix(ec, accessType, A, info, detailedInfo) \
-        ((void)0)
-    #define tlapack_warn_infs_in_vector(ec, x, info, detailedInfo) ((void)0)
-
-#endif
-
-// -----------------------------------------------------------------------------
-// Macros to handle NaNs warnings
-
-#if defined(TLAPACK_ENABLE_NANCHECK) && !defined(TLAPACK_NDEBUG)
-
-    /**
-     * @brief Run tlapack_warning if there is a nan in the matrix.
-     *
-     * @note Disable the warning by defining TLAPACK_NDEBUG
-     *  or undefining TLAPACK_ENABLE_NANCHECK
-     *
-     * @ingroup exception
-     */
-    #define tlapack_warn_nans_in_matrix(ec, accessType, A, info, detailedInfo) \
-        do {                                                                   \
-            if (static_cast<bool>(ec.nan) && hasnan(accessType, A))            \
-                tlapack_warning(info, detailedInfo);                           \
-        } while (false)
-
-    /**
-     * @brief Run tlapack_warning if there is a nan in the vector.
-     *
-     * @note Disable the warning by defining TLAPACK_NDEBUG
-     *  or undefining TLAPACK_ENABLE_NANCHECK
-     *
-     * @ingroup exception
-     */
-    #define tlapack_warn_nans_in_vector(ec, x, info, detailedInfo) \
-        do {                                                       \
-            if (static_cast<bool>(ec.nan) && hasnan(x))            \
-                tlapack_warning(info, detailedInfo);               \
-        } while (false)
-
-#else  // !defined(TLAPACK_ENABLE_NANCHECK) || defined(TLAPACK_NDEBUG)
-
-    // <T>LAPACK does not check for nans
-
-    #define tlapack_warn_nans_in_matrix(ec, accessType, A, info, detailedInfo) \
-        ((void)0)
-    #define tlapack_warn_nans_in_vector(ec, x, info, detailedInfo) ((void)0)
+    #define tlapack_error_if(cond, info, detailedInfo) ((void)0)
 
 #endif
 

--- a/include/tlapack/lapack/hasinf.hpp
+++ b/include/tlapack/lapack/hasinf.hpp
@@ -1,0 +1,144 @@
+/// @file hasinf.hpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_HASINF_HH
+#define TLAPACK_HASINF_HH
+
+#include "tlapack/base/utils.hpp"
+
+namespace tlapack {
+
+/**
+ * Returns true if and only if A has an infinite entry.
+ *
+ * @tparam uplo_t Type of access inside the algorithm.
+ *      Either Uplo or any type that implements
+ *          operator Uplo().
+ *
+ * @param[in] uplo Determines the entries of A that will be checked.
+ *      The following access types are allowed:
+ *          Uplo::General,
+ *          Uplo::UpperHessenberg,
+ *          Uplo::LowerHessenberg,
+ *          Uplo::Upper,
+ *          Uplo::Lower,
+ *          Uplo::StrictUpper,
+ *          Uplo::StrictLower.
+ *
+ * @param[in] A matrix.
+ *
+ * @return true if A has an infinite entry.
+ * @return false if A has no infinite entry.
+ */
+template <TLAPACK_UPLO uplo_t, TLAPACK_MATRIX matrix_t>
+bool hasinf(uplo_t uplo, const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+
+    tlapack_check(uplo == Uplo::General || uplo == Uplo::UpperHessenberg ||
+                  uplo == Uplo::LowerHessenberg || uplo == Uplo::Upper ||
+                  uplo == Uplo::Lower || uplo == Uplo::StrictUpper ||
+                  uplo == Uplo::StrictLower);
+
+    if (uplo == Uplo::UpperHessenberg) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < ((j < m) ? j + 2 : m); ++i)
+                if (isinf(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::Upper) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < ((j < m) ? j + 1 : m); ++i)
+                if (isinf(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::StrictUpper) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < ((j < m) ? j : m); ++i)
+                if (isinf(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::LowerHessenberg) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = ((j > 1) ? j - 1 : 0); i < m; ++i)
+                if (isinf(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::Lower) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j; i < m; ++i)
+                if (isinf(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::StrictLower) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 1; i < m; ++i)
+                if (isinf(A(i, j))) return true;
+        return false;
+    }
+    else  // if ( (Uplo) uplo == Uplo::General )
+    {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < m; ++i)
+                if (isinf(A(i, j))) return true;
+        return false;
+    }
+}
+
+/**
+ * Returns true if and only if A has an infinite entry.
+ *
+ * Specific implementation for band access types.
+ * @see tlapack::hasinf(uplo_t uplo, const matrix_t& A).
+ */
+template <TLAPACK_MATRIX matrix_t>
+bool hasinf(BandAccess accessType, const matrix_t& A) noexcept
+{
+    using idx_t = size_type<matrix_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t kl = accessType.lower_bandwidth;
+    const idx_t ku = accessType.upper_bandwidth;
+
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = ((j >= ku) ? (j - ku) : 0); i < min(m, j + kl + 1); ++i)
+            if (isinf(A(i, j))) return true;
+    return false;
+}
+
+/**
+ * Returns true if and only if x has an infinite entry.
+ *
+ * @param[in] x vector.
+ *
+ * @return true if x has an infinite entry.
+ * @return false if x has no infinite entry.
+ */
+template <TLAPACK_VECTOR vector_t>
+bool hasinf(const vector_t& x) noexcept
+{
+    using idx_t = size_type<vector_t>;
+
+    // constants
+    const idx_t n = size(x);
+
+    for (idx_t i = 0; i < n; ++i)
+        if (isinf(x[i])) return true;
+    return false;
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_HASINF_HH

--- a/include/tlapack/lapack/hasnan.hpp
+++ b/include/tlapack/lapack/hasnan.hpp
@@ -1,0 +1,144 @@
+/// @file hasnan.hpp
+/// @author Weslley S Pereira, University of Colorado Denver, USA
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_HASNAN_HH
+#define TLAPACK_HASNAN_HH
+
+#include "tlapack/base/utils.hpp"
+
+namespace tlapack {
+
+/**
+ * Returns true if and only if A has an NaN entry.
+ *
+ * @tparam uplo_t Type of access inside the algorithm.
+ *      Either Uplo or any type that implements
+ *          operator Uplo().
+ *
+ * @param[in] uplo Determines the entries of A that will be checked.
+ *      The following access types are allowed:
+ *          Uplo::General,
+ *          Uplo::UpperHessenberg,
+ *          Uplo::LowerHessenberg,
+ *          Uplo::Upper,
+ *          Uplo::Lower,
+ *          Uplo::StrictUpper,
+ *          Uplo::StrictLower.
+ *
+ * @param[in] A matrix.
+ *
+ * @return true if A has an NaN entry.
+ * @return false if A has no NaN entry.
+ */
+template <TLAPACK_UPLO uplo_t, TLAPACK_MATRIX matrix_t>
+bool hasnan(uplo_t uplo, const matrix_t& A)
+{
+    using idx_t = size_type<matrix_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+
+    tlapack_check(uplo == Uplo::General || uplo == Uplo::UpperHessenberg ||
+                  uplo == Uplo::LowerHessenberg || uplo == Uplo::Upper ||
+                  uplo == Uplo::Lower || uplo == Uplo::StrictUpper ||
+                  uplo == Uplo::StrictLower);
+
+    if (uplo == Uplo::UpperHessenberg) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < ((j < m) ? j + 2 : m); ++i)
+                if (isnan(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::Upper) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < ((j < m) ? j + 1 : m); ++i)
+                if (isnan(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::StrictUpper) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < ((j < m) ? j : m); ++i)
+                if (isnan(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::LowerHessenberg) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = ((j > 1) ? j - 1 : 0); i < m; ++i)
+                if (isnan(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::Lower) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j; i < m; ++i)
+                if (isnan(A(i, j))) return true;
+        return false;
+    }
+    else if (uplo == Uplo::StrictLower) {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 1; i < m; ++i)
+                if (isnan(A(i, j))) return true;
+        return false;
+    }
+    else  // if ( (Uplo) uplo == Uplo::General )
+    {
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = 0; i < m; ++i)
+                if (isnan(A(i, j))) return true;
+        return false;
+    }
+}
+
+/**
+ * Returns true if and only if A has an NaN entry.
+ *
+ * Specific implementation for band access types.
+ * @see tlapack::hasnan(uplo_t uplo, const matrix_t& A).
+ */
+template <TLAPACK_MATRIX matrix_t>
+bool hasnan(BandAccess accessType, const matrix_t& A) noexcept
+{
+    using idx_t = size_type<matrix_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t kl = accessType.lower_bandwidth;
+    const idx_t ku = accessType.upper_bandwidth;
+
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = ((j >= ku) ? (j - ku) : 0); i < min(m, j + kl + 1); ++i)
+            if (isnan(A(i, j))) return true;
+    return false;
+}
+
+/**
+ * Returns true if and only if x has an NaN entry.
+ *
+ * @param[in] x vector.
+ *
+ * @return true if x has an NaN entry.
+ * @return false if x has no NaN entry.
+ */
+template <TLAPACK_VECTOR vector_t>
+bool hasnan(const vector_t& x) noexcept
+{
+    using idx_t = size_type<vector_t>;
+
+    // constants
+    const idx_t n = size(x);
+
+    for (idx_t i = 0; i < n; ++i)
+        if (isnan(x[i])) return true;
+    return false;
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_HASNAN_HH

--- a/include/tlapack/lapack/potrf2.hpp
+++ b/include/tlapack/lapack/potrf2.hpp
@@ -97,8 +97,8 @@ int potrf2(uplo_t uplo, matrix_t& A, const EcOpts& opts = {})
             return 0;
         }
         else {
-            tlapack_error_internal(
-                opts.ec, 1,
+            tlapack_error_if(
+                opts.ec.internal, 1,
                 "The leading minor of order 1 is not positive definite,"
                 " and the factorization could not be completed.");
             return 1;
@@ -116,8 +116,8 @@ int potrf2(uplo_t uplo, matrix_t& A, const EcOpts& opts = {})
         // Factor A11
         int info = potrf2(uplo, A11, NO_ERROR_CHECK);
         if (info != 0) {
-            tlapack_error_internal(
-                opts.ec, info,
+            tlapack_error_if(
+                opts.ec.internal, info,
                 "The leading minor of the reported order is not positive "
                 "definite,"
                 " and the factorization could not be completed.");
@@ -148,8 +148,8 @@ int potrf2(uplo_t uplo, matrix_t& A, const EcOpts& opts = {})
         if (info == 0)
             return 0;
         else {
-            tlapack_error_internal(
-                opts.ec, info + n1,
+            tlapack_error_if(
+                opts.ec.internal, info + n1,
                 "The leading minor of the reported order is not positive "
                 "definite,"
                 " and the factorization could not be completed.");

--- a/include/tlapack/lapack/potrf_blocked.hpp
+++ b/include/tlapack/lapack/potrf_blocked.hpp
@@ -153,12 +153,6 @@ int potrf_blocked(uplo_t uplo, matrix_t& A, const BlockedCholeskyOpts& opts)
             }
         }
 
-        // Report infs and nans on the output
-        tlapack_warn_nans_in_matrix(opts.ec, uplo, A, n + 1,
-                                    "The factorization has some nans.");
-        tlapack_warn_infs_in_matrix(opts.ec, uplo, A, n + 1,
-                                    "The factorization has some infs.");
-
         return 0;
     }
 }

--- a/include/tlapack/lapack/potrf_blocked_right_looking.hpp
+++ b/include/tlapack/lapack/potrf_blocked_right_looking.hpp
@@ -139,12 +139,6 @@ int potrf_rl(uplo_t uplo, matrix_t& A, const BlockedCholeskyOpts& opts = {})
             }
         }
 
-        // Report infs and nans on the output
-        tlapack_warn_nans_in_matrix(opts.ec, uplo, A, n + 1,
-                                    "The factorization has some nans.");
-        tlapack_warn_infs_in_matrix(opts.ec, uplo, A, n + 1,
-                                    "The factorization has some infs.");
-
         return 0;
     }
 }

--- a/include/tlapack/lapack/trtri_recursive.hpp
+++ b/include/tlapack/lapack/trtri_recursive.hpp
@@ -75,9 +75,9 @@ int trtri_recursive(uplo_t uplo,
                 return 0;
             }
             else {
-                tlapack_error_internal(opts.ec, 1,
-                                       "A diagonal of entry of triangular "
-                                       "matrix is exactly zero.");
+                tlapack_error_if(opts.ec.internal, 1,
+                                 "A diagonal of entry of triangular "
+                                 "matrix is exactly zero.");
                 return 1;
             }
         }
@@ -96,18 +96,18 @@ int trtri_recursive(uplo_t uplo,
             int info = trtri_recursive(LOWER_TRIANGLE, diag, C00, opts);
 
             if (info != 0) {
-                tlapack_error_internal(opts.ec, info,
-                                       "A diagonal of entry of triangular "
-                                       "matrix is exactly zero.");
+                tlapack_error_if(opts.ec.internal, info,
+                                 "A diagonal of entry of triangular "
+                                 "matrix is exactly zero.");
                 return info;
             }
             info = trtri_recursive(LOWER_TRIANGLE, diag, C11, opts);
             if (info == 0)
                 return 0;
             else {
-                tlapack_error_internal(opts.ec, info + n0,
-                                       "A diagonal of entry of triangular "
-                                       "matrix is exactly zero.");
+                tlapack_error_if(opts.ec.internal, info + n0,
+                                 "A diagonal of entry of triangular "
+                                 "matrix is exactly zero.");
                 return info + n0;
             }
 
@@ -128,18 +128,18 @@ int trtri_recursive(uplo_t uplo,
             trsm(RIGHT_SIDE, UPPER_TRIANGLE, NO_TRANS, diag, T(+1), C11, C01);
             int info = trtri_recursive(UPPER_TRIANGLE, diag, C00, opts);
             if (info != 0) {
-                tlapack_error_internal(opts.ec, info,
-                                       "A diagonal of entry of triangular "
-                                       "matrix is exactly zero.");
+                tlapack_error_if(opts.ec.internal, info,
+                                 "A diagonal of entry of triangular "
+                                 "matrix is exactly zero.");
                 return info;
             }
             info = trtri_recursive(UPPER_TRIANGLE, diag, C11, opts);
             if (info == 0)
                 return 0;
             else {
-                tlapack_error_internal(opts.ec, info + n0,
-                                       "A diagonal of entry of triangular "
-                                       "matrix is exactly zero.");
+                tlapack_error_if(opts.ec.internal, info + n0,
+                                 "A diagonal of entry of triangular "
+                                 "matrix is exactly zero.");
                 return info + n0;
             }
 

--- a/test/src/test_optBLAS.cpp
+++ b/test/src/test_optBLAS.cpp
@@ -23,7 +23,7 @@ TEMPLATE_TEST_CASE("has_compatible_layout gives the correct result",
     using matrixA_t = TestType;
     using matrixB_t = decltype(transpose_view(std::declval<const matrixA_t>()));
     using vector_t = vector_type<TestType>;
-    using namespace tlapack::internal;
+    using namespace tlapack::traits::internal;
 
     CHECK(has_compatible_layout<T, T>);
     CHECK(has_compatible_layout<T, T, T>);

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -32,21 +32,24 @@ TEST_CASE("Random generator is consistent if seed is fixed", "[utils]")
 TEMPLATE_TEST_CASE("is_matrix works", "[utils]", TLAPACK_TYPES_TO_TEST)
 {
     using matrix_t = TestType;
+    using namespace tlapack::traits::internal;
 
-    CHECK(internal::is_matrix<matrix_t>);
+    CHECK(is_matrix<matrix_t>);
 }
 
 TEST_CASE("is_matrix and is_vector work", "[utils]")
 {
-    CHECK(!internal::is_matrix<std::vector<float> >);
-    CHECK(!internal::is_matrix<LegacyVector<float> >);
+    using namespace tlapack::traits::internal;
 
-    CHECK(internal::is_vector<std::vector<float> >);
-    CHECK(internal::is_vector<LegacyVector<float> >);
+    CHECK(!is_matrix<std::vector<float> >);
+    CHECK(!is_matrix<LegacyVector<float> >);
 
-    CHECK(!internal::is_matrix<float>);
-    CHECK(!internal::is_matrix<std::complex<double> >);
+    CHECK(is_vector<std::vector<float> >);
+    CHECK(is_vector<LegacyVector<float> >);
 
-    CHECK(!internal::is_vector<float>);
-    CHECK(!internal::is_vector<std::complex<double> >);
+    CHECK(!is_matrix<float>);
+    CHECK(!is_matrix<std::complex<double> >);
+
+    CHECK(!is_vector<float>);
+    CHECK(!is_vector<std::complex<double> >);
 }


### PR DESCRIPTION
- Removes confusing `tlapack_warn_infs_in_vector()` and `tlapack_warn_nans_in_vector()`.
- Macro `tlapack_error_internal()` is renamed to `tlapack_error_if()`.
- Organize utils.hpp. Moves `hasinf()` and `hasnan()` to separate files.