### PR TITLE
Update minimum CMake requirements to CMake 3.5

### DIFF
--- a/examples/access_types/CMakeLists.txt
+++ b/examples/access_types/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( accessTypes CXX )
 

--- a/examples/cpp_visualizer/CMakeLists.txt
+++ b/examples/cpp_visualizer/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( cpp_visualizer_example CXX )
 

--- a/examples/create_float_library/CMakeLists.txt
+++ b/examples/create_float_library/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( create_float_library CXX )
 

--- a/examples/cwrapper_gemm/CMakeLists.txt
+++ b/examples/cwrapper_gemm/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( cwrapper_gemm C )
 

--- a/examples/eigen/CMakeLists.txt
+++ b/examples/eigen/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( eigen CXX )
 

--- a/examples/eigenvalues/CMakeLists.txt
+++ b/examples/eigenvalues/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( eigenvalues CXX )
 

--- a/examples/fortranModule_caxpy/CMakeLists.txt
+++ b/examples/fortranModule_caxpy/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( fortranModule_caxpy C Fortran )
 

--- a/examples/fortranWrapper_ssymm/CMakeLists.txt
+++ b/examples/fortranWrapper_ssymm/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( fortranWrapper_ssymm C Fortran )
 

--- a/examples/gemm/CMakeLists.txt
+++ b/examples/gemm/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( gemm CXX )
 

--- a/examples/geqr2/CMakeLists.txt
+++ b/examples/geqr2/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( geqr2 CXX )
 

--- a/examples/lu/CMakeLists.txt
+++ b/examples/lu/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( lu CXX )
 

--- a/examples/mdspan/CMakeLists.txt
+++ b/examples/mdspan/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( mdspan CXX )
 

--- a/examples/performance_eigen/CMakeLists.txt
+++ b/examples/performance_eigen/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( performance_eigen CXX )
 

--- a/examples/potrf/CMakeLists.txt
+++ b/examples/potrf/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( potrf CXX )
 

--- a/examples/starpu/CMakeLists.txt
+++ b/examples/starpu/CMakeLists.txt
@@ -4,7 +4,7 @@
 # <T>LAPACK is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project( starpu CXX )
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Update minimum CMake requirements to CMake 3.5 as compatibility with CMake < 3.5 will be removed from a future version of CMake.