### PR TITLE
Multishift qz

### DIFF
--- a/include/tlapack/lapack/generalized_schur_swap.hpp
+++ b/include/tlapack/lapack/generalized_schur_swap.hpp
@@ -1,0 +1,309 @@
+/// @file generalized_schur_swap.hpp
+/// @author Thijs Steel, KU Leuven, Belgium
+/// Adapted from @see
+/// https://github.com/Reference-LAPACK/lapack/tree/master/SRC/dlaexc.f
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_GENERALIZED_SCHUR_SWAP_HH
+#define TLAPACK_GENERALIZED_SCHUR_SWAP_HH
+
+#include "tlapack/base/utils.hpp"
+#include "tlapack/blas/rot.hpp"
+#include "tlapack/blas/rotg.hpp"
+#include "tlapack/blas/swap.hpp"
+#include "tlapack/lapack/lahqr_schur22.hpp"
+#include "tlapack/lapack/lange.hpp"
+#include "tlapack/lapack/larfg.hpp"
+#include "tlapack/lapack/lasy2.hpp"
+
+namespace tlapack {
+
+/** schur_swap, swaps 2 eigenvalues of A.
+ *
+ * @return  0 if success
+ * @return  1 the swap failed, this usually means the eigenvalues
+ *            of the blocks are too close.
+ *
+ * @param[in]     want_q bool
+ *                Whether or not to apply the transformations to Q
+ * @param[in]     want_z bool
+ *                Whether or not to apply the transformations to Z
+ * @param[in,out] A n-by-n matrix.
+ *                Must be in Schur form
+ * @param[in,out] B n-by-n matrix.
+ *                Must be in Schur form
+ * @param[in,out] Q n-by-n matrix.
+ *                Orthogonal matrix, not referenced if want_q is false
+ * @param[in,out] Z n-by-n matrix.
+ *                Orthogonal matrix, not referenced if want_q is false
+ * @param[in]     j0 integer
+ *                Index of first eigenvalue block
+ * @param[in]     n1 integer
+ *                Size of first eigenvalue block
+ * @param[in]     n2 integer
+ *                Size of second eigenvalue block
+ *
+ * @ingroup auxiliary
+ */
+template <TLAPACK_CSMATRIX matrix_t,
+          enable_if_t<is_real<type_t<matrix_t>>, bool> = true>
+int generalized_schur_swap(bool want_q,
+                           bool want_z,
+                           matrix_t& A,
+                           matrix_t& B,
+                           matrix_t& Q,
+                           matrix_t& Z,
+                           const size_type<matrix_t>& j0,
+                           const size_type<matrix_t>& n1,
+                           const size_type<matrix_t>& n2)
+{
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using range = pair<idx_t, idx_t>;
+
+    // Functor for creating new matrices
+    Create<matrix_t> new_matrix;
+
+    const idx_t n = ncols(A);
+    const T zero(0);
+    const T ten(10);
+
+    tlapack_check(nrows(A) == n);
+    tlapack_check(nrows(Q) == n);
+    tlapack_check(ncols(Q) == n);
+    tlapack_check(0 <= j0);
+    tlapack_check(j0 + n1 + n2 <= n);
+    tlapack_check(n1 == 1 or n1 == 2);
+    tlapack_check(n2 == 1 or n2 == 2);
+
+    const idx_t j1 = j0 + 1;
+    const idx_t j2 = j0 + 2;
+    const idx_t j3 = j0 + 3;
+
+    // Check if the 2x2 eigenvalue blocks consist of 2 1x1 blocks
+    // If so, treat them separately
+    if (n1 == 2)
+        if (A(j1, j0) == zero) {
+            // only 2x2 swaps can fail, so we don't need to check for error
+            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j1, (idx_t)1,
+                                   n2);
+            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j0, (idx_t)1,
+                                   n2);
+            return 0;
+        }
+    if (n2 == 2)
+        if (A(j0 + n1 + 1, j0 + n1) == zero) {
+            // only 2x2 swaps can fail, so we don't need to check for error
+            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j0, n1,
+                                   (idx_t)1);
+            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j1, n1,
+                                   (idx_t)1);
+            return 0;
+        }
+
+    if (n1 == 1 and n2 == 1) {
+        //
+        // Swap two 1-by-1 blocks.
+        //
+        const T a00 = A(j0, j0);
+        const T a01 = A(j0, j1);
+        const T a11 = A(j1, j1);
+        const T b00 = B(j0, j0);
+        const T b01 = B(j0, j1);
+        const T b11 = B(j1, j1);
+
+        const bool use_b = abs(b11 * a00) > abs(b00 * a11);
+
+        //
+        // Determine the transformation to perform the interchange
+        //
+        T cl, sl, cr, sr;
+        T temp = b11 * a00 - a11 * b00;
+        T temp2 = b11 * a01 - a11 * b01;
+        rotg(temp2, temp, cr, sr);
+
+        // Apply transformation from the right
+        {
+            auto a1 = slice(A, range{0, j1 + 1}, j0);
+            auto a2 = slice(A, range{0, j1 + 1}, j1);
+            rot(a2, a1, cr, sr);
+            auto b1 = slice(B, range{0, j1 + 1}, j0);
+            auto b2 = slice(B, range{0, j1 + 1}, j1);
+            rot(b2, b1, cr, sr);
+            if (want_z) {
+                auto z1 = col(Z, j0);
+                auto z2 = col(Z, j1);
+                rot(z2, z1, cr, sr);
+            }
+        }
+
+        if (use_b) {
+            temp = B(j0, j0);
+            temp2 = B(j1, j0);
+        }
+        else {
+            temp = A(j0, j0);
+            temp2 = A(j1, j0);
+        }
+        rotg(temp, temp2, cl, sl);
+
+        // Apply transformation from the left
+        {
+            auto a1 = slice(A, j0, range{j0, n});
+            auto a2 = slice(A, j1, range{j0, n});
+            rot(a1, a2, cl, sl);
+            auto b1 = slice(B, j0, range{j0, n});
+            auto b2 = slice(B, j1, range{j0, n});
+            rot(b1, b2, cl, sl);
+            if (want_q) {
+                auto q1 = col(Q, j0);
+                auto q2 = col(Q, j1);
+                rot(q1, q2, cl, sl);
+            }
+        }
+
+        A(j1, j0) = (T)0;
+        B(j1, j0) = (T)0;
+    }
+    if (n1 == 1 and n2 == 2) {
+        //
+        // Swap 1-by-1 block with 2-by-2 block
+        //
+
+        // TODO
+    }
+    if (n1 == 2 and n2 == 1) {
+        //
+        // Swap 2-by-2 block with 1-by-1 block
+        //
+
+        // TODO
+    }
+    if (n1 == 2 and n2 == 2) {
+        //
+        // Swap 2-by-2 block with 2-by-2 block
+        //
+
+        // TODO
+    }
+
+    // Standardize the 2x2 Schur blocks (if any)
+    if (n2 == 2) {
+        // TODO
+    }
+    if (n1 == 2) {
+        // TODO
+    }
+
+    return 0;
+}
+
+/** schur_swap, swaps 2 eigenvalues of A.
+ *
+ * Implementation for complex matrices
+ *
+ * @ingroup auxiliary
+ */
+template <TLAPACK_CSMATRIX matrix_t,
+          enable_if_t<is_complex<type_t<matrix_t>>, bool> = true>
+int generalized_schur_swap(bool want_q,
+                           bool want_z,
+                           matrix_t& A,
+                           matrix_t& B,
+                           matrix_t& Q,
+                           matrix_t& Z,
+                           const size_type<matrix_t>& j0,
+                           const size_type<matrix_t>& n1,
+                           const size_type<matrix_t>& n2)
+{
+    using idx_t = size_type<matrix_t>;
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+    using range = pair<idx_t, idx_t>;
+
+    const idx_t n = ncols(A);
+
+    tlapack_check(nrows(A) == n);
+    tlapack_check(nrows(Q) == n);
+    tlapack_check(ncols(Q) == n);
+    tlapack_check(0 <= j0 and j0 < n);
+    tlapack_check(n1 == 1);
+    tlapack_check(n2 == 1);
+
+    const idx_t j1 = j0 + 1;
+
+    //
+    // In the complex case, there can only be 1x1 blocks to swap
+    //
+    const T a00 = A(j0, j0);
+    const T a01 = A(j0, j1);
+    const T a11 = A(j1, j1);
+    const T b00 = B(j0, j0);
+    const T b01 = B(j0, j1);
+    const T b11 = B(j1, j1);
+
+    const bool use_b = abs(b11 * a00) > abs(b00 * a11);
+
+    //
+    // Determine the transformation to perform the interchange
+    //
+    real_t cl, cr;
+    T sl, sr;
+    T temp = b11 * a00 - a11 * b00;
+    T temp2 = b11 * a01 - a11 * b01;
+    rotg(temp2, temp, cr, sr);
+
+    // Apply transformation from the right
+    {
+        auto a1 = slice(A, range{0, j1 + 1}, j0);
+        auto a2 = slice(A, range{0, j1 + 1}, j1);
+        rot(a2, a1, cr, sr);
+        auto b1 = slice(B, range{0, j1 + 1}, j0);
+        auto b2 = slice(B, range{0, j1 + 1}, j1);
+        rot(b2, b1, cr, sr);
+        if (want_z) {
+            auto z1 = col(Z, j0);
+            auto z2 = col(Z, j1);
+            rot(z2, z1, cr, sr);
+        }
+    }
+
+    if (use_b) {
+        temp = B(j0, j0);
+        temp2 = B(j1, j0);
+    }
+    else {
+        temp = A(j0, j0);
+        temp2 = A(j1, j0);
+    }
+    rotg(temp, temp2, cl, sl);
+
+    // Apply transformation from the left
+    {
+        auto a1 = slice(A, j0, range{j0, n});
+        auto a2 = slice(A, j1, range{j0, n});
+        rot(a1, a2, cl, sl);
+        auto b1 = slice(B, j0, range{j0, n});
+        auto b2 = slice(B, j1, range{j0, n});
+        rot(b1, b2, cl, sl);
+        if (want_q) {
+            auto q1 = col(Q, j0);
+            auto q2 = col(Q, j1);
+            rot(q1, q2, cl, conj(sl));
+        }
+    }
+
+    A(j1, j0) = (T)0;
+    B(j1, j0) = (T)0;
+
+    return 0;
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_GENERALIZED_SCHUR_SWAP_HH

--- a/include/tlapack/lapack/inv_house3.hpp
+++ b/include/tlapack/lapack/inv_house3.hpp
@@ -1,0 +1,113 @@
+/// @file inv_house3.hpp
+/// @author Thijs Steel, KU Leuven, Belgium
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_INV_HOUSE_HH
+#define TLAPACK_INV_HOUSE_HH
+
+#include "tlapack/base/utils.hpp"
+#include "tlapack/lapack/larfg.hpp"
+
+namespace tlapack {
+
+/** @brief Inv_house calculates a reflector to reduce
+ * a the first column in a 3x3 matrix from the right to a unit vector. Note that
+ * this is special because a reflector applied from the right would usually
+ * reduce a row, not a column. This is known as an inverse reflector.
+ *
+ * We need to solve the system
+ * A x = e_1
+ * If we then calculate a reflector that reduces x:
+ * H x = alpha e_1,
+ * then H is the reflector that we were looking for.
+ *
+ * Because the reflector is invariant w.r.t. the scale of x,
+ * we will solve a scaled system so that x0 = 1.
+ * The rest of x can then be calculated using:
+ * [A11 A12] [x1] = - scale * [A10]
+ * [A21 A22] [x2]             [A20]
+ *
+ * We solve this system of equations using fully pivoted LU
+ *
+ * @param[in] A 3x3 matrix.
+ * @param[out] v vector of size 3
+ * @param[out] tau
+ *
+ * @ingroup auxiliary
+ */
+template <TLAPACK_SMATRIX matrix_t, TLAPACK_VECTOR vector_t>
+void inv_house3(const matrix_t& A, vector_t& v, type_t<vector_t>& tau)
+{
+    using T = type_t<matrix_t>;
+    using real_t = real_type<T>;
+
+    using idx_t = size_type<matrix_t>;
+
+    const real_t safemin = safe_min<real_t>();
+
+    T a11, a12, a21, a22;
+
+    // Swap rows if necessary
+    real_t temp1 = max<real_t>(abs1(A(1, 1)), abs1(A(1, 2)));
+    real_t temp2 = max<real_t>(abs1(A(2, 1)), abs1(A(2, 2)));
+
+    if (temp1 < safemin and temp2 < safemin) {
+        // TODO
+    }
+    if (temp1 >= temp2) {
+        a11 = A(1, 1);
+        a12 = A(1, 2);
+        a21 = A(2, 1);
+        a22 = A(2, 2);
+        v[1] = -A(1, 0);
+        v[2] = -A(2, 0);
+    }
+    else {
+        a11 = A(2, 1);
+        a12 = A(2, 2);
+        a21 = A(1, 1);
+        a22 = A(1, 2);
+        v[1] = -A(2, 0);
+        v[2] = -A(1, 0);
+    }
+
+    // Swap columns if necessary
+    bool colswapped = false;
+    if (abs1(a12) > abs1(a11)) {
+        colswapped = true;
+        std::swap(a11, a12);
+        std::swap(a21, a22);
+    }
+
+    // Calculate LU factorization
+    T u11 = a11;
+    T u12 = a12;
+    T l21 = a21 / u11;
+    T u22 = a22 - l21 * u12;
+
+    // Solve lower triangular system
+    v[2] = v[2] - v[1] * l21;
+    // Solve upper triangular system
+    real_t scale = (real_t)1;
+    if (abs1(u22) < safemin) {
+        // TODO
+    }
+    if (abs1(u22) < abs1(v[2])) scale = abs1(u22 / v[2]);
+    if (abs1(u11) < abs1(v[1])) scale = min(scale, abs1(u11 / v[1]));
+    v[2] = (scale * v[2]) / u22;
+    v[1] = (scale * v[1] - u12 * v[2]) / u11;
+    v[0] = scale;
+    if (colswapped) std::swap(v[1], v[2]);
+
+    // Calculate Reflector
+    larfg(FORWARD, COLUMNWISE_STORAGE, v, tau);
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_INV_HOUSE_HH

--- a/include/tlapack/lapack/inv_house3.hpp
+++ b/include/tlapack/lapack/inv_house3.hpp
@@ -57,7 +57,11 @@ void inv_house3(const matrix_t& A, vector_t& v, type_t<vector_t>& tau)
     real_t temp2 = max<real_t>(abs1(A(2, 1)), abs1(A(2, 2)));
 
     if (temp1 < safemin and temp2 < safemin) {
-        // TODO
+        v[0] = (T)0;
+        v[1] = (T)1;
+        v[2] = (T)0;
+        larfg(FORWARD, COLUMNWISE_STORAGE, v, tau);
+        return;
     }
     if (temp1 >= temp2) {
         a11 = A(1, 1);
@@ -95,7 +99,11 @@ void inv_house3(const matrix_t& A, vector_t& v, type_t<vector_t>& tau)
     // Solve upper triangular system
     real_t scale = (real_t)1;
     if (abs1(u22) < safemin) {
-        // TODO
+        v[0] = (T)0;
+        v[1] = (T)1;
+        v[2] = -u12 / u11;
+        larfg(FORWARD, COLUMNWISE_STORAGE, v, tau);
+        return;
     }
     if (abs1(u22) < abs1(v[2])) scale = abs1(u22 / v[2]);
     if (abs1(u11) < abs1(v[1])) scale = min(scale, abs1(u11 / v[1]));

--- a/include/tlapack/lapack/inv_house3.hpp
+++ b/include/tlapack/lapack/inv_house3.hpp
@@ -16,12 +16,12 @@
 namespace tlapack {
 
 /** @brief Inv_house calculates a reflector to reduce
- * the first column in a 3x3 matrix from the right to a unit vector. Note that
+ * the first column in a 2x3 matrix A from the right to zero. Note that
  * this is special because a reflector applied from the right would usually
  * reduce a row, not a column. This is known as an inverse reflector.
  *
  * We need to solve the system
- * A x = e_1
+ * A x = 0
  * If we then calculate a reflector that reduces x:
  * H x = alpha e_1,
  * then H is the reflector that we were looking for.
@@ -34,7 +34,7 @@ namespace tlapack {
  *
  * We solve this system of equations using fully pivoted LU
  *
- * @param[in] A 3x3 matrix.
+ * @param[in] A 2x3 matrix.
  * @param[out] v vector of size 3
  * @param[out] tau
  *
@@ -53,8 +53,8 @@ void inv_house3(const matrix_t& A, vector_t& v, type_t<vector_t>& tau)
     T a11, a12, a21, a22;
 
     // Swap rows if necessary
-    real_t temp1 = max<real_t>(abs1(A(1, 1)), abs1(A(1, 2)));
-    real_t temp2 = max<real_t>(abs1(A(2, 1)), abs1(A(2, 2)));
+    real_t temp1 = max<real_t>(abs1(A(0, 1)), abs1(A(0, 2)));
+    real_t temp2 = max<real_t>(abs1(A(1, 1)), abs1(A(1, 2)));
 
     if (temp1 < safemin and temp2 < safemin) {
         v[0] = (T)0;
@@ -64,20 +64,20 @@ void inv_house3(const matrix_t& A, vector_t& v, type_t<vector_t>& tau)
         return;
     }
     if (temp1 >= temp2) {
-        a11 = A(1, 1);
-        a12 = A(1, 2);
-        a21 = A(2, 1);
-        a22 = A(2, 2);
-        v[1] = -A(1, 0);
-        v[2] = -A(2, 0);
-    }
-    else {
-        a11 = A(2, 1);
-        a12 = A(2, 2);
+        a11 = A(0, 1);
+        a12 = A(0, 2);
         a21 = A(1, 1);
         a22 = A(1, 2);
-        v[1] = -A(2, 0);
+        v[1] = -A(0, 0);
         v[2] = -A(1, 0);
+    }
+    else {
+        a11 = A(1, 1);
+        a12 = A(1, 2);
+        a21 = A(0, 1);
+        a22 = A(0, 2);
+        v[1] = -A(1, 0);
+        v[2] = -A(0, 0);
     }
 
     // Swap columns if necessary

--- a/include/tlapack/lapack/inv_house3.hpp
+++ b/include/tlapack/lapack/inv_house3.hpp
@@ -16,7 +16,7 @@
 namespace tlapack {
 
 /** @brief Inv_house calculates a reflector to reduce
- * a the first column in a 3x3 matrix from the right to a unit vector. Note that
+ * the first column in a 3x3 matrix from the right to a unit vector. Note that
  * this is special because a reflector applied from the right would usually
  * reduce a row, not a column. This is known as an inverse reflector.
  *

--- a/include/tlapack/lapack/lahqz.hpp
+++ b/include/tlapack/lapack/lahqz.hpp
@@ -524,7 +524,7 @@ int lahqz(bool want_s,
             }
 
             // Remove fill-in from B using an inverse reflector
-            auto T = slice(B, range{i, i + 3}, range{i, i + 3});
+            auto T = slice(B, range{i + 1, i + 3}, range{i, i + 3});
             inv_house3(T, v, t1);
 
             // The following code applies the reflector we have just calculated.

--- a/include/tlapack/lapack/lahqz.hpp
+++ b/include/tlapack/lapack/lahqz.hpp
@@ -17,6 +17,7 @@
 #include "tlapack/base/utils.hpp"
 #include "tlapack/blas/rot.hpp"
 #include "tlapack/blas/rotg.hpp"
+#include "tlapack/lapack/inv_house3.hpp"
 #include "tlapack/lapack/lahqz_eig22.hpp"
 #include "tlapack/lapack/lahqz_shiftcolumn.hpp"
 
@@ -394,18 +395,18 @@ int lahqz(bool want_s,
         // subblock. Now that we know the specific shift, we can also check
         // whether we can introduce that shift somewhere else in the subblock.
         idx_t istart2 = istart;
+        TA t1;
         if (istart + 3 < istop) {
             for (idx_t i = istop - 3; i > istart; --i) {
                 auto H = slice(A, range{i, i + 3}, range{i, i + 3});
                 auto T = slice(B, range{i, i + 3}, range{i, i + 3});
                 lahqz_shiftcolumn(H, T, v, shift1, shift2, beta1, beta2);
-
-                real_t c1, c2;
-                TA s1, s2;
-                rotg(v[1], v[2], c1, s1);
-                rotg(v[0], v[1], c2, s2);
-
-                if (abs1(-conj(s2) * A(i, i - 1)) <
+                larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+                v[0] = t1;
+                const TA refsum =
+                    conj(v[0]) * A(i, i - 1) + conj(v[1]) * A(i + 1, i - 1);
+                if (abs1(A(i + 1, i - 1) - refsum * v[1]) +
+                        abs1(refsum * v[2]) <=
                     eps * (abs1(A(i, i - 1)) + abs1(A(i, i + 1)) +
                            abs1(A(i + 1, i + 2)))) {
                     istart2 = i;
@@ -416,19 +417,123 @@ int lahqz(bool want_s,
 
         // All the preparations are done, we can apply an implicit QZ
         // iteration
-        for (idx_t i = istart2; i < istop - 1; ++i) {
-            const idx_t nr = std::min<idx_t>(3, istop - i);
-            real_t c1, c2;
-            TA s1, s2;
-
-            // Calculate rotations from the left
+        for (idx_t i = istart2; i < istop - 2; ++i) {
             if (i == istart2) {
-                auto H = slice(A, range{i, i + nr}, range{i, i + nr});
-                auto T = slice(B, range{i, i + nr}, range{i, i + nr});
-                auto x = slice(v, range{0, nr});
+                // This is the first iteration, calculate a reflector to
+                // introduce the shift
+                auto H = slice(A, range{i, i + 3}, range{i, i + 3});
+                auto T = slice(B, range{i, i + 3}, range{i, i + 3});
+                lahqz_shiftcolumn(H, T, v, shift1, shift2, beta1, beta2);
+                larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+                if (i > istart) {
+                    A(i, i - 1) = A(i, i - 1) * (one - conj(t1));
+                }
+            }
+            else {
+                // Calculate a reflector to move the bulge one position
+                v[0] = A(i, i - 1);
+                v[1] = A(i + 1, i - 1);
+                v[2] = A(i + 2, i - 1);
+                larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+                A(i, i - 1) = v[0];
+                A(i + 1, i - 1) = zero;
+                A(i + 2, i - 1) = zero;
+            }
+
+            // The following code applies the reflector we have just calculated.
+            // We write this out instead of using larf because a direct loop is
+            // more efficient for small reflectors.
+            {
+                t1 = conj(t1);
+                const TA v2 = v[1];
+                const TA t2 = t1 * v2;
+                const TA v3 = v[2];
+                const TA t3 = t1 * v[2];
+                TA sum;
+
+                // Apply reflector from the left to A
+                for (idx_t j = i; j < istop_m; ++j) {
+                    sum = A(i, j) + conj(v2) * A(i + 1, j) +
+                          conj(v3) * A(i + 2, j);
+                    A(i, j) = A(i, j) - sum * t1;
+                    A(i + 1, j) = A(i + 1, j) - sum * t2;
+                    A(i + 2, j) = A(i + 2, j) - sum * t3;
+                }
+                // Apply reflector from the left to B
+                for (idx_t j = i; j < istop_m; ++j) {
+                    sum = B(i, j) + conj(v2) * B(i + 1, j) +
+                          conj(v3) * B(i + 2, j);
+                    B(i, j) = B(i, j) - sum * t1;
+                    B(i + 1, j) = B(i + 1, j) - sum * t2;
+                    B(i + 2, j) = B(i + 2, j) - sum * t3;
+                }
+                if (want_q) {
+                    // Apply reflector to Q from the right
+                    for (idx_t j = 0; j < n; ++j) {
+                        sum = Q(j, i) + v2 * Q(j, i + 1) + v3 * Q(j, i + 2);
+                        Q(j, i) = Q(j, i) - sum * conj(t1);
+                        Q(j, i + 1) = Q(j, i + 1) - sum * conj(t2);
+                        Q(j, i + 2) = Q(j, i + 2) - sum * conj(t3);
+                    }
+                }
+            }
+
+            // Remove fill-in from B using an inverse reflector
+            auto T = slice(B, range{i, i + 3}, range{i, i + 3});
+            inv_house3(T, v, t1);
+
+            // The following code applies the reflector we have just calculated.
+            // We write this out instead of using larf because a direct loop is
+            // more efficient for small reflectors.
+            {
+                t1 = conj(t1);
+                const TA v2 = v[1];
+                const TA t2 = t1 * v2;
+                const TA v3 = v[2];
+                const TA t3 = t1 * v[2];
+                TA sum;
+
+                // Apply reflector from the right to B
+                for (idx_t j = istart_m; j < i + 3; ++j) {
+                    sum = B(j, i) + v2 * B(j, i + 1) + v3 * B(j, i + 2);
+                    B(j, i) = B(j, i) - sum * conj(t1);
+                    B(j, i + 1) = B(j, i + 1) - sum * conj(t2);
+                    B(j, i + 2) = B(j, i + 2) - sum * conj(t3);
+                }
+                B(i + 1, i) = (TA)0;
+                B(i + 2, i) = (TA)0;
+                // Apply reflector from the right to A
+                for (idx_t j = istart_m; j < min(i + 4, istop); ++j) {
+                    sum = A(j, i) + v2 * A(j, i + 1) + v3 * A(j, i + 2);
+                    A(j, i) = A(j, i) - sum * conj(t1);
+                    A(j, i + 1) = A(j, i + 1) - sum * conj(t2);
+                    A(j, i + 2) = A(j, i + 2) - sum * conj(t3);
+                }
+                if (want_z) {
+                    // Apply reflector to Z from the right
+                    for (idx_t j = 0; j < n; ++j) {
+                        sum = Z(j, i) + v2 * Z(j, i + 1) + v3 * Z(j, i + 2);
+                        Z(j, i) = Z(j, i) - sum * conj(t1);
+                        Z(j, i + 1) = Z(j, i + 1) - sum * conj(t2);
+                        Z(j, i + 2) = Z(j, i + 2) - sum * conj(t3);
+                    }
+                }
+            }
+        }
+        // Handle the final 2x2 block separately using a 2x2 rotation instead
+        // of a 3x3 reflector.
+        {
+            idx_t i = istop - 2;
+
+            real_t c2;
+            TA s2;
+
+            if (i == istart2) {
+                auto H = slice(A, range{i, i + 2}, range{i, i + 2});
+                auto T = slice(B, range{i, i + 2}, range{i, i + 2});
+                auto x = slice(v, range{0, 2});
                 lahqz_shiftcolumn(H, T, x, shift1, shift2, beta1, beta2);
 
-                if (nr == 3) rotg(x[1], x[2], c1, s1);
                 rotg(x[0], x[1], c2, s2);
 
                 if (i > istart) {
@@ -436,37 +541,12 @@ int lahqz(bool want_s,
                 }
             }
             else {
-                if (nr == 3) {
-                    rotg(A(i + 1, i - 1), A(i + 2, i - 1), c1, s1);
-                    A(i + 2, i - 1) = zero;
-                }
                 rotg(A(i, i - 1), A(i + 1, i - 1), c2, s2);
                 A(i + 1, i - 1) = zero;
             }
-            // Apply rotations from the left
-            if (nr == 3) {
-                for (idx_t j = i; j < istop_m; ++j) {
-                    auto temp = c1 * A(i + 1, j) + s1 * A(i + 2, j);
-                    A(i + 2, j) = -conj(s1) * A(i + 1, j) + c1 * A(i + 2, j);
-                    A(i + 1, j) = -conj(s2) * A(i, j) + c2 * temp;
-                    A(i, j) = c2 * A(i, j) + s2 * temp;
-                }
-                for (idx_t j = i; j < istop_m; ++j) {
-                    auto temp = c1 * B(i + 1, j) + s1 * B(i + 2, j);
-                    B(i + 2, j) = -conj(s1) * B(i + 1, j) + c1 * B(i + 2, j);
-                    B(i + 1, j) = -conj(s2) * B(i, j) + c2 * temp;
-                    B(i, j) = c2 * B(i, j) + s2 * temp;
-                }
-                if (want_q) {
-                    for (idx_t j = 0; j < n; ++j) {
-                        auto temp = c1 * Q(j, i + 1) + conj(s1) * Q(j, i + 2);
-                        Q(j, i + 2) = -s1 * Q(j, i + 1) + c1 * Q(j, i + 2);
-                        Q(j, i + 1) = -s2 * Q(j, i) + c2 * temp;
-                        Q(j, i) = c2 * Q(j, i) + conj(s2) * temp;
-                    }
-                }
-            }
-            else {
+
+            // Apply rotation from the left
+            {
                 auto a1 = slice(A, i, range{i, istop_m});
                 auto a2 = slice(A, i + 1, range{i, istop_m});
                 rot(a1, a2, c2, s2);
@@ -481,44 +561,12 @@ int lahqz(bool want_s,
             }
 
             // Remove fill-in from B
-            if (nr == 3) {
-                rotg(B(i + 2, i + 2), B(i + 2, i + 1), c1, s1);
-                s1 = -s1;
-                B(i + 2, i + 1) = (TA)0.;
-                // Also apply the rotation to the 2 elements above so that
-                // we can calculate the next rotation
-                auto temp = c1 * B(i + 1, i + 1) + conj(s1) * B(i + 1, i + 2);
-                B(i + 1, i + 2) = -s1 * B(i + 1, i + 1) + c1 * B(i + 1, i + 2);
-                B(i + 1, i + 1) = temp;
-            }
             rotg(B(i + 1, i + 1), B(i + 1, i), c2, s2);
             s2 = -s2;
             B(i + 1, i) = (TA)0.;
 
             // Apply rotation from the right
-            if (nr == 3) {
-                for (idx_t j = istart_m; j < i + 1; ++j) {
-                    auto temp = c1 * B(j, i + 1) + conj(s1) * B(j, i + 2);
-                    B(j, i + 2) = -s1 * B(j, i + 1) + c1 * B(j, i + 2);
-                    B(j, i + 1) = -s2 * B(j, i) + c2 * temp;
-                    B(j, i) = c2 * B(j, i) + conj(s2) * temp;
-                }
-                for (idx_t j = istart_m; j < min(i + 4, ihi); ++j) {
-                    auto temp = c1 * A(j, i + 1) + conj(s1) * A(j, i + 2);
-                    A(j, i + 2) = -s1 * A(j, i + 1) + c1 * A(j, i + 2);
-                    A(j, i + 1) = -s2 * A(j, i) + c2 * temp;
-                    A(j, i) = c2 * A(j, i) + conj(s2) * temp;
-                }
-                if (want_z) {
-                    for (idx_t j = 0; j < n; ++j) {
-                        auto temp = c1 * Z(j, i + 1) + conj(s1) * Z(j, i + 2);
-                        Z(j, i + 2) = -s1 * Z(j, i + 1) + c1 * Z(j, i + 2);
-                        Z(j, i + 1) = -s2 * Z(j, i) + c2 * temp;
-                        Z(j, i) = c2 * Z(j, i) + conj(s2) * temp;
-                    }
-                }
-            }
-            else {
+            {
                 auto b1 = slice(B, range{istart_m, i + 1}, i);
                 auto b2 = slice(B, range{istart_m, i + 1}, i + 1);
                 rot(b1, b2, c2, conj(s2));

--- a/include/tlapack/lapack/multishift_qz_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qz_sweep.hpp
@@ -116,14 +116,16 @@ void multishift_QZ_sweep(bool want_t,
     auto WV = slice(A, range{n_block_desired + 3, n - n_block_desired},
                     range{0, n_block_desired});
 
+    // Position of the shift train in the pencil.
+    idx_t i_pos_block;
+
     //
     // The following code block introduces the bulges into the matrix
     //
     {
         // Near-the-diagonal bulge introduction
-        // The calculations are initially limited to the window:
-        // (A,B)(ilo:ilo+n_block,ilo:ilo+n_block) The rest is updated later via
-        // level 3 BLAS
+        // The calculations are initially limited to a small window.
+        // The rest is updated later via level 3 BLAS
         idx_t n_block = min(n_block_desired, ihi - ilo);
         auto A2 =
             slice(A, range(ilo, ilo + n_block), range(ilo, ilo + n_block));
@@ -358,6 +360,221 @@ void multishift_QZ_sweep(bool want_t,
                 i = i + iblock;
             }
         }
+
+        i_pos_block = ilo + n_block - n_shifts - 1;
+    }
+
+    //
+    // The following code block moves the bulges down until they are low enough
+    // to be removed
+    //
+    while (i_pos_block + n_block_desired + 1 < ihi) {
+        // Number of positions each bulge will be moved down
+        idx_t n_pos = std::min<idx_t>(n_block_desired - n_shifts,
+                                      ihi - n_shifts - 1 - i_pos_block);
+        // Actual blocksize
+        idx_t n_block = n_shifts + n_pos;
+
+        auto Qc2 = slice(Qc, range{0, n_block}, range{0, n_block});
+        laset(GENERAL, zero, one, Qc2);
+        auto Zc2 = slice(Zc, range{0, n_block}, range{0, n_block});
+        laset(GENERAL, zero, one, Zc2);
+
+        // Near-the-diagonal bulge chase
+        // The calculations are initially limited to a small window
+        // The rest is updated later via level 3 BLAS
+        auto A2 = slice(A, range(i_pos_block, i_pos_block + 1 + n_block),
+                        range(i_pos_block, i_pos_block + n_block));
+        auto B2 = slice(B, range(i_pos_block, i_pos_block + 1 + n_block),
+                        range(i_pos_block, i_pos_block + n_block));
+
+        for (idx_t i_bulge = 0; i_bulge < n_bulges; i_bulge++) {
+            TA t1;
+            idx_t i2 = 2 * (n_bulges - i_bulge - 1);
+            for (idx_t i = i2; i < i2 + n_pos; ++i) {
+                // Remove fill-in from B using an inverse reflector
+                {
+                    auto T = slice(B2, range{i, i + 3}, range{i, i + 3});
+                    inv_house3(T, v, t1);
+                }
+
+                // Apply the reflector
+                {
+                    t1 = conj(t1);
+                    const TA v2 = v[1];
+                    const TA t2 = t1 * v2;
+                    const TA v3 = v[2];
+                    const TA t3 = t1 * v[2];
+                    TA sum;
+
+                    // Apply reflector from the right to B
+                    for (idx_t j = 0; j < i + 3; ++j) {
+                        sum = B2(j, i) + v2 * B2(j, i + 1) + v3 * B2(j, i + 2);
+                        B2(j, i) = B2(j, i) - sum * conj(t1);
+                        B2(j, i + 1) = B2(j, i + 1) - sum * conj(t2);
+                        B2(j, i + 2) = B2(j, i + 2) - sum * conj(t3);
+                    }
+                    B2(i + 1, i) = (TA)0;
+                    B2(i + 2, i) = (TA)0;
+                    // Apply reflector from the right to A
+                    for (idx_t j = 0; j < i + 4; ++j) {
+                        sum = A2(j, i) + v2 * A2(j, i + 1) + v3 * A2(j, i + 2);
+                        A2(j, i) = A2(j, i) - sum * conj(t1);
+                        A2(j, i + 1) = A2(j, i + 1) - sum * conj(t2);
+                        A2(j, i + 2) = A2(j, i + 2) - sum * conj(t3);
+                    }
+                    // Apply reflector to Zc from the right
+                    for (idx_t j = 0; j < n_block; ++j) {
+                        sum =
+                            Zc2(j, i) + v2 * Zc2(j, i + 1) + v3 * Zc2(j, i + 2);
+                        Zc2(j, i) = Zc2(j, i) - sum * conj(t1);
+                        Zc2(j, i + 1) = Zc2(j, i + 1) - sum * conj(t2);
+                        Zc2(j, i + 2) = Zc2(j, i + 2) - sum * conj(t3);
+                    }
+                }
+
+                // Calculate a reflector to move the bulge one position
+                v[0] = A2(i + 1, i);
+                v[1] = A2(i + 2, i);
+                v[2] = A2(i + 3, i);
+                larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+                A2(i + 1, i) = v[0];
+                A2(i + 2, i) = zero;
+                A2(i + 3, i) = zero;
+
+                // Apply reflector
+                {
+                    t1 = conj(t1);
+                    const TA v2 = v[1];
+                    const TA t2 = t1 * v2;
+                    const TA v3 = v[2];
+                    const TA t3 = t1 * v[2];
+                    TA sum;
+
+                    // Apply reflector from the left to A
+                    for (idx_t j = i + 1; j < n_block; ++j) {
+                        sum = A2(i + 1, j) + conj(v2) * A2(i + 2, j) +
+                              conj(v3) * A2(i + 3, j);
+                        A2(i + 1, j) = A2(i + 1, j) - sum * t1;
+                        A2(i + 2, j) = A2(i + 2, j) - sum * t2;
+                        A2(i + 3, j) = A2(i + 3, j) - sum * t3;
+                    }
+                    // Apply reflector from the left to B
+                    for (idx_t j = i + 1; j < n_block; ++j) {
+                        sum = B2(i + 1, j) + conj(v2) * B2(i + 2, j) +
+                              conj(v3) * B2(i + 3, j);
+                        B2(i + 1, j) = B2(i + 1, j) - sum * t1;
+                        B2(i + 2, j) = B2(i + 2, j) - sum * t2;
+                        B2(i + 3, j) = B2(i + 3, j) - sum * t3;
+                    }
+                    // Apply reflector to Qc from the right
+                    for (idx_t j = 0; j < n_block; ++j) {
+                        sum =
+                            Qc2(j, i) + v2 * Qc2(j, i + 1) + v3 * Qc2(j, i + 2);
+                        Qc2(j, i) = Qc2(j, i) - sum * conj(t1);
+                        Qc2(j, i + 1) = Qc2(j, i + 1) - sum * conj(t2);
+                        Qc2(j, i + 2) = Qc2(j, i + 2) - sum * conj(t3);
+                    }
+                }
+            }
+        }
+        // Update rest of the matrix
+        idx_t istart_m, istop_m;
+        if (want_t) {
+            istart_m = 0;
+            istop_m = n;
+        }
+        else {
+            istart_m = ilo;
+            istop_m = ihi;
+        }
+        // Update A
+        if (i_pos_block + n_block < istop_m) {
+            idx_t i = i_pos_block + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto A_slice =
+                    slice(A, range{i_pos_block + 1, i_pos_block + 1 + n_block},
+                          range{i, i + iblock});
+                auto WH_slice = slice(WH, range{0, nrows(A_slice)},
+                                      range{0, ncols(A_slice)});
+                gemm(CONJ_TRANS, NO_TRANS, one, Qc2, A_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        if (istart_m < i_pos_block) {
+            idx_t i = istart_m;
+            while (i < i_pos_block) {
+                idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
+                auto A_slice = slice(A, range{i, i + iblock},
+                                     range{i_pos_block, i_pos_block + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(A_slice)},
+                                      range{0, ncols(A_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, A_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        // Update B
+        if (i_pos_block + n_block < istop_m) {
+            idx_t i = i_pos_block + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto B_slice =
+                    slice(B, range{i_pos_block + 1, i_pos_block + 1 + n_block},
+                          range{i, i + iblock});
+                auto WH_slice = slice(WH, range{0, nrows(B_slice)},
+                                      range{0, ncols(B_slice)});
+                gemm(CONJ_TRANS, NO_TRANS, one, Qc2, B_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, B_slice);
+                i = i + iblock;
+            }
+        }
+        if (istart_m < i_pos_block) {
+            idx_t i = istart_m;
+            while (i < i_pos_block) {
+                idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
+                auto B_slice = slice(B, range{i, i + iblock},
+                                     range{i_pos_block, i_pos_block + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(B_slice)},
+                                      range{0, ncols(B_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, B_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, B_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Q
+        if (want_q) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Q_slice =
+                    slice(Q, range{i, i + iblock},
+                          range{i_pos_block + 1, i_pos_block + 1 + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(Q_slice)},
+                                      range{0, ncols(Q_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, Q_slice, Qc2, WV_slice);
+                lacpy(GENERAL, WV_slice, Q_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Z
+        if (want_z) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Z_slice = slice(Z, range{i, i + iblock},
+                                     range{i_pos_block, i_pos_block + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(Z_slice)},
+                                      range{0, ncols(Z_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, Z_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, Z_slice);
+                i = i + iblock;
+            }
+        }
+
+        i_pos_block = i_pos_block + n_pos;
     }
 }
 

--- a/include/tlapack/lapack/multishift_qz_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qz_sweep.hpp
@@ -1,0 +1,366 @@
+/// @file multishift_qz_sweep.hpp
+/// @author Thijs Steel, KU Leuven, Belgium
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_QZ_SWEEP_HH
+#define TLAPACK_QZ_SWEEP_HH
+
+#include "tlapack/base/utils.hpp"
+#include "tlapack/blas/gemm.hpp"
+#include "tlapack/lapack/lahqr_shiftcolumn.hpp"
+#include "tlapack/lapack/larfg.hpp"
+#include "tlapack/lapack/move_bulge.hpp"
+
+namespace tlapack {
+
+/** multishift_QR_sweep performs a single small-bulge multi-shift QR sweep.
+ *
+ * @param[in] want_t bool.
+ *      If true, the full Schur factor T will be computed.
+ *
+ * @param[in] want_q bool.
+ *      If true, the Schur vectors Q will be computed.
+ *
+ * @param[in] want_z bool.
+ *      If true, the Schur vectors Z will be computed.
+ *
+ * @param[in] ilo    integer.
+ *      Either ilo=0 or A(ilo,ilo-1) = 0.
+ *
+ * @param[in] ihi    integer.
+ *      ilo and ihi determine an isolated block in (A,B).
+ *
+ * @param[in] A  n by n matrix.
+ *      Hessenberg matrix on which AED will be performed
+ *
+ * @param[in] B  n by n matrix.
+ *      Hessenberg matrix on which AED will be performed
+ *
+ * @param[in] alpha  complex vector.
+ *      Vector containing the shifts to be used during the sweep
+ *
+ * @param[in] beta  vector.
+ *      Vector containing the scale factor of the shifts to be used during the
+ *      sweep
+ *
+ * @param[in] Q  n by n matrix.
+ *      On entry, the previously calculated Schur factors.
+ *
+ * @param[in] Z  n by n matrix.
+ *      On entry, the previously calculated Schur factors.
+ *
+ * @ingroup alloc_workspace
+ */
+template <TLAPACK_SMATRIX matrix_t,
+          TLAPACK_VECTOR alpha_t,
+          TLAPACK_VECTOR beta_t,
+          enable_if_t<is_complex<type_t<alpha_t>>, bool> = true>
+void multishift_QZ_sweep(bool want_t,
+                         bool want_q,
+                         bool want_z,
+                         size_type<matrix_t> ilo,
+                         size_type<matrix_t> ihi,
+                         matrix_t& A,
+                         matrix_t& B,
+                         const alpha_t& alpha,
+                         const beta_t& beta,
+                         matrix_t& Q,
+                         matrix_t& Z)
+{
+    using TA = type_t<matrix_t>;
+    using real_t = real_type<TA>;
+    using idx_t = size_type<matrix_t>;
+    using range = pair<idx_t, idx_t>;
+
+    const real_t one(1);
+    const real_t zero(0);
+    const idx_t n = ncols(A);
+    const real_t eps = ulp<real_t>();
+    const real_t small_num = safe_min<real_t>() * ((real_t)n / eps);
+
+    // Functor
+    Create<matrix_t> new_matrix;
+
+    // Define workspace matrices
+    // We use the lower triangular part of A and B as workspace
+    const idx_t n_block_max = (n - 3) / 3;
+    const idx_t n_shifts_max =
+        min(ihi - ilo - 1, std::max<idx_t>(2, 3 * (n_block_max / 4)));
+    idx_t n_shifts = std::min<idx_t>(size(alpha), n_shifts_max);
+    if (n_shifts % 2 == 1) n_shifts = n_shifts - 1;
+    idx_t n_bulges = n_shifts / 2;
+
+    const idx_t n_block_desired = std::min<idx_t>(2 * n_shifts, n_block_max);
+
+    // Qc stores the left orthogonal transformations
+    auto Qc =
+        slice(A, range{n - n_block_desired, n}, range{0, n_block_desired});
+    // Zc stores the left orthogonal transformations
+    auto Zc =
+        slice(B, range{n - n_block_desired, n}, range{0, n_block_desired});
+
+    // Workspace for the reflector (note, this overlaps with the multiplication
+    // workspace, they are not needed at the same time)
+    auto v = slice(A, range(n - 3, n), n_block_desired);
+
+    // Workspace for horizontal multiplications
+    auto WH = slice(A, range{n - n_block_desired, n},
+                    range{n_block_desired, n - n_block_desired - 3});
+
+    // Workspace for vertical multiplications
+    auto WV = slice(A, range{n_block_desired + 3, n - n_block_desired},
+                    range{0, n_block_desired});
+
+    //
+    // The following code block introduces the bulges into the matrix
+    //
+    {
+        // Near-the-diagonal bulge introduction
+        // The calculations are initially limited to the window:
+        // (A,B)(ilo:ilo+n_block,ilo:ilo+n_block) The rest is updated later via
+        // level 3 BLAS
+        idx_t n_block = min(n_block_desired, ihi - ilo);
+        auto A2 =
+            slice(A, range(ilo, ilo + n_block), range(ilo, ilo + n_block));
+        auto B2 =
+            slice(B, range(ilo, ilo + n_block), range(ilo, ilo + n_block));
+        auto Qc2 = slice(Qc, range{0, n_block}, range{0, n_block});
+        laset(GENERAL, zero, one, Qc2);
+        auto Zc2 = slice(Zc, range{0, n_block}, range{0, n_block});
+        laset(GENERAL, zero, one, Zc2);
+
+        for (idx_t i_bulge = 0; i_bulge < n_bulges; i_bulge++) {
+            TA t1;
+
+            {
+                auto H = slice(A2, range{0, 3}, range{0, 3});
+                auto T = slice(B2, range{0, 3}, range{0, 3});
+                lahqz_shiftcolumn(H, T, v, alpha[2 * i_bulge],
+                                  alpha[2 * i_bulge + 1], beta[2 * i_bulge],
+                                  beta[2 * i_bulge + 1]);
+                larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+            }
+
+            // Apply reflector to the block
+            {
+                t1 = conj(t1);
+                const TA v2 = v[1];
+                const TA t2 = t1 * v2;
+                const TA v3 = v[2];
+                const TA t3 = t1 * v[2];
+                TA sum;
+
+                // Apply reflector from the left to A
+                for (idx_t j = 0; j < n_block; ++j) {
+                    sum = A2(0, j) + conj(v2) * A2(1, j) + conj(v3) * A2(2, j);
+                    A2(0, j) = A2(0, j) - sum * t1;
+                    A2(1, j) = A2(1, j) - sum * t2;
+                    A2(2, j) = A2(2, j) - sum * t3;
+                }
+                // Apply reflector from the left to B
+                for (idx_t j = 0; j < n_block; ++j) {
+                    sum = B2(0, j) + conj(v2) * B2(1, j) + conj(v3) * B2(2, j);
+                    B2(0, j) = B2(0, j) - sum * t1;
+                    B2(1, j) = B2(1, j) - sum * t2;
+                    B2(2, j) = B2(2, j) - sum * t3;
+                }
+                // Apply reflector to Qc from the right
+                for (idx_t j = 0; j < n_block; ++j) {
+                    sum = Qc2(j, 0) + v2 * Qc2(j, 1) + v3 * Qc2(j, 2);
+                    Qc2(j, 0) = Qc2(j, 0) - sum * conj(t1);
+                    Qc2(j, 1) = Qc2(j, 1) - sum * conj(t2);
+                    Qc2(j, 2) = Qc2(j, 2) - sum * conj(t3);
+                }
+            }
+
+            // Move the bulge down to make room for another bulge
+            for (idx_t i = 0; i < n_block - 3 - 2 * i_bulge; ++i) {
+                // Remove fill-in from B using an inverse reflector
+                {
+                    auto T = slice(B2, range{i, i + 3}, range{i, i + 3});
+                    inv_house3(T, v, t1);
+                }
+
+                // Apply the reflector
+                {
+                    t1 = conj(t1);
+                    const TA v2 = v[1];
+                    const TA t2 = t1 * v2;
+                    const TA v3 = v[2];
+                    const TA t3 = t1 * v[2];
+                    TA sum;
+
+                    // Apply reflector from the right to B
+                    for (idx_t j = 0; j < i + 3; ++j) {
+                        sum = B2(j, i) + v2 * B2(j, i + 1) + v3 * B2(j, i + 2);
+                        B2(j, i) = B2(j, i) - sum * conj(t1);
+                        B2(j, i + 1) = B2(j, i + 1) - sum * conj(t2);
+                        B2(j, i + 2) = B2(j, i + 2) - sum * conj(t3);
+                    }
+                    B2(i + 1, i) = (TA)0;
+                    B2(i + 2, i) = (TA)0;
+                    // Apply reflector from the right to A
+                    for (idx_t j = 0; j < min(i + 4, n_block); ++j) {
+                        sum = A2(j, i) + v2 * A2(j, i + 1) + v3 * A2(j, i + 2);
+                        A2(j, i) = A2(j, i) - sum * conj(t1);
+                        A2(j, i + 1) = A2(j, i + 1) - sum * conj(t2);
+                        A2(j, i + 2) = A2(j, i + 2) - sum * conj(t3);
+                    }
+                    // Apply reflector to Zc from the right
+                    for (idx_t j = 0; j < n_block; ++j) {
+                        sum =
+                            Zc2(j, i) + v2 * Zc2(j, i + 1) + v3 * Zc2(j, i + 2);
+                        Zc2(j, i) = Zc2(j, i) - sum * conj(t1);
+                        Zc2(j, i + 1) = Zc2(j, i + 1) - sum * conj(t2);
+                        Zc2(j, i + 2) = Zc2(j, i + 2) - sum * conj(t3);
+                    }
+                }
+
+                // Calculate a reflector to move the bulge one position
+                v[0] = A2(i + 1, i);
+                v[1] = A2(i + 2, i);
+                v[2] = A2(i + 3, i);
+                larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+                A2(i + 1, i) = v[0];
+                A2(i + 2, i) = zero;
+                A2(i + 3, i) = zero;
+
+                // Apply reflector
+                {
+                    t1 = conj(t1);
+                    const TA v2 = v[1];
+                    const TA t2 = t1 * v2;
+                    const TA v3 = v[2];
+                    const TA t3 = t1 * v[2];
+                    TA sum;
+
+                    // Apply reflector from the left to A
+                    for (idx_t j = i + 1; j < n_block; ++j) {
+                        sum = A2(i + 1, j) + conj(v2) * A2(i + 2, j) +
+                              conj(v3) * A2(i + 3, j);
+                        A2(i + 1, j) = A2(i + 1, j) - sum * t1;
+                        A2(i + 2, j) = A2(i + 2, j) - sum * t2;
+                        A2(i + 3, j) = A2(i + 3, j) - sum * t3;
+                    }
+                    // Apply reflector from the left to B
+                    for (idx_t j = i + 1; j < n_block; ++j) {
+                        sum = B2(i + 1, j) + conj(v2) * B2(i + 2, j) +
+                              conj(v3) * B2(i + 3, j);
+                        B2(i + 1, j) = B2(i + 1, j) - sum * t1;
+                        B2(i + 2, j) = B2(i + 2, j) - sum * t2;
+                        B2(i + 3, j) = B2(i + 3, j) - sum * t3;
+                    }
+                    // Apply reflector to Qc from the right
+                    for (idx_t j = 0; j < n_block; ++j) {
+                        sum = Qc2(j, i + 1) + v2 * Qc2(j, i + 2) +
+                              v3 * Qc2(j, i + 3);
+                        Qc2(j, i + 1) = Qc2(j, i + 1) - sum * conj(t1);
+                        Qc2(j, i + 2) = Qc2(j, i + 2) - sum * conj(t2);
+                        Qc2(j, i + 3) = Qc2(j, i + 3) - sum * conj(t3);
+                    }
+                }
+            }
+        }
+        // Update rest of the matrix
+        idx_t istart_m, istop_m;
+        if (want_t) {
+            istart_m = 0;
+            istop_m = n;
+        }
+        else {
+            istart_m = ilo;
+            istop_m = ihi;
+        }
+        // Update A
+        if (ilo + n_shifts + 1 < istop_m) {
+            idx_t i = ilo + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto A_slice =
+                    slice(A, range{ilo, ilo + n_block}, range{i, i + iblock});
+                auto WH_slice = slice(WH, range{0, nrows(A_slice)},
+                                      range{0, ncols(A_slice)});
+                gemm(CONJ_TRANS, NO_TRANS, one, Qc2, A_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        if (istart_m < ilo) {
+            idx_t i = istart_m;
+            while (i < ilo) {
+                idx_t iblock = std::min<idx_t>(ilo - i, nrows(WV));
+                auto A_slice =
+                    slice(A, range{i, i + iblock}, range{ilo, ilo + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(A_slice)},
+                                      range{0, ncols(A_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, A_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        // Update B
+        if (ilo + n_shifts + 1 < istop_m) {
+            idx_t i = ilo + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto B_slice =
+                    slice(B, range{ilo, ilo + n_block}, range{i, i + iblock});
+                auto WH_slice = slice(WH, range{0, nrows(B_slice)},
+                                      range{0, ncols(B_slice)});
+                gemm(CONJ_TRANS, NO_TRANS, one, Qc2, B_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, B_slice);
+                i = i + iblock;
+            }
+        }
+        if (istart_m < ilo) {
+            idx_t i = istart_m;
+            while (i < ilo) {
+                idx_t iblock = std::min<idx_t>(ilo - i, nrows(WV));
+                auto B_slice =
+                    slice(B, range{i, i + iblock}, range{ilo, ilo + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(B_slice)},
+                                      range{0, ncols(B_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, B_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, B_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Q
+        if (want_q) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Q_slice =
+                    slice(Q, range{i, i + iblock}, range{ilo, ilo + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(Q_slice)},
+                                      range{0, ncols(Q_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, Q_slice, Qc2, WV_slice);
+                lacpy(GENERAL, WV_slice, Q_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Z
+        if (want_z) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Z_slice =
+                    slice(Z, range{i, i + iblock}, range{ilo, ilo + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(Z_slice)},
+                                      range{0, ncols(Z_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, Z_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, Z_slice);
+                i = i + iblock;
+            }
+        }
+    }
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_QZ_SWEEP_HH

--- a/include/tlapack/lapack/multishift_qz_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qz_sweep.hpp
@@ -184,7 +184,7 @@ void multishift_QZ_sweep(bool want_t,
             for (idx_t i = 0; i < n_block - 3 - 2 * i_bulge; ++i) {
                 // Remove fill-in from B using an inverse reflector
                 {
-                    auto T = slice(B2, range{i, i + 3}, range{i, i + 3});
+                    auto T = slice(B2, range{i + 1, i + 3}, range{i, i + 3});
                     inv_house3(T, v, t1);
                 }
 
@@ -394,7 +394,7 @@ void multishift_QZ_sweep(bool want_t,
             for (idx_t i = i2; i < i2 + n_pos; ++i) {
                 // Remove fill-in from B using an inverse reflector
                 {
-                    auto T = slice(B2, range{i, i + 3}, range{i, i + 3});
+                    auto T = slice(B2, range{i + 1, i + 3}, range{i, i + 3});
                     inv_house3(T, v, t1);
                 }
 
@@ -600,7 +600,7 @@ void multishift_QZ_sweep(bool want_t,
             for (idx_t i = i2; i < n_block - 1; ++i) {
                 // Remove fill-in from B using an inverse reflector
                 if (i + 2 < n_block) {
-                    auto T = slice(B2, range{i, i + 3}, range{i, i + 3});
+                    auto T = slice(B2, range{i + 1, i + 3}, range{i, i + 3});
                     inv_house3(T, v, t1);
 
                     // Apply the reflector

--- a/include/tlapack/lapack/multishift_qz_sweep.hpp
+++ b/include/tlapack/lapack/multishift_qz_sweep.hpp
@@ -368,10 +368,10 @@ void multishift_QZ_sweep(bool want_t,
     // The following code block moves the bulges down until they are low enough
     // to be removed
     //
-    while (i_pos_block + n_block_desired + 1 < ihi) {
+    while (i_pos_block + n_block_desired < ihi) {
         // Number of positions each bulge will be moved down
         idx_t n_pos = std::min<idx_t>(n_block_desired - n_shifts,
-                                      ihi - n_shifts - 1 - i_pos_block);
+                                      ihi - n_shifts - i_pos_block);
         // Actual blocksize
         idx_t n_block = n_shifts + n_pos;
 
@@ -575,6 +575,276 @@ void multishift_QZ_sweep(bool want_t,
         }
 
         i_pos_block = i_pos_block + n_pos;
+    }
+
+    //
+    // The following code removes the bulges from the matrix
+    //
+    {
+        // Actual blocksize
+        idx_t n_block = ihi - i_pos_block;
+
+        auto Qc2 = slice(Qc, range{0, n_block}, range{0, n_block});
+        laset(GENERAL, zero, one, Qc2);
+        auto Zc2 = slice(Zc, range{0, n_block}, range{0, n_block});
+        laset(GENERAL, zero, one, Zc2);
+
+        // The calculations are initially limited to a small window
+        // The rest is updated later via level 3 BLAS
+        auto A2 = slice(A, range(i_pos_block, ihi), range(i_pos_block, ihi));
+        auto B2 = slice(B, range(i_pos_block, ihi), range(i_pos_block, ihi));
+
+        for (idx_t i_bulge = 0; i_bulge < n_bulges; i_bulge++) {
+            TA t1;
+            idx_t i2 = 2 * (n_bulges - i_bulge - 1);
+            for (idx_t i = i2; i < n_block - 1; ++i) {
+                // Remove fill-in from B using an inverse reflector
+                if (i + 2 < n_block) {
+                    auto T = slice(B2, range{i, i + 3}, range{i, i + 3});
+                    inv_house3(T, v, t1);
+
+                    // Apply the reflector
+                    {
+                        t1 = conj(t1);
+                        const TA v2 = v[1];
+                        const TA t2 = t1 * v2;
+                        const TA v3 = v[2];
+                        const TA t3 = t1 * v[2];
+                        TA sum;
+
+                        // Apply reflector from the right to B
+                        for (idx_t j = 0; j < i + 3; ++j) {
+                            sum = B2(j, i) + v2 * B2(j, i + 1) +
+                                  v3 * B2(j, i + 2);
+                            B2(j, i) = B2(j, i) - sum * conj(t1);
+                            B2(j, i + 1) = B2(j, i + 1) - sum * conj(t2);
+                            B2(j, i + 2) = B2(j, i + 2) - sum * conj(t3);
+                        }
+                        B2(i + 1, i) = (TA)0;
+                        B2(i + 2, i) = (TA)0;
+                        // Apply reflector from the right to A
+                        for (idx_t j = 0; j < min(n_block, i + 4); ++j) {
+                            sum = A2(j, i) + v2 * A2(j, i + 1) +
+                                  v3 * A2(j, i + 2);
+                            A2(j, i) = A2(j, i) - sum * conj(t1);
+                            A2(j, i + 1) = A2(j, i + 1) - sum * conj(t2);
+                            A2(j, i + 2) = A2(j, i + 2) - sum * conj(t3);
+                        }
+                        // Apply reflector to Zc from the right
+                        for (idx_t j = 0; j < n_block; ++j) {
+                            sum = Zc2(j, i) + v2 * Zc2(j, i + 1) +
+                                  v3 * Zc2(j, i + 2);
+                            Zc2(j, i) = Zc2(j, i) - sum * conj(t1);
+                            Zc2(j, i + 1) = Zc2(j, i + 1) - sum * conj(t2);
+                            Zc2(j, i + 2) = Zc2(j, i + 2) - sum * conj(t3);
+                        }
+                    }
+                }
+                else {
+                    // For the final 2x2 block, use a rotation instead of a
+                    // reflector
+                    real_t c2;
+                    TA s2;
+                    rotg(B2(i + 1, i + 1), B2(i + 1, i), c2, s2);
+                    s2 = -s2;
+                    B2(i + 1, i) = (TA)0.;
+
+                    // Apply rotation
+                    {
+                        auto b1 = slice(B2, range{0, i + 1}, i);
+                        auto b2 = slice(B2, range{0, i + 1}, i + 1);
+                        rot(b1, b2, c2, conj(s2));
+                        auto a1 = col(A2, i);
+                        auto a2 = col(A2, i + 1);
+                        rot(a1, a2, c2, conj(s2));
+                        if (want_z) {
+                            auto z1 = col(Zc2, i);
+                            auto z2 = col(Zc2, i + 1);
+                            rot(z1, z2, c2, conj(s2));
+                        }
+                    }
+                }
+
+                // Calculate a reflector to move the bulge one position
+                if (i + 2 < n_block) {
+                    if (i + 3 < n_block) {
+                        // Normal size bulge
+                        v[0] = A2(i + 1, i);
+                        v[1] = A2(i + 2, i);
+                        v[2] = A2(i + 3, i);
+                        larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+                        A2(i + 1, i) = v[0];
+                        A2(i + 2, i) = zero;
+                        A2(i + 3, i) = zero;
+
+                        // Apply reflector
+                        {
+                            t1 = conj(t1);
+                            const TA v2 = v[1];
+                            const TA t2 = t1 * v2;
+                            const TA v3 = v[2];
+                            const TA t3 = t1 * v[2];
+                            TA sum;
+
+                            // Apply reflector from the left to A
+                            for (idx_t j = i + 1; j < n_block; ++j) {
+                                sum = A2(i + 1, j) + conj(v2) * A2(i + 2, j) +
+                                      conj(v3) * A2(i + 3, j);
+                                A2(i + 1, j) = A2(i + 1, j) - sum * t1;
+                                A2(i + 2, j) = A2(i + 2, j) - sum * t2;
+                                A2(i + 3, j) = A2(i + 3, j) - sum * t3;
+                            }
+                            // Apply reflector from the left to B
+                            for (idx_t j = i + 1; j < n_block; ++j) {
+                                sum = B2(i + 1, j) + conj(v2) * B2(i + 2, j) +
+                                      conj(v3) * B2(i + 3, j);
+                                B2(i + 1, j) = B2(i + 1, j) - sum * t1;
+                                B2(i + 2, j) = B2(i + 2, j) - sum * t2;
+                                B2(i + 3, j) = B2(i + 3, j) - sum * t3;
+                            }
+                            // Apply reflector to Qc from the right
+                            for (idx_t j = 0; j < n_block; ++j) {
+                                sum = Qc2(j, i + 1) + v2 * Qc2(j, i + 2) +
+                                      v3 * Qc2(j, i + 3);
+                                Qc2(j, i + 1) = Qc2(j, i + 1) - sum * conj(t1);
+                                Qc2(j, i + 2) = Qc2(j, i + 2) - sum * conj(t2);
+                                Qc2(j, i + 3) = Qc2(j, i + 3) - sum * conj(t3);
+                            }
+                        }
+                    }
+                    else {
+                        // Small 2x2 bulge
+                        v[0] = A2(i + 1, i);
+                        v[1] = A2(i + 2, i);
+                        v[2] = zero;
+                        larfg(FORWARD, COLUMNWISE_STORAGE, v, t1);
+                        A2(i + 1, i) = v[0];
+                        A2(i + 2, i) = zero;
+
+                        // Apply reflector
+                        {
+                            t1 = conj(t1);
+                            const TA v2 = v[1];
+                            const TA t2 = t1 * v2;
+                            TA sum;
+
+                            // Apply reflector from the left to A
+                            for (idx_t j = i + 1; j < n_block; ++j) {
+                                sum = A2(i + 1, j) + conj(v2) * A2(i + 2, j);
+                                A2(i + 1, j) = A2(i + 1, j) - sum * t1;
+                                A2(i + 2, j) = A2(i + 2, j) - sum * t2;
+                            }
+                            // Apply reflector from the left to B
+                            for (idx_t j = i + 1; j < n_block; ++j) {
+                                sum = B2(i + 1, j) + conj(v2) * B2(i + 2, j);
+                                B2(i + 1, j) = B2(i + 1, j) - sum * t1;
+                                B2(i + 2, j) = B2(i + 2, j) - sum * t2;
+                            }
+                            // Apply reflector to Qc from the right
+                            for (idx_t j = 0; j < n_block; ++j) {
+                                sum = Qc2(j, i + 1) + v2 * Qc2(j, i + 2);
+                                Qc2(j, i + 1) = Qc2(j, i + 1) - sum * conj(t1);
+                                Qc2(j, i + 2) = Qc2(j, i + 2) - sum * conj(t2);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Update rest of the matrix
+        idx_t istart_m, istop_m;
+        if (want_t) {
+            istart_m = 0;
+            istop_m = n;
+        }
+        else {
+            istart_m = ilo;
+            istop_m = ihi;
+        }
+        // Update A
+        if (i_pos_block + n_block < istop_m) {
+            idx_t i = i_pos_block + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto A_slice =
+                    slice(A, range{i_pos_block + 1, i_pos_block + 1 + n_block},
+                          range{i, i + iblock});
+                auto WH_slice = slice(WH, range{0, nrows(A_slice)},
+                                      range{0, ncols(A_slice)});
+                gemm(CONJ_TRANS, NO_TRANS, one, Qc2, A_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        if (istart_m < i_pos_block) {
+            idx_t i = istart_m;
+            while (i < i_pos_block) {
+                idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
+                auto A_slice = slice(A, range{i, i + iblock},
+                                     range{i_pos_block, i_pos_block + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(A_slice)},
+                                      range{0, ncols(A_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, A_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, A_slice);
+                i = i + iblock;
+            }
+        }
+        // Update B
+        if (i_pos_block + n_block < istop_m) {
+            idx_t i = i_pos_block + n_block;
+            while (i < istop_m) {
+                idx_t iblock = std::min<idx_t>(istop_m - i, ncols(WH));
+                auto B_slice =
+                    slice(B, range{i_pos_block + 1, i_pos_block + 1 + n_block},
+                          range{i, i + iblock});
+                auto WH_slice = slice(WH, range{0, nrows(B_slice)},
+                                      range{0, ncols(B_slice)});
+                gemm(CONJ_TRANS, NO_TRANS, one, Qc2, B_slice, WH_slice);
+                lacpy(GENERAL, WH_slice, B_slice);
+                i = i + iblock;
+            }
+        }
+        if (istart_m < i_pos_block) {
+            idx_t i = istart_m;
+            while (i < i_pos_block) {
+                idx_t iblock = std::min<idx_t>(i_pos_block - i, nrows(WV));
+                auto B_slice = slice(B, range{i, i + iblock},
+                                     range{i_pos_block, i_pos_block + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(B_slice)},
+                                      range{0, ncols(B_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, B_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, B_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Q
+        if (want_q) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Q_slice = slice(Q, range{i, i + iblock},
+                                     range{i_pos_block, i_pos_block + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(Q_slice)},
+                                      range{0, ncols(Q_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, Q_slice, Qc2, WV_slice);
+                lacpy(GENERAL, WV_slice, Q_slice);
+                i = i + iblock;
+            }
+        }
+        // Update Z
+        if (want_z) {
+            idx_t i = 0;
+            while (i < n) {
+                idx_t iblock = std::min<idx_t>(n - i, nrows(WV));
+                auto Z_slice = slice(Z, range{i, i + iblock},
+                                     range{i_pos_block, i_pos_block + n_block});
+                auto WV_slice = slice(WV, range{0, nrows(Z_slice)},
+                                      range{0, ncols(Z_slice)});
+                gemm(NO_TRANS, NO_TRANS, one, Z_slice, Zc2, WV_slice);
+                lacpy(GENERAL, WV_slice, Z_slice);
+                i = i + iblock;
+            }
+        }
     }
 }
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -98,6 +98,7 @@ add_executable(test_concepts test_concepts.cpp)
 add_executable(test_norms test_norms.cpp)
 add_executable(test_qz_eig22 test_qz_eig22.cpp testutils.cpp)
 add_executable(test_qz_algorithm test_qz_algorithm.cpp testutils.cpp)
+add_executable(test_inv_house test_inv_house.cpp testutils.cpp)
 
 if(TLAPACK_TEST_EIGEN)
   add_executable(test_eigenplugin test_eigenplugin.cpp)

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(test_qz_eig22 test_qz_eig22.cpp testutils.cpp)
 add_executable(test_qz_algorithm test_qz_algorithm.cpp testutils.cpp)
 add_executable(test_inv_house test_inv_house.cpp testutils.cpp)
 add_executable(test_qz_sweep test_qz_sweep.cpp testutils.cpp)
+add_executable(test_generalized_schur_swap test_generalized_schur_swap.cpp testutils.cpp)
 
 if(TLAPACK_TEST_EIGEN)
   add_executable(test_eigenplugin test_eigenplugin.cpp)

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -99,6 +99,7 @@ add_executable(test_norms test_norms.cpp)
 add_executable(test_qz_eig22 test_qz_eig22.cpp testutils.cpp)
 add_executable(test_qz_algorithm test_qz_algorithm.cpp testutils.cpp)
 add_executable(test_inv_house test_inv_house.cpp testutils.cpp)
+add_executable(test_qz_sweep test_qz_sweep.cpp testutils.cpp)
 
 if(TLAPACK_TEST_EIGEN)
   add_executable(test_eigenplugin test_eigenplugin.cpp)

--- a/test/src/test_generalized_schur_swap.cpp
+++ b/test/src/test_generalized_schur_swap.cpp
@@ -40,7 +40,7 @@ TEMPLATE_TEST_CASE("generalized schur swap gives correct result",
     idx_t n = 10;
 
     const idx_t j = GENERATE(0, 1, 6);
-    const idx_t n1 = GENERATE(1);
+    const idx_t n1 = GENERATE(1, 2);
     const idx_t n2 = GENERATE(1);
 
     if (is_real<T> || (n1 == 1 && n2 == 1)) {

--- a/test/src/test_generalized_schur_swap.cpp
+++ b/test/src/test_generalized_schur_swap.cpp
@@ -1,0 +1,111 @@
+/// @file test_generalized_schur_swap.cpp
+/// @author Thijs Steel, KU Leuven, Belgium
+/// @brief Test 1x1 and 2x2 generalized schur swaps
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+// Test utilities and definitions (must come before <T>LAPACK headers)
+#include "testutils.hpp"
+
+// Auxiliary routines
+#include <tlapack/lapack/lacpy.hpp>
+#include <tlapack/lapack/lange.hpp>
+
+// Other routines
+#include <tlapack/lapack/generalized_schur_swap.hpp>
+
+using namespace tlapack;
+
+TEMPLATE_TEST_CASE("generalized schur swap gives correct result",
+                   "[generalized eigenvalues]",
+                   TLAPACK_TYPES_TO_TEST)
+{
+    using matrix_t = TestType;
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    typedef real_type<T> real_t;
+
+    // Functor
+    Create<matrix_t> new_matrix;
+
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    const T zero(0);
+    const T one(1);
+    idx_t n = 10;
+
+    const idx_t j = GENERATE(0, 1, 6);
+    const idx_t n1 = GENERATE(1);
+    const idx_t n2 = GENERATE(1);
+
+    if (is_real<T> || (n1 == 1 && n2 == 1)) {
+        const real_t eps = uroundoff<real_t>();
+        const real_t tol = real_t(1.0e2 * n) * eps;
+
+        std::vector<T> A_;
+        auto A = new_matrix(A_, n, n);
+        std::vector<T> B_;
+        auto B = new_matrix(B_, n, n);
+        std::vector<T> Q_;
+        auto Q = new_matrix(Q_, n, n);
+        std::vector<T> Z_;
+        auto Z = new_matrix(Z_, n, n);
+        std::vector<T> A_copy_;
+        auto A_copy = new_matrix(A_copy_, n, n);
+        std::vector<T> B_copy_;
+        auto B_copy = new_matrix(B_copy_, n, n);
+
+        // Generate random matrix in Schur form
+        mm.random(A);
+        mm.random(B);
+
+        // Set lower triangular part to zero
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 1; i < n; ++i)
+                A(i, j) = zero;
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 1; i < n; ++i)
+                B(i, j) = zero;
+
+        if (n1 == 2) A(j + 1, j) = rand_helper<T>();
+        if (n2 == 2) A(j + n1 + 1, j + n1) = rand_helper<T>();
+
+        lacpy(GENERAL, A, A_copy);
+        lacpy(GENERAL, B, B_copy);
+        laset(GENERAL, zero, one, Q);
+        laset(GENERAL, zero, one, Z);
+
+        DYNAMIC_SECTION("j = " << j << " n1 = " << n1 << " n2 =" << n2)
+        {
+            generalized_schur_swap(true, true, A, B, Q, Z, j, n1, n2);
+            // Calculate residuals
+
+            std::vector<T> res_;
+            auto res = new_matrix(res_, n, n);
+            std::vector<T> work_;
+            auto work = new_matrix(work_, n, n);
+
+            // Calculate residuals
+            auto orth_res_norm_q = check_orthogonality(Q, res);
+            CHECK(orth_res_norm_q <= tol);
+
+            auto orth_res_norm_z = check_orthogonality(Z, res);
+            CHECK(orth_res_norm_z <= tol);
+
+            auto normA = tlapack::lange(tlapack::FROB_NORM, A_copy);
+            auto normA_res = check_generalized_similarity_transform(
+                A_copy, Q, Z, A, res, work);
+            CHECK(normA_res <= tol * normA);
+
+            auto normB = tlapack::lange(tlapack::FROB_NORM, B_copy);
+            auto normB_res = check_generalized_similarity_transform(
+                B_copy, Q, Z, B, res, work);
+            CHECK(normB_res <= tol * normB);
+        }
+    }
+}

--- a/test/src/test_generalized_schur_swap.cpp
+++ b/test/src/test_generalized_schur_swap.cpp
@@ -41,7 +41,7 @@ TEMPLATE_TEST_CASE("generalized schur swap gives correct result",
 
     const idx_t j = GENERATE(0, 1, 6);
     const idx_t n1 = GENERATE(1, 2);
-    const idx_t n2 = GENERATE(1);
+    const idx_t n2 = GENERATE(1, 2);
 
     if (is_real<T> || (n1 == 1 && n2 == 1)) {
         const real_t eps = uroundoff<real_t>();

--- a/test/src/test_generalized_schur_swap.cpp
+++ b/test/src/test_generalized_schur_swap.cpp
@@ -82,7 +82,9 @@ TEMPLATE_TEST_CASE("generalized schur swap gives correct result",
 
         DYNAMIC_SECTION("j = " << j << " n1 = " << n1 << " n2 =" << n2)
         {
-            generalized_schur_swap(true, true, A, B, Q, Z, j, n1, n2);
+            int ierr =
+                generalized_schur_swap(true, true, A, B, Q, Z, j, n1, n2);
+            CHECK(ierr == 0);
             // Calculate residuals
 
             std::vector<T> res_;

--- a/test/src/test_inv_house.cpp
+++ b/test/src/test_inv_house.cpp
@@ -1,0 +1,71 @@
+/// @file test_inv_house.cpp
+/// @author Thijs Steel, KU Leuven, Belgium
+/// @brief Test generation of inverse householder reflector.
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+// Test utilities and definitions (must come before <T>LAPACK headers)
+#include "testutils.hpp"
+
+// Auxiliary routines
+#include <tlapack/lapack/lacpy.hpp>
+#include <tlapack/lapack/lange.hpp>
+#include <tlapack/lapack/laset.hpp>
+
+// Other routines
+#include <tlapack/lapack/inv_house3.hpp>
+#include <tlapack/lapack/larf.hpp>
+
+using namespace tlapack;
+
+TEMPLATE_TEST_CASE("Inverse householder calculation is correct",
+                   "[aux]",
+                   TLAPACK_TYPES_TO_TEST)
+{
+    using matrix_t = TestType;
+    using TA = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    using real_t = real_type<TA>;
+    using complex_t = complex_type<real_t>;
+    using range = pair<idx_t, idx_t>;
+
+    // Functor
+    Create<matrix_t> new_matrix;
+
+    // MatrixMarket reader
+    MatrixMarket mm;
+    const int seed = GENERATE(2, 3, 4, 5, 6, 7, 8, 9);
+
+    const idx_t n = 3;
+    const real_t zero(0);
+    const real_t one(1);
+    const real_t tol = 5 * ulp<real_t>();
+
+    // Seed random number generator
+    mm.gen.seed(seed);
+
+    // Define the matrices
+    std::vector<TA> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<TA> v(n);
+
+    mm.random(A);
+
+    DYNAMIC_SECTION("seed = " << seed)
+    {
+        TA tau;
+        inv_house3(A, v, tau);
+
+        // Apply reflector to A
+        larf(Side::Right, Direction::Forward, StoreV::Columnwise, v, tau, A);
+
+        auto anorm = lange(MAX_NORM, A);
+
+        CHECK(abs(A(1, 0)) <= tol * anorm);
+        CHECK(abs(A(2, 0)) <= tol * anorm);
+    }
+}

--- a/test/src/test_inv_house.cpp
+++ b/test/src/test_inv_house.cpp
@@ -40,7 +40,6 @@ TEMPLATE_TEST_CASE("Inverse householder calculation is correct",
     MatrixMarket mm;
     const int seed = GENERATE(2, 3, 4, 5, 6, 7, 8, 9);
 
-    const idx_t n = 3;
     const real_t zero(0);
     const real_t one(1);
     const real_t tol = 5 * ulp<real_t>();
@@ -50,8 +49,8 @@ TEMPLATE_TEST_CASE("Inverse householder calculation is correct",
 
     // Define the matrices
     std::vector<TA> A_;
-    auto A = new_matrix(A_, n, n);
-    std::vector<TA> v(n);
+    auto A = new_matrix(A_, 2, 3);
+    std::vector<TA> v(3);
 
     mm.random(A);
 
@@ -65,7 +64,7 @@ TEMPLATE_TEST_CASE("Inverse householder calculation is correct",
 
         auto anorm = lange(MAX_NORM, A);
 
+        CHECK(abs(A(0, 0)) <= tol * anorm);
         CHECK(abs(A(1, 0)) <= tol * anorm);
-        CHECK(abs(A(2, 0)) <= tol * anorm);
     }
 }

--- a/test/src/test_qz_algorithm.cpp
+++ b/test/src/test_qz_algorithm.cpp
@@ -145,8 +145,11 @@ TEMPLATE_TEST_CASE("QZ algorithm",
         auto work = new_matrix(work_, n, n);
 
         // Calculate residuals
-        auto orth_res_norm = check_orthogonality(Q, res);
-        CHECK(orth_res_norm <= tol);
+        auto orth_res_norm_q = check_orthogonality(Q, res);
+        CHECK(orth_res_norm_q <= tol);
+
+        auto orth_res_norm_z = check_orthogonality(Z, res);
+        CHECK(orth_res_norm_z <= tol);
 
         auto normA = tlapack::lange(tlapack::FROB_NORM, A);
         auto normA_res =

--- a/test/src/test_qz_sweep.cpp
+++ b/test/src/test_qz_sweep.cpp
@@ -104,10 +104,10 @@ TEMPLATE_TEST_CASE("QZ sweep is backward stable",
 
         // Clean the lower triangular part that was used a workspace
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = j + 3; i < n; ++i)
+            for (idx_t i = j + 4; i < n; ++i)
                 H(i, j) = zero;
         for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = j + 3; i < n; ++i)
+            for (idx_t i = j + 4; i < n; ++i)
                 T(i, j) = zero;
 
         const real_t eps = uroundoff<real_t>();

--- a/test/src/test_qz_sweep.cpp
+++ b/test/src/test_qz_sweep.cpp
@@ -1,0 +1,135 @@
+/// @file test_qz_sweep.cpp
+/// @author Thijs Steel, KU Leuven, Belgium
+/// @brief Test qz sweep.
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+// Test utilities and definitions (must come before <T>LAPACK headers)
+#include "testutils.hpp"
+
+// Auxiliary routines
+#include <tlapack/lapack/lacpy.hpp>
+#include <tlapack/lapack/lange.hpp>
+#include <tlapack/lapack/laset.hpp>
+
+// Other routines
+#include <tlapack/lapack/geqrf.hpp>
+#include <tlapack/lapack/gghrd.hpp>
+#include <tlapack/lapack/lahqz.hpp>
+#include <tlapack/lapack/multishift_qz_sweep.hpp>
+#include <tlapack/lapack/unmqr.hpp>
+
+using namespace tlapack;
+
+TEMPLATE_TEST_CASE("QZ sweep is backward stable",
+                   "[generalized eigenvalues]",
+                   TLAPACK_TYPES_TO_TEST)
+{
+    using matrix_t = TestType;
+    using TA = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    using real_t = real_type<TA>;
+    using complex_t = complex_type<real_t>;
+    using range = pair<idx_t, idx_t>;
+
+    // Functor
+    Create<matrix_t> new_matrix;
+
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    using test_tuple_t = std::tuple<std::string, idx_t>;
+
+    const idx_t n = GENERATE(12, 30);
+    const idx_t ns = GENERATE(2, 4, 6);
+    const idx_t ilo = 0;
+    const idx_t ihi = n;
+    const real_t zero(0);
+    const real_t one(1);
+
+    // Define the matrices
+    std::vector<TA> A_;
+    auto A = new_matrix(A_, n, n);
+    std::vector<TA> B_;
+    auto B = new_matrix(B_, n, n);
+    std::vector<TA> H_;
+    auto H = new_matrix(H_, n, n);
+    std::vector<TA> T_;
+    auto T = new_matrix(T_, n, n);
+    std::vector<TA> Q_;
+    auto Q = new_matrix(Q_, n, n);
+    std::vector<TA> Z_;
+    auto Z = new_matrix(Z_, n, n);
+
+    mm.hessenberg(A);
+    mm.random(Uplo::Upper, B);
+
+    // Make sure ilo and ihi correspond to the actual matrix
+    for (idx_t j = 0; j < ilo; ++j)
+        for (idx_t i = j + 1; i < n; ++i)
+            A(i, j) = (TA)0.0;
+    for (idx_t i = ihi; i < n; ++i)
+        for (idx_t j = 0; j < i; ++j)
+            A(i, j) = (TA)0.0;
+
+    // Clear out subdiagonal
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = j + 2; i < n; ++i)
+            A(i, j) = zero;
+    for (idx_t j = 0; j < n; ++j)
+        for (idx_t i = j + 1; i < n; ++i)
+            B(i, j) = zero;
+
+    lacpy(GENERAL, A, H);
+    lacpy(GENERAL, B, T);
+    std::vector<complex_t> alpha(ns);
+    std::vector<TA> beta(ns);
+    laset(GENERAL, zero, one, Q);
+    laset(GENERAL, zero, one, Z);
+
+    for (idx_t i = 0; i < ns; i++) {
+        alpha[i] = (complex_t)i;
+        beta[i] = (TA)1.0;
+    }
+
+    DYNAMIC_SECTION(" n = " << n << " ns = " << ns << " ilo = " << ilo
+                            << " ihi = " << ihi)
+    {
+        multishift_QZ_sweep(true, true, true, ilo, ihi, H, T, alpha, beta, Q,
+                            Z);
+
+        // Clean the lower triangular part that was used a workspace
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 3; i < n; ++i)
+                H(i, j) = zero;
+        for (idx_t j = 0; j < n; ++j)
+            for (idx_t i = j + 3; i < n; ++i)
+                T(i, j) = zero;
+
+        const real_t eps = uroundoff<real_t>();
+        const real_t tol = real_t(n * 1.0e2) * eps;
+
+        std::vector<TA> res_;
+        auto res = new_matrix(res_, n, n);
+        std::vector<TA> work_;
+        auto work = new_matrix(work_, n, n);
+
+        // Calculate residuals
+        auto orth_res_norm = check_orthogonality(Q, res);
+        CHECK(orth_res_norm <= tol);
+
+        auto normA = tlapack::lange(tlapack::FROB_NORM, A);
+        auto normA_res =
+            check_generalized_similarity_transform(A, Q, Z, H, res, work);
+        CHECK(normA_res <= tol * normA);
+
+        auto normB = tlapack::lange(tlapack::FROB_NORM, B);
+        auto normB_res =
+            check_generalized_similarity_transform(B, Q, Z, T, res, work);
+        CHECK(normB_res <= tol * normB);
+    }
+}


### PR DESCRIPTION
Note, i just wanted to track my own changes, this is still a draft.

Changes in this PR:
- implement inverse householder reflector of order 3.
- Use inverse householder in unblocked QZ. This resulted in a surprizing amount of speedup. Almost 30%
- implement schur swap (this has a significant change w.r.t. lapack, because i use 2x2 svd and givens instead of QR), should be significantly more accurate, but i need to do some benchmarks to see if it is also fast.
- implement multishift sweep

TODO:
- implement schur move
- implement AED
- implement full multishift QZ

