### PR TITLE
Fix typo and warnings

### DIFF
--- a/include/tlapack/lapack/lahqz_eig22.hpp
+++ b/include/tlapack/lapack/lahqz_eig22.hpp
@@ -39,9 +39,6 @@ void lahqz_eig22(const A_t& A,
                  T& beta1,
                  T& beta2)
 {
-    // Aliases
-    using real_t = real_type<T>;
-
     // Calculate X = AB^{-1}
     auto x00 = A(0, 0) / B(0, 0);
     auto x01 = A(0, 1) / B(1, 1);

--- a/include/tlapack/lapack/rot_sequence.hpp
+++ b/include/tlapack/lapack/rot_sequence.hpp
@@ -90,8 +90,8 @@ int rot_sequence(
     const idx_t k = (side == Side::Left) ? m - 1 : n - 1;
 
     // Check dimensions
-    tlapack_check(size(c) == k);
-    tlapack_check(size(s) == k);
+    tlapack_check((idx_t)size(c) == k);
+    tlapack_check((idx_t)size(s) == k);
 
     // quick return
     if (k < 1) return 0;

--- a/test/src/test_qz_eig22.cpp
+++ b/test/src/test_qz_eig22.cpp
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("check that lahqz_eig22 gives correct eigenvalues",
     Create<complex_type<matrix_t>> new_complex_matrix;
 
     // MatrixMarket reader
-    u_int64_t seed = GENERATE(1, 2, 3, 4, 5, 6);
+    uint64_t seed = GENERATE(1, 2, 3, 4, 5, 6);
     MatrixMarket mm;
     mm.gen.seed(seed);
 


### PR DESCRIPTION
The typo was identified by the windows build in the CI. Great to see that we have more information by testing on different platforms.