### PR TITLE
Improve the random generation in the MatrixMarket

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8 # v4.15.0
       with:
-        clang-format-version: '10'
+        clang-format-version: '11'
         check-path: ${{ matrix.path }}
         include-regex: '^.*\.(hpp|cpp|h\.in|c)$'
         fallback-style: 'Google'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -102,6 +102,11 @@ jobs:
         sudo apt install -y gfortran
         sudo apt install -y liblapacke-dev
         sudo apt install -y libmpfrc++-dev
+    
+    - name: Install GCC on MacOS
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        brew install gcc
 
     - name: Build and install Eigen on Ubuntu
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -137,9 +142,9 @@ jobs:
       if: ${{ matrix.os == 'macos-latest' }}
       run: >
         cmake -B build -G Ninja
-        -D CMAKE_C_COMPILER="gcc-11"
-        -D CMAKE_CXX_COMPILER="g++-11"
-        -D CMAKE_Fortran_COMPILER="gfortran-11"
+        -D CMAKE_C_COMPILER="gcc-14"
+        -D CMAKE_CXX_COMPILER="g++-14"
+        -D CMAKE_Fortran_COMPILER="gfortran-14"
         -D TLAPACK_TEST_QUAD=ON
 
     - name: Specific configurations for CMake on Windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ file(READ version.txt version_txt)
 # We require C++17 features like if constexpr
 # If possible, compile with C++20 so we can use concepts
 set (CMAKE_CXX_STANDARD_REQUIRED 17)
-set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to use")
 
 #-------------------------------------------------------------------------------
 # <T>LAPACK project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,8 +208,8 @@ find_package(Git QUIET)
 find_package(ClangFormat QUIET)
 if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git" AND CLANG_FORMAT_FOUND)
   message(STATUS "ClangFormat found: ${CLANG_FORMAT_EXECUTABLE} (version ${CLANG_FORMAT_VERSION})")
