### PR TITLE
Reference actions by commit SHA

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -33,7 +33,7 @@ jobs:
           - 'test/include'
           - 'test/src'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v4.10.1
       with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,32 +2,34 @@ name: CMake
 
 on:
   pull_request:
-    paths-ignore:
-    - '.github/workflows/deploy_pages.yml'
-    - '.github/workflows/doxygen.yml'
-    - '.github/workflows/clang-format-check.yml'
-    - '.gitattributes'
-    - '.gitignore'
-    - '.gitmodules'
-    - 'docs/**'
-    - 'LICENSE'
-    - 'version.txt'
-    - '**.md'
+    paths:
+    - '.github/workflows/cmake.yml'
+    - 'cmake/**'
+    - 'config/**'
+    - 'examples/**'
+    - 'include/**'
+    - 'src/**'
+    - 'test/**'
+    - 'README.md'
+    - 'test/include/**'
+    - 'test/src/**'
+    - '!**.md'
 
   push:
     branches:
     - master
-    paths-ignore:
-    - '.github/workflows/deploy_pages.yml'
-    - '.github/workflows/doxygen.yml'
-    - '.github/workflows/clang-format-check.yml'
-    - '.gitattributes'
-    - '.gitignore'
-    - '.gitmodules'
-    - 'docs/**'
-    - 'LICENSE'
-    - 'version.txt'
-    - '**.md'
+    paths:
+    - '.github/workflows/cmake.yml'
+    - 'cmake/**'
+    - 'config/**'
+    - 'examples/**'
+    - 'include/**'
+    - 'src/**'
+    - 'test/**'
+    - 'README.md'
+    - 'test/include/**'
+    - 'test/src/**'
+    - '!**.md'
 
 permissions:
   contents: read
@@ -71,7 +73,7 @@ jobs:
     steps:
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     
     - name: Install the Basics
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -223,7 +225,7 @@ jobs:
     steps:     
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     
     - name: Install the Basics
       run: |
@@ -272,7 +274,7 @@ jobs:
     steps:
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     
     - name: Install the Basics
       run: |
@@ -349,7 +351,7 @@ jobs:
     steps:
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     
     - name: Install the Basics
       run: |
@@ -437,7 +439,7 @@ jobs:
       run: sudo apt install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mkl
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v3
@@ -507,7 +509,7 @@ jobs:
     steps:
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     
     - name: Install the Basics
       run: |
@@ -588,7 +590,7 @@ jobs:
     steps:
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     
     - name: Install the Basics
       run: |
@@ -662,7 +664,7 @@ jobs:
     steps:
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v3
@@ -759,7 +761,7 @@ jobs:
     steps:
     
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     
     - name: Install the Basics
       run: |

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3.0.6
 
       - name: Install Basic Dependencies
         run: |
@@ -53,10 +53,10 @@ jobs:
         run: doxygen docs/Doxyfile
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
         with:
           # Upload docs/html
           path: 'docs/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@9dbe3824824f8a1377b8e298bafde1a50ede43e5 # v2.0.4

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
 
     - name: Checkout <T>LAPACK
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Install Basic Dependencies
       run: |


### PR DESCRIPTION
It's important to know that I have got this SHA from the original repository, not forks, which is a caution we must have here. Suggested by @gabibguti at https://github.com/Reference-LAPACK/lapack/issues/825 for LAPACK.

This commit also simplifies the dependency rules of cmake.yml.