### PR TITLE
add debugutils for eigen::half and vectors

### DIFF
--- a/include/tlapack/plugins/debugutils.hpp
+++ b/include/tlapack/plugins/debugutils.hpp
@@ -141,6 +141,40 @@ std::string visualize_matrix(const matrix_t& A)
         return visualize_matrix_table(A);
 }
 
+/**
+ * @brief Constructs a json string representing the vector
+ *        for use with vscode-debug-visualizer
+ *
+ * @return String containing JSON representation of v
+ *
+ * @param v size n vector
+ */
+template <TLAPACK_VECTOR vector_t>
+std::string visualize_vector(const vector_t& v)
+{
+    using idx_t = size_type<vector_t>;
+    const idx_t n = size(v);
+
+    const int width = is_complex<type_t<vector_t>> ? 25 : 10;
+
+    std::stringstream stream;
+    stream << "{ \"kind\":{ \"text\": true },\"text\": \"";
+
+    // Col indices
+    for (idx_t i = 0; i < n; ++i)
+        stream << std::setw(width) << i << " ";
+    stream << "\\n";
+
+    // Add the matrix values
+    for (idx_t i = 0; i < n; ++i)
+        stream << std::setw(width) << std::setprecision(3) << v[i] << " ";
+    stream << "\\n";
+
+    stream << "\"}";
+
+    return stream.str();
+}
+
 }  // namespace tlapack
 
 #endif  // TLAPACK_DEBUG_UTILS_HH

--- a/test/src/testutils.cpp
+++ b/test/src/testutils.cpp
@@ -16,6 +16,11 @@ namespace catch2 {
 // GDB doesn't handle templates well, so we explicitly define some versions of
 // the functions for common template arguments
 //
+void print_matrix_half(
+    const Eigen::Matrix<Eigen::half, Eigen::Dynamic, Eigen::Dynamic>& A)
+{
+    print_matrix(A);
+}
 void print_matrix_r(const LegacyMatrix<float, size_t, Layout::ColMajor>& A)
 {
     print_matrix(A);
@@ -98,6 +103,43 @@ std::string visualize_rowmajormatrix_z(
     const LegacyMatrix<std::complex<double>, size_t, Layout::RowMajor>& A)
 {
     return visualize_matrix(A);
+}
+std::string visualize_matrix_half(
+    const Eigen::Matrix<Eigen::half, Eigen::Dynamic, Eigen::Dynamic>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_matrix_chalf(
+    const Eigen::
+        Matrix<std::complex<Eigen::half>, Eigen::Dynamic, Eigen::Dynamic>& A)
+{
+    return visualize_matrix(A);
+}
+
+std::string visualize_vector_r(const std::vector<float>& v)
+{
+    return visualize_vector(v);
+}
+std::string visualize_vector_d(const std::vector<double>& v)
+{
+    return visualize_vector(v);
+}
+std::string visualize_vector_c(const std::vector<std::complex<float>>& v)
+{
+    return visualize_vector(v);
+}
+std::string visualize_vector_z(const std::vector<std::complex<double>>& v)
+{
+    return visualize_vector(v);
+}
+std::string visualize_vector_half(const std::vector<Eigen::half>& v)
+{
+    return visualize_vector(v);
+}
+std::string visualize_vector_chalf(
+    const std::vector<std::complex<Eigen::half>>& v)
+{
+    return visualize_vector(v);
 }
 
 }  // namespace tlapack

--- a/test/src/testutils.cpp
+++ b/test/src/testutils.cpp
@@ -104,17 +104,6 @@ std::string visualize_rowmajormatrix_z(
 {
     return visualize_matrix(A);
 }
-std::string visualize_matrix_half(
-    const Eigen::Matrix<Eigen::half, Eigen::Dynamic, Eigen::Dynamic>& A)
-{
-    return visualize_matrix(A);
-}
-std::string visualize_matrix_chalf(
-    const Eigen::
-        Matrix<std::complex<Eigen::half>, Eigen::Dynamic, Eigen::Dynamic>& A)
-{
-    return visualize_matrix(A);
-}
 
 std::string visualize_vector_r(const std::vector<float>& v)
 {
@@ -132,6 +121,7 @@ std::string visualize_vector_z(const std::vector<std::complex<double>>& v)
 {
     return visualize_vector(v);
 }
+#ifdef TLAPACK_TEST_EIGEN
 std::string visualize_vector_half(const std::vector<Eigen::half>& v)
 {
     return visualize_vector(v);
@@ -141,5 +131,17 @@ std::string visualize_vector_chalf(
 {
     return visualize_vector(v);
 }
+std::string visualize_matrix_half(
+    const Eigen::Matrix<Eigen::half, Eigen::Dynamic, Eigen::Dynamic>& A)
+{
+    return visualize_matrix(A);
+}
+std::string visualize_matrix_chalf(
+    const Eigen::
+        Matrix<std::complex<Eigen::half>, Eigen::Dynamic, Eigen::Dynamic>& A)
+{
+    return visualize_matrix(A);
+}
+#endif
 
 }  // namespace tlapack


### PR DESCRIPTION
I often find myself in a situation where only the Eigen::Half tests are failing. Which is annoying because there are no pretty printers for Eigen::Half in gdb.

This PR extends the debugutils for visualizing matrix to vectors and adds functions for Eigen::Half.