-  if( ${CLANG_FORMAT_MAJOR_VERSION} NOT EQUAL 10 )
-    message( WARNING "Please use ClangFormat version 10" )
+  if( ${CLANG_FORMAT_MAJOR_VERSION} NOT EQUAL 11 )
+    message( WARNING "Please use ClangFormat version 11" )
   else()
     add_custom_target( format-all-hpp-cpp-files
       COMMAND

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ In this section we describe the code style used in \<T\>LAPACK. We also describe
 
 ### Automatic code formatting
 
-\<T\>LAPACK uses [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) (version 10) to enforce a consistent code style. The configuration file is located at [`.clang-format`](.clang-format). The code style is based on the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and the differences are marked in the configuration file. You should never modify the [`.clang-format`](.clang-format) file in \<T\>LAPACK, unless this is the reason behind your pull request.
+\<T\>LAPACK uses [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) (version 11) to enforce a consistent code style. The configuration file is located at [`.clang-format`](.clang-format). The code style is based on the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and the differences are marked in the configuration file. You should never modify the [`.clang-format`](.clang-format) file in \<T\>LAPACK, unless this is the reason behind your pull request.
 
 To format code you are adding or modifying, we suggest using the [git-clang-format](https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/git-clang-format) script that is distributed together with ClangFormat. Use `git-clang-format` to format the code that was modified or added before a commit. You can use `git-clang-format --help` to access all options. Mind that one of the tests in the Continuous Integration checks that the code is properly formatted.
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Here are the \<T\>LAPACK specific options and their default values
 | Project                            | Version       | When                                                 |
 | ---------------------------------- | ------------- | ---------------------------------------------------- |
 | CMake                              | >= v3.14      | Always                                               |
-| ClangFormat                        | 10            | Always                                               |
+| ClangFormat                        | 11            | Always                                               |
 | Catch2                             | >= 3.0.1      | `BUILD_TESTING=ON`                                   |
 | Git                                | -             | `BUILD_BLASPP_TESTS=ON  OR  BUILD_LAPACKPP_TESTS=ON` |
 | github.com/icl-utk-edu/testsweeper | >= 2021.04.00 | `BUILD_BLASPP_TESTS=ON  OR  BUILD_LAPACKPP_TESTS=ON` |

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -22,7 +22,7 @@
 # ${CLANG_FORMAT_VERSION}") endif()
 
 find_program(CLANG_FORMAT_EXECUTABLE
-             NAMES clang-format-10  # First option will be searched first
+             NAMES clang-format-11  # First option will be searched first
                    clang-format
                    clang-format-7
                    clang-format-6.0

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -45,7 +45,7 @@ void ladiv(const real_t& a,
 {
     // internal function ladiv2
     auto ladiv2 = [](const real_t& a, const real_t& b, const real_t& c,
-                      const real_t& d, const real_t& r, const real_t& t) {
+                     const real_t& d, const real_t& r, const real_t& t) {
         const real_t zero(0);
         if (r != zero) {
             const real_t br = b * r;
@@ -60,7 +60,7 @@ void ladiv(const real_t& a,
 
     // internal function ladiv1
     auto ladiv1 = [ladiv2](const real_t& a, const real_t& b, const real_t& c,
-                             const real_t& d, real_t& p, real_t& q) {
+                           const real_t& d, real_t& p, real_t& q) {
         const real_t r = d / c;
         const real_t t = real_t(1) / (c + d * r);
         p = ladiv2(a, b, c, d, r, t);

--- a/include/tlapack/lapack/ladiv.hpp
+++ b/include/tlapack/lapack/ladiv.hpp
@@ -43,8 +43,8 @@ void ladiv(const real_t& a,
            real_t& p,
            real_t& q)
 {
-    // internal function sladiv2
-    auto sladiv2 = [](const real_t& a, const real_t& b, const real_t& c,
+    // internal function ladiv2
+    auto ladiv2 = [](const real_t& a, const real_t& b, const real_t& c,
                       const real_t& d, const real_t& r, const real_t& t) {
         const real_t zero(0);
         if (r != zero) {
@@ -58,13 +58,13 @@ void ladiv(const real_t& a,
             return (a + d * (b / c)) * t;
     };
 
-    // internal function sladiv1
-    auto sladiv1 = [sladiv2](const real_t& a, const real_t& b, const real_t& c,
+    // internal function ladiv1
+    auto ladiv1 = [ladiv2](const real_t& a, const real_t& b, const real_t& c,
                              const real_t& d, real_t& p, real_t& q) {
         const real_t r = d / c;
         const real_t t = real_t(1) / (c + d * r);
-        p = sladiv2(a, b, c, d, r, t);
-        q = sladiv2(b, -a, c, d, r, t);
+        p = ladiv2(a, b, c, d, r, t);
+        q = ladiv2(b, -a, c, d, r, t);
     };
 
     // constant to control the lower limit of the overflow threshold
@@ -78,6 +78,20 @@ void ladiv(const real_t& a,
     const real_t safeMin = safe_min<real_t>();
     const real_t u = uroundoff<real_t>();
     const real_t be = bs / (u * u);
+
+    // Treat separate cases of c = 0 and d = 0.
+    // It is quicker and prevents the generation of NaNs when doing
+    // `d * (b / c)` in ladiv2.
+    if (d == real_t(0)) {
+        p = a / c;
+        q = b / c;
+        return;
+    }
+    if (c == real_t(0)) {
+        p = b / d;
+        q = -a / d;
+        return;
+    }
 
     // constants
     const real_t ab = max(abs(a), abs(b));
@@ -114,10 +128,10 @@ void ladiv(const real_t& a,
 
     // compute the quotient
     if (abs(d) <= abs(c)) {
-        sladiv1(aa, bb, cc, dd, p, q);
+        ladiv1(aa, bb, cc, dd, p, q);
     }
     else {
-        sladiv1(bb, aa, dd, cc, p, q);
+        ladiv1(bb, aa, dd, cc, p, q);
         q = -q;
     }
 

--- a/include/tlapack/plugins/gnuquad.hpp
+++ b/include/tlapack/plugins/gnuquad.hpp
@@ -20,7 +20,11 @@
 
 namespace std {
 
+#if !defined(__STRICT_ANSI__) && defined(_GLIBCXX_USE_FLOAT128)
 constexpr __float128 abs(__float128 x);  // See include/bits/std_abs.h
+#else
+constexpr __float128 abs(__float128 x) noexcept { return fabsq(x); }
+#endif
 inline __float128 ceil(__float128 x) noexcept { return ceilq(x); }
 inline __float128 floor(__float128 x) noexcept { return floorq(x); }
 inline bool isinf(__float128 x) noexcept { return isinfq(x); }

--- a/include/tlapack/plugins/gnuquad.hpp
+++ b/include/tlapack/plugins/gnuquad.hpp
@@ -23,7 +23,7 @@ namespace std {
 #if !defined(__STRICT_ANSI__) && defined(_GLIBCXX_USE_FLOAT128)
 constexpr __float128 abs(__float128 x);  // See include/bits/std_abs.h
 #else
-constexpr __float128 abs(__float128 x) noexcept { return fabsq(x); }
+inline __float128 abs(__float128 x) noexcept { return fabsq(x); }
 #endif
 inline __float128 ceil(__float128 x) noexcept { return ceilq(x); }
 inline __float128 floor(__float128 x) noexcept { return floorq(x); }

--- a/include/tlapack/plugins/gnuquad.hpp
+++ b/include/tlapack/plugins/gnuquad.hpp
@@ -16,6 +16,8 @@
 #include <limits>
 #include <ostream>
 
+#include "tlapack/base/types.hpp"
+
 namespace std {
 
 constexpr __float128 abs(__float128 x);  // See include/bits/std_abs.h
@@ -157,5 +159,24 @@ constexpr __float128 numeric_limits<__float128>::denorm_min() noexcept
 }
 
 }  // namespace std
+
+namespace tlapack {
+
+namespace traits {
+    // __float128 is a real type that satisfies tlapack::concepts::Real
+    template <>
+    struct real_type_traits<__float128, int> {
+        using type = __float128;
+        constexpr static bool is_real = true;
+    };
+    // The complex type of __float128 is std::complex<__float128>
+    template <>
+    struct complex_type_traits<__float128, int> {
+        using type = std::complex<__float128>;
+        constexpr static bool is_complex = false;
+    };
+}  // namespace traits
+
+}  // namespace tlapack
 
 #endif

--- a/include/tlapack/starpu/Matrix.hpp
+++ b/include/tlapack/starpu/Matrix.hpp
@@ -12,6 +12,7 @@
 
 #include <starpu.h>
 
+#include <array>
 #include <iomanip>
 #include <memory>
 #include <ostream>

--- a/include/tlapack/starpu/MatrixEntry.hpp
+++ b/include/tlapack/starpu/MatrixEntry.hpp
@@ -273,17 +273,12 @@ namespace starpu {
             cl.cpu_funcs[0] = internal::data_op_value<T, U, op>;
             cl.nbuffers = 1;
             cl.modes[0] = (op == Operation::Assign) ? STARPU_W : STARPU_RW;
-            cl.name = (op == Operation::Assign)
-                          ? "assign_value"
-                          : (op == Operation::Add)
-                                ? "add_value"
-                                : (op == Operation::Subtract)
-                                      ? "subtract_value"
-                                      : (op == Operation::Multiply)
-                                            ? "multiply_value"
-                                            : (op == Operation::Divide)
-                                                  ? "divide_value"
-                                                  : "unknown";
+            cl.name = (op == Operation::Assign)     ? "assign_value"
+                      : (op == Operation::Add)      ? "add_value"
+                      : (op == Operation::Subtract) ? "subtract_value"
+                      : (op == Operation::Multiply) ? "multiply_value"
+                      : (op == Operation::Divide)   ? "divide_value"
+                                                    : "unknown";
 
             // The following lines are needed to make the codelet const
             // See _starpu_codelet_check_deprecated_fields() in StarPU:
@@ -319,17 +314,12 @@ namespace starpu {
             cl.nbuffers = 2;
             cl.modes[0] = (op == Operation::Assign) ? STARPU_W : STARPU_RW;
             cl.modes[1] = STARPU_R;
-            cl.name = (op == Operation::Assign)
-                          ? "assign_data"
-                          : (op == Operation::Add)
-                                ? "add_data"
-                                : (op == Operation::Subtract)
-                                      ? "subtract_data"
-                                      : (op == Operation::Multiply)
-                                            ? "multiply_data"
-                                            : (op == Operation::Divide)
-                                                  ? "divide_data"
-                                                  : "unknown";
+            cl.name = (op == Operation::Assign)     ? "assign_data"
+                      : (op == Operation::Add)      ? "add_data"
+                      : (op == Operation::Subtract) ? "subtract_data"
+                      : (op == Operation::Multiply) ? "multiply_data"
+                      : (op == Operation::Divide)   ? "divide_data"
+                                                    : "unknown";
 
             // The following lines are needed to make the codelet const
             // See _starpu_codelet_check_deprecated_fields() in StarPU:
@@ -364,17 +354,12 @@ namespace starpu {
             cl.cpu_funcs[0] = internal::matrixentry_op_matrixentry<T, op>;
             cl.nbuffers = 1;
             cl.modes[0] = STARPU_RW;
-            cl.name = (op == Operation::Assign)
-                          ? "copy_entry"
-                          : (op == Operation::Add)
-                                ? "add_entry"
-                                : (op == Operation::Subtract)
-                                      ? "subtract_entry"
-                                      : (op == Operation::Multiply)
-                                            ? "multiply_entry"
-                                            : (op == Operation::Divide)
-                                                  ? "divide_entry"
-                                                  : "unknown";
+            cl.name = (op == Operation::Assign)     ? "copy_entry"
+                      : (op == Operation::Add)      ? "add_entry"
+                      : (op == Operation::Subtract) ? "subtract_entry"
+                      : (op == Operation::Multiply) ? "multiply_entry"
+                      : (op == Operation::Divide)   ? "divide_entry"
+                                                    : "unknown";
 
             // The following lines are needed to make the codelet const
             // See _starpu_codelet_check_deprecated_fields() in StarPU:

--- a/test/include/MatrixMarket.hpp
+++ b/test/include/MatrixMarket.hpp
@@ -36,7 +36,7 @@ class PCG32 {
     PCG32(uint64_t s = 1302) noexcept { seed(s); }
 
     /// Sets the current state of PCG32. Same as PCG32(s).
-    constexpr void seed(uint64_t s) noexcept
+    void seed(uint64_t s) noexcept
     {
         state = 0;
         operator()();

--- a/test/include/MatrixMarket.hpp
+++ b/test/include/MatrixMarket.hpp
@@ -121,8 +121,8 @@ T rand_helper(Generator& gen)
         typename std::conditional<(is_same_v<real_t, float> ||
                                    is_same_v<real_t, double> ||
                                    is_same_v<real_t, long double>),
-                                  std::normal_distribution<real_t>,
-                                  std::normal_distribution<float> >::type;
+                                  std::uniform_real_distribution<real_t>,
+                                  std::uniform_real_distribution<float> >::type;
 
     dist_t d;
     return rand_helper<T>(gen, d);

--- a/test/include/MatrixMarket.hpp
+++ b/test/include/MatrixMarket.hpp
@@ -12,85 +12,120 @@
 #ifndef TLAPACK_MATRIXMARKET_HH
 #define TLAPACK_MATRIXMARKET_HH
 
+#include <random>
 #include <tlapack/base/utils.hpp>
+#include <type_traits>
 
 namespace tlapack {
 
 /**
- * @brief Random number generator.
+ * @brief Permuted Congruential Generator
  *
- * This is a simple random number generator that generates a sequence of
- * pseudo-random numbers using a linear congruential generator (LCG).
- *
- * The LCG is defined by the recurrence relation:
- *
- * \[
- *     X_{n+1} = (a X_n + c) \mod m
- * \]
- *
- * where $X_0$ is the seed, $a$ is the multiplier, $c$ is the
- * increment, and $m$ is the modulus.
+ * Defined in https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf as PCG-XSL-RR.
+ * Constants taken from https://github.com/imneme/pcg-cpp.
  */
-class rand_generator {
+class PCG32 {
    private:
-    const uint64_t a = 6364136223846793005;  ///< multiplier (64-bit)
-    const uint64_t c = 1442695040888963407;  ///< increment (64-bit)
-    uint64_t state = 1302;                   ///< seed (64-bit)
+    const uint64_t a = 6364136223846793005ULL;  ///< multiplier (64-bit)
+    const uint64_t c = 1442695040888963407ULL;  ///< increment (64-bit)
+    uint64_t state;                             ///< RNG state (64-bit)
 
    public:
+    /// @brief Constructor
+    /// @param s Default is 1302 for no good reason.
+    PCG32(uint64_t s = 1302) noexcept { seed(s); }
+
+    /// Sets the current state of PCG32. Same as PCG32(s).
+    constexpr void seed(uint64_t s) noexcept
+    {
+        state = 0;
+        operator()();
+        state += s;
+        operator()();
+    }
+
     static constexpr uint32_t min() noexcept { return 0; }
     static constexpr uint32_t max() noexcept { return UINT32_MAX; }
-    constexpr void seed(uint64_t s) noexcept { state = s; }
 
-    /// Generates a pseudo-random number.
-    constexpr uint32_t operator()()
+    /// Generates a pseudo-random number using PCG's output function (XSH-RR).
+    uint32_t operator()() noexcept
     {
+        // Constants for a 64-bit state and 32-bit output
+        const uint8_t bits = 64;
+        const uint8_t opbits = 5;
+        constexpr uint8_t mask = (1 << opbits) - 1;
+        constexpr uint8_t xshift = (opbits + 32) / 2;
+        constexpr uint8_t bottomspare = (bits - 32) - opbits;
+
+        // Random rotation
+        uint8_t rot = uint8_t(state >> (bits - opbits)) & mask;
+
+        // XOR shift high
+        uint32_t result =
+            static_cast<uint32_t>((state ^ (state >> xshift)) >> bottomspare);
+
+        // Rotate right
+        result = (result >> rot) | (result << ((-rot) & mask));
+
+        // Updates the state
         state = state * a + c;
-        return state >> 32;
+
+        return result;
     }
 };
 
 /**
  * @brief Helper function to generate random numbers.
  * @param[in,out] gen Random number generator.
+ * @param[in,out] d Random distribution.
  */
-template <typename T, enable_if_t<is_real<T>, bool> = true>
-T rand_helper(rand_generator& gen)
+template <class T,
+          class Generator,
+          class Distribution,
+          enable_if_t<is_real<T>, bool> = true>
+T rand_helper(Generator& gen, Distribution& d)
 {
-    return T(static_cast<float>(gen()) / static_cast<float>(gen.max()));
+    return T(d(gen));
 }
 
 /**
- * @overload T rand_helper(rand_generator& gen)
+ * @overload T rand_helper(Generator& gen, Distribution& d)
  */
-template <typename T, enable_if_t<is_complex<T>, bool> = true>
-T rand_helper(rand_generator& gen)
+template <class T,
+          class Generator,
+          class Distribution,
+          enable_if_t<is_complex<T>, bool> = true>
+T rand_helper(Generator& gen, Distribution& d)
 {
     using real_t = real_type<T>;
-    real_t r1(static_cast<float>(gen()) / static_cast<float>(gen.max()));
-    real_t r2(static_cast<float>(gen()) / static_cast<float>(gen.max()));
+    real_t r1(d(gen));
+    real_t r2(d(gen));
     return complex_type<real_t>(r1, r2);
 }
 
 /**
- * @brief Helper function to generate random numbers.
+ * @brief Helper function to generate random numbers using an uniform
+ * distribution in [0,1).
+ *
+ * The type of the uniform distribution is T if real_type<T> is either float,
+ * double or long double. Otherwise, the uniform distribution will be defined
+ * using the type float.
+ *
+ * @param[in,out] gen Random number generator.
  */
-template <typename T, enable_if_t<is_real<T>, bool> = true>
-T rand_helper()
-{
-    return T(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));
-}
-
-/**
- * @overload T rand_helper()
- */
-template <typename T, enable_if_t<is_complex<T>, bool> = true>
-T rand_helper()
+template <class T, class Generator>
+T rand_helper(Generator& gen)
 {
     using real_t = real_type<T>;
-    real_t r1(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));
-    real_t r2(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));
-    return complex_type<real_t>(r1, r2);
+    using dist_t =
+        typename std::conditional<(is_same_v<real_t, float> ||
+                                   is_same_v<real_t, double> ||
+                                   is_same_v<real_t, long double>),
+                                  std::normal_distribution<real_t>,
+                                  std::normal_distribution<float> >::type;
+
+    dist_t d;
+    return rand_helper<T>(gen, d);
 }
 
 /**
@@ -282,7 +317,7 @@ struct MatrixMarket {
         }
     }
 
-    rand_generator gen;
+    PCG32 gen;
 };
 
 }  // namespace tlapack

--- a/test/src/old/test_gelq2.cpp
+++ b/test/src/old/test_gelq2.cpp
@@ -62,9 +62,11 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix",
 
     std::vector<T> tauw(min(m, n));
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < m; ++i)
-            A(i, j) = rand_helper<T>();
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    // Fill A with random values
+    mm.random(A);
 
     lacpy(GENERAL, A, A_copy);
 

--- a/test/src/old/test_gelqf.cpp
+++ b/test/src/old/test_gelqf.cpp
@@ -66,9 +66,11 @@ TEMPLATE_TEST_CASE("LQ factorization of a general m-by-n matrix, blocked",
     GelqfOpts gelqfOpts;
     gelqfOpts.nb = nb;
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < m; ++i)
-            A(i, j) = rand_helper<T>();
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    // Fill A with random values
+    mm.random(A);
 
     lacpy(GENERAL, A, A_copy);
 

--- a/test/src/old/test_geql2.cpp
+++ b/test/src/old/test_geql2.cpp
@@ -61,9 +61,11 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
 
     std::vector<T> tau(k);
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < m; ++i)
-            A(i, j) = rand_helper<T>();
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    // Fill A with random values
+    mm.random(A);
 
     lacpy(GENERAL, A, A_copy);
 

--- a/test/src/old/test_geqlf.cpp
+++ b/test/src/old/test_geqlf.cpp
@@ -64,9 +64,11 @@ TEMPLATE_TEST_CASE("QL factorization of a general m-by-n matrix",
     GeqlfOpts geqlfOpts;
     geqlfOpts.nb = nb;
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < m; ++i)
-            A(i, j) = rand_helper<T>();
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    // Fill A with random values
+    mm.random(A);
 
     lacpy(GENERAL, A, A_copy);
 

--- a/test/src/old/test_gerq2.cpp
+++ b/test/src/old/test_gerq2.cpp
@@ -61,9 +61,11 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
 
     std::vector<T> tau(min(m, n));
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < m; ++i)
-            A(i, j) = rand_helper<T>();
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    // Fill A with random values
+    mm.random(A);
 
     lacpy(GENERAL, A, A_copy);
 

--- a/test/src/old/test_gerqf.cpp
+++ b/test/src/old/test_gerqf.cpp
@@ -64,9 +64,11 @@ TEMPLATE_TEST_CASE("RQ factorization of a general m-by-n matrix",
     GerqfOpts gerqfOpts;
     gerqfOpts.nb = nb;
 
-    for (idx_t j = 0; j < n; ++j)
-        for (idx_t i = 0; i < m; ++i)
-            A(i, j) = rand_helper<T>();
+    // MatrixMarket reader
+    MatrixMarket mm;
+
+    // Fill A with random values
+    mm.random(A);
 
     lacpy(GENERAL, A, A_copy);
 

--- a/test/src/test_generalized_schur_move.cpp
+++ b/test/src/test_generalized_schur_move.cpp
@@ -79,20 +79,20 @@ TEMPLATE_TEST_CASE("move of generalized eigenvalue block gives correct results",
 
         if (n1 == 2) {
             if (ifst < n - 1)
-                A(ifst + 1, ifst) = rand_helper<T>();
+                A(ifst + 1, ifst) = rand_helper<T>(mm.gen);
             else
-                A(ifst, ifst - 1) = rand_helper<T>();
+                A(ifst, ifst - 1) = rand_helper<T>(mm.gen);
         }
         if (n2 == 2) {
             if (ilst < n - 1)
-                A(ilst + 1, ilst) = rand_helper<T>();
+                A(ilst + 1, ilst) = rand_helper<T>(mm.gen);
             else
-                A(ilst, ilst - 1) = rand_helper<T>();
+                A(ilst, ilst - 1) = rand_helper<T>(mm.gen);
         }
 
         if (is_real<T>) {
             // Put a 2x2 block in the middle
-            A(5, 4) = rand_helper<T>();
+            A(5, 4) = rand_helper<T>(mm.gen);
         }
 
         lacpy(GENERAL, A, A_copy);

--- a/test/src/test_generalized_schur_swap.cpp
+++ b/test/src/test_generalized_schur_swap.cpp
@@ -72,8 +72,8 @@ TEMPLATE_TEST_CASE("generalized schur swap gives correct result",
             for (idx_t i = j + 1; i < n; ++i)
                 B(i, j) = zero;
 
-        if (n1 == 2) A(j + 1, j) = rand_helper<T>();
-        if (n2 == 2) A(j + n1 + 1, j + n1) = rand_helper<T>();
+        if (n1 == 2) A(j + 1, j) = rand_helper<T>(mm.gen);
+        if (n2 == 2) A(j + n1 + 1, j + n1) = rand_helper<T>(mm.gen);
 
         lacpy(GENERAL, A, A_copy);
         lacpy(GENERAL, B, B_copy);

--- a/test/src/test_gesvd.cpp
+++ b/test/src/test_gesvd.cpp
@@ -45,7 +45,7 @@ TEMPLATE_TEST_CASE("svd with small unitary matrix is backward stable",
     idx_t k = min(m, n);
 
     const int seed = GENERATE(2, 3, 4, 5, 6, 7, 8, 9, 10);
-    rand_generator gen;
+    PCG32 gen;
     gen.seed(seed);
 
     const real_t eps = ulp<real_t>();
@@ -140,7 +140,7 @@ TEMPLATE_TEST_CASE("svd with full unitary matrix is backward stable",
     idx_t k = min(m, n);
 
     const int seed = GENERATE(2, 3, 4, 5, 6, 7, 8, 9, 10);
-    rand_generator gen;
+    PCG32 gen;
     gen.seed(seed);
 
     const real_t eps = ulp<real_t>();

--- a/test/src/test_hessenberg_rq.cpp
+++ b/test/src/test_hessenberg_rq.cpp
@@ -99,7 +99,7 @@ TEMPLATE_TEST_CASE("RQ of Hessenberg matrix is accurate",
 
     // MatrixMarket reader
     MatrixMarket mm;
-    rand_generator gen;
+    PCG32 gen;
 
     const idx_t n = GENERATE(2, 3, 4, 5, 10, 13);
 

--- a/test/src/test_hessenberg_rq.cpp
+++ b/test/src/test_hessenberg_rq.cpp
@@ -106,7 +106,7 @@ TEMPLATE_TEST_CASE("RQ of Hessenberg matrix is accurate",
     const idx_t k = n - 1;
 
     const real_t eps = ulp<real_t>();
-    const real_t tol = real_t(k+1) * eps;
+    const real_t tol = real_t(k + 1) * eps;
 
     // Define the matrices and vectors
     std::vector<T> H_;

--- a/test/src/test_hessenberg_rq.cpp
+++ b/test/src/test_hessenberg_rq.cpp
@@ -106,7 +106,7 @@ TEMPLATE_TEST_CASE("RQ of Hessenberg matrix is accurate",
     const idx_t k = n - 1;
 
     const real_t eps = ulp<real_t>();
-    const real_t tol = real_t(k) * eps;
+    const real_t tol = real_t(k+1) * eps;
 
     // Define the matrices and vectors
     std::vector<T> H_;

--- a/test/src/test_hetd2.cpp
+++ b/test/src/test_hetd2.cpp
@@ -151,7 +151,7 @@ TEMPLATE_TEST_CASE("Tridiagnolization of a symmetric matrix works",
             gemm(NO_TRANS, CONJ_TRANS, one, R, Q, -one, A);
 
             // Check that the error is close to zero
-            CHECK(lange(Norm::Fro, A) / normA < tol);
+            CHECK(lange(Norm::Fro, A) <= tol * normA);
         }
     }
 }

--- a/test/src/test_hetd2.cpp
+++ b/test/src/test_hetd2.cpp
@@ -45,6 +45,9 @@ TEMPLATE_TEST_CASE("Tridiagnolization of a symmetric matrix works",
     idx_t n = GENERATE(1, 2, 6, 13, 29);
     const Uplo uplo = GENERATE(Uplo::Lower, Uplo::Upper);
 
+    // MatrixMarket reader
+    MatrixMarket mm;
+
     DYNAMIC_SECTION("n = " << n << " uplo = " << uplo)
     {
         // Constants
@@ -62,9 +65,7 @@ TEMPLATE_TEST_CASE("Tridiagnolization of a symmetric matrix works",
         std::vector<T> tau(n - 1);
 
         // Fill A with random values
-        for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < n; ++i)
-                A(i, j) = rand_helper<T>();
+        mm.random(A);
 
         // Compute the norm of A
         real_t normA = lange(Norm::Fro, A);

--- a/test/src/test_ladiv.cpp
+++ b/test/src/test_ladiv.cpp
@@ -19,11 +19,45 @@ using namespace tlapack;
 
 TEST_CASE("ladiv works properly", "[aux]")
 {
-    double a, b, c, d, p, q;
+    using real_t = double;
 
-    a = b = c = d = pow(2, DBL_MAX_EXP - 1);
-    ladiv(a, b, c, d, p, q);
+    const real_t M = std::numeric_limits<real_t>::max();
+    const int E = std::numeric_limits<real_t>::max_exponent;
+    const real_t eps = std::numeric_limits<real_t>::epsilon();
 
-    CHECK(p == 1.0);
-    CHECK(q == 0.0);
+    real_t a, b, c, d, p, q;
+
+    {
+        a = b = c = d = pow(2, E - 1);
+        ladiv(a, b, c, d, p, q);
+
+        CHECK(p == 1.0);
+        CHECK(q == 0.0);
+    }
+    {
+        a = b = M;
+        c = eps;
+        d = 0;
+
+        ladiv(a, b, c, d, p, q);
+
+        INFO("p = " << p);
+        INFO("q = " << q);
+
+        CHECK(isinf(p));
+        CHECK(isinf(q));
+    }
+    {
+        a = b = M;
+        c = 0;
+        d = eps;
+
+        ladiv(a, b, c, d, p, q);
+
+        INFO("p = " << p);
+        INFO("q = " << q);
+
+        CHECK(isinf(p));
+        CHECK(isinf(q));
+    }
 }

--- a/test/src/test_larf.cpp
+++ b/test/src/test_larf.cpp
@@ -35,6 +35,9 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
     // Functor
     Create<vector_t> new_vector;
 
+    // Pseudo random number generator
+    PCG32 prng;
+
     // Test parameters
     const idx_t n = GENERATE(10, 19, 30);
     const Direction direction =
@@ -58,8 +61,8 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
     const real_t zero(0);
     const real_t one(1);
     const real_t two(2);
-    const T alpha =
-        (typeAlpha == "Real") ? rand_helper<real_t>() : rand_helper<T>();
+    const T alpha = (typeAlpha == "Real") ? rand_helper<real_t>(prng)
+                                          : rand_helper<T>(prng);
     const idx_t alphaIdx = (direction == Direction::Forward) ? 0 : n - 1;
 
     // Print test parameters
@@ -84,7 +87,7 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
         }
         else {  // initialX == 'R'
             for (idx_t i = 0; i < n; ++i) {
-                v[i] = rand_helper<T>();
+                v[i] = rand_helper<T>(prng);
             }
         }
         v[alphaIdx] = alpha;
@@ -161,6 +164,9 @@ TEMPLATE_TEST_CASE("Application of Householder reflectors",
     Create<vector_t> new_vector;
     Create<matrix_t> new_matrix;
 
+    // MatrixMarket reader
+    MatrixMarket mm;
+
     // Test parameters
     const idx_t m = GENERATE(1, 11, 30);
     const idx_t n = GENERATE(1, 11, 30);
@@ -189,7 +195,7 @@ TEMPLATE_TEST_CASE("Application of Householder reflectors",
 
         // Build v and tau
         for (idx_t i = 0; i < k; ++i)
-            v[i] = rand_helper<T>();
+            v[i] = rand_helper<T>(mm.gen);
         T tau;
         larfg(direction, storeMode, v, tau);
         v[oneIdx] =
@@ -202,9 +208,7 @@ TEMPLATE_TEST_CASE("Application of Householder reflectors",
         // Initialize matrix C
         std::vector<T> C_;
         auto C = new_matrix(C_, m, n);
-        for (idx_t j = 0; j < n; ++j)
-            for (idx_t i = 0; i < m; ++i)
-                C(i, j) = rand_helper<T>();
+        mm.random(C);
 
         // Copy C to C0
         std::vector<T> C0_;

--- a/test/src/test_larf.cpp
+++ b/test/src/test_larf.cpp
@@ -57,13 +57,17 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
     auto w = new_vector(w_, n);
 
     // Constants
-    const real_t tol = real_t(n) * ulp<real_t>();
+    const real_t eps = ulp<real_t>();
+    const real_t tol = real_t(n) * eps;
     const real_t zero(0);
     const real_t one(1);
     const real_t two(2);
-    const T alpha = (typeAlpha == "Real") ? rand_helper<real_t>(prng)
-                                          : rand_helper<T>(prng);
     const idx_t alphaIdx = (direction == Direction::Forward) ? 0 : n - 1;
+    T alpha(0);
+    while (alpha == T(0)) {
+        alpha = (typeAlpha == "Real") ? rand_helper<real_t>(prng)
+                                      : rand_helper<T>(prng);
+    }
 
     // Print test parameters
     INFO("Which larfg: " << whichLARFG);
@@ -111,6 +115,8 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
             larfg(direction, storeMode, v, tau);
         }
 
+        INFO("tau = " << tau);
+
         // Post-process v and extract beta
         const T beta = v[alphaIdx];
         v[alphaIdx] = one;
@@ -126,7 +132,7 @@ TEMPLATE_TEST_CASE("Generation of Householder reflectors",
         else {
             CHECK(one <= real(tau));
             CHECK(real(tau) <= two);
-            CHECK(abs(tau - one) <= one);
+            CHECK(abs(tau - one) <= one + 2 * eps);
         }
 
         const T vHw = dot(v, w);

--- a/test/src/test_lasy2.cpp
+++ b/test/src/test_lasy2.cpp
@@ -26,6 +26,9 @@ TEMPLATE_TEST_CASE("sylvester solver gives correct result",
     using idx_t = size_type<matrix_t>;
     typedef real_type<T> real_t;
 
+    // Sylvester solver does not work great with 16-bit precision types
+    if constexpr (sizeof(real_t) <= 2) SKIP_TEST;
+
     // Functor
     Create<matrix_t> new_matrix;
 
@@ -69,10 +72,32 @@ TEMPLATE_TEST_CASE("sylvester solver gives correct result",
         T scale(0), xnorm;
         lasy2(NO_TRANS, NO_TRANS, 1, TL, TR, B, scale, X, xnorm);
 
-        // Check that X_exact == X
+        UNSCOPED_INFO("scale = " << scale);
+        UNSCOPED_INFO("xnorm = " << xnorm);
+
+        for (idx_t i = 0; i < n1; ++i)
+            for (idx_t j = 0; j < n1; ++j)
+                UNSCOPED_INFO("TL(" << i << ", " << j << ") = " << TL(i, j));
+
+        for (idx_t i = 0; i < n2; ++i)
+            for (idx_t j = 0; j < n2; ++j)
+                UNSCOPED_INFO("TR(" << i << ", " << j << ") = " << TR(i, j));
+
         for (idx_t i = 0; i < n1; ++i)
             for (idx_t j = 0; j < n2; ++j)
+                UNSCOPED_INFO("X_exact(" << i << ", " << j
+                                         << ") = " << X_exact(i, j));
+
+        for (idx_t i = 0; i < n1; ++i)
+            for (idx_t j = 0; j < n2; ++j)
+                UNSCOPED_INFO("B(" << i << ", " << j << ") = " << B(i, j));
+
+        // Check that X_exact == X
+        for (idx_t i = 0; i < n1; ++i)
+            for (idx_t j = 0; j < n2; ++j) {
+                INFO("X(" << i << ", " << j << ") = " << X(i, j));
                 CHECK(abs1(X_exact(i, j) - scale * X(i, j)) <=
                       tol * X_exact(i, j));
+            }
     }
 }

--- a/test/src/test_lauum.cpp
+++ b/test/src/test_lauum.cpp
@@ -69,7 +69,7 @@ TEMPLATE_TEST_CASE("LAUUM is stable", "[lauum]", TLAPACK_TYPES_TO_TEST)
             herk(UPPER_TRIANGLE, NO_TRANS, real_t(1), C, real_t(-1), A);
         }
 
-        real_t res = lanhe(MAX_NORM, uplo, A) / normC / normC;
-        CHECK(res <= tol);
+        real_t res = lanhe(MAX_NORM, uplo, A);
+        CHECK(res <= tol * normC * normC);
     }
 }

--- a/test/src/test_lu_mult.cpp
+++ b/test/src/test_lu_mult.cpp
@@ -72,8 +72,8 @@ TEMPLATE_TEST_CASE("lu multiplication is backward stable",
 
                 gemm(NO_TRANS, NO_TRANS, real_t(1), L, U, real_t(-1), A);
 
-                real_t lu_mult_res_norm = lange(MAX_NORM, A) / norma;
-                CHECK(lu_mult_res_norm <= tol);
+                real_t lu_mult_res_norm = lange(MAX_NORM, A);
+                CHECK(lu_mult_res_norm <= tol * norma);
             }
         }
     }

--- a/test/src/test_multishift_qz.cpp
+++ b/test/src/test_multishift_qz.cpp
@@ -35,6 +35,9 @@ TEMPLATE_TEST_CASE("QZ algorithm",
     using complex_t = complex_type<real_t>;
     using range = pair<idx_t, idx_t>;
 
+    // QZ algorithm does may not work with 16-bit precision types
+    if constexpr (sizeof(real_t) <= 2) SKIP_TEST;
+
     // Functor
     Create<matrix_t> new_matrix;
 

--- a/test/src/test_qr_algorithm.cpp
+++ b/test/src/test_qr_algorithm.cpp
@@ -75,7 +75,7 @@ TEMPLATE_TEST_CASE("QR algorithm",
         SKIP_TEST;
 
     // Random number generator
-    rand_generator gen;
+    PCG32 gen;
     gen.seed(seed);
 
     // Define the matrices

--- a/test/src/test_rot_sequence.cpp
+++ b/test/src/test_rot_sequence.cpp
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE("Application of rotation sequence is accurate",
 
     // MatrixMarket reader
     MatrixMarket mm;
-    rand_generator gen;
+    PCG32 gen;
 
     const Side side = GENERATE(Side::Left, Side::Right);
     const Direction direction =

--- a/test/src/test_rot_sequence3.cpp
+++ b/test/src/test_rot_sequence3.cpp
@@ -40,7 +40,7 @@ TEMPLATE_TEST_CASE("Application of rotation sequence is accurate",
 
     // MatrixMarket reader
     MatrixMarket mm;
-    rand_generator gen;
+    PCG32 gen;
 
     const Side side = GENERATE(Side::Left, Side::Right);
     const Direction direction =

--- a/test/src/test_rscl.cpp
+++ b/test/src/test_rscl.cpp
@@ -60,7 +60,7 @@ TEMPLATE_TEST_CASE("reciprocal scaling works on limit cases",
     }
     {
         using T = NaNPropagComplex<real_t>;
-        using trustR = long double;
+        using trustR = double;
         using trustT = NaNPropagComplex<trustR>;
 
         // scaling constants

--- a/test/src/test_schur_move.cpp
+++ b/test/src/test_schur_move.cpp
@@ -69,20 +69,20 @@ TEMPLATE_TEST_CASE("move of eigenvalue block gives correct results",
 
         if (n1 == 2) {
             if (ifst < n - 1)
-                A(ifst + 1, ifst) = rand_helper<T>();
+                A(ifst + 1, ifst) = rand_helper<T>(mm.gen);
             else
-                A(ifst, ifst - 1) = rand_helper<T>();
+                A(ifst, ifst - 1) = rand_helper<T>(mm.gen);
         }
         if (n2 == 2) {
             if (ilst < n - 1)
-                A(ilst + 1, ilst) = rand_helper<T>();
+                A(ilst + 1, ilst) = rand_helper<T>(mm.gen);
             else
-                A(ilst, ilst - 1) = rand_helper<T>();
+                A(ilst, ilst - 1) = rand_helper<T>(mm.gen);
         }
 
         if (is_real<T>) {
             // Put a 2x2 block in the middle
-            A(5, 4) = rand_helper<T>();
+            A(5, 4) = rand_helper<T>(mm.gen);
         }
 
         lacpy(GENERAL, A, A_copy);

--- a/test/src/test_schur_swap.cpp
+++ b/test/src/test_schur_swap.cpp
@@ -62,8 +62,8 @@ TEMPLATE_TEST_CASE("schur swap gives correct result",
             for (idx_t i = j + 1; i < n; ++i)
                 A(i, j) = zero;
 
-        if (n1 == 2) A(j + 1, j) = rand_helper<T>();
-        if (n2 == 2) A(j + n1 + 1, j + n1) = rand_helper<T>();
+        if (n1 == 2) A(j + 1, j) = rand_helper<T>(mm.gen);
+        if (n2 == 2) A(j + n1 + 1, j + n1) = rand_helper<T>(mm.gen);
 
         lacpy(GENERAL, A, A_copy);
         laset(GENERAL, zero, one, Q);

--- a/test/src/test_svd22.cpp
+++ b/test/src/test_svd22.cpp
@@ -77,9 +77,20 @@ TEMPLATE_TEST_CASE("2x2 svd gives correct result",
         h = T(0.);
     }
 
+    INFO("f = " << f);
+    INFO("g = " << g);
+    INFO("h = " << h);
+
     DYNAMIC_SECTION("matrix type = " << matrix_type)
     {
         svd22(f, g, h, ssmin1, ssmax1, csl, snl, csr, snr);
+
+        INFO("ssmin1 = " << ssmin1);
+        INFO("ssmax1 = " << ssmax1);
+        INFO("csl = " << csl);
+        INFO("snl = " << snl);
+        INFO("csr = " << csr);
+        INFO("snr = " << snr);
 
         // Check the decomposition
         std::vector<T> A_;

--- a/test/src/test_svd22.cpp
+++ b/test/src/test_svd22.cpp
@@ -30,6 +30,9 @@ TEMPLATE_TEST_CASE("2x2 svd gives correct result",
     // Functor
     Create<matrix_t> new_matrix;
 
+    // Pseudo random number generator
+    PCG32 prng;
+
     const T eps = uroundoff<T>();
     const T tol = T(4.0e1) * eps;
 
@@ -39,38 +42,38 @@ TEMPLATE_TEST_CASE("2x2 svd gives correct result",
     T f, g, h, ssmin1, ssmax1, ssmin2, ssmax2, csl, snl, csr, snr;
 
     if (matrix_type == "rand") {
-        f = rand_helper<T>();
-        g = rand_helper<T>();
-        h = rand_helper<T>();
+        f = rand_helper<T>(prng);
+        g = rand_helper<T>(prng);
+        h = rand_helper<T>(prng);
     }
     if (matrix_type == "large f") {
-        f = T(100.) * rand_helper<T>();
-        g = rand_helper<T>();
-        h = rand_helper<T>();
+        f = T(100.) * rand_helper<T>(prng);
+        g = rand_helper<T>(prng);
+        h = rand_helper<T>(prng);
     }
     if (matrix_type == "large g") {
-        f = rand_helper<T>();
-        g = T(100.) * rand_helper<T>();
-        h = rand_helper<T>();
+        f = rand_helper<T>(prng);
+        g = T(100.) * rand_helper<T>(prng);
+        h = rand_helper<T>(prng);
     }
     if (matrix_type == "large h") {
-        f = rand_helper<T>();
-        g = rand_helper<T>();
-        h = T(100.) * rand_helper<T>();
+        f = rand_helper<T>(prng);
+        g = rand_helper<T>(prng);
+        h = T(100.) * rand_helper<T>(prng);
     }
     if (matrix_type == "zero f") {
         f = T(0.);
-        g = rand_helper<T>();
-        h = rand_helper<T>();
+        g = rand_helper<T>(prng);
+        h = rand_helper<T>(prng);
     }
     if (matrix_type == "zero g") {
-        f = rand_helper<T>();
+        f = rand_helper<T>(prng);
         g = T(0.);
-        h = rand_helper<T>();
+        h = rand_helper<T>(prng);
     }
     if (matrix_type == "zero h") {
-        f = rand_helper<T>();
-        g = rand_helper<T>();
+        f = rand_helper<T>(prng);
+        g = rand_helper<T>(prng);
         h = T(0.);
     }
 

--- a/test/src/test_svd_qr.cpp
+++ b/test/src/test_svd_qr.cpp
@@ -35,6 +35,9 @@ TEMPLATE_TEST_CASE("svd is backward stable",
     // Functor
     Create<matrix_t> new_matrix;
 
+    // Pseudo random number generator
+    PCG32 prng;
+
     const real_t zero(0);
     const real_t one(1);
 
@@ -59,9 +62,9 @@ TEMPLATE_TEST_CASE("svd is backward stable",
 
     // Generate random bidiagonal matrix
     for (idx_t j = 0; j < n; ++j)
-        d[j] = rand_helper<real_t>();
+        d[j] = rand_helper<real_t>(prng);
     for (idx_t j = 0; j + 1 < n; ++j)
-        e[j] = rand_helper<real_t>();
+        e[j] = rand_helper<real_t>(prng);
 
     copy(d, d_copy);
     copy(e, e_copy);

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -18,13 +18,13 @@ TEST_CASE("Random generator is consistent if seed is fixed", "[utils]")
     PCG32 gen;
     gen.seed(6845315);
 
-    CHECK(gen() == 1225581775);
-    CHECK(gen() == 1985311242);
-    CHECK(gen() == 300629471);
-    CHECK(gen() == 2636314308);
-    CHECK(gen() == 1603395911);
-    CHECK(gen() == 393807335);
-    CHECK(gen() == 3641191292);
+    CHECK(gen() == 1769014346);
+    CHECK(gen() == 2707482059);
+    CHECK(gen() == 2875142166);
+    CHECK(gen() == 980837000);
+    CHECK(gen() == 167563027);
+    CHECK(gen() == 4104548500);
+    CHECK(gen() == 2141462913);
 }
 
 TEMPLATE_TEST_CASE("is_matrix works", "[utils]", TLAPACK_TYPES_TO_TEST)

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -15,7 +15,7 @@ using namespace tlapack;
 
 TEST_CASE("Random generator is consistent if seed is fixed", "[utils]")
 {
-    rand_generator gen;
+    PCG32 gen;
     gen.seed(6845315);
 
     CHECK(gen() == 1225581775);


### PR DESCRIPTION
- `rand_generator` is renamed as `PCG32`. This uses the algorithm PCG-XSH-RR from https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf with implementation from https://github.com/imneme/pcg-cpp. The advantage is that the PCG is well studied and has better properties than the implementation currently in our library.
- `rand_helper()` now receives to parameters: a random number generator and a distribution. The default is the uniform distribution in [0,1).
- There is no `rand_helper()` using the `rand()` generator. This implementation depends on the compiler, so not a good choice.