### PR TITLE
implement wavefront algorithm for sequence of rotations

### DIFF
--- a/include/tlapack/lapack/rot_sequence3.hpp
+++ b/include/tlapack/lapack/rot_sequence3.hpp
@@ -147,20 +147,74 @@ void rot_sequence3(
                     }
                     // Pipeline phase
                     for (idx_t i1 = ib; i1 < ib2; ++i1) {
-                        for (idx_t j = l - 1; j < m - 1; ++j) {
-                            for (idx_t i = 0, g2 = j; i < l; ++i, --g2) {
+                        for (idx_t j = l - 1; j + 1 < m - 1; j += 2) {
+                            for (idx_t i = 0, g2 = j; i + 1 < l;
+                                 i += 2, g2 -= 2) {
                                 idx_t g = m - 2 - g2;
+                                //
+                                // Apply first rotation
+                                //
+
+                                // A(g,i1) after first rotation
+                                T temp1 =
+                                    C(g, i) * A(g, i1) + S(g, i) * A(g + 1, i1);
+                                // A(g+1,i1) after first rotation
+                                T temp2 = -conj(S(g, i)) * A(g, i1) +
+                                          C(g, i) * A(g + 1, i1);
+
+                                //
+                                // Apply second rotation
+                                //
+
+                                // A(g,i1) after second rotation
+                                T temp3 = -conj(S(g - 1, i)) * A(g - 1, i1) +
+                                          C(g - 1, i) * temp1;
+                                A(g - 1, i1) = C(g - 1, i) * A(g - 1, i1) +
+                                               S(g - 1, i) * temp1;
+
+                                //
+                                // Apply third rotation
+                                //
+
+                                // A(g+1,i1) after third rotation
+                                T temp4 = C(g + 1, i + 1) * temp2 +
+                                          S(g + 1, i + 1) * A(g + 2, i1);
+                                A(g + 2, i1) = -conj(S(g + 1, i + 1)) * temp2 +
+                                               C(g + 1, i + 1) * A(g + 2, i1);
+
+                                // Apply fourth rotation
+                                A(g, i1) =
+                                    C(g, i + 1) * temp3 + S(g, i + 1) * temp4;
+                                A(g + 1, i1) = -conj(S(g, i + 1)) * temp3 +
+                                               C(g, i + 1) * temp4;
+                            }
+
+                            if (l % 2 == 1) {
+                                // Apply two more rotations that could not be
+                                // fused
+                                idx_t i = l - 1;
+                                idx_t g2 = j - (l - 1);
+                                idx_t g = m - 2 - g2;
+
+                                // Apply first rotation
                                 T temp =
                                     C(g, i) * A(g, i1) + S(g, i) * A(g + 1, i1);
                                 A(g + 1, i1) = -conj(S(g, i)) * A(g, i1) +
                                                C(g, i) * A(g + 1, i1);
                                 A(g, i1) = temp;
+
+                                // Apply second rotation
+                                T temp2 = C(g - 1, i) * A(g - 1, i1) +
+                                          S(g - 1, i) * A(g, i1);
+                                A(g, i1) = -conj(S(g - 1, i)) * A(g - 1, i1) +
+                                           C(g - 1, i) * A(g, i1);
+                                A(g - 1, i1) = temp2;
                             }
                         }
                     }
                     // Shutdown phase
                     for (idx_t i1 = ib; i1 < ib2; ++i1) {
-                        for (idx_t j = 1; j < l; ++j) {
+                        for (idx_t j = ((m - l + 1) % 2); j < l; ++j) {
                             for (idx_t i = j, g2 = m - 2; i < l; ++i, --g2) {
                                 idx_t g = m - 2 - g2;
                                 T temp =
@@ -192,19 +246,74 @@ void rot_sequence3(
                     }
                     // Pipeline phase
                     for (idx_t i1 = ib; i1 < ib2; ++i1) {
-                        for (idx_t j = l - 1; j < m - 1; ++j) {
-                            for (idx_t i = 0, g = j; i < l; ++i, --g) {
+                        for (idx_t j = l - 1; j + 1 < m - 1; j += 2) {
+                            for (idx_t i = 0, g = j; i + 1 < l;
+                                 i += 2, g -= 2) {
+                                //
+                                // Apply first rotation
+                                //
+
+                                // A(g,i1) after first rotation
+                                T temp1 =
+                                    C(g, i) * A(g, i1) + S(g, i) * A(g + 1, i1);
+                                // A(g+1,i1) after first rotation
+                                T temp2 = -conj(S(g, i)) * A(g, i1) +
+                                          C(g, i) * A(g + 1, i1);
+
+                                //
+                                // Apply second rotation
+                                //
+
+                                // A(g+1,i1) after second rotation
+                                T temp3 = C(g + 1, i) * temp2 +
+                                          S(g + 1, i) * A(g + 2, i1);
+                                A(g + 2, i1) = -conj(S(g + 1, i)) * temp2 +
+                                               C(g + 1, i) * A(g + 2, i1);
+
+                                //
+                                // Apply third rotation
+                                //
+
+                                // A(g,i1) after third rotation
+                                T temp4 =
+                                    -conj(S(g - 1, i + 1)) * A(g - 1, i1) +
+                                    C(g - 1, i + 1) * temp1;
+                                A(g - 1, i1) = C(g - 1, i + 1) * A(g - 1, i1) +
+                                               S(g - 1, i + 1) * temp1;
+
+                                // Apply fourth rotation
+                                A(g, i1) =
+                                    C(g, i + 1) * temp4 + S(g, i + 1) * temp3;
+                                A(g + 1, i1) = -conj(S(g, i + 1)) * temp4 +
+                                               C(g, i + 1) * temp3;
+                            }
+
+                            if (l % 2 == 1) {
+                                // Apply two more rotations that could not be
+                                // fused
+                                idx_t i = l - 1;
+                                idx_t g = j - (l - 1);
+
+                                // Apply first rotation
                                 T temp =
                                     C(g, i) * A(g, i1) + S(g, i) * A(g + 1, i1);
                                 A(g + 1, i1) = -conj(S(g, i)) * A(g, i1) +
                                                C(g, i) * A(g + 1, i1);
                                 A(g, i1) = temp;
+
+                                // Apply second rotation
+                                T temp2 = C(g + 1, i) * A(g + 1, i1) +
+                                          S(g + 1, i) * A(g + 2, i1);
+                                A(g + 2, i1) =
+                                    -conj(S(g + 1, i)) * A(g + 1, i1) +
+                                    C(g + 1, i) * A(g + 2, i1);
+                                A(g + 1, i1) = temp2;
                             }
                         }
                     }
                     // Shutdown phase
                     for (idx_t i1 = ib; i1 < ib2; ++i1) {
-                        for (idx_t j = 1; j < l; ++j) {
+                        for (idx_t j = ((m - l + 1) % 2); j < l; ++j) {
                             for (idx_t i = j, g = m - 2; i < l; ++i, --g) {
                                 T temp =
                                     C(g, i) * A(g, i1) + S(g, i) * A(g + 1, i1);

--- a/include/tlapack/lapack/rot_sequence3.hpp
+++ b/include/tlapack/lapack/rot_sequence3.hpp
@@ -1,0 +1,228 @@
+/// @file rot_sequence3.hpp
+/// @author Thijs Steel, KU Leuven, Belgium
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef TLAPACK_ROT_SEQUENCE3_HH
+#define TLAPACK_ROT_SEQUENCE3_HH
+
+#include "tlapack/base/utils.hpp"
+#include "tlapack/blas/rot.hpp"
+
+namespace tlapack {
+
+/** Applies a sequence of plane rotations to an (m-by-n) matrix
+ *
+ * When side = Side::Left, the transformation takes the form
+ *
+ *     A := P*A
+ *
+ * and when side = Side::Right, the transformation takes the form
+ *
+ *     A := A*P**H
+ *
+ * where P is an orthogonal matrix consisting of a sequence of k*l plane
+ * rotations, with k = m-1 when side = Side::Left and k = n-1 when side =
+ * Side::Right and l is the number of columns of C and S.
+ *
+ * When direction = Direction::Forward, then
+ *
+ *    P = P(k-1,l-1) * ... * P(0,l-1) * ... * P(k-1,l-2) * ... * P(0,l-2)
+ *        * ... * P(k-1,0) * ... * P(0,0)
+ *
+ * and when direction = Direction::Backward, then
+ *
+ *    P = P(0,l-1) * ... * P(k-1,l-1) * ... * P(0,l-2) * ... * P(k-1,l-2)
+ *        * ... * P(0,0) * ... * P(k-1,0)
+ *
+ * where P(i,j) is a plane rotation matrix defined as
+ *
+ *    P(i,j) = ( 1                                            )
+ *             (    ...                                       )
+ *             (         ...                                  )
+ *             (              C(i,j)        S(i,j)            )
+ *             (             -conj(S(i,j))  C(i,j)            )
+ *             (                                    1         )
+ *             (                                       ...    )
+ *             (                                            1 )
+ *
+ *  which only modifies rows/columns i and i + 1.
+ *
+ * This function is a variant of rot_sequence, which also applies sequence of
+ * plane rotations to a matrix. This variant can been seen as multiple
+ * applications of rot_sequence, but more cache-efficient.
+ *
+ * Note: One of the implicit blocking parameters in this routine is l.
+ * The routine will work blocks in A of size 2*l-by-nb, where nb is a blocking
+ * parameter. If l is large, it may be better to call this routine multiple
+ * times.
+ *
+ * @return  0 if success
+ *
+ * @param[in] side
+ *      Specifies whether the plane rotation matrix P is applied to A
+ *      on the left or the right
+ *      - Side::Left:  A := P * A;
+ *      - Side::Right: A := A * P**T.
+ *
+ * @param[in] direction
+ *     Specifies whether P is a forward or backward sequence of plane rotations.
+ *
+ * @param[in] C Real k-by-l matrix.
+ *     Cosines of the rotations
+ *
+ * @param[in] S k-by-l matrix.
+ *     Sines of the rotations
+ *
+ * @param[in,out] A m-by-n matrix.
+ *     Matrix that the rotations will be applied to.
+ *
+ * @ingroup computational
+ */
+template <TLAPACK_SIDE side_t,
+          TLAPACK_DIRECTION direction_t,
+          TLAPACK_SMATRIX C_t,
+          TLAPACK_SMATRIX S_t,
+          TLAPACK_SMATRIX A_t>
+void rot_sequence3(
+    side_t side, direction_t direction, const C_t& C, const S_t& S, A_t& A)
+{
+    using T = type_t<A_t>;
+    using idx_t = size_type<A_t>;
+
+    // constants
+    const idx_t m = nrows(A);
+    const idx_t n = ncols(A);
+    const idx_t k = (side == Side::Left) ? m - 1 : n - 1;
+    const idx_t l = ncols(C);
+
+    // Blocking parameter
+    const idx_t nb = 256;
+
+    // Check dimensions
+    tlapack_check((idx_t)ncols(S) == l);
+    tlapack_check((idx_t)nrows(C) == k);
+    tlapack_check((idx_t)nrows(S) == k);
+    // tlapack_check(k >= l);
+
+    // quick return
+    if (k < 1 or l < 1) return;
+
+    // If there is only one sequence, then use rot_sequence
+    if (l == 1) {
+        auto c = col(C, 0);
+        auto s = col(S, 0);
+        rot_sequence(side, direction, c, s, A);
+        return;
+    }
+
+    // Apply rotations
+    if (side == Side::Left) {
+        if (direction == Direction::Forward) {
+            // Number of blocks
+            const idx_t n_blocks = (k + l - 1) / l + 1;
+
+            // Apply the rotations in blocks
+            for (idx_t jb = 0; jb < n; jb += nb) {
+                for (idx_t b = n_blocks; b > 0; --b) {
+                    for (idx_t h = 0; h < l; h++) {
+                        for (idx_t i2 = std::min((b - 1) * l + h, k);
+                             i2 > std::max<idx_t>((b - 1) * l + h, l) - l;
+                             --i2) {
+                            idx_t i = i2 - 1;
+                            for (idx_t j = jb; j < std::min<idx_t>(n, jb + nb);
+                                 ++j) {
+                                T temp =
+                                    C(i, h) * A(i, j) + S(i, h) * A(i + 1, j);
+                                A(i + 1, j) = -conj(S(i, h)) * A(i, j) +
+                                              C(i, h) * A(i + 1, j);
+                                A(i, j) = temp;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            // Number of blocks
+            const idx_t n_blocks = (k + l - 1) / l + 1;
+
+            // Apply the rotations in blocks
+            for (idx_t jb = 0; jb < n; jb += nb) {
+                for (idx_t b = 1; b <= n_blocks; ++b) {
+                    for (idx_t h = 0; h < l; h++) {
+                        for (idx_t i = std::max<idx_t>(b * l - h, l) - l;
+                             i < std::min(b * l - h, k); ++i) {
+                            for (idx_t j = jb; j < std::min<idx_t>(n, jb + nb);
+                                 ++j) {
+                                T temp =
+                                    C(i, h) * A(i, j) + S(i, h) * A(i + 1, j);
+                                A(i + 1, j) = -conj(S(i, h)) * A(i, j) +
+                                              C(i, h) * A(i + 1, j);
+                                A(i, j) = temp;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    else {
+        if (direction == Direction::Forward) {
+            // Number of blocks
+            const idx_t n_blocks = (k + l - 1) / l + 1;
+
+            // Apply the rotations in blocks
+            for (idx_t jb = 0; jb < m; jb += nb) {
+                for (idx_t b = n_blocks; b > 0; --b) {
+                    for (idx_t h = 0; h < l; h++) {
+                        for (idx_t i2 = std::min((b - 1) * l + h, k);
+                             i2 > std::max<idx_t>((b - 1) * l + h, l) - l;
+                             --i2) {
+                            idx_t i = i2 - 1;
+                            for (idx_t j = jb; j < std::min<idx_t>(m, jb + nb);
+                                 ++j) {
+                                T temp = C(i, h) * A(j, i) +
+                                         conj(S(i, h)) * A(j, i + 1);
+                                A(j, i + 1) =
+                                    -S(i, h) * A(j, i) + C(i, h) * A(j, i + 1);
+                                A(j, i) = temp;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            // Number of blocks
+            const idx_t n_blocks = (k + l - 1) / l + 1;
+
+            // Apply the rotations in blocks
+            for (idx_t jb = 0; jb < m; jb += nb) {
+                for (idx_t b = 1; b <= n_blocks; ++b) {
+                    for (idx_t h = 0; h < l; h++) {
+                        for (idx_t i = std::max<idx_t>(b * l - h, l) - l;
+                             i < std::min(b * l - h, k); ++i) {
+                            for (idx_t j = jb; j < std::min<idx_t>(m, jb + nb);
+                                 ++j) {
+                                T temp = C(i, h) * A(j, i) +
+                                         conj(S(i, h)) * A(j, i + 1);
+                                A(j, i + 1) =
+                                    -S(i, h) * A(j, i) + C(i, h) * A(j, i + 1);
+                                A(j, i) = temp;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace tlapack
+
+#endif  // TLAPACK_ROT_SEQUENCE3_HH

--- a/include/tlapack/lapack/rot_sequence3.hpp
+++ b/include/tlapack/lapack/rot_sequence3.hpp
@@ -61,6 +61,9 @@ namespace tlapack {
  * parameter. If l is large, it may be better to call this routine multiple
  * times.
  *
+ * Reference: "Restructuring the Tridiagonal and Bidiagonal QR algorithms for
+ * Performance" F. G. Van Zee, R. A. Van de Geijn, G. Quintana-Orti
+ *
  * @param[in] side
  *      Specifies whether the plane rotation matrix P is applied to A
  *      on the left or the right

--- a/include/tlapack/lapack/rot_sequence3.hpp
+++ b/include/tlapack/lapack/rot_sequence3.hpp
@@ -128,6 +128,7 @@ void rot_sequence3(
     if constexpr (layout<A_t> == Layout::ColMajor) {
         if (side == Side::Left) {
             if (direction == Direction::Forward) {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < n; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, n);
                     // Startup phase
@@ -172,6 +173,7 @@ void rot_sequence3(
                 }
             }
             else {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < n; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, n);
                     // Startup phase
@@ -215,6 +217,7 @@ void rot_sequence3(
         }
         else {
             if (direction == Direction::Forward) {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < m; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, m);
                     // Startup phase
@@ -259,6 +262,7 @@ void rot_sequence3(
                 }
             }
             else {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < m; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, m);
                     // Startup phase
@@ -305,6 +309,7 @@ void rot_sequence3(
         // Matrix is not col-major, optimize for row-major
         if (side == Side::Left) {
             if (direction == Direction::Forward) {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < n; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, n);
                     // Startup phase
@@ -349,6 +354,7 @@ void rot_sequence3(
                 }
             }
             else {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < n; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, n);
                     // Startup phase
@@ -392,6 +398,7 @@ void rot_sequence3(
         }
         else {
             if (direction == Direction::Forward) {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < m; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, m);
                     // Startup phase
@@ -436,6 +443,7 @@ void rot_sequence3(
                 }
             }
             else {
+#pragma omp parallel for
                 for (idx_t ib = 0; ib < m; ib += nb) {
                     idx_t ib2 = std::min(ib + nb, m);
                     // Startup phase

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -101,6 +101,7 @@ add_executable(test_generalized_schur_move test_generalized_schur_move.cpp)
 add_executable(test_generalized_aed test_generalized_aed.cpp)
 add_executable(test_multishift_qz test_multishift_qz.cpp)
 add_executable(test_hetd2 test_hetd2.cpp testutils.cpp)
+add_executable(test_rot_sequence3 test_rot_sequence3.cpp testutils.cpp)
 
 if(TLAPACK_TEST_EIGEN)
   add_executable(test_eigenplugin test_eigenplugin.cpp)

--- a/test/src/test_rot_sequence3.cpp
+++ b/test/src/test_rot_sequence3.cpp
@@ -1,0 +1,104 @@
+/// @file test_rot_sequence3.cpp
+/// @author Thijs Steel, KU Leuven, Belgium
+/// @brief Test application of sequence of rotations
+//
+// Copyright (c) 2021-2023, University of Colorado Denver. All rights reserved.
+//
+// This file is part of <T>LAPACK.
+// <T>LAPACK is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+// Test utilities and definitions (must come before <T>LAPACK headers)
+#include "testutils.hpp"
+
+// Auxiliary routines
+#include <tlapack/lapack/lacpy.hpp>
+#include <tlapack/lapack/lange.hpp>
+
+// Other routines
+#include <tlapack/lapack/rot_sequence.hpp>
+#include <tlapack/lapack/rot_sequence3.hpp>
+
+#include "tlapack/blas/rot.hpp"
+#include "tlapack/blas/rotg.hpp"
+
+using namespace tlapack;
+
+TEMPLATE_TEST_CASE("Application of rotation sequence is accurate",
+                   "[auxiliary]",
+                   TLAPACK_TYPES_TO_TEST)
+{
+    using matrix_t = TestType;
+    using T = type_t<matrix_t>;
+    using idx_t = size_type<matrix_t>;
+    using real_t = real_type<T>;
+    using real_matrix_t = real_type<matrix_t>;
+
+    // Functor
+    Create<matrix_t> new_matrix;
+    Create<real_matrix_t> new_real_matrix;
+
+    // MatrixMarket reader
+    MatrixMarket mm;
+    rand_generator gen;
+
+    const Side side = GENERATE(Side::Left, Side::Right);
+    const Direction direction =
+        GENERATE(Direction::Forward, Direction::Backward);
+    const idx_t n = GENERATE(1, 2, 3, 4, 5, 10, 13);
+    const idx_t m = GENERATE(1, 2, 3, 4, 5, 10, 13);
+    const idx_t l = GENERATE(1, 2, 3, 4);
+
+    DYNAMIC_SECTION("m = " << m << " n = " << n << " l = " << l << " side = "
+                           << side << " direction = " << direction)
+    {
+        const idx_t k = (side == Side::Left) ? m - 1 : n - 1;
+
+        const real_t eps = ulp<real_t>();
+        const real_t tol = real_t(k) * eps;
+
+        if (k < 1) SKIP_TEST;
+
+        // Define the matrices and vectors
+        std::vector<T> A_;
+        auto A = new_matrix(A_, m, n);
+        std::vector<T> B_;
+        auto B = new_matrix(B_, m, n);
+        std::vector<real_t> c_;
+        auto C = new_real_matrix(c_, k, l);
+        std::vector<T> s_;
+        auto S = new_matrix(s_, k, l);
+
+        mm.random(A);
+
+        // Generate random rotation matrices
+        for (idx_t j = 0; j < l; ++j) {
+            for (idx_t i = 0; i < k; ++i) {
+                T t1 = rand_helper<T>(gen);
+                T t2 = rand_helper<T>(gen);
+                rotg(t1, t2, C(i, j), S(i, j));
+            }
+        }
+        tlapack::lacpy(GENERAL, A, B);
+
+        // Apply the rotations
+        rot_sequence3(side, direction, C, S, A);
+
+        // Apply the rotations using rot_sequence
+        for (idx_t j = 0; j < l; ++j) {
+            auto c = col(C, j);
+            auto s = col(S, j);
+            rot_sequence(side, direction, c, s, B);
+        }
+
+        real_t bnorm = lange(MAX_NORM, B);
+        for (idx_t j = 0; j < n; ++j) {
+            for (idx_t i = 0; i < m; ++i) {
+                B(i, j) -= A(i, j);
+            }
+        }
+        real_t res_norm = lange(MAX_NORM, B);
+
+        CHECK(res_norm <= tol * bnorm);
+    }
+}


### PR DESCRIPTION
In the paper: "Restructuring the Tridiagonal and Bidiagonal QR Algorithms for Performance" F. G. Van Zee, R. A. Van de Geijn, G. Quintana-Orti

The authors describe a wavefront algorithm to efficiently apply givens rotations. If we can apply multiple sequences of rotations at a similar flop rate as a gemm call, we can greatly speed up things like singular value and hermitian eigenvalue problems if using the implicit QR algorithm.

Some speed comparisons are below:
- CPU: i7-1255U
- Number of columns in C and S (number of sequences of rotations to apply): 40
- Matrix A is square and of size n
- Timing is average of 8 runs with 2 warmup runs

From the left side (inherently less efficient because matrices are column major)
| n        | blocked(s) | unblocked(s) |
|------    |-----------|--------|
| 256    | 0.0037          |   0.0078     |
| 512    | 0.013          |   0.026     |
| 1024  | 0.048          | 0.107       |
| 2048  | 0.20          |  0.413      |
| 4096  | 0.78           |  1.63      |

Speedup is around 2

From the right side
| n        | blocked(s) | unblocked(s) |
|------    |-----------|--------|
| 256    | 0.00050         |   0.0025     |
| 512    | 0.0026         |  0.0094     |
| 1024  |0.0093         | 0.031      |
| 2048  | 0.030         |  0.12      |
| 4096  |  0.12         |  0.48      |

Here, the speedup is around 4

I also added some openmp pragmas, since the blocked routine allows for a trivial parallelization of the column/row blocks. This only results in minor speedups of ~1.5