### PR TITLE
change behavior for 1-by-1 matrix Z for case n=1 for STEQR if wantz

### DIFF
--- a/include/tlapack/lapack/steqr.hpp
+++ b/include/tlapack/lapack/steqr.hpp
@@ -86,10 +86,7 @@ int steqr(bool want_z, d_t& d, e_t& e, matrix_t& Z)
 
     // Quick return if possible
     if (n == 0) return 0;
-    if (n == 1) {
-        if (want_z) Z(0, 0) = one;
-        return 0;
-    }
+    if (n == 1) return 0;
 
     // Determine the unit roundoff and over/underflow thresholds.
     const real_t eps = ulp<real_t>();


### PR DESCRIPTION
If n=1, then "if (want_z) Z(0, 0) = one;" overwrites the Z of the tridiagonal reduction. The current interface says that, if wantz, then Z must be initialized in input, so it could be better that Z is not overwritten in the n=1 case. 

Setting Z(0,0) to one in STEQR is a correct behavior.  

But we can also leave Z(0,0) as is. For example, Z(0,0) could be an e^iθ in input and it would be OK to leave it as such. (This would be the output of a weird choice for an n=1 tridiagonalization algorithm but valid.)

I do not feel too strongly about either way. All in all, I think a quick return is better.