### PR TITLE
Improve generalized schur swap

### DIFF
--- a/include/tlapack/lapack/generalized_schur_swap.hpp
+++ b/include/tlapack/lapack/generalized_schur_swap.hpp
@@ -347,18 +347,23 @@ int generalized_schur_swap(bool want_q,
         //
         std::vector<T> H_;
         auto H = new_matrix(H_, 2, 3);
-        std::vector<T> v(3);
+        T taur, taulA, taulB;
+        std::vector<T> vr(3);
+        std::vector<T> vlA(3);
+        std::vector<T> vlB(3);
 
-        complex_type<T> alpha1, alpha2;
-        T beta1, beta2;
+        std::vector<T> AA_;
+        auto AA = new_matrix(AA_, 3, 3);
+        std::vector<T> BB_;
+        auto BB = new_matrix(BB_, 3, 3);
+        lacpy(GENERAL, slice(A, range(j0, j3), range(j0, j3)), AA);
+        lacpy(GENERAL, slice(B, range(j0, j3), range(j0, j3)), BB);
 
-        auto A1 = slice(A, range(j0, j2), range(j0, j2));
-        auto B1 = slice(B, range(j0, j2), range(j0, j2));
-        lahqz_eig22(A1, B1, alpha1, alpha2, beta1, beta2);
         auto a22 = A(j2, j2);
         auto b22 = B(j2, j2);
 
-        bool use_b = abs(b22 * alpha1) > abs(beta1 * a22);
+        T norma = lange(FROB_NORM, AA);
+        T normb = lange(FROB_NORM, BB);
 
         H(0, 0) = b22 * A(j0, j0) - a22 * B(j0, j0);
         H(0, 1) = b22 * A(j0, j1) - a22 * B(j0, j1);
@@ -367,60 +372,134 @@ int generalized_schur_swap(bool want_q,
         H(1, 1) = b22 * A(j1, j1) - a22 * B(j1, j1);
         H(1, 2) = b22 * A(j1, j2) - a22 * B(j1, j2);
 
-        T tau;
-        inv_house3(H, v, tau);
+        inv_house3(H, vr, taur);
 
-        // Apply update from the right
-        for (idx_t j = 0; j < j3; ++j) {
-            T sum = A(j, j0) + v[1] * A(j, j1) + v[2] * A(j, j2);
-            A(j, j0) = A(j, j0) - sum * tau;
-            A(j, j1) = A(j, j1) - sum * tau * v[1];
-            A(j, j2) = A(j, j2) - sum * tau * v[2];
+        // Apply update from the right to the local matrices
+        for (idx_t j = 0; j < 3; ++j) {
+            T sum = AA(j, 0) + vr[1] * AA(j, 1) + vr[2] * AA(j, 2);
+            AA(j, 0) = AA(j, 0) - sum * taur;
+            AA(j, 1) = AA(j, 1) - sum * taur * vr[1];
+            AA(j, 2) = AA(j, 2) - sum * taur * vr[2];
         }
-        for (idx_t j = 0; j < j3; ++j) {
-            T sum = B(j, j0) + v[1] * B(j, j1) + v[2] * B(j, j2);
-            B(j, j0) = B(j, j0) - sum * tau;
-            B(j, j1) = B(j, j1) - sum * tau * v[1];
-            B(j, j2) = B(j, j2) - sum * tau * v[2];
-        }
-        for (idx_t j = 0; j < n; ++j) {
-            T sum = Z(j, j0) + v[1] * Z(j, j1) + v[2] * Z(j, j2);
-            Z(j, j0) = Z(j, j0) - sum * tau;
-            Z(j, j1) = Z(j, j1) - sum * tau * v[1];
-            Z(j, j2) = Z(j, j2) - sum * tau * v[2];
+        for (idx_t j = 0; j < 3; ++j) {
+            T sum = BB(j, 0) + vr[1] * BB(j, 1) + vr[2] * BB(j, 2);
+            BB(j, 0) = BB(j, 0) - sum * taur;
+            BB(j, 1) = BB(j, 1) - sum * taur * vr[1];
+            BB(j, 2) = BB(j, 2) - sum * taur * vr[2];
         }
 
-        if (use_b) {
-            v[0] = B(j0, j0);
-            v[1] = B(j1, j0);
-            v[2] = B(j2, j0);
-        }
-        else {
-            v[0] = A(j0, j0);
-            v[1] = A(j1, j0);
-            v[2] = A(j2, j0);
-        }
-        larfg(FORWARD, COLUMNWISE_STORAGE, v, tau);
+        // Determine two sets of left transformations
+        // one that zeroes out the first column of A and one that zeroes out the
+        // first column of B
+        // We will later choose the one that gives the smaller error
+        vlA[0] = AA(0, 0);
+        vlA[1] = AA(1, 0);
+        vlA[2] = AA(2, 0);
+        larfg(FORWARD, COLUMNWISE_STORAGE, vlA, taulA);
+
+        vlB[0] = BB(0, 0);
+        vlB[1] = BB(1, 0);
+        vlB[2] = BB(2, 0);
+        larfg(FORWARD, COLUMNWISE_STORAGE, vlB, taulB);
 
         // Apply update from the left
-        for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j0, j) + v[1] * A(j1, j) + v[2] * A(j2, j);
-            A(j0, j) = A(j0, j) - sum * tau;
-            A(j1, j) = A(j1, j) - sum * tau * v[1];
-            A(j2, j) = A(j2, j) - sum * tau * v[2];
+        for (idx_t j = 0; j < 3; ++j) {
+            T sum = AA(0, j) + vlB[1] * AA(1, j) + vlB[2] * AA(2, j);
+            AA(0, j) = AA(0, j) - sum * taulB;
+            AA(1, j) = AA(1, j) - sum * taulB * vlB[1];
+            AA(2, j) = AA(2, j) - sum * taulB * vlB[2];
         }
-        for (idx_t j = j0; j < n; ++j) {
-            T sum = B(j0, j) + v[1] * B(j1, j) + v[2] * B(j2, j);
-            B(j0, j) = B(j0, j) - sum * tau;
-            B(j1, j) = B(j1, j) - sum * tau * v[1];
-            B(j2, j) = B(j2, j) - sum * tau * v[2];
+        for (idx_t j = 0; j < 3; ++j) {
+            T sum = BB(0, j) + vlA[1] * BB(1, j) + vlA[2] * BB(2, j);
+            BB(0, j) = BB(0, j) - sum * taulA;
+            BB(1, j) = BB(1, j) - sum * taulA * vlA[1];
+            BB(2, j) = BB(2, j) - sum * taulA * vlA[2];
         }
-        if (want_q) {
+
+        //
+        // Determine if the swap was successful
+        //
+        T errA = lapy2(AA(1, 0), AA(2, 0));
+        T errB = lapy2(BB(1, 0), BB(2, 0));
+        const T eps = ulp<T>();
+        const T small_num = safe_min<T>();
+
+        if (errA > max((T)20 * norma * eps, small_num) and
+            errB > max((T)20 * normb * eps, small_num)) {
+            // The swap failed, return with error
+            // Note, though we don't have a proof that this will always be the
+            // case, there are currently no known cases where this swap can
+            // fail.
+            return 1;
+        }
+
+        //
+        // Swap is accepted, apply the updates to the original matrices
+        //
+        for (idx_t j = 0; j < j3; ++j) {
+            T sum = A(j, j0) + vr[1] * A(j, j1) + vr[2] * A(j, j2);
+            A(j, j0) = A(j, j0) - sum * taur;
+            A(j, j1) = A(j, j1) - sum * taur * vr[1];
+            A(j, j2) = A(j, j2) - sum * taur * vr[2];
+        }
+        for (idx_t j = 0; j < j3; ++j) {
+            T sum = B(j, j0) + vr[1] * B(j, j1) + vr[2] * B(j, j2);
+            B(j, j0) = B(j, j0) - sum * taur;
+            B(j, j1) = B(j, j1) - sum * taur * vr[1];
+            B(j, j2) = B(j, j2) - sum * taur * vr[2];
+        }
+        if (want_z) {
             for (idx_t j = 0; j < n; ++j) {
-                T sum = Q(j, j0) + v[1] * Q(j, j1) + v[2] * Q(j, j2);
-                Q(j, j0) = Q(j, j0) - sum * tau;
-                Q(j, j1) = Q(j, j1) - sum * tau * v[1];
-                Q(j, j2) = Q(j, j2) - sum * tau * v[2];
+                T sum = Z(j, j0) + vr[1] * Z(j, j1) + vr[2] * Z(j, j2);
+                Z(j, j0) = Z(j, j0) - sum * taur;
+                Z(j, j1) = Z(j, j1) - sum * taur * vr[1];
+                Z(j, j2) = Z(j, j2) - sum * taur * vr[2];
+            }
+        }
+        if (errB * norma < errA * normb) {
+            // The error is smallest when using vlA
+            for (idx_t j = j0; j < n; ++j) {
+                T sum = A(j0, j) + vlA[1] * A(j1, j) + vlA[2] * A(j2, j);
+                A(j0, j) = A(j0, j) - sum * taulA;
+                A(j1, j) = A(j1, j) - sum * taulA * vlA[1];
+                A(j2, j) = A(j2, j) - sum * taulA * vlA[2];
+            }
+            for (idx_t j = j0; j < n; ++j) {
+                T sum = B(j0, j) + vlA[1] * B(j1, j) + vlA[2] * B(j2, j);
+                B(j0, j) = B(j0, j) - sum * taulA;
+                B(j1, j) = B(j1, j) - sum * taulA * vlA[1];
+                B(j2, j) = B(j2, j) - sum * taulA * vlA[2];
+            }
+            if (want_q) {
+                for (idx_t j = 0; j < n; ++j) {
+                    T sum = Q(j, j0) + vlA[1] * Q(j, j1) + vlA[2] * Q(j, j2);
+                    Q(j, j0) = Q(j, j0) - sum * taulA;
+                    Q(j, j1) = Q(j, j1) - sum * taulA * vlA[1];
+                    Q(j, j2) = Q(j, j2) - sum * taulA * vlA[2];
+                }
+            }
+        }
+        else {
+            // The error is smallest when using vlB
+            for (idx_t j = j0; j < n; ++j) {
+                T sum = A(j0, j) + vlB[1] * A(j1, j) + vlB[2] * A(j2, j);
+                A(j0, j) = A(j0, j) - sum * taulB;
+                A(j1, j) = A(j1, j) - sum * taulB * vlB[1];
+                A(j2, j) = A(j2, j) - sum * taulB * vlB[2];
+            }
+            for (idx_t j = j0; j < n; ++j) {
+                T sum = B(j0, j) + vlB[1] * B(j1, j) + vlB[2] * B(j2, j);
+                B(j0, j) = B(j0, j) - sum * taulB;
+                B(j1, j) = B(j1, j) - sum * taulB * vlB[1];
+                B(j2, j) = B(j2, j) - sum * taulB * vlB[2];
+            }
+            if (want_q) {
+                for (idx_t j = 0; j < n; ++j) {
+                    T sum = Q(j, j0) + vlB[1] * Q(j, j1) + vlB[2] * Q(j, j2);
+                    Q(j, j0) = Q(j, j0) - sum * taulB;
+                    Q(j, j1) = Q(j, j1) - sum * taulB * vlB[1];
+                    Q(j, j2) = Q(j, j2) - sum * taulB * vlB[2];
+                }
             }
         }
 

--- a/include/tlapack/lapack/generalized_schur_swap.hpp
+++ b/include/tlapack/lapack/generalized_schur_swap.hpp
@@ -92,20 +92,24 @@ int generalized_schur_swap(bool want_q,
     // If so, treat them separately
     if (n1 == 2)
         if (A(j1, j0) == zero) {
-            // only 2x2 swaps can fail, so we don't need to check for error
-            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j1, (idx_t)1,
-                                   n2);
-            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j0, (idx_t)1,
-                                   n2);
+            int info;
+            info = generalized_schur_swap(want_q, want_z, A, B, Q, Z, j1,
+                                          (idx_t)1, n2);
+            if (info != 0) return info;
+            info = generalized_schur_swap(want_q, want_z, A, B, Q, Z, j0,
+                                          (idx_t)1, n2);
+            if (info != 0) return info;
             return 0;
         }
     if (n2 == 2)
         if (A(j0 + n1 + 1, j0 + n1) == zero) {
-            // only 2x2 swaps can fail, so we don't need to check for error
-            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j0, n1,
-                                   (idx_t)1);
-            generalized_schur_swap(want_q, want_z, A, B, Q, Z, j1, n1,
-                                   (idx_t)1);
+            int info;
+            info = generalized_schur_swap(want_q, want_z, A, B, Q, Z, j0, n1,
+                                          (idx_t)1);
+            if (info != 0) return info;
+            info = generalized_schur_swap(want_q, want_z, A, B, Q, Z, j1, n1,
+                                          (idx_t)1);
+            if (info != 0) return info;
             return 0;
         }
 

--- a/include/tlapack/lapack/generalized_schur_swap.hpp
+++ b/include/tlapack/lapack/generalized_schur_swap.hpp
@@ -41,9 +41,9 @@ namespace tlapack {
  * @param[in,out] B n-by-n matrix.
  *                Must be in Schur form
  * @param[in,out] Q n-by-n matrix.
- *                Orthogonal matrix, not referenced if want_q is false
+ *                Unitary matrix, not referenced if want_q is false
  * @param[in,out] Z n-by-n matrix.
- *                Orthogonal matrix, not referenced if want_q is false
+ *                Unitary matrix, not referenced if want_z is false
  * @param[in]     j0 integer
  *                Index of first eigenvalue block
  * @param[in]     n1 integer
@@ -179,80 +179,161 @@ int generalized_schur_swap(bool want_q,
 
         std::vector<T> H_;
         auto H = new_matrix(H_, 2, 3);
-        std::vector<T> v(3);
+        std::vector<T> vl(3);
+        std::vector<T> vrA(3);
+        std::vector<T> vrB(3);
+        T taul, taurA, taurB;
 
-        complex_type<T> alpha1, alpha2;
-        T beta1, beta2;
+        std::vector<T> AA_;
+        auto AA = new_matrix(AA_, 3, 3);
+        std::vector<T> BB_;
+        auto BB = new_matrix(BB_, 3, 3);
+        lacpy(GENERAL, slice(A, range(j0, j3), range(j0, j3)), AA);
+        lacpy(GENERAL, slice(B, range(j0, j3), range(j0, j3)), BB);
 
-        auto A1 = slice(A, range(j1, j3), range(j1, j3));
-        auto B1 = slice(B, range(j1, j3), range(j1, j3));
-        lahqz_eig22(A1, B1, alpha1, alpha2, beta1, beta2);
-        auto a00 = A(j0, j0);
-        auto b00 = B(j0, j0);
+        auto a00 = AA(0, 0);
+        auto b00 = BB(0, 0);
 
-        bool use_b = abs(b00 * alpha1) > abs(beta1 * a00);
+        T norma = lange(FROB_NORM, AA);
+        T normb = lange(FROB_NORM, BB);
 
-        H(0, 0) = b00 * A(j2, j1) - a00 * B(j2, j1);
-        H(0, 1) = b00 * A(j1, j1) - a00 * B(j1, j1);
-        H(0, 2) = b00 * A(j0, j1) - a00 * B(j0, j1);
-        H(1, 0) = b00 * A(j2, j2) - a00 * B(j2, j2);
-        H(1, 1) = b00 * A(j1, j2) - a00 * B(j1, j2);
-        H(1, 2) = b00 * A(j0, j2) - a00 * B(j0, j2);
+        H(0, 0) = b00 * AA(2, 1) - a00 * BB(2, 1);
+        H(0, 1) = b00 * AA(1, 1) - a00 * BB(1, 1);
+        H(0, 2) = b00 * AA(0, 1) - a00 * BB(0, 1);
+        H(1, 0) = b00 * AA(2, 2) - a00 * BB(2, 2);
+        H(1, 1) = b00 * AA(1, 2) - a00 * BB(1, 2);
+        H(1, 2) = b00 * AA(0, 2) - a00 * BB(0, 2);
 
-        T tau;
-        inv_house3(H, v, tau);
+        inv_house3(H, vl, taul);
 
-        // Apply update from the left
+        // Tentatively apply update from the left to local matrices
+        for (idx_t j = 0; j < 3; ++j) {
+            T sum = AA(2, j) + vl[1] * AA(1, j) + vl[2] * AA(0, j);
+            AA(2, j) = AA(2, j) - sum * taul;
+            AA(1, j) = AA(1, j) - sum * taul * vl[1];
+            AA(0, j) = AA(0, j) - sum * taul * vl[2];
+        }
+        for (idx_t j = 0; j < 3; ++j) {
+            T sum = BB(2, j) + vl[1] * BB(1, j) + vl[2] * BB(0, j);
+            BB(2, j) = BB(2, j) - sum * taul;
+            BB(1, j) = BB(1, j) - sum * taul * vl[1];
+            BB(0, j) = BB(0, j) - sum * taul * vl[2];
+        }
+
+        // Determine two sets of right transformations
+        // one that zeroes out the last row of A and one that zeroes out the
+        // last row of B
+        // We will later choose the one that gives the smaller error
+        vrA[0] = AA(2, 2);
+        vrA[1] = AA(2, 1);
+        vrA[2] = AA(2, 0);
+        larfg(FORWARD, COLUMNWISE_STORAGE, vrA, taurA);
+
+        vrB[0] = BB(2, 2);
+        vrB[1] = BB(2, 1);
+        vrB[2] = BB(2, 0);
+        larfg(FORWARD, COLUMNWISE_STORAGE, vrB, taurB);
+
+        // Apply the update calculated using BB to AA
+        // and vice versa. We choose the one that gives the smaller error
+        for (idx_t j = 2; j < 3; ++j) {
+            T sum = AA(j, 2) + vrB[1] * AA(j, 1) + vrB[2] * AA(j, 0);
+            AA(j, 2) = AA(j, 2) - sum * taurB;
+            AA(j, 1) = AA(j, 1) - sum * taurB * vrB[1];
+            AA(j, 0) = AA(j, 0) - sum * taurB * vrB[2];
+        }
+        for (idx_t j = 2; j < 3; ++j) {
+            T sum = BB(j, 2) + vrA[1] * BB(j, 1) + vrA[2] * BB(j, 0);
+            BB(j, 2) = BB(j, 2) - sum * taurA;
+            BB(j, 1) = BB(j, 1) - sum * taurA * vrA[1];
+            BB(j, 0) = BB(j, 0) - sum * taurA * vrA[2];
+        }
+
+        //
+        // Determine if the swap was successful
+        //
+        T errA = lapy2(AA(2, 0), AA(2, 1));
+        T errB = lapy2(BB(2, 0), BB(2, 1));
+        const T eps = ulp<T>();
+        const T small_num = safe_min<T>();
+
+        if (errA > max((T)20 * norma * eps, small_num) and
+            errB > max((T)20 * normb * eps, small_num)) {
+            // The swap failed, return with error
+            // Note, though we don't have a proof that this will always be the
+            // case, there are currently no known cases where this swap can
+            // fail.
+            return 1;
+        }
+
+        //
+        // Swap is accepted, apply the updates to the original matrices
+        //
         for (idx_t j = j0; j < n; ++j) {
-            T sum = A(j2, j) + v[1] * A(j1, j) + v[2] * A(j0, j);
-            A(j2, j) = A(j2, j) - sum * tau;
-            A(j1, j) = A(j1, j) - sum * tau * v[1];
-            A(j0, j) = A(j0, j) - sum * tau * v[2];
+            T sum = A(j2, j) + vl[1] * A(j1, j) + vl[2] * A(j0, j);
+            A(j2, j) = A(j2, j) - sum * taul;
+            A(j1, j) = A(j1, j) - sum * taul * vl[1];
+            A(j0, j) = A(j0, j) - sum * taul * vl[2];
         }
         for (idx_t j = j0; j < n; ++j) {
-            T sum = B(j2, j) + v[1] * B(j1, j) + v[2] * B(j0, j);
-            B(j2, j) = B(j2, j) - sum * tau;
-            B(j1, j) = B(j1, j) - sum * tau * v[1];
-            B(j0, j) = B(j0, j) - sum * tau * v[2];
+            T sum = B(j2, j) + vl[1] * B(j1, j) + vl[2] * B(j0, j);
+            B(j2, j) = B(j2, j) - sum * taul;
+            B(j1, j) = B(j1, j) - sum * taul * vl[1];
+            B(j0, j) = B(j0, j) - sum * taul * vl[2];
         }
-        for (idx_t j = 0; j < n; ++j) {
-            T sum = Q(j, j2) + v[1] * Q(j, j1) + v[2] * Q(j, j0);
-            Q(j, j2) = Q(j, j2) - sum * tau;
-            Q(j, j1) = Q(j, j1) - sum * tau * v[1];
-            Q(j, j0) = Q(j, j0) - sum * tau * v[2];
+        if (want_q) {
+            for (idx_t j = 0; j < n; ++j) {
+                T sum = Q(j, j2) + vl[1] * Q(j, j1) + vl[2] * Q(j, j0);
+                Q(j, j2) = Q(j, j2) - sum * taul;
+                Q(j, j1) = Q(j, j1) - sum * taul * vl[1];
+                Q(j, j0) = Q(j, j0) - sum * taul * vl[2];
+            }
         }
-
-        if (use_b) {
-            v[0] = B(j2, j2);
-            v[1] = B(j2, j1);
-            v[2] = B(j2, j0);
+        if (errB * norma < errA * normb) {
+            // The error is smallest when using vrA
+            for (idx_t j = 0; j < j3; ++j) {
+                T sum = A(j, j2) + vrA[1] * A(j, j1) + vrA[2] * A(j, j0);
+                A(j, j2) = A(j, j2) - sum * taurA;
+                A(j, j1) = A(j, j1) - sum * taurA * vrA[1];
+                A(j, j0) = A(j, j0) - sum * taurA * vrA[2];
+            }
+            for (idx_t j = 0; j < j3; ++j) {
+                T sum = B(j, j2) + vrA[1] * B(j, j1) + vrA[2] * B(j, j0);
+                B(j, j2) = B(j, j2) - sum * taurA;
+                B(j, j1) = B(j, j1) - sum * taurA * vrA[1];
+                B(j, j0) = B(j, j0) - sum * taurA * vrA[2];
+            }
+            if (want_z) {
+                for (idx_t j = 0; j < n; ++j) {
+                    T sum = Z(j, j2) + vrA[1] * Z(j, j1) + vrA[2] * Z(j, j0);
+                    Z(j, j2) = Z(j, j2) - sum * taurA;
+                    Z(j, j1) = Z(j, j1) - sum * taurA * vrA[1];
+                    Z(j, j0) = Z(j, j0) - sum * taurA * vrA[2];
+                }
+            }
         }
         else {
-            v[0] = A(j2, j2);
-            v[1] = A(j2, j1);
-            v[2] = A(j2, j0);
-        }
-
-        larfg(FORWARD, COLUMNWISE_STORAGE, v, tau);
-
-        // Apply update from the right
-        for (idx_t j = 0; j < j3; ++j) {
-            T sum = A(j, j2) + v[1] * A(j, j1) + v[2] * A(j, j0);
-            A(j, j2) = A(j, j2) - sum * tau;
-            A(j, j1) = A(j, j1) - sum * tau * v[1];
-            A(j, j0) = A(j, j0) - sum * tau * v[2];
-        }
-        for (idx_t j = 0; j < j3; ++j) {
-            T sum = B(j, j2) + v[1] * B(j, j1) + v[2] * B(j, j0);
-            B(j, j2) = B(j, j2) - sum * tau;
-            B(j, j1) = B(j, j1) - sum * tau * v[1];
-            B(j, j0) = B(j, j0) - sum * tau * v[2];
-        }
-        for (idx_t j = 0; j < n; ++j) {
-            T sum = Z(j, j2) + v[1] * Z(j, j1) + v[2] * Z(j, j0);
-            Z(j, j2) = Z(j, j2) - sum * tau;
-            Z(j, j1) = Z(j, j1) - sum * tau * v[1];
-            Z(j, j0) = Z(j, j0) - sum * tau * v[2];
+            // The error is smallest when using vrB
+            for (idx_t j = 0; j < j3; ++j) {
+                T sum = A(j, j2) + vrB[1] * A(j, j1) + vrB[2] * A(j, j0);
+                A(j, j2) = A(j, j2) - sum * taurB;
+                A(j, j1) = A(j, j1) - sum * taurB * vrB[1];
+                A(j, j0) = A(j, j0) - sum * taurB * vrB[2];
+            }
+            for (idx_t j = 0; j < j3; ++j) {
+                T sum = B(j, j2) + vrB[1] * B(j, j1) + vrB[2] * B(j, j0);
+                B(j, j2) = B(j, j2) - sum * taurB;
+                B(j, j1) = B(j, j1) - sum * taurB * vrB[1];
+                B(j, j0) = B(j, j0) - sum * taurB * vrB[2];
+            }
+            if (want_z) {
+                for (idx_t j = 0; j < n; ++j) {
+                    T sum = Z(j, j2) + vrB[1] * Z(j, j1) + vrB[2] * Z(j, j0);
+                    Z(j, j2) = Z(j, j2) - sum * taurB;
+                    Z(j, j1) = Z(j, j1) - sum * taurB * vrB[1];
+                    Z(j, j0) = Z(j, j0) - sum * taurB * vrB[2];
+                }
+            }
         }
 
         A(j2, j0) = (T)0;
@@ -334,11 +415,13 @@ int generalized_schur_swap(bool want_q,
             B(j1, j) = B(j1, j) - sum * tau * v[1];
             B(j2, j) = B(j2, j) - sum * tau * v[2];
         }
-        for (idx_t j = 0; j < n; ++j) {
-            T sum = Q(j, j0) + v[1] * Q(j, j1) + v[2] * Q(j, j2);
-            Q(j, j0) = Q(j, j0) - sum * tau;
-            Q(j, j1) = Q(j, j1) - sum * tau * v[1];
-            Q(j, j2) = Q(j, j2) - sum * tau * v[2];
+        if (want_q) {
+            for (idx_t j = 0; j < n; ++j) {
+                T sum = Q(j, j0) + v[1] * Q(j, j1) + v[2] * Q(j, j2);
+                Q(j, j0) = Q(j, j0) - sum * tau;
+                Q(j, j1) = Q(j, j1) - sum * tau * v[1];
+                Q(j, j2) = Q(j, j2) - sum * tau * v[2];
+            }
         }
 
         A(j1, j0) = (T)0;
@@ -533,8 +616,6 @@ int generalized_schur_swap(bool want_q,
         const T small_num = safe_min<T>();
         if (enorma > max((T)20 * norma * eps, small_num)) return 1;
         if (enormb > max((T)20 * normb * eps, small_num)) return 1;
-
-        // TODO: strong stability test
 
         // Apply rotations from the left
         {

--- a/include/tlapack/lapack/generalized_schur_swap.hpp
+++ b/include/tlapack/lapack/generalized_schur_swap.hpp
@@ -21,6 +21,7 @@
 #include "tlapack/lapack/getrf.hpp"
 #include "tlapack/lapack/inv_house3.hpp"
 #include "tlapack/lapack/lahqz_eig22.hpp"
+#include "tlapack/lapack/lahqz_schur22.hpp"
 #include "tlapack/lapack/lange.hpp"
 #include "tlapack/lapack/larfg.hpp"
 #include "tlapack/lapack/svd22.hpp"
@@ -994,6 +995,12 @@ int generalized_schur_swap(bool want_q,
 
     // Standardize the 2x2 Schur blocks (if any)
     if (n2 == 2) {
+        auto A22 = slice(A, range(j0, j2), range(j0, j2));
+        auto B22 = slice(B, range(j0, j2), range(j0, j2));
+
+        complex_type<T> alpha1, alpha2;
+        real_type<T> beta1, beta2;
+
         // Make B upper triangular
         T cl1, sl1;
         rotg(B(j0, j0), B(j1, j0), cl1, sl1);
@@ -1002,27 +1009,22 @@ int generalized_schur_swap(bool want_q,
             auto b1 = slice(B, j0, range(j1, j2));
             auto b2 = slice(B, j1, range(j1, j2));
             rot(b1, b2, cl1, sl1);
+            auto a1 = slice(A, j0, range(j0, j2));
+            auto a2 = slice(A, j1, range(j0, j2));
+            rot(a1, a2, cl1, sl1);
         }
-        // Standard form
-        T ssmin, ssmax, cl2, sl2, cr, sr;
-        svd22(B(j0, j0), B(j0, j1), B(j1, j1), ssmin, ssmax, cl2, sl2, cr, sr);
-        if (ssmax < (T)0) {
-            cr = -cr;
-            sr = -sr;
-            ssmin = -ssmin;
-            ssmax = -ssmax;
-        }
-        B(j0, j0) = ssmax;
-        B(j1, j1) = ssmin;
-        B(j0, j1) = (T)0;
+
+        T cl2, sl2, cr, sr, scal0, scal1;
+        lahqz_schur22(A22, B22, alpha1, alpha2, beta1, beta2, cl2, sl2, cr, sr,
+                      scal0, scal1);
         // Fuse left rotations
         T cl, sl;
         cl = cl1 * cl2 - sl1 * sl2;
         sl = cl2 * sl1 + sl2 * cl1;
         // Apply left rotation
         {
-            auto a1 = slice(A, j0, range(j0, n));
-            auto a2 = slice(A, j1, range(j0, n));
+            auto a1 = slice(A, j0, range(j2, n));
+            auto a2 = slice(A, j1, range(j2, n));
             rot(a1, a2, cl, sl);
             auto b1 = slice(B, j0, range(j2, n));
             auto b2 = slice(B, j1, range(j2, n));
@@ -1031,10 +1033,10 @@ int generalized_schur_swap(bool want_q,
             auto q1 = col(Q, j1);
             rot(q0, q1, cl, sl);
         }
-        // Apply right rotation
+        // Apply right rotation and scaling
         {
-            auto a1 = slice(A, range(0, j2), j0);
-            auto a2 = slice(A, range(0, j2), j1);
+            auto a1 = slice(A, range(0, j0), j0);
+            auto a2 = slice(A, range(0, j0), j1);
             rot(a1, a2, cr, sr);
             auto b1 = slice(B, range(0, j0), j0);
             auto b2 = slice(B, range(0, j0), j1);
@@ -1042,6 +1044,18 @@ int generalized_schur_swap(bool want_q,
             auto z0 = col(Z, j0);
             auto z1 = col(Z, j1);
             rot(z0, z1, cr, sr);
+
+            if (scal0 != (T)1) {
+                scal(scal0, a1);
+                scal(scal0, b1);
+                scal(scal0, z0);
+            }
+
+            if (scal1 != (T)1) {
+                scal(scal1, a2);
+                scal(scal1, b2);
+                scal(scal1, z1);
+            }
         }
     }
     if (n1 == 2) {
@@ -1053,28 +1067,26 @@ int generalized_schur_swap(bool want_q,
             auto b1 = slice(B, j0 + n2, range(j1 + n2, j2 + n2));
             auto b2 = slice(B, j1 + n2, range(j1 + n2, j2 + n2));
             rot(b1, b2, cl1, sl1);
+            auto a1 = slice(A, j0 + n2, range(j0 + n2, j2 + n2));
+            auto a2 = slice(A, j1 + n2, range(j0 + n2, j2 + n2));
+            rot(a1, a2, cl1, sl1);
         }
-        // Standard form
-        T ssmin, ssmax, cl2, sl2, cr, sr;
-        svd22(B(j0 + n2, j0 + n2), B(j0 + n2, j1 + n2), B(j1 + n2, j1 + n2),
-              ssmin, ssmax, cl2, sl2, cr, sr);
-        if (ssmax < (T)0) {
-            cr = -cr;
-            sr = -sr;
-            ssmin = -ssmin;
-            ssmax = -ssmax;
-        }
-        B(j0 + n2, j0 + n2) = ssmax;
-        B(j1 + n2, j1 + n2) = ssmin;
-        B(j0 + n2, j1 + n2) = (T)0;
+
+        complex_type<T> alpha1, alpha2;
+        real_type<T> beta1, beta2;
+        auto A22 = slice(A, range(j0 + n2, j2 + n2), range(j0 + n2, j2 + n2));
+        auto B22 = slice(B, range(j0 + n2, j2 + n2), range(j0 + n2, j2 + n2));
+        T cl2, sl2, cr, sr, scal0, scal1;
+        lahqz_schur22(A22, B22, alpha1, alpha2, beta1, beta2, cl2, sl2, cr, sr,
+                      scal0, scal1);
         // Fuse left rotations
         T cl, sl;
         cl = cl1 * cl2 - sl1 * sl2;
         sl = cl2 * sl1 + sl2 * cl1;
         // Apply left rotation
         {
-            auto a1 = slice(A, j0 + n2, range(j0 + n2, n));
-            auto a2 = slice(A, j1 + n2, range(j0 + n2, n));
+            auto a1 = slice(A, j0 + n2, range(j2 + n2, n));
+            auto a2 = slice(A, j1 + n2, range(j2 + n2, n));
             rot(a1, a2, cl, sl);
             auto b1 = slice(B, j0 + n2, range(j2 + n2, n));
             auto b2 = slice(B, j1 + n2, range(j2 + n2, n));
@@ -1085,8 +1097,8 @@ int generalized_schur_swap(bool want_q,
         }
         // Apply right rotation
         {
-            auto a1 = slice(A, range(0, j2 + n2), j0 + n2);
-            auto a2 = slice(A, range(0, j2 + n2), j1 + n2);
+            auto a1 = slice(A, range(0, j0 + n2), j0 + n2);
+            auto a2 = slice(A, range(0, j0 + n2), j1 + n2);
             rot(a1, a2, cr, sr);
             auto b1 = slice(B, range(0, j0 + n2), j0 + n2);
             auto b2 = slice(B, range(0, j0 + n2), j1 + n2);
@@ -1094,6 +1106,18 @@ int generalized_schur_swap(bool want_q,
             auto z0 = col(Z, j0 + n2);
             auto z1 = col(Z, j1 + n2);
             rot(z0, z1, cr, sr);
+
+            if (scal0 != (T)1) {
+                scal(scal0, a1);
+                scal(scal0, b1);
+                scal(scal0, z0);
+            }
+
+            if (scal1 != (T)1) {
+                scal(scal1, a2);
+                scal(scal1, b2);
+                scal(scal1, z1);
+            }
         }
     }
 

--- a/include/tlapack/lapack/generalized_schur_swap.hpp
+++ b/include/tlapack/lapack/generalized_schur_swap.hpp
@@ -581,7 +581,7 @@ int generalized_schur_swap(bool want_q,
 
         // Find Zc so that
         //       [ -x[0] -x[2] ]   [ *  * ]
-        //  Zc^T  [ -x[1] -x[3] ] = [ *  * ]
+        //  Zc^T [ -x[1] -x[3] ] = [ *  * ]
         //       [ 1     0     ]   [ 0  0 ]
         //       [ 0     1     ]   [ 0  0 ]
 
@@ -640,9 +640,15 @@ int generalized_schur_swap(bool want_q,
         auto AA = new_matrix(AA_, 4, 4);
         std::vector<T> BB_;
         auto BB = new_matrix(BB_, 4, 4);
+        std::vector<T> QQ_;
+        auto QQ = new_matrix(QQ_, 4, 4);
+        std::vector<T> ZZ_;
+        auto ZZ = new_matrix(ZZ_, 4, 4);
 
         lacpy(GENERAL, slice(A, range(j0, j3 + 1), range(j0, j3 + 1)), AA);
         lacpy(GENERAL, slice(B, range(j0, j3 + 1), range(j0, j3 + 1)), BB);
+        laset(GENERAL, T(0), T(1), QQ);
+        laset(GENERAL, T(0), T(1), ZZ);
 
         auto norma = lange(FROB_NORM, AA);
         auto normb = lange(FROB_NORM, BB);
@@ -666,6 +672,16 @@ int generalized_schur_swap(bool want_q,
             rot(b2, b3, cyl, syl);
             rot(b2, b0, cy1, sy1);
             rot(b3, b1, cy2, sy2);
+
+            auto q0 = col(QQ, 0);
+            auto q1 = col(QQ, 1);
+            auto q2 = col(QQ, 2);
+            auto q3 = col(QQ, 3);
+
+            rot(q0, q1, cyr, syr);
+            rot(q2, q3, cyl, syl);
+            rot(q2, q0, cy1, sy1);
+            rot(q3, q1, cy2, sy2);
         }
         // Apply rotations from the right to local matrices
         {
@@ -686,6 +702,15 @@ int generalized_schur_swap(bool want_q,
             rot(b2, b3, cxr, sxr);
             rot(b0, b2, cx1, sx1);
             rot(b1, b3, cx2, sx2);
+
+            auto z0 = col(ZZ, 0);
+            auto z1 = col(ZZ, 1);
+            auto z2 = col(ZZ, 2);
+            auto z3 = col(ZZ, 3);
+            rot(z0, z1, cxl, sxl);
+            rot(z2, z3, cxr, sxr);
+            rot(z0, z2, cx1, sx1);
+            rot(z1, z3, cx2, sx2);
         }
 
         // Weak stability test
@@ -693,68 +718,208 @@ int generalized_schur_swap(bool want_q,
         auto enormb = lange(FROB_NORM, slice(BB, range(2, 4), range(0, 2)));
         const T eps = ulp<T>();
         const T small_num = safe_min<T>();
-        if (enorma > max((T)20 * norma * eps, small_num)) return 1;
-        if (enormb > max((T)20 * normb * eps, small_num)) return 1;
 
-        // Apply rotations from the left
-        {
-            auto a0 = slice(A, j0, range(j0, n));
-            auto a1 = slice(A, j1, range(j0, n));
-            auto a2 = slice(A, j2, range(j0, n));
-            auto a3 = slice(A, j3, range(j0, n));
-            rot(a0, a1, cyr, syr);
-            rot(a2, a3, cyl, syl);
-            rot(a2, a0, cy1, sy1);
-            rot(a3, a1, cy2, sy2);
+        idx_t iter = 0;
+        T tolA = max((T)20 * norma * eps, small_num);
+        T tolB = max((T)20 * normb * eps, small_num);
+        while (iter < 30) {
+            std::cout << "enorma: " << enorma << " tolA: " << tolA
+                      << " enormb: " << enormb << " tolB: " << tolB
+                      << std::endl;
+            if (enorma <= tolA and enormb <= tolB) break;
+            if (iter == 29) return 1;
+            // The swap is not (yet) accepted, apply iterative refinement to
+            // try to improve the swap.
 
-            auto b0 = slice(B, j0, range(j0, n));
-            auto b1 = slice(B, j1, range(j0, n));
-            auto b2 = slice(B, j2, range(j0, n));
-            auto b3 = slice(B, j3, range(j0, n));
-            rot(b0, b1, cyr, syr);
-            rot(b2, b3, cyl, syl);
-            rot(b2, b0, cy1, sy1);
-            rot(b3, b1, cy2, sy2);
+            for (idx_t j = 0; j < 8; ++j)
+                for (idx_t i = 0; i < 8; ++i)
+                    M(i, j) = (T)0;
 
-            auto q0 = col(Q, j0);
-            auto q1 = col(Q, j1);
-            auto q2 = col(Q, j2);
-            auto q3 = col(Q, j3);
-            rot(q0, q1, cyr, syr);
-            rot(q2, q3, cyl, syl);
-            rot(q2, q0, cy1, sy1);
-            rot(q3, q1, cy2, sy2);
+            /// Construct matrix with kronecker structure
+            // I (x) AA(2:3,2:3)
+            M(0, 0) = AA(2, 2);
+            M(0, 1) = AA(2, 3);
+            M(1, 0) = AA(3, 2);
+            M(1, 1) = AA(3, 3);
+            M(2, 2) = AA(2, 2);
+            M(2, 3) = AA(2, 3);
+            M(3, 2) = AA(3, 2);
+            M(3, 3) = AA(3, 3);
+            // -AA(0:1,0:1)^T (x) I
+            M(0, 4) = -AA(0, 0);
+            M(0, 5) = -AA(1, 0);
+            M(1, 6) = -AA(0, 0);
+            M(1, 7) = -AA(1, 0);
+            M(2, 4) = -AA(0, 1);
+            M(2, 5) = -AA(1, 1);
+            M(3, 6) = -AA(0, 1);
+            M(3, 7) = -AA(1, 1);
+
+            // I (x) BB(2:3,2:3)
+            M(4, 0) = BB(2, 2);
+            M(4, 1) = BB(2, 3);
+            M(5, 0) = BB(3, 2);
+            M(5, 1) = BB(3, 3);
+            M(6, 2) = BB(2, 2);
+            M(6, 3) = BB(2, 3);
+            M(7, 2) = BB(3, 2);
+            M(7, 3) = BB(3, 3);
+            // -BB(0:1,0:1)^T (x) I
+            M(4, 4) = -BB(0, 0);
+            M(4, 5) = -BB(1, 0);
+            M(5, 6) = -BB(0, 0);
+            M(5, 7) = -BB(1, 0);
+            M(6, 4) = -BB(0, 1);
+            M(6, 5) = -BB(1, 1);
+            M(7, 6) = -BB(0, 1);
+            M(7, 7) = -BB(1, 1);
+
+            // RHS
+            x[0] = AA(2, 0);
+            x[1] = AA(3, 0);
+            x[2] = AA(2, 1);
+            x[3] = AA(3, 1);
+            x[4] = BB(2, 0);
+            x[5] = BB(3, 0);
+            x[6] = BB(2, 1);
+            x[7] = BB(3, 1);
+
+            // LU of M
+            int ierr = getrf(M, piv);
+            if (ierr != 0) return 1;
+            // Apply pivot to rhs
+            for (idx_t i = 0; i < 8; ++i) {
+                if (i != piv[i]) std::swap(x[i], x[piv[i]]);
+            }
+            // Solve Ly = rhs
+            trsv(LOWER_TRIANGLE, NO_TRANS, UNIT_DIAG, M, x);
+            // Solve Ux = y
+            trsv(UPPER_TRIANGLE, NO_TRANS, NON_UNIT_DIAG, M, x);
+
+            // Find Zc so that
+            //       [ 1      0    ]   [ *  * ]
+            //  Zc^T [ 0      1    ] = [ *  * ]
+            //       [ -x[0] -x[2] ]   [ 0  0 ]
+            //       [ -x[1] -x[3] ]   [ 0  0 ]
+
+            // Rotation to make X upper triangular
+            T cxl1, sxl1;
+            rotg(x[0], x[1], cxl1, sxl1);
+            x[1] = (T)0;
+            T rottemp = cxl1 * x[2] + sxl1 * x[3];
+            x[3] = -sxl1 * x[2] + cxl1 * x[3];
+            x[2] = rottemp;
+            // SVD of (upper triangular) X
+            T cxl2, sxl2, cxr, sxr, ssx1, ssx2;
+            svd22(x[0], x[2], x[3], ssx2, ssx1, cxl2, sxl2, cxr, sxr);
+            // Fuse left rotations
+            T cxl, sxl;
+            cxl = cxl1 * cxl2 - sxl1 * sxl2;
+            sxl = cxl2 * sxl1 + sxl2 * cxl1;
+            // Rotations based on the singular values
+            ssx1 = -ssx1;
+            ssx2 = -ssx2;
+            T temp = (T)1;
+            T cx1, sx1, cx2, sx2;
+            rotg(temp, ssx1, cx1, sx1);
+            temp = (T)1;
+            rotg(temp, ssx2, cx2, sx2);
+
+            // Find Qc so that
+            //       [ 1     0     ]   [ 0  0 ]
+            //  Qc^T  [ 0     1     ] = [ 0  0 ]
+            //       [ x[4]  x[6]  ]   [ *  * ]
+            //       [ x[5]  x[7]  ]   [ *  * ]
+
+            // Rotation to make Y^T upper triangular
+            T cyl1, syl1;
+            rotg(x[4], x[5], cyl1, syl1);
+            x[5] = (T)0;
+            rottemp = cyl1 * x[6] + syl1 * x[7];
+            x[7] = -syl1 * x[6] + cyl1 * x[7];
+            x[6] = rottemp;
+            // SVD of (upper triangular) Y
+            T cyl2, syl2, cyr, syr, ssy1, ssy2;
+            svd22(x[4], x[6], x[7], ssy2, ssy1, cyl2, syl2, cyr, syr);
+            // Fuse left rotations
+            T cyl, syl;
+            cyl = cyl1 * cyl2 - syl1 * syl2;
+            syl = cyl2 * syl1 + syl2 * cyl1;
+            // Rotations based on the singular values
+            temp = (T)1;
+            ssx1 = -ssx1;
+            ssx2 = -ssx2;
+            T cy1, sy1, cy2, sy2;
+            rotg(temp, ssy1, cy1, sy1);
+            temp = (T)1;
+            rotg(temp, ssy2, cy2, sy2);
+
+            // Apply rotations from the left to local matrices
+            {
+                auto a0 = row(AA, 0);
+                auto a1 = row(AA, 1);
+                auto a2 = row(AA, 2);
+                auto a3 = row(AA, 3);
+                rot(a0, a1, cyr, syr);
+                rot(a2, a3, cyl, syl);
+                rot(a0, a2, cy1, -sy1);
+                rot(a1, a3, cy2, -sy2);
+
+                auto b0 = row(BB, 0);
+                auto b1 = row(BB, 1);
+                auto b2 = row(BB, 2);
+                auto b3 = row(BB, 3);
+                rot(b0, b1, cyr, syr);
+                rot(b2, b3, cyl, syl);
+                rot(b0, b2, cy1, -sy1);
+                rot(b1, b3, cy2, -sy2);
+
+                auto q0 = col(QQ, 0);
+                auto q1 = col(QQ, 1);
+                auto q2 = col(QQ, 2);
+                auto q3 = col(QQ, 3);
+
+                rot(q0, q1, cyr, syr);
+                rot(q2, q3, cyl, syl);
+                rot(q0, q2, cy1, -sy1);
+                rot(q1, q3, cy2, -sy2);
+            }
+            // Apply rotations from the right to local matrices
+            {
+                auto a0 = col(AA, 0);
+                auto a1 = col(AA, 1);
+                auto a2 = col(AA, 2);
+                auto a3 = col(AA, 3);
+                rot(a0, a1, cxr, sxr);
+                rot(a2, a3, cxl, sxl);
+                rot(a0, a2, cx1, sx1);
+                rot(a1, a3, cx2, sx2);
+
+                auto b0 = col(BB, 0);
+                auto b1 = col(BB, 1);
+                auto b2 = col(BB, 2);
+                auto b3 = col(BB, 3);
+                rot(b0, b1, cxr, sxr);
+                rot(b2, b3, cxl, sxl);
+                rot(b0, b2, cx1, sx1);
+                rot(b1, b3, cx2, sx2);
+
+                auto z0 = col(ZZ, 0);
+                auto z1 = col(ZZ, 1);
+                auto z2 = col(ZZ, 2);
+                auto z3 = col(ZZ, 3);
+                rot(z0, z1, cxr, sxr);
+                rot(z2, z3, cxl, sxl);
+                rot(z0, z2, cx1, sx1);
+                rot(z1, z3, cx2, sx2);
+            }
+
+            enorma = lange(FROB_NORM, slice(AA, range(2, 4), range(0, 2)));
+            enormb = lange(FROB_NORM, slice(BB, range(2, 4), range(0, 2)));
+            iter++;
         }
 
-        // Apply rotations from the right
-        {
-            auto a0 = slice(A, range(0, j3 + 1), j0);
-            auto a1 = slice(A, range(0, j3 + 1), j1);
-            auto a2 = slice(A, range(0, j3 + 1), j2);
-            auto a3 = slice(A, range(0, j3 + 1), j3);
-            rot(a0, a1, cxl, sxl);
-            rot(a2, a3, cxr, sxr);
-            rot(a0, a2, cx1, sx1);
-            rot(a1, a3, cx2, sx2);
-
-            auto b0 = slice(B, range(0, j3 + 1), j0);
-            auto b1 = slice(B, range(0, j3 + 1), j1);
-            auto b2 = slice(B, range(0, j3 + 1), j2);
-            auto b3 = slice(B, range(0, j3 + 1), j3);
-            rot(b0, b1, cxl, sxl);
-            rot(b2, b3, cxr, sxr);
-            rot(b0, b2, cx1, sx1);
-            rot(b1, b3, cx2, sx2);
-
-            auto z0 = col(Z, j0);
-            auto z1 = col(Z, j1);
-            auto z2 = col(Z, j2);
-            auto z3 = col(Z, j3);
-            rot(z0, z1, cxl, sxl);
-            rot(z2, z3, cxr, sxr);
-            rot(z0, z2, cx1, sx1);
-            rot(z1, z3, cx2, sx2);
-        }
+        // TODO: apply accumulated rotations to the original matrices
 
         // Set relevant parts to zero
         A(j2, j0) = (T)0;

--- a/include/tlapack/lapack/generalized_schur_swap.hpp
+++ b/include/tlapack/lapack/generalized_schur_swap.hpp
@@ -13,6 +13,7 @@
 #define TLAPACK_GENERALIZED_SCHUR_SWAP_HH
 
 #include "tlapack/base/utils.hpp"
+#include "tlapack/blas/gemm.hpp"
 #include "tlapack/blas/rot.hpp"
 #include "tlapack/blas/rotg.hpp"
 #include "tlapack/blas/swap.hpp"
@@ -569,7 +570,9 @@ int generalized_schur_swap(bool want_q,
         x[7] = B(j1, j3);
         // LU of M
         int ierr = getrf(M, piv);
-        if (ierr != 0) return 1;
+        if (ierr != 0) {
+            return 1;
+        }
         // Apply pivot to rhs
         for (idx_t i = 0; i < 8; ++i) {
             if (i != piv[i]) std::swap(x[i], x[piv[i]]);
@@ -722,12 +725,12 @@ int generalized_schur_swap(bool want_q,
         idx_t iter = 0;
         T tolA = max((T)20 * norma * eps, small_num);
         T tolB = max((T)20 * normb * eps, small_num);
-        while (iter < 30) {
-            std::cout << "enorma: " << enorma << " tolA: " << tolA
-                      << " enormb: " << enormb << " tolB: " << tolB
-                      << std::endl;
+        const idx_t max_iter = 6;
+        while (iter < max_iter) {
             if (enorma <= tolA and enormb <= tolB) break;
-            if (iter == 29) return 1;
+            if (iter == max_iter - 1) {
+                return 1;
+            }
             // The swap is not (yet) accepted, apply iterative refinement to
             // try to improve the swap.
 
@@ -831,14 +834,14 @@ int generalized_schur_swap(bool want_q,
             //       [ x[4]  x[6]  ]   [ *  * ]
             //       [ x[5]  x[7]  ]   [ *  * ]
 
-            // Rotation to make Y^T upper triangular
+            std::swap(x[5], x[6]);
             T cyl1, syl1;
             rotg(x[4], x[5], cyl1, syl1);
             x[5] = (T)0;
             rottemp = cyl1 * x[6] + syl1 * x[7];
             x[7] = -syl1 * x[6] + cyl1 * x[7];
             x[6] = rottemp;
-            // SVD of (upper triangular) Y
+            // SVD of (upper triangular) X
             T cyl2, syl2, cyr, syr, ssy1, ssy2;
             svd22(x[4], x[6], x[7], ssy2, ssy1, cyl2, syl2, cyr, syr);
             // Fuse left rotations
@@ -846,9 +849,9 @@ int generalized_schur_swap(bool want_q,
             cyl = cyl1 * cyl2 - syl1 * syl2;
             syl = cyl2 * syl1 + syl2 * cyl1;
             // Rotations based on the singular values
+            ssy1 = -ssy1;
+            ssy2 = -ssy2;
             temp = (T)1;
-            ssx1 = -ssx1;
-            ssx2 = -ssx2;
             T cy1, sy1, cy2, sy2;
             rotg(temp, ssy1, cy1, sy1);
             temp = (T)1;
@@ -862,8 +865,8 @@ int generalized_schur_swap(bool want_q,
                 auto a3 = row(AA, 3);
                 rot(a0, a1, cyr, syr);
                 rot(a2, a3, cyl, syl);
-                rot(a0, a2, cy1, -sy1);
-                rot(a1, a3, cy2, -sy2);
+                rot(a0, a2, cy1, sy1);
+                rot(a1, a3, cy2, sy2);
 
                 auto b0 = row(BB, 0);
                 auto b1 = row(BB, 1);
@@ -871,8 +874,8 @@ int generalized_schur_swap(bool want_q,
                 auto b3 = row(BB, 3);
                 rot(b0, b1, cyr, syr);
                 rot(b2, b3, cyl, syl);
-                rot(b0, b2, cy1, -sy1);
-                rot(b1, b3, cy2, -sy2);
+                rot(b0, b2, cy1, sy1);
+                rot(b1, b3, cy2, sy2);
 
                 auto q0 = col(QQ, 0);
                 auto q1 = col(QQ, 1);
@@ -881,8 +884,8 @@ int generalized_schur_swap(bool want_q,
 
                 rot(q0, q1, cyr, syr);
                 rot(q2, q3, cyl, syl);
-                rot(q0, q2, cy1, -sy1);
-                rot(q1, q3, cy2, -sy2);
+                rot(q0, q2, cy1, sy1);
+                rot(q1, q3, cy2, sy2);
             }
             // Apply rotations from the right to local matrices
             {
@@ -919,7 +922,60 @@ int generalized_schur_swap(bool want_q,
             iter++;
         }
 
-        // TODO: apply accumulated rotations to the original matrices
+        // TODO: this is a large workspace, add it to the interface
+        std::vector<T> workl_;
+        auto workl = new_matrix(workl_, 4, n);
+        std::vector<T> workr_;
+        auto workr = new_matrix(workr_, n, 4);
+
+        // Apply QQ
+        {
+            auto A_slice = slice(A, range(j0, j3 + 1), range(j0, n));
+            auto work_slice = slice(workl, range(0, 4), range(j0, n));
+            gemm(TRANSPOSE, NO_TRANS, (T)1, QQ, A_slice, StrongZero(T(0)),
+                 work_slice);
+            lacpy(GENERAL, work_slice, A_slice);
+        }
+        {
+            auto B_slice = slice(B, range(j0, j3 + 1), range(j0, n));
+            auto work_slice = slice(workl, range(0, 4), range(j0, n));
+            gemm(TRANSPOSE, NO_TRANS, (T)1, QQ, B_slice, StrongZero(T(0)),
+                 work_slice);
+            lacpy(GENERAL, work_slice, B_slice);
+        }
+        {
+            auto Q_slice = slice(Q, range(0, n), range(j0, j3 + 1));
+            auto work_slice = slice(workr, range(0, n), range(0, 4));
+            gemm(NO_TRANS, NO_TRANS, (T)1, Q_slice, QQ, StrongZero(T(0)),
+                 work_slice);
+            lacpy(GENERAL, work_slice, Q_slice);
+        }
+        // Apply ZZ
+        {
+            auto A_slice =
+                slice(A, range(0, min(n, j3 + 1)), range(j0, j3 + 1));
+            auto work_slice =
+                slice(workr, range(0, min(n, j3 + 1)), range(0, 4));
+            gemm(NO_TRANS, NO_TRANS, (T)1, A_slice, ZZ, StrongZero(T(0)),
+                 work_slice);
+            lacpy(GENERAL, work_slice, A_slice);
+        }
+        {
+            auto B_slice =
+                slice(B, range(0, min(n, j3 + 1)), range(j0, j3 + 1));
+            auto work_slice =
+                slice(workr, range(0, min(n, j3 + 1)), range(0, 4));
+            gemm(NO_TRANS, NO_TRANS, (T)1, B_slice, ZZ, StrongZero(T(0)),
+                 work_slice);
+            lacpy(GENERAL, work_slice, B_slice);
+        }
+        {
+            auto Z_slice = slice(Z, range(0, n), range(j0, j3 + 1));
+            auto work_slice = slice(workr, range(0, n), range(0, 4));
+            gemm(NO_TRANS, NO_TRANS, (T)1, Z_slice, ZZ, StrongZero(T(0)),
+                 work_slice);
+            lacpy(GENERAL, work_slice, Z_slice);
+        }
 
         // Set relevant parts to zero
         A(j2, j0) = (T)0;

--- a/include/tlapack/lapack/lahqz_schur22.hpp
+++ b/include/tlapack/lapack/lahqz_schur22.hpp
@@ -26,7 +26,7 @@ namespace tlapack {
  * (A, B) = (Q*S*Z', Q*T*Z'), where T is upper triangular, S is
  * quasi-triangular, and Q and Z are unitary.
  *
- * Q' is given by [cl, sl; -conj(sl), cl] and Z is given by [cr, -conj(sr); sr,
+ * Q is given by [cl, -sl; conj(sl), cl] and Z is given by [cr, -conj(sr); sr,
  * cr][scal0 0; 0 scal1].
  *
  *
@@ -131,8 +131,6 @@ void lahqz_schur22(A_t& A,
         temp = cl * B(0, 1) + sl * B(1, 1);
         B(1, 1) = cl * B(1, 1) - conj(sl) * B(0, 1);
         B(0, 1) = temp;
-
-        sl = conj(sl);
 
         cr = real_t(1);
         sr = TA(0);
@@ -251,8 +249,6 @@ void lahqz_schur22(A_t& A,
             temp = cl * B(0, 1) + sl * B(1, 1);
             B(1, 1) = cl * B(1, 1) - conj(sl) * B(0, 1);
             B(0, 1) = temp;
-
-            sl = conj(sl);
         }
         else {
             if constexpr (is_real<TA>) {

--- a/include/tlapack/lapack/lahqz_schur22.hpp
+++ b/include/tlapack/lapack/lahqz_schur22.hpp
@@ -223,24 +223,45 @@ void lahqz_schur22(A_t& A,
             //
             // Now make both A and B upper triangular by applying a left
             // rotation
+            // It is hard to predict whether zeroing A(1,0) or B(1,0) will be
+            // more stable, so we try both and pick the one that gives the
+            // smallest error. Note: the normwise criterion used in LAPACK does
+            // not always work!
             //
-
             real_t Anrm = max<real_t>(abs1(A(0, 0)) + abs1(A(0, 1)),
                                       abs1(A(1, 0)) + abs1(A(1, 1)));
             real_t Bnrm = max<real_t>(abs1(B(0, 0)) + abs1(B(0, 1)),
                                       abs1(B(1, 0)) + abs1(B(1, 1)));
-            if (Anrm >= Bnrm) {
-                rotg(A(0, 0), A(1, 0), cl, sl);
-                A(1, 0) = TA(0);
-                B(0, 0) = cl * B(0, 0) + sl * B(1, 0);
-                B(1, 0) = TA(0);
+
+            real_t clA, clB;
+            TA slA, slB;
+
+            // Generate rotation based on A and calculate
+            // the resulting B(1,0)
+            TA tempA0 = A(0, 0);
+            TA tempA1 = A(1, 0);
+            rotg(tempA0, tempA1, clA, slA);
+            TA eB10 = -conj(slA) * B(0, 0) + clA * B(1, 0);
+
+            TA tempB0 = B(0, 0);
+            TA tempB1 = B(1, 0);
+            rotg(tempB0, tempB1, clB, slB);
+            TA eA10 = -conj(slB) * A(0, 0) + clB * A(1, 0);
+
+            if (abs1(eA10) * Bnrm <= abs1(eB10) * Anrm) {
+                cl = clB;
+                sl = slB;
+                B(0, 0) = tempB0;
+                A(0, 0) = cl * A(0, 0) + sl * A(1, 0);
             }
             else {
-                rotg(B(0, 0), B(1, 0), cl, sl);
-                B(1, 0) = TA(0);
-                A(0, 0) = cl * A(0, 0) + sl * A(1, 0);
-                A(1, 0) = TA(0);
+                cl = clA;
+                sl = slA;
+                A(0, 0) = tempA0;
+                B(0, 0) = cl * B(0, 0) + sl * B(1, 0);
             }
+            A(1, 0) = TA(0);
+            B(1, 0) = TA(0);
 
             // Apply the rotation to A, B, and form Q
             temp = cl * A(0, 1) + sl * A(1, 1);

--- a/include/tlapack/lapack/lahqz_schur22.hpp
+++ b/include/tlapack/lapack/lahqz_schur22.hpp
@@ -26,6 +26,10 @@ namespace tlapack {
  * (A, B) = (Q*S*Z', Q*T*Z'), where T is upper triangular, S is
  * quasi-triangular, and Q and Z are unitary.
  *
+ * Q' is given by [cl, sl; -conj(sl), cl] and Z is given by [cr, -conj(sr); sr,
+ * cr][scal0 0; 0 scal1].
+ *
+ *
  * The Schur factorization is normalized in the following way:
  * - If the matrix is complex, or if the matrix has real eigenvalues,
  *   then S is upper triangular.
@@ -39,31 +43,35 @@ namespace tlapack {
  * @param[in,out] B 2x2 upper triangular matrix
  *                On entry, the matrix B.
  *                On exit, the matrix T.
- * @param[out]    Q 2x2 unitary matrix
- *                   On exit, the matrix Q.
- * @param[out]    Z 2x2 unitary matrix
- *                   On exit, the matrix Z.
  * @param[out]    alpha1 complex number
  * @param[out]    alpha2 complex number
  * @param[out]    beta1 number
  * @param[out]    beta2 number
  *                   On exit, (alpha1, beta1), (alpha2, beta2) are the
  *                   generalized eigenvalues of the pencil (A,B)
+ * @param[out]    cl cosine of left rotation
+ * @param[out]    sl sine of left rotation
+ * @param[out]    cr cosine of right rotation
+ * @param[out]    sr sine of right rotation
+ * @param[out]    scal0 scaling factor for first column of Z
+ * @param[out]    scal1 scaling factor for second column of Z
+ *
  *
  *
  */
-template <TLAPACK_MATRIX A_t,
-          TLAPACK_MATRIX B_t,
-          TLAPACK_MATRIX Q_t,
-          TLAPACK_MATRIX Z_t>
+template <TLAPACK_MATRIX A_t, TLAPACK_MATRIX B_t>
 void lahqz_schur22(A_t& A,
                    B_t& B,
-                   Q_t& Q,
-                   Z_t& Z,
                    complex_type<type_t<A_t>>& alpha1,
                    complex_type<type_t<A_t>>& alpha2,
                    real_type<type_t<A_t>>& beta1,
-                   real_type<type_t<A_t>>& beta2)
+                   real_type<type_t<A_t>>& beta2,
+                   real_type<type_t<A_t>>& cl,
+                   type_t<A_t>& sl,
+                   real_type<type_t<A_t>>& cr,
+                   type_t<A_t>& sr,
+                   type_t<A_t>& scal0,
+                   type_t<A_t>& scal1)
 {
     using TA = type_t<A_t>;
     using real_t = real_type<TA>;
@@ -100,8 +108,12 @@ void lahqz_schur22(A_t& A,
     real_t tst = abs1(A(0, 0)) + abs1(A(1, 1));
     if (abs1(A(1, 0)) <= eps * tst) {
         A(1, 0) = TA(0);
-        laset(GENERAL, TA(0), TA(1), Q);
-        laset(GENERAL, TA(0), TA(1), Z);
+
+        cl = real_t(1);
+        sl = TA(0);
+
+        cr = real_t(1);
+        sr = TA(0);
     }
     //
     // Check if B is singular
@@ -111,43 +123,35 @@ void lahqz_schur22(A_t& A,
     //
     else if (abs1(B(0, 0)) <= eps) {
         B(0, 0) = TA(0);
-        real_t c;
-        TA s;
-        rotg(A(0, 0), A(1, 0), c, s);
+        rotg(A(0, 0), A(1, 0), cl, sl);
         A(1, 0) = TA(0);
-        TA temp = c * A(0, 1) + s * A(1, 1);
-        A(1, 1) = c * A(1, 1) - conj(s) * A(0, 1);
+        TA temp = cl * A(0, 1) + sl * A(1, 1);
+        A(1, 1) = cl * A(1, 1) - conj(sl) * A(0, 1);
         A(0, 1) = temp;
-        temp = c * B(0, 1) + s * B(1, 1);
-        B(1, 1) = c * B(1, 1) - conj(s) * B(0, 1);
+        temp = cl * B(0, 1) + sl * B(1, 1);
+        B(1, 1) = cl * B(1, 1) - conj(sl) * B(0, 1);
         B(0, 1) = temp;
 
-        Q(0, 0) = c;
-        Q(1, 0) = conj(s);
-        Q(0, 1) = -s;
-        Q(1, 1) = c;
+        sl = conj(sl);
 
-        laset(GENERAL, TA(0), TA(1), Z);
+        cr = real_t(1);
+        sr = TA(0);
     }
     else if (abs1(B(1, 1)) <= eps) {
         B(1, 1) = TA(0);
-        real_t c;
-        TA s;
-        rotg(A(1, 1), A(1, 0), c, s);
+        rotg(A(1, 1), A(1, 0), cr, sr);
         A(1, 0) = TA(0);
-        TA temp = c * A(0, 1) + s * A(0, 0);
-        A(0, 0) = c * A(0, 0) - conj(s) * A(0, 1);
+        TA temp = cr * A(0, 1) + sr * A(0, 0);
+        A(0, 0) = cr * A(0, 0) - conj(sr) * A(0, 1);
         A(0, 1) = temp;
-        temp = c * B(0, 1) + s * B(0, 0);
-        B(0, 0) = c * B(0, 0) - conj(s) * B(0, 1);
+        temp = cr * B(0, 1) + sr * B(0, 0);
+        B(0, 0) = cr * B(0, 0) - conj(sr) * B(0, 1);
         B(0, 1) = temp;
 
-        Z(0, 0) = c;
-        Z(0, 1) = s;
-        Z(1, 0) = -conj(s);
-        Z(1, 1) = c;
+        sr = -conj(sr);
 
-        laset(GENERAL, TA(0), TA(1), Q);
+        cl = real_t(1);
+        sl = TA(0);
     }
     else {
         // A cannot be deflated and B is nonsingular
@@ -191,37 +195,32 @@ void lahqz_schur22(A_t& A,
                 qq = lapy2(h10, h11);
             }
 
-            real_t c;
-            TA s;
             if (rr > qq) {
                 // Find right rotation matrix to zero 0,0 element
                 // of (sA - wB)
-                rotg(h01, h00, c, s);
+                rotg(h01, h00, cr, sr);
             }
             else {
                 // Find right rotation matrix to zero 1,0 element
                 // of (sA - wB)
-                rotg(h11, h10, c, s);
+                rotg(h11, h10, cr, sr);
             }
 
             // Apply the rotation to A, B, and form Z
             TA temp;
-            temp = c * A(0, 1) + s * A(0, 0);
-            A(0, 0) = c * A(0, 0) - conj(s) * A(0, 1);
+            temp = cr * A(0, 1) + sr * A(0, 0);
+            A(0, 0) = cr * A(0, 0) - conj(sr) * A(0, 1);
             A(0, 1) = temp;
-            temp = c * A(1, 1) + s * A(1, 0);
-            A(1, 0) = c * A(1, 0) - conj(s) * A(1, 1);
+            temp = cr * A(1, 1) + sr * A(1, 0);
+            A(1, 0) = cr * A(1, 0) - conj(sr) * A(1, 1);
             A(1, 1) = temp;
-            temp = c * B(0, 1) + s * B(0, 0);
-            B(0, 0) = c * B(0, 0) - conj(s) * B(0, 1);
+            temp = cr * B(0, 1) + sr * B(0, 0);
+            B(0, 0) = cr * B(0, 0) - conj(sr) * B(0, 1);
             B(0, 1) = temp;
-            B(1, 0) = -conj(s) * B(1, 1);
-            B(1, 1) = c * B(1, 1);
+            B(1, 0) = -conj(sr) * B(1, 1);
+            B(1, 1) = cr * B(1, 1);
 
-            Z(0, 0) = c;
-            Z(0, 1) = s;
-            Z(1, 0) = -conj(s);
-            Z(1, 1) = c;
+            sr = -conj(sr);
 
             //
             // Now make both A and B upper triangular by applying a left
@@ -233,41 +232,35 @@ void lahqz_schur22(A_t& A,
             real_t Bnrm = max<real_t>(abs1(B(0, 0)) + abs1(B(0, 1)),
                                       abs1(B(1, 0)) + abs1(B(1, 1)));
             if (Anrm >= Bnrm) {
-                rotg(A(0, 0), A(1, 0), c, s);
+                rotg(A(0, 0), A(1, 0), cl, sl);
                 A(1, 0) = TA(0);
-                B(0, 0) = c * B(0, 0) + s * B(1, 0);
+                B(0, 0) = cl * B(0, 0) + sl * B(1, 0);
                 B(1, 0) = TA(0);
             }
             else {
-                rotg(B(0, 0), B(1, 0), c, s);
+                rotg(B(0, 0), B(1, 0), cl, sl);
                 B(1, 0) = TA(0);
-                A(0, 0) = c * A(0, 0) + s * A(1, 0);
+                A(0, 0) = cl * A(0, 0) + sl * A(1, 0);
                 A(1, 0) = TA(0);
             }
 
             // Apply the rotation to A, B, and form Q
-            temp = c * A(0, 1) + s * A(1, 1);
-            A(1, 1) = c * A(1, 1) - conj(s) * A(0, 1);
+            temp = cl * A(0, 1) + sl * A(1, 1);
+            A(1, 1) = cl * A(1, 1) - conj(sl) * A(0, 1);
             A(0, 1) = temp;
-            temp = c * B(0, 1) + s * B(1, 1);
-            B(1, 1) = c * B(1, 1) - conj(s) * B(0, 1);
+            temp = cl * B(0, 1) + sl * B(1, 1);
+            B(1, 1) = cl * B(1, 1) - conj(sl) * B(0, 1);
             B(0, 1) = temp;
 
-            Q(0, 0) = c;
-            Q(1, 0) = conj(s);
-            Q(0, 1) = -s;
-            Q(1, 1) = c;
+            sl = conj(sl);
         }
         else {
             if constexpr (is_real<TA>) {
-                laset(GENERAL, TA(0), TA(1), Q);
-                laset(GENERAL, TA(0), TA(1), Z);
-
                 // The pencil is real and has complex conjugate eigenvalues.
                 // It cannot be reduced further without using complex
                 // arithmetic. As normalization, we make B a diagonal matrix
                 // using a 2x2 SVD.
-                real_t ssmin, ssmax, cl, sl, cr, sr;
+                real_t ssmin, ssmax;
                 svd22<real_t>(B(0, 0), B(0, 1), B(1, 1), ssmin, ssmax, cl, sl,
                               cr, sr);
                 B(0, 0) = ssmax;
@@ -282,11 +275,6 @@ void lahqz_schur22(A_t& A,
                 A(1, 1) = cl * A(1, 1) - sl * A(0, 1);
                 A(0, 1) = temp;
 
-                Q(0, 0) = cl;
-                Q(1, 0) = sl;
-                Q(0, 1) = -sl;
-                Q(1, 1) = cl;
-
                 // Apply right rotation to A and form Z
                 temp = cr * A(0, 0) + sr * A(0, 1);
                 A(0, 1) = cr * A(0, 1) - sr * A(0, 0);
@@ -294,11 +282,6 @@ void lahqz_schur22(A_t& A,
                 temp = cr * A(1, 0) + sr * A(1, 1);
                 A(1, 1) = cr * A(1, 1) - sr * A(1, 0);
                 A(1, 0) = temp;
-
-                Z(0, 0) = cr;
-                Z(0, 1) = -sr;
-                Z(1, 0) = sr;
-                Z(1, 1) = cr;
             }
         }
     }
@@ -320,7 +303,7 @@ void lahqz_schur22(A_t& A,
             c = -c;
             s = -s;
         }
-        TA scal0 = complex_t(c, -s);
+        scal0 = complex_t(c, -s);
         B(0, 0) = br;
         A(0, 0) *= scal0;
         A(1, 0) *= scal0;
@@ -333,33 +316,28 @@ void lahqz_schur22(A_t& A,
             c = -c;
             s = -s;
         }
-        TA scal1 = complex_t(c, -s);
+        scal1 = complex_t(c, -s);
         B(1, 1) = br;
         B(0, 1) *= scal1;
         A(0, 1) *= scal1;
         A(1, 1) *= scal1;
-
-        Z(0, 0) *= scal0;
-        Z(1, 0) *= scal0;
-        Z(0, 1) *= scal1;
-        Z(1, 1) *= scal1;
     }
     else {
         // Ensure that the diagonal of B is non-negative
+        scal0 = TA(1);
+        scal1 = TA(1);
         if (B(0, 0) < 0) {
             B(0, 0) = -B(0, 0);
             A(0, 0) = -A(0, 0);
             A(1, 0) = -A(1, 0);
-            Z(0, 0) = -Z(0, 0);
-            Z(1, 0) = -Z(1, 0);
+            scal0 = TA(-1);
         }
         if (B(1, 1) < 0) {
             B(0, 1) = -B(0, 1);
             B(1, 1) = -B(1, 1);
             A(0, 1) = -A(0, 1);
             A(1, 1) = -A(1, 1);
-            Z(0, 1) = -Z(0, 1);
-            Z(1, 1) = -Z(1, 1);
+            scal1 = TA(-1);
         }
     }
 

--- a/test/src/test_qz_schur22.cpp
+++ b/test/src/test_qz_schur22.cpp
@@ -91,8 +91,8 @@ TEMPLATE_TEST_CASE(
                       scal1);
 
         Q(0, 0) = cl;
-        Q(0, 1) = -conj(sl);
-        Q(1, 0) = sl;
+        Q(0, 1) = -sl;
+        Q(1, 0) = conj(sl);
         Q(1, 1) = cl;
 
         Z(0, 0) = cr * scal0;
@@ -234,8 +234,8 @@ TEMPLATE_TEST_CASE(
                       scal1);
 
         Q(0, 0) = cl;
-        Q(0, 1) = -conj(sl);
-        Q(1, 0) = sl;
+        Q(0, 1) = -sl;
+        Q(1, 0) = conj(sl);
         Q(1, 1) = cl;
 
         Z(0, 0) = cr * scal0;
@@ -391,8 +391,8 @@ TEMPLATE_TEST_CASE(
                       scal1);
 
         Q(0, 0) = cl;
-        Q(0, 1) = -conj(sl);
-        Q(1, 0) = sl;
+        Q(0, 1) = -sl;
+        Q(1, 0) = conj(sl);
         Q(1, 1) = cl;
 
         Z(0, 0) = cr * scal0;

--- a/test/src/test_qz_schur22.cpp
+++ b/test/src/test_qz_schur22.cpp
@@ -84,7 +84,21 @@ TEMPLATE_TEST_CASE(
         real_t beta1, beta2;
         complex_t alpha1, alpha2;
 
-        lahqz_schur22(S, T, Q, Z, alpha1, alpha2, beta1, beta2);
+        real_t cl, cr;
+        TA sl, sr, scal0, scal1;
+
+        lahqz_schur22(S, T, alpha1, alpha2, beta1, beta2, cl, sl, cr, sr, scal0,
+                      scal1);
+
+        Q(0, 0) = cl;
+        Q(0, 1) = -conj(sl);
+        Q(1, 0) = sl;
+        Q(1, 1) = cl;
+
+        Z(0, 0) = cr * scal0;
+        Z(0, 1) = -conj(sr) * scal1;
+        Z(1, 0) = sr * scal0;
+        Z(1, 1) = cr * scal1;
 
         // Check that the eigenvalues match with the diagonal elements
         CHECK(abs1(alpha1 - S(0, 0)) <= eps * max(real_t(1), abs1(S(0, 0))));
@@ -213,7 +227,21 @@ TEMPLATE_TEST_CASE(
         real_t beta1, beta2;
         complex_t alpha1, alpha2;
 
-        lahqz_schur22(S, T, Q, Z, alpha1, alpha2, beta1, beta2);
+        real_t cl, cr;
+        TA sl, sr, scal0, scal1;
+
+        lahqz_schur22(S, T, alpha1, alpha2, beta1, beta2, cl, sl, cr, sr, scal0,
+                      scal1);
+
+        Q(0, 0) = cl;
+        Q(0, 1) = -conj(sl);
+        Q(1, 0) = sl;
+        Q(1, 1) = cl;
+
+        Z(0, 0) = cr * scal0;
+        Z(0, 1) = -conj(sr) * scal1;
+        Z(1, 0) = sr * scal0;
+        Z(1, 1) = cr * scal1;
 
         // Check that the eigenvalues match with the diagonal elements
         CHECK(abs1(alpha1 - S(0, 0)) <= eps * max(real_t(1), abs1(S(0, 0))));
@@ -356,7 +384,21 @@ TEMPLATE_TEST_CASE(
         real_t beta1, beta2;
         complex_t alpha1, alpha2;
 
-        lahqz_schur22(S, T, Q, Z, alpha1, alpha2, beta1, beta2);
+        real_t cl, cr;
+        TA sl, sr, scal0, scal1;
+
+        lahqz_schur22(S, T, alpha1, alpha2, beta1, beta2, cl, sl, cr, sr, scal0,
+                      scal1);
+
+        Q(0, 0) = cl;
+        Q(0, 1) = -conj(sl);
+        Q(1, 0) = sl;
+        Q(1, 1) = cl;
+
+        Z(0, 0) = cr * scal0;
+        Z(0, 1) = -conj(sr) * scal1;
+        Z(1, 0) = sr * scal0;
+        Z(1, 1) = cr * scal1;
 
         // Check that the diagonal of B is real and non-negative
         CHECK(real(T(0, 0)) >= real_t(0));


### PR DESCRIPTION
Improved generalized schur swap in the following ways:

Improved stability of swapping 1x1 with 2x2 blocks by trying both options.

Added iterative refinement for swapping 2x2 with 2x2 blocks, allowing ill-conditioned blocks with close eigenvalues to still be swapped accurately (in most cases, it may take too many iterations for some blocks)

Always use the full normalization using schur22 instead of only apply the svd normalisation. Slightly rewrote the interface of schur22 to facilitate that.

I occasionally got large errors which could be attributed to schur22. I updated one of the selection criteria there which significantly reduced the error. I will definitely look into pushing that change to LAPACK.

Ready for review now if someone want to check.