### PR TITLE
rework sgn function so it returns 1 when x = 0

### DIFF
--- a/include/tlapack/base/utils.hpp
+++ b/include/tlapack/base/utils.hpp
@@ -103,12 +103,19 @@ constexpr T conj(const T& x) noexcept
 }
 
 // -----------------------------------------------------------------------------
-/// Type-safe sgn function
-/// @see Source: https://stackoverflow.com/a/4609795/5253097
+/// Sign function for real numbers
+/// Note, this has the following behavior:
+/// sgn(x) = 1 if x > 0
+/// sgn(x) = -1 if x < 0
+/// sgn(0) = 1
+/// sgn(-0) = 1
+/// sgn(+Inf) = 1
+/// sgn(-Inf) = 1
+/// sgn(NaN) = -1
 template <typename T, enable_if_t<is_real<T>, int> = 0>
-constexpr int sgn(const T& val)
+constexpr T sgn(const T& val)
 {
-    return (T(0) < val) - (val < T(0));
+    return (val >= T(0)) ? T(1) : T(-1);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
closes #363 

Some changes to the sgn function:

- Return type T instead of int, this is preferred because we usually just use the result of sgn to multiply with a value of type T. This avoids some unnecessary promotion
- Return 1 when x = 0 or x = -0

