### PR TITLE
Install Doxygen binaries instead of building from source

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -40,26 +40,17 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3.0.6
 
-      - name: Checkout Doxygen
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          repository: doxygen/doxygen
-          ref: c2fe5c3e4986974eb2a97608b24086683502f07f # v1.9.8
-          path: doxygen
-
       - name: Install Basic Dependencies
         run: |
           sudo apt update
           sudo apt install -y cmake graphviz
 
       - name: Install Doxygen
-        working-directory: doxygen
         run: |
-          mkdir build
-          cd build
-          cmake -G "Unix Makefiles" ..
-          make
-          sudo make install
+          wget https://www.doxygen.nl/files/doxygen-1.9.8.linux.bin.tar.gz
+          tar -xzf doxygen-1.9.8.linux.bin.tar.gz
+          cd doxygen-1.9.8
+          sudo mv bin/* /usr/local/bin
 
       - name: Prepare the documentation
         run: |

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -36,26 +36,17 @@ jobs:
     - name: Checkout <T>LAPACK
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-    - name: Checkout Doxygen
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      with:
-        repository: doxygen/doxygen
-        ref: c2fe5c3e4986974eb2a97608b24086683502f07f # v1.9.8
-        path: doxygen
-
     - name: Install Basic Dependencies
       run: |
         sudo apt update
         sudo apt install -y cmake graphviz
 
     - name: Install Doxygen
-      working-directory: doxygen
       run: |
-        mkdir build
-        cd build
-        cmake -G "Unix Makefiles" ..
-        make
-        sudo make install
+        wget https://www.doxygen.nl/files/doxygen-1.9.8.linux.bin.tar.gz
+        tar -xzf doxygen-1.9.8.linux.bin.tar.gz
+        cd doxygen-1.9.8
+        sudo mv bin/* /usr/local/bin
 
     - name: Prepare the documentation
       run: |


### PR DESCRIPTION
We are using the most version from Doxygen. Building from source is too much slow. This PR moves to "install the binary" mode.