### PR TITLE
Explain return types in the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,3 +237,15 @@ You can use `@todo` to mark incomplete code. For instance, some code may work fo
 ```
 
 Using the triple slash `///` with tag `@todo` will make sure that the reminder is visible in the Doxygen documentation.
+
+### Return types of \<T\>LAPACK routines
+
+\<T\>LAPACK routines have three types of return:
+
+1. Routines that return `void`. The void return is reserved for BLAS routines that do not return a value, e.g., `tlapack::scal()` and `tlapack::gemm()`, and for some auxiliary routines like `tlapack::lassq()` and `tlapack::larf()`. Those routines are not supposed to fail and do not need to signal invalid outputs, so they do not return an error code. They could still throw an exception if the input is invalid. See flag `TLAPACK_CHECK_INPUT` in [README.md](https://github.com/tlapack/tlapack/blob/master/README.md) for more details.
+
+2. Routine that return a value. Those routines are supposed to return a value, e.g., `tlapack::iamax()` and `tlapack::lange()`. The return value is the result of the routine as explained in its documentation. 
+
+3. Routines that return an integer. Those routines are supposed to return an error code, e.g., `tlapack::getrf()` and `tlapack::potrf()`. A zero return means that the routine was successful. A non-zero return means that the routine failed to execute and that the output parameters are not valid. The documentation of each routine should specify the significance of each error code.
+
+A routine that fits in the categories 2 and 3, i.e., returns a value and may signal invalid outputs, should have those invalid outputs explicitly in its documentation. For instance, a return 0 in `tlapack::iamax()` will be used to both (1) signal that the input vector is empty and (2) signal that there is a `NAN` at the first position of the input vector.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ Using the triple slash `///` with tag `@todo` will make sure that the reminder i
 
 \<T\>LAPACK routines have three types of return:
 
-1. Routines that return `void`. The void return is reserved for BLAS routines that do not return a value, e.g., `tlapack::scal()` and `tlapack::gemm()`, and for some auxiliary routines like `tlapack::lassq()` and `tlapack::larf()`. Those routines are not supposed to fail and do not need to signal invalid outputs, so they do not return an error code. They could still throw an exception if the input is invalid. See flag `TLAPACK_CHECK_INPUT` in [README.md](https://github.com/tlapack/tlapack/blob/master/README.md) for more details.
+1. Routines that return `void`. The void return is reserved for BLAS routines that do not return a value, e.g., `tlapack::scal()` and `tlapack::gemm()`, and for some auxiliary routines like `tlapack::lassq()` and `tlapack::larf()`. Those routines are not supposed to fail and do not need to signal invalid outputs, so they do not return an error code. They could still throw an exception if the input is invalid. See flag `TLAPACK_CHECK_INPUT` in [README.md](README.md#tlapack-options) for more details.
 
 2. Routine that return a value. Those routines are supposed to return a value, e.g., `tlapack::iamax()` and `tlapack::lange()`. The return value is the result of the routine as explained in its documentation. 
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Please read [CONTRIBUTING.md](https://github.com/tlapack/tlapack/blob/master/CON
 
 ## Testing
 
-\<T\>LAPACK is continuously tested on Ubuntu, MacOS and Windows using GNU compilers. See the latest test results in the [Github Actions](https://github.com/tlapack/tlapack/actions/workflows/cmake.yml) webpage for \<T\>LAPACK. The tests split into three categories:
+\<T\>LAPACK is continuously tested on Ubuntu, MacOS and Windows using GNU compilers. See the latest test results in the [Github Actions](https://github.com/tlapack/tlapack/actions) webpage for \<T\>LAPACK. The tests split into three categories:
 
 - Test routines in [test/src](test/src) using
 

--- a/include/tlapack/lapack/lahqr.hpp
+++ b/include/tlapack/lapack/lahqr.hpp
@@ -36,7 +36,6 @@ namespace tlapack {
  *
  *
  * @return  0 if success
- * @return -i if the ith argument is invalid
  * @return  i if the QR algorithm failed to compute all the eigenvalues
  *            in a total of 30 iterations per eigenvalue. elements
  *            i:ihi of w contain those eigenvalues which have been
@@ -212,47 +211,48 @@ int lahqr(bool want_t,
                 istart = ilo;
                 continue;
             }
-            if (is_real<TA> && istart + 2 == istop) {
-                // 2x2 block, normalize the block
-                real_t cs;
-                TA sn;
-                // We don't check the error flag here because it should never
-                // fail for real values.
-                TA Aii = A(istart, istart);
-                TA Ajj = A(istart + 1, istart + 1);
-                TA Aij = A(istart, istart + 1);
-                TA Aji = A(istart + 1, istart);
-                complex_type<TA> wi = w[istart];
-                complex_type<TA> wj = w[istart + 1];
-                lahqr_schur22(Aii, Aij, Aji, Ajj, wi, wj, cs, sn);
-                A(istart, istart) = Aii;
-                A(istart + 1, istart + 1) = Ajj;
-                A(istart, istart + 1) = Aij;
-                A(istart + 1, istart) = Aji;
-                w[istart] = wi;
-                w[istart + 1] = wj;
-                // Apply the rotations from the normalization to the rest of the
-                // matrix.
-                if (want_t) {
-                    if (istart + 2 < istop_m) {
-                        auto x = slice(A, istart, range{istart + 2, istop_m});
-                        auto y =
-                            slice(A, istart + 1, range{istart + 2, istop_m});
+            if constexpr (is_real<TA>) {
+                if (istart + 2 == istop) {
+                    // 2x2 block, normalize the block
+                    real_t cs;
+                    TA sn;
+                    TA Aii = A(istart, istart);
+                    TA Ajj = A(istart + 1, istart + 1);
+                    TA Aij = A(istart, istart + 1);
+                    TA Aji = A(istart + 1, istart);
+                    complex_type<TA> wi = w[istart];
+                    complex_type<TA> wj = w[istart + 1];
+                    lahqr_schur22(Aii, Aij, Aji, Ajj, wi, wj, cs, sn);
+                    A(istart, istart) = Aii;
+                    A(istart + 1, istart + 1) = Ajj;
+                    A(istart, istart + 1) = Aij;
+                    A(istart + 1, istart) = Aji;
+                    w[istart] = wi;
+                    w[istart + 1] = wj;
+                    // Apply the rotations from the normalization to the rest of
+                    // the matrix.
+                    if (want_t) {
+                        if (istart + 2 < istop_m) {
+                            auto x =
+                                slice(A, istart, range{istart + 2, istop_m});
+                            auto y = slice(A, istart + 1,
+                                           range{istart + 2, istop_m});
+                            rot(x, y, cs, sn);
+                        }
+                        auto x2 = slice(A, range{istart_m, istart}, istart);
+                        auto y2 = slice(A, range{istart_m, istart}, istart + 1);
+                        rot(x2, y2, cs, sn);
+                    }
+                    if (want_z) {
+                        auto x = col(Z, istart);
+                        auto y = col(Z, istart + 1);
                         rot(x, y, cs, sn);
                     }
-                    auto x2 = slice(A, range{istart_m, istart}, istart);
-                    auto y2 = slice(A, range{istart_m, istart}, istart + 1);
-                    rot(x2, y2, cs, sn);
+                    k_defl = 0;
+                    istop = istart;
+                    istart = ilo;
+                    continue;
                 }
-                if (want_z) {
-                    auto x = col(Z, istart);
-                    auto y = col(Z, istart + 1);
-                    rot(x, y, cs, sn);
-                }
-                k_defl = 0;
-                istop = istart;
-                istart = ilo;
-                continue;
             }
         }
 

--- a/include/tlapack/lapack/lahqr_schur22.hpp
+++ b/include/tlapack/lapack/lahqr_schur22.hpp
@@ -23,14 +23,6 @@ namespace tlapack {
  *  A = [a b] = [cs -sn] [aa bb] [ cs sn]
  *      [c d]   [sn  cs] [cc dd] [-sn cs]
  *
- * This routine is designed for real matrices.
- * If the template T is complex, it returns with error
- * and does nothing. (This is so we don't need c++17's static if
- * but still keep the code somewhat clean).
- *
- * @return 0 if the template T is real
- * @return -1 if the template T is complex
- *
  * @param[in,out] a scalar, A(0,0).
  * @param[in,out] b scalar, A(0,1).
  * @param[in,out] c scalar, A(1,0).
@@ -48,15 +40,15 @@ namespace tlapack {
  *
  * @ingroup auxiliary
  */
-template <TLAPACK_REAL T, enable_if_t<is_real<T>, bool> = true>
-int lahqr_schur22(T& a,
-                  T& b,
-                  T& c,
-                  T& d,
-                  complex_type<T>& s1,
-                  complex_type<T>& s2,
-                  T& cs,
-                  T& sn)
+template <TLAPACK_REAL T>
+void lahqr_schur22(T& a,
+                   T& b,
+                   T& c,
+                   T& d,
+                   complex_type<T>& s1,
+                   complex_type<T>& s2,
+                   T& cs,
+                   T& sn)
 {
     const T zero(0);
     const T half(0.5);
@@ -186,13 +178,6 @@ int lahqr_schur22(T& a,
         s1 = a;
         s2 = d;
     }
-    return 0;
-}
-
-template <TLAPACK_COMPLEX T, enable_if_t<is_complex<T>, bool> = true>
-int lahqr_schur22(T& a, T& b, T& c, T& d, T& s1, T& s2, real_type<T>& cs, T& sn)
-{
-    return -1;
 }
 
 }  // namespace tlapack

--- a/include/tlapack/lapack/lasy2.hpp
+++ b/include/tlapack/lapack/lasy2.hpp
@@ -25,6 +25,10 @@ namespace tlapack {
  *
  *  where TL is N1 by N1, TR is N2 by N2, B is N1 by N2, and ISGN = 1 or
  *  -1.  op(T) = T or T**T, where T**T denotes the transpose of T.
+ * 
+ * @note Sets <tt>scale = 1</tt> and <tt>xnorm = 0</tt> if N1 = N2 = 0.
+ * 
+ * @todo Implement for n1=2 and n2=1 or n1=1 and n2=2.
  *
  * @ingroup auxiliary
  */
@@ -58,6 +62,8 @@ int lasy2(Op trans_l,
     tlapack_check(isign == -1 or isign == 1);
 
     // Quick return
+    scale = one;
+    xnorm = zero;
     if (n1 == 0 or n2 == 0) return 0;
 
     T sgn(isign);
@@ -80,7 +86,9 @@ int lasy2(Op trans_l,
         return info;
     }
     if ((n1 == 2 and n2 == 1) or (n1 == 1 and n2 == 2)) {
-        /// @todo
+        tlapack_error(-1,
+                      "lasy2: not implemented for n1=2 and n2=1 or n1=1 and "
+                      "n2=2");
         return -1;
     }
     if (n1 == 2 and n2 == 2) {

--- a/include/tlapack/lapack/lasy2.hpp
+++ b/include/tlapack/lapack/lasy2.hpp
@@ -25,9 +25,9 @@ namespace tlapack {
  *
  *  where TL is N1 by N1, TR is N2 by N2, B is N1 by N2, and ISGN = 1 or
  *  -1.  op(T) = T or T**T, where T**T denotes the transpose of T.
- * 
+ *
  * @note Sets <tt>scale = 1</tt> and <tt>xnorm = 0</tt> if N1 = N2 = 0.
- * 
+ *
  * @todo Implement for n1=2 and n2=1 or n1=1 and n2=2.
  *
  * @ingroup auxiliary

--- a/include/tlapack/lapack/multishift_qr.hpp
+++ b/include/tlapack/lapack/multishift_qr.hpp
@@ -418,7 +418,6 @@ int multishift_qr_work(bool want_t,
  *
  *
  * @return  0 if success
- * @return -i if the ith argument is invalid
  * @return  i if the QR algorithm failed to compute all the eigenvalues
  *            elements i:ihi of w contain those eigenvalues which have been
  *            successfully computed.

--- a/include/tlapack/lapack/potrf.hpp
+++ b/include/tlapack/lapack/potrf.hpp
@@ -92,10 +92,8 @@ int potrf(uplo_t uplo, matrix_t& A, const PotrfOpts& opts = {})
         return potrf2(uplo, A, opts);
     else if (opts.variant == PotrfVariant::Level2)
         return potf2(uplo, A);
-    else if (opts.variant == PotrfVariant::RightLooking)
-        return potrf_rl(uplo, A, opts);
     else
-        return -3;
+        return potrf_rl(uplo, A, opts);
 }
 
 }  // namespace tlapack

--- a/include/tlapack/lapack/qr_iteration.hpp
+++ b/include/tlapack/lapack/qr_iteration.hpp
@@ -103,7 +103,6 @@ int qr_iteration_work(bool want_t,
  *
  *
  * @return  0 if success
- * @return -i if the ith argument is invalid
  * @return  i if the QR algorithm failed to compute all the eigenvalues
  *            in a total of 30 iterations per eigenvalue. elements
  *            i:ihi of w contain those eigenvalues which have been

--- a/test/src/test_qr_algorithm.cpp
+++ b/test/src/test_qr_algorithm.cpp
@@ -162,7 +162,7 @@ TEMPLATE_TEST_CASE("QR algorithm",
         idx_t i = ilo;
         while (i < ihi) {
             int nb = 1;
-            if (is_real<T>)
+            if constexpr (is_real<T>)
                 if (i + 1 < ihi)
                     if (H(i + 1, i) != zero) nb = 2;
 
@@ -179,7 +179,8 @@ TEMPLATE_TEST_CASE("QR algorithm",
                 a21 = H(i + 1, i);
                 a22 = H(i + 1, i + 1);
                 complex_t s1, s2, swp;
-                lahqr_schur22(a11, a12, a21, a22, s1, s2, cs, sn);
+                if constexpr (is_real<T>)
+                    lahqr_schur22(a11, a12, a21, a22, s1, s2, cs, sn);
                 if (abs1(s1 - s[i]) > abs1(s2 - s[i])) {
                     swp = s1;
                     s1 = s2;


### PR DESCRIPTION
Explains the current design for the return types.

Also,
- Uses `if constexpr()` in `lahqr()` and removes `lahqr_schur22()` implementation for complex types.
- `lasy2()` sets `scale=0; xnorm=0` if `n1 == 0` or `n2 == 0`. Closes #297.